### PR TITLE
Update Amazon Linux

### DIFF
--- a/_docker-images/gruntwork-amazon-linux-test/Dockerfile
+++ b/_docker-images/gruntwork-amazon-linux-test/Dockerfile
@@ -1,14 +1,16 @@
 # TODO: Is it worth referencing a specific tag instead of latest?
-FROM amazonlinux:latest
+FROM amazonlinux:2017.12
 
 # Reduce Docker image size per https://blog.replicated.com/refactoring-a-dockerfile-for-image-size/
 # - The last line upgrades pip to the latest version.
 RUN yum update -y && \
     yum upgrade -y && \
     yum install -y \
+        hostname \
         jq \
         rsyslog \
         sudo \
+        tar \
         vim \
         wget && \
         yum clean all
@@ -17,9 +19,7 @@ RUN yum update -y && \
 # in /usr/local/bin, but amazonlinux's sudo uses a sanitzed PATH that does not include /usr/local/bin, so we symlink pip.
 RUN curl https://bootstrap.pypa.io/ez_setup.py | sudo /usr/bin/python && \
     easy_install pip && \
-    pip install --upgrade pip && \
-    ln -s /usr/local/bin/pip /usr/bin/pip
+    pip install --upgrade pip
 
 # Install the AWSCLI (which apparently does not come pre-bundled with Amazon Linux!)
-RUN pip install --upgrade setuptools && \
-    pip install awscli --upgrade
+RUN pip install awscli --upgrade

--- a/_docker-images/gruntwork-amazon-linux-test/README.md
+++ b/_docker-images/gruntwork-amazon-linux-test/README.md
@@ -9,6 +9,6 @@ but it doesn't exist by default in Docker `amazonlinux:latest`.
 This Docker image should publicly accessible via Docker Hub at https://hub.docker.com/r/gruntwork/amazonlinux-test/. To build and
 upload it:
 
-1. `docker build -t gruntwork/amazonlinux-test:latest .`
-1. `docker push gruntwork/amazonlinux-test:latest`
+1. `docker build -t gruntwork/amazon-linux-test:2017.12 .`
+1. `docker push gruntwork/amazon-linux-test:2017.12`
 


### PR DESCRIPTION
Amazon Linux decided to push a new `amazonlinux:latest` to Docker Image which broke our previous implementation of Zookeeper, I believe because they introduced Systemd. This PR reverts to a versioned Amazon Linux image and installs the now missing dependencies.

In the interest of consistency, I've also renamed some folders and the Docker Hub repo.