### PR TITLE
Catch errors when calling init

### DIFF
--- a/apply.go
+++ b/apply.go
@@ -13,7 +13,9 @@ func Apply(options *TerratestOptions) (string, error) {
 	logger := log.NewLogger(options.TestName)
 	var output string
 
-	terraform.Init(options.TemplatePath, logger)
+	if err := terraform.Init(options.TemplatePath, logger); err != nil {
+		return "", err
+	}
 
 	// TERRAFORM APPLY
 	// Download all the Terraform modules


### PR DESCRIPTION
I was randomly browsing the Terratest code to look up a method when I noticed we weren’t catching errors when calling `Init`. 