### PR TITLE
Try to update dependencies

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,142 +1,62 @@
-hash: b6dc6be3eae9c9d91d0d706c5510c21bdae4217bb4a87f74736981579db0fcaf
-updated: 2016-08-30T12:22:41.828471767+01:00
+hash: 609d76c584f1e60c8cd433f3e492c0e8574772f14f73fbbc424f18f9ce80f19b
+updated: 2017-04-27T16:32:24.695090281+01:00
 imports:
 - name: github.com/aws/aws-sdk-go
-  version: e39222bf4583af667250cfd83a41388937ba56d4
+  version: 00fb2125993965df739fa3398b03bef3eb2e198f
   subpackages:
   - aws
+  - aws/awserr
+  - aws/awsutil
+  - aws/client
+  - aws/client/metadata
+  - aws/corehandlers
+  - aws/credentials
+  - aws/credentials/ec2rolecreds
+  - aws/credentials/endpointcreds
+  - aws/credentials/stscreds
+  - aws/defaults
+  - aws/ec2metadata
+  - aws/endpoints
+  - aws/request
   - aws/session
-  - service/ec2
+  - aws/signer/v4
+  - private/protocol
+  - private/protocol/ec2query
+  - private/protocol/json/jsonutil
+  - private/protocol/jsonrpc
+  - private/protocol/query
+  - private/protocol/query/queryutil
+  - private/protocol/rest
+  - private/protocol/restxml
+  - private/protocol/xml/xmlutil
+  - private/waiter
   - service/cloudwatchlogs
+  - service/ec2
   - service/iam
   - service/s3
   - service/sns
-  - aws/awserr
-  - aws/credentials
-  - aws/client/metadata
-  - aws/request
-  - aws/ec2metadata
   - service/sts
-  - private/endpoints
-  - private/protocol/rest
-  - awsmigrate/awsmigrate-renamer/rename
-  - private/model/api
-  - private/util
-  - service/kms
-  - service/s3/s3crypto
-  - service/acm
-  - service/apigateway
-  - service/applicationdiscoveryservice
-  - service/autoscaling
-  - service/cloudformation
-  - service/cloudfront
-  - service/cloudhsm
-  - service/cloudsearch
-  - service/cloudtrail
-  - service/cloudwatch
-  - service/codecommit
-  - service/codedeploy
-  - service/codepipeline
-  - service/cognitoidentity
-  - service/cognitosync
-  - service/configservice
-  - service/datapipeline
-  - service/devicefarm
-  - service/directconnect
-  - service/directoryservice
-  - service/dynamodb
-  - service/dynamodbstreams
-  - service/ecs
-  - service/efs
-  - service/elasticache
-  - service/elasticbeanstalk
-  - service/elb
-  - service/elastictranscoder
-  - service/emr
-  - service/elasticsearchservice
-  - service/glacier
-  - service/iot
-  - service/iotdataplane
-  - service/kinesis
-  - service/lambda
-  - service/machinelearning
-  - service/opsworks
-  - service/rds
-  - service/redshift
-  - service/route53
-  - service/route53domains
-  - service/ses
-  - service/simpledb
-  - service/sqs
-  - service/ssm
-  - service/storagegateway
-  - service/support
-  - service/swf
-  - service/waf
-  - service/workspaces
-  - awstesting/unit
-  - service/cloudsearchdomain
-  - service/cloudwatchevents
-  - service/dynamodb/dynamodbattribute
-  - service/ecr
-  - service/firehose
-  - service/inspector
-  - service/marketplacecommerceanalytics
-  - service/mobileanalytics
-  - service/cloudfront/sign
-  - private/protocol/query/queryutil
-  - private/protocol/xml/xmlutil
-  - service/s3/s3iface
-- name: github.com/davecgh/go-spew
-  version: 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d
-  subpackages:
-  - spew
 - name: github.com/go-ini/ini
-  version: 6e4869b434bd001f6983749881c7ead3545887d8
-- name: github.com/gucumber/gucumber
-  version: 71608e2f6e76fd4da5b09a376aeec7a5c0b5edbc
-  subpackages:
-  - gherkin
+  version: e7fea39b01aea8d5671f6858f0532f56e8bff3a5
 - name: github.com/jmespath/go-jmespath
   version: bd40a432e4c76585ef6b72d3fd96fb9b6dc7b68d
+- name: github.com/stretchr/testify
+  version: 4d4bfba8f1d1027c4fdbe371823030df51419987
+  subpackages:
+  - assert
+- name: golang.org/x/crypto
+  version: c7af5bf2638a1164f2eb5467c39c6cffbd13a02e
+  subpackages:
+  - curve25519
+  - ed25519
+  - ed25519/internal/edwards25519
+  - ssh
+testImports:
+- name: github.com/davecgh/go-spew
+  version: 04cdfd42973bb9c8589fd6a731800cf222fde1a9
+  subpackages:
+  - spew
 - name: github.com/pmezard/go-difflib
   version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
   subpackages:
   - difflib
-- name: github.com/shiena/ansicolor
-  version: a422bbe96644373c5753384a59d678f7d261ff10
-- name: github.com/stretchr/objx
-  version: cbeaeb16a013161a98496fad62933b1d21786672
-- name: github.com/stretchr/testify
-  version: d77da356e56a7428ad25149ca77381849a6a5232
-  subpackages:
-  - assert
-  - http
-  - mock
-- name: golang.org/x/crypto
-  version: 351dc6a5bf92a5f2ae22fadeee08eb6a45aa2d93
-  subpackages:
-  - ssh
-  - acme/internal/acme
-  - blowfish
-  - ed25519/internal/edwards25519
-  - nacl/secretbox
-  - salsa20/salsa
-  - poly1305
-  - openpgp/armor
-  - openpgp/errors
-  - openpgp/packet
-  - openpgp/s2k
-  - pkcs12/internal/rc2
-- name: golang.org/x/net
-  version: 6250b412798208e6c90b03b7c4f226de5aa299e2
-  subpackages:
-  - context
-  - context/ctxhttp
-- name: golang.org/x/tools
-  version: 9deed8c6c1c89e0b6d68d727f215de8e851d1064
-  subpackages:
-  - go/loader
-  - go/ast/astutil
-  - go/buildutil
-devImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -3,11 +3,9 @@ owners:
 - name: Gruntwork
   homepage: https://gruntwork.io
 import:
-- package: golang.org/x/crypto
-  subpackages:
-  - ssh
 - package: github.com/stretchr/testify/assert
 - package: github.com/aws/aws-sdk-go
+  version: v1.6.27
   subpackages:
   - aws
   - aws/session


### PR DESCRIPTION
I’m trying to update to the latest version of Terratest in https://github.com/gruntwork-io/module-data-storage/pull/20, but am running into a bug with Glide (https://github.com/Masterminds/glide/issues/640). My best guess is that this bug is caused by the way dependencies are specified for Terratest. As a shot in the dark, this PR changes how we do the dependencies.