### PR TITLE
Add utilities for running parts of tests in parallel

### DIFF
--- a/parallel/parallel.go
+++ b/parallel/parallel.go
@@ -1,0 +1,71 @@
+// This package contains utilities for running parts of a single test in parallel. Normally, you would just have
+// multiple tests and let Go execute them in parallel by calling t.Parallel(), but for test cases with expensive set
+// up and tear down procedures (e.g. a big integration test where you have to start up and shut down many different
+// servers), you may want to have just a single test and to run a bunch of pieces within that test in parallel.
+package parallel
+
+import (
+	"time"
+	"log"
+	"fmt"
+	"errors"
+)
+
+// We use goroutines and channels to run parts things in parallel. There are two limitations to note when doing this:
+//
+// 1. Channels can only return a single value.
+// 2. You can only call t.Fatal or t.Fail from the original goroutine used for the test.
+//
+// Therefore, this struct is useful for allowing the parallelized parts of the tests to return values and errors to the
+// original goroutine via a channel.
+type TestResult struct {
+	Description 	string	// A description of the test. This should always be set.
+	Value		string	// An optional value to return from the test that might be passed on to other tests.
+	Err		error	// An error. This should only be set if the test failed.
+}
+
+func (result TestResult) WithValue(value string) TestResult {
+	result.Value = value
+	return result
+}
+
+func (result TestResult) WithError(err error) TestResult {
+	result.Err = err
+	return result
+}
+
+// A wrapper type for a function that returns a TestResult
+type Test func() TestResult
+
+const DEFAULT_MAX_WAIT_FOR_CHANNEL = time.Minute * 10
+
+// Runs the given test function in a goroutine and reports its result via the given channel
+func RunTestInParallel(test Test, resultChannel chan <-TestResult) {
+	go func() { resultChannel <- test() }()
+}
+
+// Calls GetTestResultWithTimeout with a default time out of DEFAULT_MAX_WAIT_FOR_CHANNEL. See GetTestResultWithTimeout
+// for more info.
+func GetTestResult(resultChannel <-chan TestResult, channelName string, logger *log.Logger) TestResult {
+	return GetTestResultWithTimeout(resultChannel, channelName, logger, DEFAULT_MAX_WAIT_FOR_CHANNEL)
+}
+
+// Wait on the given channel for up to maxTimeout and return the TestResult the channel returns. If maxTimeout is
+// exceeded, return a TestResult with an error.
+func GetTestResultWithTimeout(resultChannel <-chan TestResult, channelName string, logger *log.Logger, maxTimeout time.Duration) TestResult {
+	logger.Printf("Waiting on a result from channel %s for up to %s", channelName, maxTimeout.String())
+	select {
+	case result := <-resultChannel:
+		logger.Printf("Channel %s returned a result: '%s'", channelName, result)
+		return result
+	case <-time.After(maxTimeout):
+		errorMsg := fmt.Sprintf("Exceeded max timeout of %s waiting for channel %s", maxTimeout.String(), channelName)
+		logger.Println(errorMsg)
+		return TestResult{Err: errors.New(errorMsg), Description: errorMsg}
+	}
+
+	errorMsg := "The code should not be able to get here. The select statement should always return or fail the test."
+	return TestResult{Err: errors.New(errorMsg), Description: errorMsg}
+}
+
+

--- a/parallel/parallel_test.go
+++ b/parallel/parallel_test.go
@@ -1,0 +1,138 @@
+package parallel
+
+import (
+	"testing"
+	"time"
+	"log"
+	terralog "github.com/gruntwork-io/terratest/log"
+	"strconv"
+	"fmt"
+	"errors"
+)
+
+func TestParallelCounters(t *testing.T) {
+	t.Parallel()
+
+	testName := "TestParallelCounters"
+	logger := terralog.NewLogger(testName)
+	count := 5
+
+	// Create a bunch of test functions, each one returning one of the integers from 1 to count. However, before
+	// returning the integer, the function will sleep for count - its integer value (e.g. the function that returns
+	// 0 will sleep for 5 seconds, the function that returns 2 will sleep for 3 seconds, etc). That way, if these
+	// functions are really running in parallel, when we listen on our channel later on, we would expect to get the
+	// numbers back in reverse order.
+	counterTests := []Test {}
+	for i := 0; i < count; i++ {
+		sleepTime := time.Duration(count - i) * time.Second
+		counterTests = append(counterTests, createCounterFunction(sleepTime, strconv.Itoa(i + 1), logger))
+	}
+
+	// Run all the counter functions in parallel
+	counterResultChannel := make(chan TestResult, count)
+	for i := 0; i < count; i++ {
+		RunTestInParallel(counterTests[i], counterResultChannel)
+	}
+
+	// Listen on the counter channel. We should get back the values in reverse order.
+	for i := 0; i < count; i++ {
+		result := GetTestResult(counterResultChannel, testName, logger)
+		expectedValue := strconv.Itoa(count - i)
+		checkResultWithValue(result, expectedValue, logger, t)
+	}
+}
+
+func TestGetTestResultReturnsExpectedResults(t *testing.T) {
+	t.Parallel()
+
+	testName := "TestGetTestResultReturnsExpectedResults"
+	logger := terralog.NewLogger(testName)
+	count := 5
+
+	results := make(chan TestResult, count)
+	for i := 0; i < count; i++ {
+		results <- TestResult{Value: strconv.Itoa(i), Description: strconv.Itoa(i)}
+	}
+
+	for i := 0; i < count; i++ {
+		result := GetTestResult(results, testName, logger)
+		checkResultWithValue(result, strconv.Itoa(i), logger, t)
+	}
+}
+
+func TestGetTestResultReturnsResultsAndErrors(t *testing.T) {
+	t.Parallel()
+
+	testName := "TestGetTestResultReturnsResultsAndErrors"
+	logger := terralog.NewLogger(testName)
+	count := 5
+	errorIndex := 3
+
+	results := make(chan TestResult, count)
+	for i := 0; i < count; i++ {
+		if i == errorIndex {
+			errText := fmt.Sprintf("We have intentionally inserted an error in result %d", i)
+			results <- TestResult{Err: errors.New(errText), Description: errText}
+		} else {
+			results <- TestResult{Value: strconv.Itoa(i), Description: strconv.Itoa(i)}
+		}
+	}
+
+	for i := 0; i < count; i++ {
+		result := GetTestResult(results, testName, logger)
+		if i == errorIndex {
+			checkResultWithError(result, logger, t)
+		} else {
+			checkResultWithValue(result, strconv.Itoa(i), logger, t)
+		}
+	}
+}
+
+func TestGetTestResultTimesOut(t *testing.T) {
+	t.Parallel()
+
+	testName := "TestGetTestResultTimesOut"
+	logger := terralog.NewLogger(testName)
+
+	emptyResultsChannel := make(chan TestResult, 1)
+	result := GetTestResultWithTimeout(emptyResultsChannel, testName, logger, 5 * time.Second)
+	checkResultWithError(result, logger, t)
+}
+
+func createCounterFunction(sleepTime time.Duration, value string, logger *log.Logger) Test {
+	return func() TestResult {
+		result := TestResult{Description: fmt.Sprintf("Sleeping for %s before returning value %s", sleepTime.String(), value)}
+		logger.Println(result.Description)
+
+		time.Sleep(sleepTime)
+		return result.WithValue(value)
+	}
+}
+
+func checkResultWithValue(result TestResult, expectedValue string, logger *log.Logger, t *testing.T) {
+	if result.Err != nil {
+		t.Fatalf("Did not expect result to contain an error, but found %s", result.Err.Error())
+	}
+
+	if result.Description == "" {
+		t.Fatal("Expected the result to contain a description, but it was empty")
+	}
+
+	if result.Value == expectedValue {
+		logger.Printf("Got expected value %s", expectedValue)
+	} else {
+		t.Fatalf("Expected value %s but got %s", expectedValue, result.Value)
+	}
+}
+
+func checkResultWithError(result TestResult, logger *log.Logger, t *testing.T) {
+	if result.Err == nil {
+		t.Fatalf("Expected the result to contain an error but got nil")
+	} else {
+		logger.Printf("Got error message as expected: %s", result.Err.Error())
+	}
+
+	if result.Description == "" {
+		t.Fatal("Expected the result to contain a description, but it was empty")
+	}
+}


### PR DESCRIPTION
In a recent PR in terraform-modules (https://github.com/gruntwork-io/terraform-modules/pull/42) I used goroutines and channels to run parts of the integration test in parallel. This PR extracts the reusable utilities from that code, refactors them, and adds them to terratest. The refactor does the following:
1. Tries to encapsulate things more so the test code using these helpers isn't littered with the usage of channels and goroutines. If you look at the terraform-modules PR that uses this PR (https://github.com/gruntwork-io/terraform-modules/pull/43), you'll see that the code now (especially all the `testXXX` sanity check helper functions) looks a little more like normal Go code, returning values or errors, as the parallel aspects are more transparent now.
2. I’ve also added some unit tests for these parallel helpers.

Please review, but do not merge, this PR. It is based off the branch of another PR (https://github.com/gruntwork-io/terratest/pull/20/files), since I’m using both locally at the moment. Once the other PR is merged, I’ll close this one and reopen it against master.
