### PR TITLE
Add support for lists and maps in TerratestOptions.Vars

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,14 +1,16 @@
-hash: 1fd2bb1541bf122b5574342b28559618618bba9773aabebbe09a7c9933e330fb
-updated: 2016-04-06T16:41:09.045786912-07:00
+hash: b6dc6be3eae9c9d91d0d706c5510c21bdae4217bb4a87f74736981579db0fcaf
+updated: 2016-08-30T12:22:41.828471767+01:00
 imports:
 - name: github.com/aws/aws-sdk-go
-  version: 6f62fc3ff9aa98c629b350376825cda566658d75
+  version: e39222bf4583af667250cfd83a41388937ba56d4
   subpackages:
   - aws
   - aws/session
   - service/ec2
+  - service/cloudwatchlogs
   - service/iam
   - service/s3
+  - service/sns
   - aws/awserr
   - aws/credentials
   - aws/client/metadata
@@ -16,11 +18,15 @@ imports:
   - aws/ec2metadata
   - service/sts
   - private/endpoints
+  - private/protocol/rest
   - awsmigrate/awsmigrate-renamer/rename
   - private/model/api
   - private/util
+  - service/kms
+  - service/s3/s3crypto
   - service/acm
   - service/apigateway
+  - service/applicationdiscoveryservice
   - service/autoscaling
   - service/cloudformation
   - service/cloudfront
@@ -28,7 +34,6 @@ imports:
   - service/cloudsearch
   - service/cloudtrail
   - service/cloudwatch
-  - service/cloudwatchlogs
   - service/codecommit
   - service/codedeploy
   - service/codepipeline
@@ -53,7 +58,6 @@ imports:
   - service/iot
   - service/iotdataplane
   - service/kinesis
-  - service/kms
   - service/lambda
   - service/machinelearning
   - service/opsworks
@@ -63,7 +67,6 @@ imports:
   - service/route53domains
   - service/ses
   - service/simpledb
-  - service/sns
   - service/sqs
   - service/ssm
   - service/storagegateway
@@ -71,6 +74,7 @@ imports:
   - service/swf
   - service/waf
   - service/workspaces
+  - awstesting/unit
   - service/cloudsearchdomain
   - service/cloudwatchevents
   - service/dynamodb/dynamodbattribute
@@ -79,36 +83,43 @@ imports:
   - service/inspector
   - service/marketplacecommerceanalytics
   - service/mobileanalytics
+  - service/cloudfront/sign
   - private/protocol/query/queryutil
   - private/protocol/xml/xmlutil
-  - private/protocol/rest
+  - service/s3/s3iface
 - name: github.com/davecgh/go-spew
   version: 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d
   subpackages:
   - spew
 - name: github.com/go-ini/ini
-  version: 12f418cc7edc5a618a51407b7ac1f1f512139df3
-- name: github.com/jmespath/go-jmespath
-  version: 0b12d6b521d83fc7f755e7cfc1b1fbdd35a01a74
-- name: github.com/lsegal/gucumber
-  version: 44a4d7eb3b14a88cf82b073dfb7e06277afdc549
+  version: 6e4869b434bd001f6983749881c7ead3545887d8
+- name: github.com/gucumber/gucumber
+  version: 71608e2f6e76fd4da5b09a376aeec7a5c0b5edbc
   subpackages:
   - gherkin
+- name: github.com/jmespath/go-jmespath
+  version: bd40a432e4c76585ef6b72d3fd96fb9b6dc7b68d
 - name: github.com/pmezard/go-difflib
   version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
   subpackages:
   - difflib
 - name: github.com/shiena/ansicolor
   version: a422bbe96644373c5753384a59d678f7d261ff10
+- name: github.com/stretchr/objx
+  version: cbeaeb16a013161a98496fad62933b1d21786672
 - name: github.com/stretchr/testify
-  version: 6fe211e493929a8aac0469b93f28b1d0688a9a3a
+  version: d77da356e56a7428ad25149ca77381849a6a5232
   subpackages:
   - assert
+  - http
+  - mock
 - name: golang.org/x/crypto
-  version: b8a0f4bb4040f8d884435cff35b9691e362cf00c
+  version: 351dc6a5bf92a5f2ae22fadeee08eb6a45aa2d93
   subpackages:
   - ssh
+  - acme/internal/acme
   - blowfish
+  - ed25519/internal/edwards25519
   - nacl/secretbox
   - salsa20/salsa
   - poly1305
@@ -117,8 +128,13 @@ imports:
   - openpgp/packet
   - openpgp/s2k
   - pkcs12/internal/rc2
+- name: golang.org/x/net
+  version: 6250b412798208e6c90b03b7c4f226de5aa299e2
+  subpackages:
+  - context
+  - context/ctxhttp
 - name: golang.org/x/tools
-  version: 83f918d66bc8f7d594cf0f2ff3756944f491adf5
+  version: 9deed8c6c1c89e0b6d68d727f215de8e851d1064
   subpackages:
   - go/loader
   - go/ast/astutil

--- a/glide.yaml
+++ b/glide.yaml
@@ -6,6 +6,7 @@ import:
 - package: golang.org/x/crypto
   subpackages:
   - ssh
+- package: github.com/stretchr/testify/assert
 - package: github.com/aws/aws-sdk-go
   subpackages:
   - aws

--- a/output_test.go
+++ b/output_test.go
@@ -20,14 +20,14 @@ func TestGetOutput(t *testing.T) {
 	options.UniqueId = randomResourceCollection.UniqueId
 	options.TestName = "Test - TestGetOutput"
 	options.TemplatePath = path.Join(fixtureDir, "output-test-passthrough")
-	options.Vars = map[string]string{"var1": "expectedVar1Value", "var2": "expectedVar2Value"}
+	options.Vars = map[string]interface{}{"var1": "expectedVar1Value", "var2": "expectedVar2Value"}
 
 	if _, err := Apply(options); err != nil {
 		t.Fatal(err)
 	}
 
-	testOutput(options, "var1", options.Vars["var1"], t)
-	testOutput(options, "var2", options.Vars["var2"], t)
+	testOutput(options, "var1", options.Vars["var1"].(string), t)
+	testOutput(options, "var2", options.Vars["var2"].(string), t)
 }
 
 func testOutput(terratestOptions *TerratestOptions, key string, expectedOutput string, t *testing.T) {

--- a/rand_resources.go
+++ b/rand_resources.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"github.com/gruntwork-io/terratest/aws"
 	"github.com/gruntwork-io/terratest/util"
-	"strings"
 )
 
 // A RandomResourceCollection is a typed holder for resources we need as we do a Terraform run.
@@ -109,14 +108,6 @@ func (r *RandomResourceCollection) FetchAwsAvailabilityZones() []string {
 		return aws.GetAvailabilityZones(r.AwsRegion)
 	}
 	return nil
-}
-
-// Return the AWS Availability Zones as a list of comma-separated values
-func (r *RandomResourceCollection) FetchAwsAvailabilityZonesAsString() string {
-	if r != nil && r.AwsRegion != "" {
-		return strings.Join(aws.GetAvailabilityZones(r.AwsRegion), ",")
-	}
-	return ""
 }
 
 func (r *RandomResourceCollection) GetRandomPrivateCidrBlock(prefix int) string {

--- a/rand_resources_test.go
+++ b/rand_resources_test.go
@@ -57,26 +57,6 @@ func TestFetchAwsAvailabilityZones(t *testing.T) {
 	}
 }
 
-func TestFetchAwsAvailabilityZonesAsString(t *testing.T) {
-	t.Parallel()
-
-	ro := NewRandomResourceCollectionOptions()
-	rand, err := CreateRandomResourceCollection(ro)
-	defer rand.DestroyResources()
-	if err != nil {
-		t.Fatalf("Failed to create RandomResourceCollection: %s", err.Error())
-	}
-
-	// Manually set the AWS Region to us-west-2 for testing purposes
-	rand.AwsRegion = "us-west-2"
-	actual := rand.FetchAwsAvailabilityZonesAsString()
-	expected := "us-west-2a,us-west-2b,us-west-2c"
-
-	if actual != expected {
-		t.Fatalf("Expected: %s, but received %s", expected, actual)
-	}
-}
-
 func TestGetRandomPrivateCidrBlock(t *testing.T) {
 	t.Parallel()
 

--- a/ssh/ssh_test.go
+++ b/ssh/ssh_test.go
@@ -66,7 +66,7 @@ func createTerratestOptions(testName string, templatePath string, randomResource
 		t.Fatalf("Failed to get default VPC: %s\n", err.Error())
 	}
 
-	terratestOptions.Vars = map[string]string {
+	terratestOptions.Vars = map[string]interface{} {
 		"aws_region": randomResourceCollection.AwsRegion,
 		"ami": randomResourceCollection.AmiId,
 		"keypair_name": randomResourceCollection.KeyPair.Name,

--- a/terraform/apply.go
+++ b/terraform/apply.go
@@ -21,19 +21,19 @@ import (
 var terraformDebugEnv = map[string]string{}
 
 // Call Terraform Apply on the template at "templatePath" with the given "vars"
-func Apply(templatePath string, vars map[string]string, logger *log.Logger) error {
+func Apply(templatePath string, vars map[string]interface{}, logger *log.Logger) error {
 	return shell.RunCommand(shell.Command { Command: "terraform", Args: FormatArgs(vars, "apply", "-input=false"), WorkingDir: templatePath, Env: terraformDebugEnv }, logger)
 }
 
 // Call Terraform Apply on the template at "templatePath" with the given "vars", and return the output as a string
-func ApplyAndGetOutput(terraformPath string, vars map[string]string, logger *log.Logger) (string, error) {
+func ApplyAndGetOutput(terraformPath string, vars map[string]interface{}, logger *log.Logger) (string, error) {
 	logger.Println("Applying Terraform templates in folder", terraformPath)
 	return shell.RunCommandAndGetOutput( shell.Command { Command: "terraform", Args: FormatArgs(vars, "apply", "-input=false"), WorkingDir: terraformPath, Env: terraformDebugEnv }, logger)
 }
 
 // Regrettably Terraform has many bugs. Often, just re-running terraform apply will resolve the issue.
 // This function declares which Terraform error messages warrant an automatic retry and does the retry.
-func ApplyAndGetOutputWithRetry(terraformPath string, vars map[string]string, errors map[string]string, logger *log.Logger) (string, error) {
+func ApplyAndGetOutputWithRetry(terraformPath string, vars map[string]interface{}, errors map[string]string, logger *log.Logger) (string, error) {
 	output, err := ApplyAndGetOutput(terraformPath, vars, logger)
 	if err != nil {
 		logger.Printf("Terraform apply failed with error: %s\n", err.Error())

--- a/terraform/destroy.go
+++ b/terraform/destroy.go
@@ -8,13 +8,13 @@ import (
 )
 
 // Call Terraform Destroy on the template at "templatePath" with the given "vars"
-func Destroy(templatePath string, vars map[string]string, logger *log.Logger) error {
+func Destroy(templatePath string, vars map[string]interface{}, logger *log.Logger) error {
 	logger.Println("Destroy Terraform changes in folder", templatePath)
 	return shell.RunCommand(shell.Command { Command: "terraform", Args: FormatArgs(vars, "destroy", "-force", "-input=false"), WorkingDir: templatePath, Env: terraformDebugEnv }, logger)
 }
 
 // Call Terraform Destroy on the template at "templatePath" with the given "vars", and return the output as a string
-func DestroyAndGetOutput(templatePath string, vars map[string]string, logger *log.Logger) (string, error) {
+func DestroyAndGetOutput(templatePath string, vars map[string]interface{}, logger *log.Logger) (string, error) {
 	logger.Println("Destroy Terraform changes in folder", templatePath)
 	return shell.RunCommandAndGetOutput(shell.Command { Command: "terraform", Args: FormatArgs(vars, "destroy", "-force", "-input=false"), WorkingDir: templatePath, Env: terraformDebugEnv }, logger)
 }

--- a/terraform/hcl.go
+++ b/terraform/hcl.go
@@ -1,0 +1,119 @@
+package terraform
+
+import (
+	"reflect"
+	"fmt"
+	"strings"
+)
+
+// Format the given variables as command-line args for Terraform (e.g. of the format -var key=value).
+func FormatTerraformVarsAsArgs(vars map[string]interface{}) []string {
+	args := []string{}
+
+	for key, value := range vars {
+		hclString := toHclString(value)
+		argValue := fmt.Sprintf("%s = %s", key, hclString)
+		args = append(args, "-var", argValue)
+	}
+
+	return args
+}
+
+// Terraform allows you to pass in command-line variables using HCL syntax (e.g. -var foo=[1,2,3]). Unfortunately,
+// while their golang hcl library can convert an HCL string to a Go type, they don't seem to offer a library to convert
+// arbitrary Go types to an HCL string. Therefore, this method is a VERY simple implementation that correctly handles
+// ints, booleans, non-nested lists, and non-nested maps. Everything else is forced into a string using Sprintf.
+// Hopefully, this approach is good enough for the type of variables we deal with in terratest.
+func toHclString(value interface{}) string {
+	// Ideally, we'd use a type switch here to identify slices and maps, but we can't do that, because Go doesn't
+	// support generics, and the type switch only matches concrete types. So we could match []interface{}, but if
+	// a user passes in []string{}, that would NOT match (the same logic applies to maps). Therefore, we have to
+	// use reflection and manually convert into []interface{} and map[string]interface{}.
+
+	if slice, isSlice := tryToConvertToGenericSlice(value); isSlice {
+		return sliceToHclString(slice)
+	} else if m, isMap := tryToConvertToGenericMap(value); isMap {
+		return mapToHclString(m)
+	} else {
+		return primitiveToHclString(value)
+	}
+}
+
+// Try to convert the given value to a generic slice. Return the slice and true if the underlying value itself was a
+// slice and an empty slice and false if it wasn't. This is necessary because Go is a shitty language that doesn't
+// have generics, nor useful utility methods built-in. For more info, see: http://stackoverflow.com/a/12754757/483528
+func tryToConvertToGenericSlice(value interface{}) ([]interface{}, bool) {
+	reflectValue := reflect.ValueOf(value)
+	if reflectValue.Kind() != reflect.Slice {
+		return []interface{}{}, false
+	}
+
+	genericSlice := make([]interface{}, reflectValue.Len())
+
+	for i := 0; i < reflectValue.Len(); i++ {
+		genericSlice[i] = reflectValue.Index(i).Interface()
+	}
+
+	return genericSlice, true
+}
+
+// Try to convert the given value to a generic map. Return the map and true if the underlying value itself was a
+// map and an empty map and false if it wasn't. This is necessary because Go is a shitty language that doesn't
+// have generics, nor useful utility methods built-in. For more info, see: http://stackoverflow.com/a/12754757/483528
+func tryToConvertToGenericMap(value interface{}) (map[string]interface{}, bool) {
+	reflectValue := reflect.ValueOf(value)
+	if reflectValue.Kind() != reflect.Map {
+		return map[string]interface{}{}, false
+	}
+
+	reflectType := reflect.TypeOf(value)
+	if reflectType.Key().Kind() != reflect.String {
+		return map[string]interface{}{}, false
+	}
+
+	genericMap := make(map[string]interface{}, reflectValue.Len())
+
+	mapKeys := reflectValue.MapKeys()
+	for _, key := range mapKeys {
+		genericMap[key.String()] = reflectValue.MapIndex(key).Interface()
+	}
+
+	return genericMap, true
+}
+
+// Convert a non-nested slice to an HCL string. See ToHclString for details.
+func sliceToHclString(slice []interface{}) string {
+	hclValues := []string{}
+
+	for _, value := range slice {
+		hclValue := primitiveToHclString(value)
+		hclValues = append(hclValues, hclValue)
+	}
+
+	return fmt.Sprintf("[%s]", strings.Join(hclValues, ", "))
+}
+
+// Convert a non-nested map to an HCL string. See ToHclString for details.
+func mapToHclString(m map[string]interface{}) string {
+	keyValuePairs := []string{}
+
+	for key, value := range m {
+		keyValuePair := fmt.Sprintf("%s = %s", key, primitiveToHclString(value))
+		keyValuePairs = append(keyValuePairs, keyValuePair)
+	}
+
+	return fmt.Sprintf("{%s}", strings.Join(keyValuePairs, ", "))
+}
+
+// Convert a primitive, such as a bool, int, or string, to an HCL string. If this isn't a primitive, force its value
+// using Sprintf. See ToHclString for details.
+func primitiveToHclString(value interface{}) string {
+	switch v := value.(type) {
+		// Note: due to a Terraform bug, we can't use proper HCL syntax for ints and booleans and instead have
+		// to treat EVERYTHING as a string. For more info, see: https://github.com/hashicorp/terraform/issues/7962
+		//case int: return strconv.Itoa(v)
+		//case bool: return strconv.FormatBool(v)
+
+		default: return fmt.Sprintf("\"%v\"", v)
+	}
+}

--- a/terraform/hcl_test.go
+++ b/terraform/hcl_test.go
@@ -1,0 +1,215 @@
+package terraform
+
+import (
+	"testing"
+	"github.com/stretchr/testify/assert"
+	"fmt"
+)
+
+func TestFormatTerraformVarsAsArgs(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		vars     map[string]interface{}
+		expected []string
+	}{
+		{map[string]interface{}{}, []string{}},
+		{map[string]interface{}{"foo": "bar"}, []string{"-var", "foo = \"bar\""}},
+		{map[string]interface{}{"foo": 123}, []string{"-var", "foo = \"123\""}},
+		{map[string]interface{}{"foo": true}, []string{"-var", "foo = \"true\""}},
+		{map[string]interface{}{"foo": []int{1, 2, 3}}, []string{"-var", "foo = [\"1\", \"2\", \"3\"]"}},
+		{map[string]interface{}{"foo": map[string]string{"baz": "blah"}}, []string{"-var", "foo = {baz = \"blah\"}"}},
+		{
+			map[string]interface{}{"str": "bar", "int": -1, "bool": false, "list": []string{"foo", "bar", "baz"}, "map": map[string]int{"foo": 0}},
+			[]string{"-var", "str = \"bar\"", "-var", "int = \"-1\"", "-var", "bool = \"false\"", "-var", "list = [\"foo\", \"bar\", \"baz\"]", "-var", "map = {foo = \"0\"}"},
+		},
+	}
+
+	for _, testCase := range testCases {
+		checkResultWithRetry(t, 100, testCase.expected, fmt.Sprintf("FormatTerraformVarsAsArgs(%v)", testCase.vars), func() interface{} {
+			return FormatTerraformVarsAsArgs(testCase.vars)
+		})
+	}
+}
+
+func TestPrimitiveToHclString(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		value    interface{}
+		expected string
+	}{
+		{"", "\"\""},
+		{"foo", "\"foo\""},
+		{"true", "\"true\""},
+		{true, "\"true\""},
+		{3, "\"3\""},
+		{[]int{1, 2, 3}, "\"[1 2 3]\""}, // Anything that isn't a primitive is forced into a string
+	}
+
+	for _, testCase := range testCases {
+		actual := primitiveToHclString(testCase.value)
+		assert.Equal(t, testCase.expected, actual, "Value: %v", testCase.value)
+	}
+}
+
+func TestMapToHclString(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		value    map[string]interface{}
+		expected string
+	}{
+		{map[string]interface{}{}, "{}"},
+		{map[string]interface{}{"key1": "value1"}, "{key1 = \"value1\"}"},
+		{map[string]interface{}{"key1": 123}, "{key1 = \"123\"}"},
+		{map[string]interface{}{"key1": true}, "{key1 = \"true\"}"},
+		{map[string]interface{}{"key1": []int{1, 2, 3}}, "{key1 = \"[1 2 3]\"}"}, // Any value that isn't a primitive is forced into a string
+		{map[string]interface{}{"key1": "value1", "key2": 0, "key3": false}, "{key1 = \"value1\", key2 = \"0\", key3 = \"false\"}"},
+	}
+
+	for _, testCase := range testCases {
+		checkResultWithRetry(t, 100, testCase.expected, fmt.Sprintf("mapToHclString(%v)", testCase.value), func() interface{} {
+			return mapToHclString(testCase.value)
+		})
+	}
+}
+
+// Some of our tests execute code that loops over a map to produce output. The problem is that the order of map
+// iteration is generally unpredictable and, to make it even more unpredictable, Go intentionally randomizes the
+// iteration order (https://blog.golang.org/go-maps-in-action#TOC_7). Therefore, the order of items in the output
+// is unpredictable, and doing a simple assert.Equals call will intermittently fail.
+//
+// We have a few unsatisfactory ways to solve this problem:
+//
+// 1. Enforce iteration order. This is easy to do in other languages, where you have built-in sorted maps. In Go, no
+//    such map exists, and if you create a custom one, you can't use the range keyword on it
+//    (http://stackoverflow.com/a/35810932/483528). As a result, we'd have to modify our implementation code to take
+//    iteration order into account which is a totally unnecessary feature that increases complexity.
+// 2. We could parse the output string and do an order-independent comparison. However, that adds a bunch of parsing
+//    logic into the test code which is a totally unnecessary feature that increases complexity.
+// 3. We accept that Go is a shitty language and, if the test fails, we re-run it a bunch of times in the hope that, if
+//    the bug is caused by key ordering, we will randomly get the proper order in a future run. The code being tested
+//    here is tiny & fast, so doing a hundred retries is still sub millisecond, so while ugly, this provides a very
+//    simple solution.
+//
+// Isn't it great that Go's designers built features into the language to prevent bugs that now force every Go
+// developer to write thousands of lines of extra code like this, which is of course likely to contain bugs itself?
+func checkResultWithRetry(t *testing.T, maxRetries int, expectedValue interface{}, description string, generateValue func() interface{}) {
+	for i := 0; i < maxRetries; i++ {
+		actualValue := generateValue()
+		if assert.ObjectsAreEqual(expectedValue, actualValue) {
+			return
+		} else {
+			t.Logf("Retry %d of %s failed: expected %v, got %v", i, description, expectedValue, actualValue)
+		}
+	}
+
+	assert.Fail(t, "checkResultWithRetry failed", "After %d retries, %s still not succeeding (see retries above)", description)
+}
+
+func TestSliceToHclString(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		value    []interface{}
+		expected string
+	}{
+		{[]interface{}{}, "[]"},
+		{[]interface{}{"foo"}, "[\"foo\"]"},
+		{[]interface{}{123}, "[\"123\"]"},
+		{[]interface{}{true}, "[\"true\"]"},
+		{[]interface{}{[]int{1, 2, 3}}, "[\"[1 2 3]\"]"}, // Any value that isn't a primitive is forced into a string
+		{[]interface{}{"foo", 0, false}, "[\"foo\", \"0\", \"false\"]"},
+	}
+
+	for _, testCase := range testCases {
+		actual := sliceToHclString(testCase.value)
+		assert.Equal(t, testCase.expected, actual, "Value: %v", testCase.value)
+	}
+}
+
+func TestToHclString(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		value    interface{}
+		expected string
+	}{
+		{"", "\"\""},
+		{"foo", "\"foo\""},
+		{123, "\"123\""},
+		{true, "\"true\""},
+		{[]int{1, 2, 3}, "[\"1\", \"2\", \"3\"]"},
+		{[]string{"foo", "bar", "baz"}, "[\"foo\", \"bar\", \"baz\"]"},
+		{map[string]string{"key1": "value1"}, "{key1 = \"value1\"}"},
+		{map[string]int{"key1": 123}, "{key1 = \"123\"}"},
+	}
+
+	for _, testCase := range testCases {
+		actual := toHclString(testCase.value)
+		assert.Equal(t, testCase.expected, actual, "Value: %v", testCase.value)
+	}
+}
+
+func TestTryToConvertToGenericSlice(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		value           interface{}
+		expectedSlice   []interface{}
+		expectedIsSlice bool
+	}{
+		{"", []interface{}{}, false},
+		{"foo", []interface{}{}, false},
+		{true, []interface{}{}, false},
+		{531, []interface{}{}, false},
+		{map[string]string{"foo": "bar"}, []interface{}{}, false},
+		{[]string{}, []interface{}{}, true},
+		{[]int{}, []interface{}{}, true},
+		{[]bool{}, []interface{}{}, true},
+		{[]interface{}{}, []interface{}{}, true},
+		{[]string{"foo", "bar", "baz"}, []interface{}{"foo", "bar", "baz"}, true},
+		{[]int{1, 2, 3}, []interface{}{1, 2, 3}, true},
+		{[]bool{true, true, false}, []interface{}{true, true, false}, true},
+		{[]interface{}{"foo", "bar", "baz"}, []interface{}{"foo", "bar", "baz"}, true},
+	}
+
+	for _, testCase := range testCases {
+		actualSlice, actualIsSlice := tryToConvertToGenericSlice(testCase.value)
+		assert.Equal(t, testCase.expectedSlice, actualSlice, "Value: %v", testCase.value)
+		assert.Equal(t, testCase.expectedIsSlice, actualIsSlice, "Value: %v", testCase.value)
+	}
+}
+
+func TestTryToConvertToGenericMap(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		value         interface{}
+		expectedMap   map[string]interface{}
+		expectedIsMap bool
+	}{
+		{"", map[string]interface{}{}, false},
+		{"foo", map[string]interface{}{}, false},
+		{true, map[string]interface{}{}, false},
+		{531, map[string]interface{}{}, false},
+		{[]string{"foo", "bar"}, map[string]interface{}{}, false},
+		{map[int]int{}, map[string]interface{}{}, false},
+		{map[bool]string{}, map[string]interface{}{}, false},
+		{map[string]string{}, map[string]interface{}{}, true},
+		{map[string]int{}, map[string]interface{}{}, true},
+		{map[string]bool{}, map[string]interface{}{}, true},
+		{map[string]interface{}{}, map[string]interface{}{}, true},
+		{map[string]string{"key1": "value1", "key2": "value2"}, map[string]interface{}{"key1": "value1", "key2": "value2"}, true},
+		{map[string]int{"key1": 1, "key2": 2, "key3": 3}, map[string]interface{}{"key1": 1, "key2": 2, "key3": 3}, true},
+		{map[string]bool{"key1": true}, map[string]interface{}{"key1": true}, true},
+		{map[string]interface{}{"key1": "value1"}, map[string]interface{}{"key1": "value1"}, true},
+	}
+
+	for _, testCase := range testCases {
+		actualMap, actualIsMap := tryToConvertToGenericMap(testCase.value)
+		assert.Equal(t, testCase.expectedMap, actualMap, "Value: %v", testCase.value)
+		assert.Equal(t, testCase.expectedIsMap, actualIsMap, "Value: %v", testCase.value)
+	}
+}

--- a/terraform/utils.go
+++ b/terraform/utils.go
@@ -1,12 +1,9 @@
 package terraform
 
-// Convert the inputs to a format palatable to terraform
-func FormatArgs(customVars map[string]string, args ...string) []string {
-	customArgs := []string{}
-
-	for key, value := range customVars {
-		customArgs = append(customArgs, "-var", key + "=\"" + value + "\"")
-	}
-
-	return append(args, customArgs...)
+// Convert the inputs to a format palatable to terraform. This includes converting the given vars to the format the
+// Terraform CLI expects (-var key=value).
+func FormatArgs(customVars map[string]interface{}, args ...string) []string {
+	varsAsArgs := FormatTerraformVarsAsArgs(customVars)
+	return append(args, varsAsArgs...)
 }
+

--- a/terratest_options.go
+++ b/terratest_options.go
@@ -2,13 +2,13 @@ package terratest
 
 // The options to be passed into any terratest.Apply or Destroy function
 type TerratestOptions struct {
-	UniqueId		    string	      // A unique identifier for this terraform run.
-	TestName                    string            // the name of the test to run, for logging purposes.
-	TemplatePath                string            // the relative or absolute path to the terraform template to be applied.
-	Vars                        map[string]string // the vars to pass to the terraform template.
-	RetryableTerraformErrors    map[string]string // a map of error messages which we expect on this template and which should invoke a second terraform apply, along with an additional message offering details on this error text.
-	TfRemoteStateS3BucketName   string            // S3 bucket name where terraform.tfstate files should be stored for running any terraform runs. Bucket should already exist.
-	TfRemoteStateS3BucketRegion string            // AWS Region where the TfRemoteStateS3BucketName exists.
+	UniqueId		    string	           // A unique identifier for this terraform run.
+	TestName                    string                 // the name of the test to run, for logging purposes.
+	TemplatePath                string                 // the relative or absolute path to the terraform template to be applied.
+	Vars                        map[string]interface{} // the vars to pass to the terraform template.
+	RetryableTerraformErrors    map[string]string      // a map of error messages which we expect on this template and which should invoke a second terraform apply, along with an additional message offering details on this error text.
+	TfRemoteStateS3BucketName   string                 // S3 bucket name where terraform.tfstate files should be stored for running any terraform runs. Bucket should already exist.
+	TfRemoteStateS3BucketRegion string                 // AWS Region where the TfRemoteStateS3BucketName exists.
 }
 
 // Initialize a TerratestOptions struct with default values

--- a/test-fixtures/var-test/README.md
+++ b/test-fixtures/var-test/README.md
@@ -1,0 +1,5 @@
+# var-test
+
+This test makes sure that terratest can successfully pass complicated variables (e.g. lists and maps) on the command
+line to Terraform using the -var option. The templates in this example take in a number of different types of variables
+and pass them through to outputs.

--- a/test-fixtures/var-test/outputs.tf
+++ b/test-fixtures/var-test/outputs.tf
@@ -1,0 +1,21 @@
+output "string" {
+  value = "${var.string}"
+}
+
+output "boolean" {
+  value = "${var.boolean}"
+}
+
+output "int" {
+  value = "${var.int}"
+}
+
+output "map" {
+  value = "${var.map}"
+}
+
+output "list" {
+  value = ["${var.list}"]
+}
+
+

--- a/test-fixtures/var-test/vars.tf
+++ b/test-fixtures/var-test/vars.tf
@@ -1,0 +1,26 @@
+variable "string" {
+  description = "An input to check that we handle string variables correctly"
+}
+
+variable "boolean" {
+  description = "An input to check that we handle boolean variables correctly"
+}
+
+variable "int" {
+  description = "An input to check that we handle int variables correctly"
+}
+
+variable "map" {
+  description = "An input to check that we handle map variables correctly"
+  type = "map"
+  # If we don't specify a default, we get the error "variable map should be type map, got list". For more info, see:
+  # https://github.com/hashicorp/terraform/issues/8057
+  default = {}
+}
+
+variable "list" {
+  description = "An input to check that we handle list variables correctly"
+  type = "list"
+}
+
+

--- a/url_checker_test.go
+++ b/url_checker_test.go
@@ -34,7 +34,7 @@ func TestUrlCheckerWithDummyServer(t *testing.T) {
 	options.UniqueId = randomResourceCollection.UniqueId
 	options.TestName = "Test - TestUrlCheckerWithDummyServer"
 	options.TemplatePath = path.Join(fixtureDir, "url-checker-with-server-passthrough")
-	options.Vars = map[string]string{DOMAIN_KEY: TEST_SERVER_DOMAIN, PORT_KEY: strconv.Itoa(port)}
+	options.Vars = map[string]interface{}{DOMAIN_KEY: TEST_SERVER_DOMAIN, PORT_KEY: strconv.Itoa(port)}
 
 	defer Destroy(options, randomResourceCollection)
 	if _, err := Apply(options); err != nil {
@@ -60,7 +60,7 @@ func TestUrlCheckerWithoutDummyServer(t *testing.T) {
 	options.UniqueId = randomResourceCollection.UniqueId
 	options.TestName = "Test - TestUrlCheckerWithoutDummyServer"
 	options.TemplatePath = path.Join(fixtureDir, "url-checker-without-server-passthrough")
-	options.Vars = map[string]string{DOMAIN_KEY: TEST_SERVER_DOMAIN, PORT_KEY: "12345"}
+	options.Vars = map[string]interface{}{DOMAIN_KEY: TEST_SERVER_DOMAIN, PORT_KEY: "12345"}
 
 	defer Destroy(options, randomResourceCollection)
 	if _, err := Apply(options); err != nil {


### PR DESCRIPTION
This PR updates the `Vars` variable in `TerratestOptions` so it can pass lists and maps on the command-line, which is a feature supported as of Terraform 0.7. This involved the messy process of: 
1. Converting lists and maps to HCL syntax, as there doesn't seem to be an existing library for doing that. 
2. Working around Terraform bugs that prevent you from using real HCL syntax on the command-line (e.g. ints and booleans don't work).
3. Dealing with the fact that Go is a shitty language (by decree, every one of my PRs must say this)
