### PR TITLE
Add helpers for finding EC2 instances and fetching CloudWatch logs

### DIFF
--- a/aws/cloudwatch_logs.go
+++ b/aws/cloudwatch_logs.go
@@ -6,11 +6,11 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 )
 
-// Return the CloudWatch log messages for the given log group and log stream
-func GetCloudWatchLogEntries(logGroupName string, logStreamName string) ([]string, error) {
+// Return the CloudWatch log messages in the given region for the given log stream and log group
+func GetCloudWatchLogEntries(awsRegion string, logStreamName string, logGroupName string) ([]string, error) {
 	entries := []string{}
 
-	svc := cloudwatchlogs.New(session.New())
+	svc := cloudwatchlogs.New(session.New(), aws.NewConfig().WithRegion(awsRegion))
 	output, err := svc.GetLogEvents(&cloudwatchlogs.GetLogEventsInput{
 		LogGroupName: aws.String(logGroupName),
 		LogStreamName: aws.String(logStreamName),

--- a/aws/ec2.go
+++ b/aws/ec2.go
@@ -4,19 +4,19 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/aws"
+	"fmt"
 )
 
-// Return all the ids of EC2 instances with the given tag
-func getEc2InstanceIdsByTag(tagName string, tagValue string) ([]string, error) {
+// Return all the ids of EC2 instances in the given region with the given tag
+func GetEc2InstanceIdsByTag(awsRegion string, tagName string, tagValue string) ([]string, error) {
 	instanceIds := []string{}
-	svc := ec2.New(session.New())
+	svc := ec2.New(session.New(), aws.NewConfig().WithRegion(awsRegion))
 
-	// TODO: filter using tags
-	asgFilter := &ec2.Filter{
-		Name: aws.String("requester-id"),
-		Values: []*string{aws.String(asgId)},
+	tagFilter := &ec2.Filter{
+		Name: aws.String(fmt.Sprintf("tag:key=%s", tagName)),
+		Values: []*string{aws.String(tagValue)},
 	}
-	output, err := svc.DescribeInstances(&ec2.DescribeInstancesInput{Filters: []*ec2.Filter{asgFilter}})
+	output, err := svc.DescribeInstances(&ec2.DescribeInstancesInput{Filters: []*ec2.Filter{tagFilter}})
 	if err != nil {
 		return instanceIds, err
 	}


### PR DESCRIPTION
I’m adding automated tests in terraform-modules to check that CloudWatch Log aggregation is actually working. To support that effort, I’ve added a couple helper functions in terratest for:
1. Fetching CloudWatch Log events for a given log group and log stream.
2. Fetching the ids of EC2 instances with specific tags. This is necessary because the way we’ve set up CloudWatch Log Aggregation in script-modules is to use the instance id as the log stream name. Since the instances in the example app run in an ASG, we need to dynamically find their instance ids.
