### PR TITLE
Use Go libs for SSH. Add retry helpers.

### DIFF
--- a/ssh/session.go
+++ b/ssh/session.go
@@ -1,0 +1,94 @@
+package ssh
+
+import (
+	"golang.org/x/crypto/ssh"
+	"fmt"
+	"io"
+	"net"
+	"reflect"
+	"log"
+)
+
+type SshConnectionOptions struct {
+	Username   		string
+	Address    		string
+	Port       		int
+	AuthMethods   		[]ssh.AuthMethod
+	Command			string
+	JumpHost		*SshConnectionOptions
+}
+
+func (options *SshConnectionOptions) ConnectionString() string {
+	return fmt.Sprintf("%s:%d", options.Address, options.Port)
+}
+
+// A container object for all resources created by an SSH session. The reason we need this is so that we can do a
+// single defer in a top-level method that calls the Cleanup method to go through and ensure all of these resources are
+// released and cleaned up.
+type SshSession struct {
+	Options		*SshConnectionOptions
+	Client 		*ssh.Client
+	Session 	*ssh.Session
+	JumpHost	*JumpHostSession
+}
+
+func (sshSession *SshSession) Cleanup(logger *log.Logger) {
+	if sshSession == nil {
+		return
+	}
+
+
+	// Closing the session may result in an EOF error if it's already closed (e.g. due to hitting CTRL + D), so
+	// don't report those errors, as there is nothing actually wrong in that case.
+	Close(sshSession.Session, logger, io.EOF.Error())
+	Close(sshSession.Client, logger)
+	sshSession.JumpHost.Cleanup(logger)
+}
+
+type JumpHostSession struct {
+	JumpHostClient 		*ssh.Client
+	HostVirtualConnection 	net.Conn
+	HostConnection		ssh.Conn
+}
+
+func (jumpHost *JumpHostSession) Cleanup(logger *log.Logger) {
+	if jumpHost == nil {
+		return
+	}
+
+	// Closing a connection may result in an EOF error if it's already closed (e.g. due to hitting CTRL + D), so
+	// don't report those errors, as there is nothing actually wrong in that case.
+	Close(jumpHost.HostConnection, logger, io.EOF.Error())
+	Close(jumpHost.HostVirtualConnection, logger, io.EOF.Error())
+	Close(jumpHost.JumpHostClient, logger)
+}
+
+type Closeable interface {
+	Close() error
+}
+
+func Close(closeable Closeable, logger *log.Logger, ignoreErrors ...string) {
+	if interfaceIsNil(closeable) {
+		return
+	}
+
+	if err := closeable.Close(); err != nil && !contains(ignoreErrors, err.Error()) {
+		logger.Printf("Error closing %s: %s", closeable, err.Error())
+	}
+}
+
+func contains(haystack []string, needle string) bool {
+	for _, hay := range haystack {
+		if hay == needle {
+			return true
+		}
+	}
+	return false
+}
+
+// Go is a shitty language. Checking an interface directly against nil does not work, and if you don't know the exact
+// types the interface may be ahead of time, the only way to know if you're dealing with nil is to use reflection.
+// http://stackoverflow.com/questions/13476349/check-for-nil-and-nil-interface-in-go
+func interfaceIsNil(i interface{}) bool {
+	return i == nil || reflect.ValueOf(i).IsNil()
+}

--- a/ssh/ssh_test.go
+++ b/ssh/ssh_test.go
@@ -1,0 +1,147 @@
+package ssh
+
+import (
+	"testing"
+	"github.com/gruntwork-io/terratest"
+	"fmt"
+	terralog "github.com/gruntwork-io/terratest/log"
+	"strings"
+	"log"
+	"github.com/gruntwork-io/terratest/util"
+	"time"
+)
+
+const TERRAFORM_OUTPUT_PUBLIC_IP = "example_public_ip"
+const TERRAFORM_OUTPUT_PRIVATE_IP = "example_private_ip"
+const EXPECTED_TEXT_FROM_SSH = "Hello World"
+
+func TestSsh(t *testing.T) {
+	t.Parallel()
+
+	randomResourceCollection := createBaseRandomResourceCollection(t)
+	terratestOptions := createTerratestOptions("TestSsh", "../test-fixtures/ssh-test", randomResourceCollection, t)
+	defer terratest.Destroy(terratestOptions, randomResourceCollection)
+
+	logger := terralog.NewLogger(terratestOptions.TestName)
+
+	if _, err := terratest.Apply(terratestOptions); err != nil {
+		t.Fatalf("Failed to apply templates: %s\n", err.Error())
+	}
+
+	if err := testSshToPublicHost(terratestOptions, randomResourceCollection, logger); err != nil {
+		t.Fatalf("Failed to SSH to public host: %s\n", err.Error())
+	}
+
+	if err := testSshToPrivateHost(terratestOptions, randomResourceCollection, logger); err != nil {
+		t.Fatalf("Failed to SSH to private host: %s\n", err.Error())
+	}
+}
+
+// As of 6/9/16, these AWS regions do not support t2.nano instances
+var REGIONS_WITHOUT_T2_NANO = []string{
+	"ap-southeast-2",
+}
+
+func createBaseRandomResourceCollection(t *testing.T) *terratest.RandomResourceCollection {
+	resourceCollectionOptions := terratest.NewRandomResourceCollectionOptions()
+	resourceCollectionOptions.ForbiddenRegions = REGIONS_WITHOUT_T2_NANO
+
+	randomResourceCollection, err := terratest.CreateRandomResourceCollection(resourceCollectionOptions)
+	if err != nil {
+		t.Fatalf("Failed to create random resource collection: %s\n", err.Error())
+	}
+
+	return randomResourceCollection
+}
+
+func createTerratestOptions(testName string, templatePath string, randomResourceCollection *terratest.RandomResourceCollection, t *testing.T) *terratest.TerratestOptions {
+	terratestOptions := terratest.NewTerratestOptions()
+
+	terratestOptions.UniqueId = randomResourceCollection.UniqueId
+	terratestOptions.TemplatePath = templatePath
+	terratestOptions.TestName = testName
+
+	vpc, err := randomResourceCollection.GetDefaultVpc()
+	if err != nil {
+		t.Fatalf("Failed to get default VPC: %s\n", err.Error())
+	}
+
+	terratestOptions.Vars = map[string]string {
+		"aws_region": randomResourceCollection.AwsRegion,
+		"ami": randomResourceCollection.AmiId,
+		"keypair_name": randomResourceCollection.KeyPair.Name,
+		"vpc_id": vpc.Id,
+		"name_prefix": fmt.Sprintf("ssh-test-%s", randomResourceCollection.UniqueId),
+	}
+
+	return terratestOptions
+}
+
+func testSshToPublicHost(terratestOptions *terratest.TerratestOptions, resourceCollection *terratest.RandomResourceCollection, logger *log.Logger) error {
+	ip, err := terratest.Output(terratestOptions, TERRAFORM_OUTPUT_PUBLIC_IP)
+	if err != nil {
+		return err
+	}
+
+	host := Host {
+		Hostname: ip,
+		SshUserName: "ubuntu",
+		SshKeyPair: resourceCollection.KeyPair,
+	}
+
+	_, err = util.DoWithRetry(fmt.Sprintf("SSH to %s", TERRAFORM_OUTPUT_PUBLIC_IP), 10, 30 * time.Second, logger, func() (string, error) {
+		output, err := CheckSshCommand(host, fmt.Sprintf("echo '%s'", EXPECTED_TEXT_FROM_SSH), logger)
+
+		if err != nil {
+			return "", err
+		}
+		if ! strings.Contains(output, EXPECTED_TEXT_FROM_SSH) {
+			return "", fmt.Errorf("Expected output to contain '%s' but got %s", EXPECTED_TEXT_FROM_SSH, output)
+		}
+
+		logger.Printf("Got expected output after SSHing to %s: %s", TERRAFORM_OUTPUT_PUBLIC_IP, EXPECTED_TEXT_FROM_SSH)
+		return output, nil
+	})
+
+	return err
+}
+
+func testSshToPrivateHost(terratestOptions *terratest.TerratestOptions, resourceCollection *terratest.RandomResourceCollection, logger *log.Logger) error {
+	publicIp, err := terratest.Output(terratestOptions, TERRAFORM_OUTPUT_PUBLIC_IP)
+	if err != nil {
+		return err
+	}
+
+	privateIp, err := terratest.Output(terratestOptions, TERRAFORM_OUTPUT_PRIVATE_IP)
+	if err != nil {
+		return err
+	}
+
+	publicHost := Host {
+		Hostname: publicIp,
+		SshUserName: "ubuntu",
+		SshKeyPair: resourceCollection.KeyPair,
+	}
+
+	privateHost := Host {
+		Hostname: privateIp,
+		SshUserName: "ubuntu",
+		SshKeyPair: resourceCollection.KeyPair,
+	}
+
+	_, err = util.DoWithRetry(fmt.Sprintf("SSH to %s via %s", TERRAFORM_OUTPUT_PRIVATE_IP, TERRAFORM_OUTPUT_PUBLIC_IP), 10, 30 * time.Second, logger, func() (string, error) {
+		output, err := CheckPrivateSshConnection(publicHost, privateHost, fmt.Sprintf("echo '%s'", EXPECTED_TEXT_FROM_SSH), logger)
+
+		if err != nil {
+			return "", err
+		}
+		if ! strings.Contains(output, EXPECTED_TEXT_FROM_SSH) {
+			return "", fmt.Errorf("Expected output to contain '%s' but got %s", EXPECTED_TEXT_FROM_SSH, output)
+		}
+
+		logger.Printf("Got expected output after SSHing to %s via %s: %s", TERRAFORM_OUTPUT_PRIVATE_IP, TERRAFORM_OUTPUT_PUBLIC_IP, EXPECTED_TEXT_FROM_SSH)
+		return output, nil
+	})
+
+	return err
+}

--- a/test-fixtures/ssh-test/main.tf
+++ b/test-fixtures/ssh-test/main.tf
@@ -1,0 +1,71 @@
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# CREATE TWO EC2 INSTANCES FOR TESTING SSH CONNECTIVITY
+# These templates deploy two EC2 instances, one with a public IP and one with only a private IP. These can be used to
+# test SSH connectivity.
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+# ---------------------------------------------------------------------------------------------------------------------
+# CONFIGURE OUR AWS CONNECTION
+# ---------------------------------------------------------------------------------------------------------------------
+
+provider "aws" {
+  region = "${var.aws_region}"
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# CREATE AN AWS INSTANCE WITH A PUBLIC IP
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "aws_instance" "example_public" {
+  ami = "${var.ami}"
+  instance_type = "t2.nano"
+  key_name = "${var.keypair_name}"
+  vpc_security_group_ids = ["${aws_security_group.example.id}"]
+  associate_public_ip_address = true
+  tags {
+    Name = "${var.name_prefix}-public"
+  }
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# CREATE AN AWS INSTANCE WITH ONLY A PRIVATE IP
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "aws_instance" "example_private" {
+  ami = "${var.ami}"
+  instance_type = "t2.nano"
+  key_name = "${var.keypair_name}"
+  vpc_security_group_ids = ["${aws_security_group.example.id}"]
+  associate_public_ip_address = false
+  tags {
+    Name = "${var.name_prefix}-private"
+  }
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# CREATE A SECURITY GROUP THAT ALLOWS SSH ACCESS TO THE EC2 INSTANCES
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "aws_security_group" "example" {
+  vpc_id = "${var.vpc_id}"
+
+  # Outbound Everything
+  egress {
+    from_port = 0
+    to_port = 0
+    protocol = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  # Inbound SSH from anywhere
+  ingress {
+    from_port = 22
+    to_port = 22
+    protocol = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags {
+    Name = "${var.name_prefix}-example"
+  }
+}

--- a/test-fixtures/ssh-test/outputs.tf
+++ b/test-fixtures/ssh-test/outputs.tf
@@ -1,0 +1,7 @@
+output "example_public_ip" {
+  value = "${aws_instance.example_public.public_ip}"
+}
+
+output "example_private_ip" {
+  value = "${aws_instance.example_private.private_ip}"
+}

--- a/test-fixtures/ssh-test/vars.tf
+++ b/test-fixtures/ssh-test/vars.tf
@@ -1,0 +1,40 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# ENVIRONMENT VARIABLES
+# Define these secrets as environment variables
+# ---------------------------------------------------------------------------------------------------------------------
+
+# AWS_ACCESS_KEY_ID
+# AWS_SECRET_ACCESS_KEY
+
+# ---------------------------------------------------------------------------------------------------------------------
+# MODULE PARAMETERS
+# These variables are expected to be passed in by the operator
+# ---------------------------------------------------------------------------------------------------------------------
+
+variable "aws_region" {
+  description = "The AWS region in which all resources will be created"
+}
+
+variable "ami" {
+  description = "The ID of the AMI to run on each instance in this example"
+  # Ubuntu Server 14.04 LTS (HVM), SSD Volume Type in us-east-1
+  default = "ami-fce3c696"
+}
+
+variable "keypair_name" {
+  description = "The name of the Key Pair that can be used to SSH to each instance in this example"
+}
+
+variable "vpc_id" {
+  description = "The ID of the VPC in which to run these instances"
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# DEFINE CONSTANTS
+# Generally, these values won't need to be changed.
+# ---------------------------------------------------------------------------------------------------------------------
+
+variable "name_prefix" {
+  description = "The prefix to use for the names of all resources in these templates"
+  default = "ssh-test"
+}

--- a/util/retry.go
+++ b/util/retry.go
@@ -1,0 +1,62 @@
+package util
+
+import (
+	"fmt"
+	"time"
+	"github.com/gruntwork-io/terratest/parallel"
+	"log"
+)
+
+// Run the specified action and wait up to the specified timeout for it to complete. Return the output of the action if
+// it completes on time or an error otherwise.
+func DoWithTimeout(actionDescription string, timeout time.Duration, action func() (string, error)) (string, error) {
+	resultChannel := make(chan parallel.TestResult, 1)
+
+	go func() {
+		out, err := action()
+		resultChannel <- parallel.TestResult{Description: actionDescription, Value: out, Err: err}
+	}()
+
+	select {
+	case result := <-resultChannel:
+		return result.Value, result.Err
+	case <-time.After(timeout):
+		return "", TimeoutExceeded{Description: actionDescription, Timeout: timeout}
+	}
+}
+
+// Run the specified action. If it returns a value, return that value. If it returns an error, sleep for
+// sleepBetweenRetries and try again, up to a maximum of maxRetries retries.
+func DoWithRetry(actionDescription string, maxRetries int, sleepBetweenRetries time.Duration, logger *log.Logger, action func() (string, error)) (string, error) {
+	for i := 0; i < maxRetries; i++ {
+		output, err := action()
+		if err == nil {
+			return output, nil
+		}
+
+		logger.Printf("%s returned an error: %s. Sleeping for %s and will try again.", actionDescription, err.Error(), sleepBetweenRetries)
+		time.Sleep(sleepBetweenRetries)
+	}
+
+	return "", MaxRetriesExceeded{Description: actionDescription, MaxRetries: maxRetries}
+}
+
+// Custom error types
+
+type TimeoutExceeded struct {
+	Description string
+	Timeout     time.Duration
+}
+
+func (err TimeoutExceeded) Error() string {
+	return fmt.Sprintf("'%s' did not complete before timeout of %s", err.Description, err.Timeout)
+}
+
+type MaxRetriesExceeded struct {
+	Description string
+	MaxRetries  int
+}
+
+func (err MaxRetriesExceeded) Error() string {
+	return fmt.Sprintf("'%s' unsuccessful after %d retries", err.Description, err.MaxRetries)
+}

--- a/util/retry_test.go
+++ b/util/retry_test.go
@@ -1,0 +1,114 @@
+package util
+
+import (
+	"testing"
+	"time"
+	terralog "github.com/gruntwork-io/terratest/log"
+	"fmt"
+)
+
+func TestDoWithRetry(t *testing.T) {
+	t.Parallel()
+
+	expectedOutput := "expected"
+	expectedError := fmt.Errorf("expected error")
+
+	actionAlwaysReturnsExpected := func() (string, error) { return expectedOutput, nil }
+	actionAlwaysReturnsError := func() (string, error) { return "", expectedError }
+
+	createActionThatReturnsExpectedAfterFiveRetries := func() func() (string, error) {
+		count := 0
+		return func() (string, error) {
+			count++
+			if count > 5 {
+				return expectedOutput, nil
+			} else {
+				return "", expectedError
+			}
+		}
+	}
+
+	testCases := []struct {
+		description         string
+		maxRetries          int
+		expectedError       error
+		action              func() (string, error)
+	}{
+		{"Return value on first try", 10, nil, actionAlwaysReturnsExpected},
+		{"Return error on all retries", 10, MaxRetriesExceeded{Description: "Return error on all retries", MaxRetries: 10}, actionAlwaysReturnsError},
+		{"Return value after 5 retries", 10, nil, createActionThatReturnsExpectedAfterFiveRetries()},
+		{"Return value after 5 retries, but only do 4 retries", 4, MaxRetriesExceeded{Description: "Return value after 5 retries, but only do 4 retries", MaxRetries: 4}, createActionThatReturnsExpectedAfterFiveRetries()},
+	}
+
+	logger := terralog.NewLogger("TestDoWithRetry")
+
+	for _, testCase := range testCases {
+		actualOutput, err := DoWithRetry(testCase.description, testCase.maxRetries, 1 * time.Millisecond, logger, testCase.action)
+		if testCase.expectedError != nil {
+			if err != testCase.expectedError {
+				t.Fatalf("Expected error '%v' for test case '%s' but got '%v'", testCase.description, testCase.expectedError, err)
+			}
+		} else {
+			if err != nil {
+				t.Fatalf("Did not expect an error for test case '%s' but got: %s", testCase.description, err.Error())
+			}
+			if actualOutput != expectedOutput {
+				t.Fatalf("Expected output '%s' but got '%s'", expectedOutput, actualOutput)
+			}
+		}
+	}
+}
+
+func TestDoWithTimeout(t *testing.T) {
+	t.Parallel()
+
+	expectedOutput := "expected"
+	expectedError := fmt.Errorf("expected error")
+
+	actionReturnsValueImmediately := func() (string, error) { return expectedOutput, nil }
+	actionReturnsErrorImmediately := func() (string, error) { return "", expectedError}
+
+	createActionThatReturnsValueAfterDelay := func(delay time.Duration) func() (string, error) {
+		return func() (string, error) {
+			time.Sleep(delay)
+			return expectedOutput, nil
+		}
+	}
+
+	createActionThatReturnsErrorAfterDelay := func(delay time.Duration) func() (string, error) {
+		return func() (string, error) {
+			time.Sleep(delay)
+			return "", expectedError
+		}
+	}
+
+	testCases := []struct {
+		description         string
+		timeout             time.Duration
+		expectedError       error
+		action              func() (string, error)
+	}{
+		{"Returns value immediately", 5 * time.Second, nil, actionReturnsValueImmediately},
+		{"Returns error immediately", 5 * time.Second, expectedError, actionReturnsErrorImmediately},
+		{"Returns value after 2 seconds", 5 * time.Second, nil, createActionThatReturnsValueAfterDelay(2 * time.Second)},
+		{"Returns error after 2 seconds", 5 * time.Second, expectedError, createActionThatReturnsErrorAfterDelay(2 * time.Second)},
+		{"Returns value after timeout exceeded", 5 * time.Second, TimeoutExceeded{Description: "Returns value after timeout exceeded", Timeout: 5 * time.Second}, createActionThatReturnsValueAfterDelay(10 * time.Second)},
+		{"Returns error after timeout exceeded", 5 * time.Second, TimeoutExceeded{Description: "Returns error after timeout exceeded", Timeout: 5 * time.Second}, createActionThatReturnsErrorAfterDelay(10 * time.Second)},
+	}
+
+	for _, testCase := range testCases {
+		actualOutput, err := DoWithTimeout(testCase.description, testCase.timeout, testCase.action)
+		if testCase.expectedError != nil {
+			if err != testCase.expectedError {
+				t.Fatalf("Expected error '%v' for test case '%s' but got '%v'", testCase.description, testCase.expectedError, err)
+			}
+		} else {
+			if err != nil {
+				t.Fatalf("Did not expect an error for test case '%s' but got: %s", testCase.description, err.Error())
+			}
+			if actualOutput != expectedOutput {
+				t.Fatalf("Expected output '%s' but got '%s'", expectedOutput, actualOutput)
+			}
+		}
+	}
+}


### PR DESCRIPTION
This PR does the following:
1. Instead of shelling out to the `ssh` command, we now use the Go SSH libraries. This means that we also no longer need to write Key Pair files to disk and `scp` them to remote servers, but can just use the Go SSH library auth methods to do everything in memory.
2. Added some helpers to assist with retries and timeouts.

This is some necessary yak shaving to allow me to do some more advanced SSH stuff in module-vpc, as well as a good change for all terratest users.
