### PR TITLE
Update RunSshCommand to output both stdout and stderr.

### DIFF
--- a/ssh/ssh.go
+++ b/ssh/ssh.go
@@ -92,7 +92,7 @@ func runSshCommand(sshSession *SshSession) (string, error) {
 		return "", err
 	}
 
-	bytes, err := sshSession.Session.Output(sshSession.Options.Command)
+	bytes, err := sshSession.Session.CombinedOutput(sshSession.Options.Command)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
While using Terratest, I continually got an "exit code == 1" error without seeing the underlying error message. At worst, this makes us no worse off, but hopefully it makes things better.