### PR TITLE
Add a command to fetch a terraform output

### DIFF
--- a/output.go
+++ b/output.go
@@ -1,0 +1,11 @@
+package terratest
+
+import (
+	"github.com/gruntwork-io/terratest/terraform"
+	"github.com/gruntwork-io/terratest/log"
+)
+
+func Output(ao *ApplyOptions, key string) (string, error) {
+	logger := log.NewLogger(ao.TestName)
+	return terraform.Output(ao.TemplatePath, key, logger)
+}

--- a/terraform/output.go
+++ b/terraform/output.go
@@ -1,0 +1,17 @@
+package terraform
+
+import (
+	"log"
+	"github.com/gruntwork-io/terratest/shell"
+	"strings"
+)
+
+func Output(templatePath string, key string, logger *log.Logger) (string, error) {
+	logger.Println("Getting Terraform output for key", key, "in folder", templatePath)
+	output, err := shell.RunCommandAndGetOutput(shell.Command { Command: "terraform", Args: []string{"output", "-no-color", key}, WorkingDir: templatePath }, logger)
+	if err != nil {
+		return "", err
+	} else {
+		return strings.TrimSpace(output), nil
+	}
+}


### PR DESCRIPTION
This PR adds a function to terratest that wraps the terraform “output” command.
