### PR TITLE
Add unit test for the output command

### DIFF
--- a/output_test.go
+++ b/output_test.go
@@ -1,0 +1,43 @@
+package terratest
+
+import (
+	"testing"
+	"path"
+	"errors"
+)
+
+func TestGetOutput(t *testing.T) {
+	t.Parallel()
+
+	randomResourceCollectionOptions := NewRandomResourceCollectionOptions()
+	randomResourceCollection, err := CreateRandomResourceCollection(randomResourceCollectionOptions)
+	defer randomResourceCollection.DestroyResources()
+	if err != nil {
+		t.Errorf("Failed to create random resource collection: %s\n", err.Error())
+	}
+
+	options := NewTerratestOptions()
+	options.UniqueId = randomResourceCollection.UniqueId
+	options.TestName = "Test - TestGetOutput"
+	options.TemplatePath = path.Join(fixtureDir, "local-resources-only-example")
+
+	if _, err := Apply(options); err != nil {
+		t.Fatal(err)
+	}
+
+	testOutput(options, "template1", "template1", t)
+	testOutput(options, "template2", "template2", t)
+}
+
+func testOutput(terratestOptions *TerratestOptions, key string, expectedOutput string, t *testing.T) {
+	actualOutput, err := Output(terratestOptions, key)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if actualOutput != expectedOutput {
+		t.Fatal(errors.New("Got unexpected output for key " + key + ". Expected: " + expectedOutput + ". Actual: " + actualOutput + "."))
+	}
+}
+

--- a/test-fixtures/local-resources-only-example/README.md
+++ b/test-fixtures/local-resources-only-example/README.md
@@ -1,0 +1,6 @@
+# local-resources-only-example
+
+A set of templates that create only *local* Terraform resources. That is, resources such as `template_file` that exist
+only locally, as opposed to resources such as `aws_instance` that require an external provider such as AWS. When
+testing Terraform wrappers, this allows the unit tests to run much faster than if we had to wait
+on an external provider, such as waiting for AWS to create EC2 instances.

--- a/test-fixtures/local-resources-only-example/main.tf
+++ b/test-fixtures/local-resources-only-example/main.tf
@@ -1,0 +1,7 @@
+resource "template_file" "template1" {
+  template = "template1"
+}
+
+resource "template_file" "template2" {
+  template = "template2"
+}

--- a/test-fixtures/local-resources-only-example/outputs.tf
+++ b/test-fixtures/local-resources-only-example/outputs.tf
@@ -1,0 +1,7 @@
+output "template1" {
+  value = "${template_file.template1.rendered}"
+}
+
+output "template2" {
+  value = "${template_file.template2.rendered}"
+}


### PR DESCRIPTION
I forgot to add unit tests for #4, so this is a follow-up PR that adds unit tests for the `terraform output` wrapper.

I will merge this in right away, but as always, feel free to make comments as always, and I’ll fix them later!
