### PR TITLE
Add check for SSH connectivity through bastion host to private host.

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,40 +1,126 @@
 hash: 1fd2bb1541bf122b5574342b28559618618bba9773aabebbe09a7c9933e330fb
-updated: 2016-03-17T11:09:55.925712503-07:00
+updated: 2016-04-06T16:41:09.045786912-07:00
 imports:
 - name: github.com/aws/aws-sdk-go
-  version: 6a5db7c4ffe484f74f8661d919b2a3ef1fd621f7
+  version: 6f62fc3ff9aa98c629b350376825cda566658d75
   subpackages:
   - aws
   - aws/session
   - service/ec2
+  - service/iam
   - service/s3
   - aws/awserr
   - aws/credentials
-  - aws/client
-  - aws/corehandlers
-  - aws/defaults
-  - aws/request
-  - private/endpoints
-  - aws/awsutil
   - aws/client/metadata
-  - private/protocol
-  - private/protocol/ec2query
-  - private/signer/v4
-  - private/waiter
-  - private/protocol/restxml
-  - aws/credentials/ec2rolecreds
+  - aws/request
   - aws/ec2metadata
+  - service/sts
+  - private/endpoints
+  - awsmigrate/awsmigrate-renamer/rename
+  - private/model/api
+  - private/util
+  - service/acm
+  - service/apigateway
+  - service/autoscaling
+  - service/cloudformation
+  - service/cloudfront
+  - service/cloudhsm
+  - service/cloudsearch
+  - service/cloudtrail
+  - service/cloudwatch
+  - service/cloudwatchlogs
+  - service/codecommit
+  - service/codedeploy
+  - service/codepipeline
+  - service/cognitoidentity
+  - service/cognitosync
+  - service/configservice
+  - service/datapipeline
+  - service/devicefarm
+  - service/directconnect
+  - service/directoryservice
+  - service/dynamodb
+  - service/dynamodbstreams
+  - service/ecs
+  - service/efs
+  - service/elasticache
+  - service/elasticbeanstalk
+  - service/elb
+  - service/elastictranscoder
+  - service/emr
+  - service/elasticsearchservice
+  - service/glacier
+  - service/iot
+  - service/iotdataplane
+  - service/kinesis
+  - service/kms
+  - service/lambda
+  - service/machinelearning
+  - service/opsworks
+  - service/rds
+  - service/redshift
+  - service/route53
+  - service/route53domains
+  - service/ses
+  - service/simpledb
+  - service/sns
+  - service/sqs
+  - service/ssm
+  - service/storagegateway
+  - service/support
+  - service/swf
+  - service/waf
+  - service/workspaces
+  - service/cloudsearchdomain
+  - service/cloudwatchevents
+  - service/dynamodb/dynamodbattribute
+  - service/ecr
+  - service/firehose
+  - service/inspector
+  - service/marketplacecommerceanalytics
+  - service/mobileanalytics
   - private/protocol/query/queryutil
   - private/protocol/xml/xmlutil
   - private/protocol/rest
-  - private/protocol/query
+- name: github.com/davecgh/go-spew
+  version: 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d
+  subpackages:
+  - spew
 - name: github.com/go-ini/ini
-  version: 776aa739ce9373377cd16f526cdf06cb4c89b40f
+  version: 12f418cc7edc5a618a51407b7ac1f1f512139df3
 - name: github.com/jmespath/go-jmespath
   version: 0b12d6b521d83fc7f755e7cfc1b1fbdd35a01a74
+- name: github.com/lsegal/gucumber
+  version: 44a4d7eb3b14a88cf82b073dfb7e06277afdc549
+  subpackages:
+  - gherkin
+- name: github.com/pmezard/go-difflib
+  version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
+  subpackages:
+  - difflib
+- name: github.com/shiena/ansicolor
+  version: a422bbe96644373c5753384a59d678f7d261ff10
+- name: github.com/stretchr/testify
+  version: 6fe211e493929a8aac0469b93f28b1d0688a9a3a
+  subpackages:
+  - assert
 - name: golang.org/x/crypto
-  version: 6025851c7c2bf210daf74d22300c699b16541847
+  version: b8a0f4bb4040f8d884435cff35b9691e362cf00c
   subpackages:
   - ssh
-  - curve25519
+  - blowfish
+  - nacl/secretbox
+  - salsa20/salsa
+  - poly1305
+  - openpgp/armor
+  - openpgp/errors
+  - openpgp/packet
+  - openpgp/s2k
+  - pkcs12/internal/rc2
+- name: golang.org/x/tools
+  version: 83f918d66bc8f7d594cf0f2ff3756944f491adf5
+  subpackages:
+  - go/loader
+  - go/ast/astutil
+  - go/buildutil
 devImports: []

--- a/ssh/ssh.go
+++ b/ssh/ssh.go
@@ -29,6 +29,47 @@ func CheckSshConnection(host string, user string, keyPair *terratest.Ec2Keypair,
 	return nil
 }
 
+// CheckPrivateSshConnection attempts to connect to a private server (i.e. not addressable from the Internet) via a separate public server (i.e. addressable from the Internet)
+// It is useful for checking that it's possible to SSH from a Bastion Host to a private instance.
+func CheckPrivateSshConnection(publicHost string, publicHostUser string, publicHostKeyPair *terratest.Ec2Keypair, privateHost string, privateHostUser string, privateHostKeyPair *terratest.Ec2Keypair, logger *log.Logger) error {
+	defer cleanupKeyPairFile(publicHostKeyPair, logger)
+	writeKeyPairFile(publicHostKeyPair, logger)
+
+	// We need the SSH key to be available when we SSH from the Bastion Host to the Private Host.
+	// We cannot guarantee ssh-agent will be in the test environment, so we use scp to copy the key to the bastion host file system.
+	// Start by setting permissions on the key to 0600.
+	chmodErr := shell.RunCommand(shell.Command{Command: "chmod", Args: []string{"0600", publicHostKeyPair.Name}}, logger)
+	exitCode, err := shell.GetExitCodeForRunCommandError(chmodErr)
+	if err != nil {
+		return err
+	}
+	if exitCode != 0 {
+		return errors.New("Attempt to set permissions on local key file exited with a non-zero exit code: " + strconv.Itoa(exitCode))
+	}
+
+	// Upload the key to the bastion host
+	sshErr := shell.RunCommand(shell.Command{Command: "scp", Args: []string{"-p", "-i", publicHostKeyPair.Name, "-o", "UserKnownHostsFile=/dev/null", "-o", "StrictHostKeyChecking=no", publicHostKeyPair.Name, publicHostUser + "@" + publicHost + ":key.pem"}}, logger)
+	exitCode, err = shell.GetExitCodeForRunCommandError(sshErr)
+	if err != nil {
+		return err
+	}
+	if exitCode != 0 {
+		return errors.New("Attempt to SSH and write key file exited with a non-zero exit code: " + strconv.Itoa(exitCode))
+	}
+
+	// Now connect directly to the privateHost
+	sshErr = shell.RunCommand(shell.Command{Command: "ssh", Args: []string{"-i", publicHostKeyPair.Name, "-o", "UserKnownHostsFile=/dev/null", "-o", "StrictHostKeyChecking=no", publicHostUser + "@" + publicHost, "ssh -i key.pem -o StrictHostKeyChecking=no", privateHostUser + "@" + privateHost}}, logger)
+	exitCode, err = shell.GetExitCodeForRunCommandError(sshErr)
+	if err != nil {
+		return err
+	}
+	if exitCode != 0 {
+		return errors.New("Attempt to SSH to private host exited with a non-zero exit code: " + strconv.Itoa(exitCode))
+	}
+
+	return nil
+}
+
 func writeKeyPairFile(keyPair *terratest.Ec2Keypair, logger *log.Logger) error {
 	logger.Println("Creating test-time Key Pair file", keyPair.Name)
 	return ioutil.WriteFile(keyPair.Name, []byte(keyPair.PrivateKey), 0400)


### PR DESCRIPTION
The goal of this PR is to allow terratest to check SSH on an EC2 Instance in a private subnet _through_ the Bastion Host.

The only non-trivial part of this is how to get access to the SSH key from the bastion host so that it can be used to SSH to the private host. In practice, I'd just use `ssh-agent`, but since I can't guarantee that will be in the test environment, I wanted to write the key file to the server.

Unfortunately, this failed:

```
test-multi-vpc-setup 2016/04/06 17:49:05 Creating test-time Key Pair file wdzxbo
test-multi-vpc-setup 2016/04/06 17:49:05 Running command ssh with args [-i wdzxbo -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no ubuntu@23.22.68.96 'echo " -----BEGIN RSA PRIVATE KEY-----
MIIEogIBAAKCAQEAsaXz4L6xXmdTKGrOQAyGeP9H3psK/gIQGPwBbdFyTsdjkD2z
bZzzMgjYoIg/cW0hhQ5OixddT0Doqhk1Ka2NkxnbuOGiMWMn61cgP3nVOvILOTyi
/Lj8EirSFrGaDWx862LhLxse0zA+Qg6IZUSzwNabD1YZtoL540MVlT3vs2zAlYpZ
9d5bEnYrzIcZAIKwVqjQ5ONz7tAPsHLAsrpRE3NWhyKv/mm46AgqucNaka+nbbro
wmYmQREu/YTT13U95+Msi7WgtWCTeKbqRaq/lMdl/j2kVD6oFZy3BoAmG08FPfoG
dsc3N4Wkc5yAh08ajSmVaA9uIE4I7+CM/NotHQIDAQABAoIBAFLzlN9a6+OTB8eV
p91Me/Y/7cVKTGWzfOTNt7UZ2fBjNmCCDyid4wl4C/9Z35YNSVuiBJb6P/3j50CW
KLbfbX5E0s6PvXamQFuqAUrijujJYOhHIiw0DLBHAnbKU471G5emQlQGq+wdWNTr
iFERNYZUL2+H2tXYburpxkg79ZOn6xn++ZLOViJL5/WpaH9i/uU0djDjHI2HLTLE
x4b8csxc54XhBH1id+bTgYIKaab+BDRXxSrqDDePXH53EonrmzpUYArNEpzxh9yy
QBurX822EVQQza8g0fhIlwFKU6ijSiUSFH9tP++lrFMGg4x7i+bUbpYDgbbrQc1Q
8TNBJYECgYEAy0SYSPoPuHoo98xPGZnZrGBQuFNEB8dzBOD/LdH6KhVf5FEH82jw
RctTd8a1KPmeHyArJCzbPrL05grnDuxU3qQK0KExTZf0N96BCRK8vSz1PfmUwzsB
6QlqdEGBQ4hLriZPjEWautEK1M0unrra+hmQ1MuOjLWwCOho7eRCEQ0CgYEA37vn
4XyAk9U8PF60H4SLwC8AHPDpRwoJUIdTGLXra5lojq5LgRXXxJS4x1CU/1bapRxS
mozh7eqJIs16LJM0Rbeo9QtiQ/CZkyWdt3S4V0oKew1+FWqyK+gWF4Vj5gNFCTlC
f4iLeQem7kubUYT8lL6/zqleZn2h01G/EzC76FECgYB/PTEWfXHZyJ5cf0gEfooD
nUbqGzU6qV8WbsFNrWMrdLXR9edENywwhFZ7Y6eDPr38PebDflC/rsYeOjTo4oc9
1vHuJvj12WjGkEG1rET5JmtdoB2/F/DaL0qz+00vOOIm4VRqOifhSXm+O7IzKkRo
yhgfHEzfR9wpt1H3mCrDAQKBgAnTOKWgUA0t6g1Eo2hW68QuzDR5J+VkvW/54V5O
bt40yHCrmsk6alVJqqumEET+TW++xKng0fMev5L1rw3SEROWsya/rzsIj9X0au6p
g4bhy4AH4aeTHevrrzytMOvi7N8w0ojDOEzCV0RTsahszKLDlay/p1Oc5MRg7KEt
HLNhAoGAXz2XhxwNzD28+IdeqL7cf5GVAl+N9xxYkBey+f9BemxFtL9uBE/zczqG
IlBsBxI2ym0Z5DZgz4YCWHFYkYMCNf6Xm0e8A2jH1vQQiWom7KJUYxhw9ORzvz1S
Cly9bQrlIZ+/3e+lImhBQpWNGO9eiQpgvLZD36Y6fBOZRh4E/Zk=
-----END RSA PRIVATE KEY-----
 " > key.pem; chmod 0600 key.pem']
test-multi-vpc-setup 2016/04/06 17:49:06 Warning: Permanently added '23.22.68.96' (ECDSA) to the list of known hosts.
test-multi-vpc-setup 2016/04/06 17:49:06 bash: line 27: echo " -----BEGIN RSA PRIVATE KEY-----
test-multi-vpc-setup 2016/04/06 17:49:06 MIIEogIBAAKCAQEAsaXz4L6xXmdTKGrOQAyGeP9H3psK/gIQGPwBbdFyTsdjkD2z
test-multi-vpc-setup 2016/04/06 17:49:06 bZzzMgjYoIg/cW0hhQ5OixddT0Doqhk1Ka2NkxnbuOGiMWMn61cgP3nVOvILOTyi
test-multi-vpc-setup 2016/04/06 17:49:06 /Lj8EirSFrGaDWx862LhLxse0zA+Qg6IZUSzwNabD1YZtoL540MVlT3vs2zAlYpZ
test-multi-vpc-setup 2016/04/06 17:49:06 9d5bEnYrzIcZAIKwVqjQ5ONz7tAPsHLAsrpRE3NWhyKv/mm46AgqucNaka+nbbro
test-multi-vpc-setup 2016/04/06 17:49:06 wmYmQREu/YTT13U95+Msi7WgtWCTeKbqRaq/lMdl/j2kVD6oFZy3BoAmG08FPfoG
test-multi-vpc-setup 2016/04/06 17:49:06 dsc3N4Wkc5yAh08ajSmVaA9uIE4I7+CM/NotHQIDAQABAoIBAFLzlN9a6+OTB8eV
test-multi-vpc-setup 2016/04/06 17:49:06 p91Me/Y/7cVKTGWzfOTNt7UZ2fBjNmCCDyid4wl4C/9Z35YNSVuiBJb6P/3j50CW
test-multi-vpc-setup 2016/04/06 17:49:06 KLbfbX5E0s6PvXamQFuqAUrijujJYOhHIiw0DLBHAnbKU471G5emQlQGq+wdWNTr
test-multi-vpc-setup 2016/04/06 17:49:06 iFERNYZUL2+H2tXYburpxkg79ZOn6xn++ZLOViJL5/WpaH9i/uU0djDjHI2HLTLE
test-multi-vpc-setup 2016/04/06 17:49:06 x4b8csxc54XhBH1id+bTgYIKaab+BDRXxSrqDDePXH53EonrmzpUYArNEpzxh9yy
test-multi-vpc-setup 2016/04/06 17:49:06 QBurX822EVQQza8g0fhIlwFKU6ijSiUSFH9tP++lrFMGg4x7i+bUbpYDgbbrQc1Q
test-multi-vpc-setup 2016/04/06 17:49:06 8TNBJYECgYEAy0SYSPoPuHoo98xPGZnZrGBQuFNEB8dzBOD/LdH6KhVf5FEH82jw
test-multi-vpc-setup 2016/04/06 17:49:06 RctTd8a1KPmeHyArJCzbPrL05grnDuxU3qQK0KExTZf0N96BCRK8vSz1PfmUwzsB
test-multi-vpc-setup 2016/04/06 17:49:06 6QlqdEGBQ4hLriZPjEWautEK1M0unrra+hmQ1MuOjLWwCOho7eRCEQ0CgYEA37vn
test-multi-vpc-setup 2016/04/06 17:49:06 4XyAk9U8PF60H4SLwC8AHPDpRwoJUIdTGLXra5lojq5LgRXXxJS4x1CU/1bapRxS
test-multi-vpc-setup 2016/04/06 17:49:06 mozh7eqJIs16LJM0Rbeo9QtiQ/CZkyWdt3S4V0oKew1+FWqyK+gWF4Vj5gNFCTlC
test-multi-vpc-setup 2016/04/06 17:49:06 f4iLeQem7kubUYT8lL6/zqleZn2h01G/EzC76FECgYB/PTEWfXHZyJ5cf0gEfooD
test-multi-vpc-setup 2016/04/06 17:49:06 nUbqGzU6qV8WbsFNrWMrdLXR9edENywwhFZ7Y6eDPr38PebDflC/rsYeOjTo4oc9
test-multi-vpc-setup 2016/04/06 17:49:06 1vHuJvj12WjGkEG1rET5JmtdoB2/F/DaL0qz+00vOOIm4VRqOifhSXm+O7IzKkRo
test-multi-vpc-setup 2016/04/06 17:49:06 yhgfHEzfR9wpt1H3mCrDAQKBgAnTOKWgUA0t6g1Eo2hW68QuzDR5J+VkvW/54V5O
test-multi-vpc-setup 2016/04/06 17:49:06 bt40yHCrmsk6alVJqqumEET+TW++xKng0fMev5L1rw3SEROWsya/rzsIj9X0au6p
test-multi-vpc-setup 2016/04/06 17:49:06 g4bhy4AH4aeTHevrrzytMOvi7N8w0ojDOEzCV0RTsahszKLDlay/p1Oc5MRg7KEt
test-multi-vpc-setup 2016/04/06 17:49:06 HLNhAoGAXz2XhxwNzD28+IdeqL7cf5GVAl+N9xxYkBey+f9BemxFtL9uBE/zczqG
test-multi-vpc-setup 2016/04/06 17:49:06 IlBsBxI2ym0Z5DZgz4YCWHFYkYMCNf6Xm0e8A2jH1vQQiWom7KJUYxhw9ORzvz1S
test-multi-vpc-setup 2016/04/06 17:49:06 Cly9bQrlIZ+/3e+lImhBQpWNGO9eiQpgvLZD36Y6fBOZRh4E/Zk=
test-multi-vpc-setup 2016/04/06 17:49:06 -----END RSA PRIVATE KEY-----
test-multi-vpc-setup 2016/04/06 17:49:06  " > key.pem; chmod 0600 key.pem: No such file or directory
```

No file is getting written, so the `chmod` command has the error `No such file`.

Once this is fixed, I'll be able to validate the VPC modules and finish out https://github.com/gruntwork-io/terraform-modules/pull/23.  That build is currently failing because it expects the `CheckPrivateSshConnection` function defined in this PR.

Feedback is welcome on alternate approaches to handling the key access.
