### PR TITLE
add GetDedicatedTestKeyArn

### DIFF
--- a/aws/kms.go
+++ b/aws/kms.go
@@ -15,6 +15,10 @@ func CreateKmsClient(awsRegion string) (*kms.KMS, error) {
 	return kms.New(session.New(), awsConfig), nil
 }
 
+// This exists because KMS keys cost $1/mo for each one created. In our automated tests, we often run 100s times in,
+// especially during inital development when debugging. Rather than create a new key each time we run a test and incurring
+// the $1 charge, a dedicated key with the alias 'dedicated-test-key' has been created in each region. This method allows
+// this key to be retrieved and used for testing purposes.
 func GetDedicatedTestKeyArn(awsRegion string) (string, error) {
 	kmsClient, err := CreateKmsClient(awsRegion)
 	if err != nil {


### PR DESCRIPTION
The purpose of this is to add a helper method that retrieves the ARN of a dedicated KMS key we can use for testing within CIRCLECI. 

I have created a key with the alias "dedicated-test-key" and granted all the _circle users encrypt/decrypt rights and the Gruntwork Grunts are all administrators.

Now we don't have to run the risk of creating multiple keys in tests and incurring the $1/mo per key fee each time a new key is generated. 

From our tests we can just call GetDedicatedTestKeyArn and pass in the resulting key to terraform modules.