### PR TITLE
Use unique names for Key Pair files

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -25,30 +25,20 @@ dependencies:
           wget https://github.com/Masterminds/glide/releases/download/0.9.3/glide-0.9.3-linux-amd64.zip
           unzip glide-0.9.3-linux-amd64.zip -d ~/glide
         fi
+
+    # Run glide to install Go dependencies.
+    - |
+        cd ${REPO}
+        ~/glide/linux-amd64/glide install
+
   cache_directories:
     - ~/terraform
     - ~/glide
 
 test:
   override:
-    # Run glide to install Go dependencies.
-    - |
-        cd ${REPO}
-        ~/glide/linux-amd64/glide update --all-dependencies
-
-    # If this commit is part of a Pull Request...
     # Run all go tests (./...) except those in the vendor directory.
     - |
-        if [[ ! -z $CI_PULL_REQUEST ]]; then
-          cd ${REPO}
-          go test -parallel 8 $(go list ./... | grep -v /vendor/)
-        fi
+        cd ${REPO}
+        go test -v -parallel 128 $(go list ./... | grep -v /vendor/)
 
-deployment:
-  # When the code is merged to master run all unit tests again.
-  automerge:
-    branch: [master]
-    commands:
-      - |
-          cd ${REPO}
-          go test -parallel 8 $(go list ./... | grep -v /vendor/)

--- a/ssh/ssh.go
+++ b/ssh/ssh.go
@@ -8,6 +8,8 @@ import (
 	"strconv"
 	"io/ioutil"
 	"os"
+	"fmt"
+	"github.com/gruntwork-io/terratest/util"
 )
 
 type Host struct {
@@ -17,10 +19,12 @@ type Host struct {
 }
 
 func CheckSshConnection(host Host, logger *log.Logger) error {
-	defer cleanupKeyPairFile(host.SshKeyPair, logger)
-	writeKeyPairFile(host.SshKeyPair, logger)
+	keyPairWithUniqueName := createKeyPairCopyWithUniqueName(*host.SshKeyPair)
 
-	sshErr := shell.RunCommand(shell.Command{Command: "ssh", Args: []string{"-i", host.SshKeyPair.Name, "-o", "UserKnownHostsFile=/dev/null", "-o", "StrictHostKeyChecking=no", host.SshUserName + "@" + host.Hostname, "'exit'"}}, logger)
+	defer cleanupKeyPairFile(keyPairWithUniqueName, logger)
+	writeKeyPairFile(keyPairWithUniqueName, logger)
+
+	sshErr := shell.RunCommand(shell.Command{Command: "ssh", Args: []string{"-i", keyPairWithUniqueName.Name, "-o", "UserKnownHostsFile=/dev/null", "-o", "StrictHostKeyChecking=no", host.SshUserName + "@" + host.Hostname, "'exit'"}}, logger)
 
 	exitCode, err := shell.GetExitCodeForRunCommandError(sshErr)
 
@@ -39,16 +43,19 @@ func CheckSshConnection(host Host, logger *log.Logger) error {
 // publicHost (which is addressable from the Internet) and then executes "command" on privateHost and returns its output.
 // It is useful for checking that it's possible to SSH from a Bastion Host to a private instance.
 func CheckPrivateSshConnection(publicHost Host, privateHost Host, command string, logger *log.Logger) (string, error) {
-	defer cleanupKeyPairFile(publicHost.SshKeyPair, logger)
-	writeKeyPairFile(publicHost.SshKeyPair, logger)
+	publicKeyPairWithUniqueName := createKeyPairCopyWithUniqueName(*publicHost.SshKeyPair)
+	privateKeyPairWithUniqueName := createKeyPairCopyWithUniqueName(*privateHost.SshKeyPair)
 
-	defer cleanupKeyPairFile(privateHost.SshKeyPair, logger)
-	writeKeyPairFile(privateHost.SshKeyPair, logger)
+	defer cleanupKeyPairFile(publicKeyPairWithUniqueName, logger)
+	writeKeyPairFile(publicKeyPairWithUniqueName, logger)
+
+	defer cleanupKeyPairFile(privateKeyPairWithUniqueName, logger)
+	writeKeyPairFile(privateKeyPairWithUniqueName, logger)
 
 	// We need the SSH key to be available when we SSH from the Bastion Host to the Private Host.
 	// We cannot guarantee ssh-agent will be in the test environment, so we use scp to copy the key to the bastion host file system.
 	// Start by setting permissions on the key to 0600. These permissions (read/write for file owner only) are required by ssh to access the key.
-	chmodErr := shell.RunCommand(shell.Command{Command: "chmod", Args: []string{"0600", privateHost.SshKeyPair.Name}}, logger)
+	chmodErr := shell.RunCommand(shell.Command{Command: "chmod", Args: []string{"0600", privateKeyPairWithUniqueName.Name}}, logger)
 	exitCode, err := shell.GetExitCodeForRunCommandError(chmodErr)
 	if err != nil {
 		return "", err
@@ -58,7 +65,7 @@ func CheckPrivateSshConnection(publicHost Host, privateHost Host, command string
 	}
 
 	// Upload the key to the bastion host
-	sshErr := shell.RunCommand(shell.Command{Command: "scp", Args: []string{"-p", "-i", publicHost.SshKeyPair.Name, "-o", "UserKnownHostsFile=/dev/null", "-o", "StrictHostKeyChecking=no", privateHost.SshKeyPair.Name, publicHost.SshUserName + "@" + publicHost.Hostname + ":key.pem"}}, logger)
+	sshErr := shell.RunCommand(shell.Command{Command: "scp", Args: []string{"-p", "-i", publicKeyPairWithUniqueName.Name, "-o", "UserKnownHostsFile=/dev/null", "-o", "StrictHostKeyChecking=no", privateKeyPairWithUniqueName.Name, publicHost.SshUserName + "@" + publicHost.Hostname + ":key.pem"}}, logger)
 	exitCode, err = shell.GetExitCodeForRunCommandError(sshErr)
 	if err != nil {
 		return "", err
@@ -68,7 +75,7 @@ func CheckPrivateSshConnection(publicHost Host, privateHost Host, command string
 	}
 
 	// Now connect directly to the privateHost
-	output, sshErr := shell.RunCommandAndGetOutput(shell.Command{Command: "ssh", Args: []string{"-i", publicHost.SshKeyPair.Name, "-o", "UserKnownHostsFile=/dev/null", "-o", "StrictHostKeyChecking=no", publicHost.SshUserName + "@" + publicHost.Hostname, "ssh -i key.pem -o StrictHostKeyChecking=no", privateHost.SshUserName + "@" + privateHost.Hostname, command}}, logger)
+	output, sshErr := shell.RunCommandAndGetOutput(shell.Command{Command: "ssh", Args: []string{"-i", publicKeyPairWithUniqueName.Name, "-o", "UserKnownHostsFile=/dev/null", "-o", "StrictHostKeyChecking=no", publicHost.SshUserName + "@" + publicHost.Hostname, "ssh -i key.pem -o StrictHostKeyChecking=no", privateHost.SshUserName + "@" + privateHost.Hostname, command}}, logger)
 	exitCode, err = shell.GetExitCodeForRunCommandError(sshErr)
 	if err != nil {
 		return output, err
@@ -80,12 +87,22 @@ func CheckPrivateSshConnection(publicHost Host, privateHost Host, command string
 	return output, nil
 }
 
-func writeKeyPairFile(keyPair *terratest.Ec2Keypair, logger *log.Logger) error {
+func writeKeyPairFile(keyPair terratest.Ec2Keypair, logger *log.Logger) error {
 	logger.Println("Creating test-time Key Pair file", keyPair.Name)
 	return ioutil.WriteFile(keyPair.Name, []byte(keyPair.PrivateKey), 0400)
 }
 
-func cleanupKeyPairFile(keyPair *terratest.Ec2Keypair, logger *log.Logger) error {
+func cleanupKeyPairFile(keyPair terratest.Ec2Keypair, logger *log.Logger) error {
 	logger.Println("Cleaning up test-time Key Pair file", keyPair.Name)
 	return os.Remove(keyPair.Name)
+}
+
+// Testing SSH connectivity involves writing and deleting Key Pair files on disk. Since there might be multiple SSH
+// checks happening in parallel, we use this function to give the Key Pair file a unique name, and thereby avoid the
+// files overwriting each other.
+func createKeyPairCopyWithUniqueName(keyPair terratest.Ec2Keypair) terratest.Ec2Keypair {
+	// This automatically creates a shallow copy in Go
+	keyPairWithUniqueName := keyPair
+	keyPairWithUniqueName.Name = fmt.Sprintf("%s-%s", keyPairWithUniqueName.Name, util.UniqueId())
+	return keyPairWithUniqueName
 }


### PR DESCRIPTION
This PR modifies the SSH checking functionality in terratest to create a unique name for each Key Pair file before writing it to disk. This is because we may be doing multiple SSH checks in parallel with the same Key Pair file (see [my PR in terraform-modules](https://github.com/gruntwork-io/terraform-modules/pull/42/files)), and if we don’t use unique file names, a Key Pair file may be deleted by one SSH check right when another check is trying to use the same Key Pair file.
