### PR TITLE
Add new required SSH param HostKeyCallback

### DIFF
--- a/ssh/ssh.go
+++ b/ssh/ssh.go
@@ -4,6 +4,7 @@ import (
 	"github.com/gruntwork-io/terratest"
 	"log"
 	"golang.org/x/crypto/ssh"
+	"net"
 )
 
 type Host struct {
@@ -162,7 +163,9 @@ func createSshClientConfig(hostOptions *SshConnectionOptions) *ssh.ClientConfig 
 		User: hostOptions.Username,
 		Auth: hostOptions.AuthMethods,
 		// Do not do a host key check, as Terratest is only used for testing, not prod
-		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+		HostKeyCallback: func(hostname string, remote net.Addr, key ssh.PublicKey) error {
+			return nil
+		},
 	}
 	clientConfig.SetDefaults()
 	return clientConfig


### PR DESCRIPTION
A security vulnerability was found in Go (https://github.com/golang/go/issues/19767) where its SSH library did not do host key checking by default. This was fixed (https://go-review.googlesource.com/c/38701/) and the fix is (by design) backwards incompatible in that you are now required to pass a `HostKeyCallback` param or you get a runtime error.