### PR TITLE
Install additional tools in Docker images.

### DIFF
--- a/_docker-images/gruntwork-amazon-linux-test/Dockerfile
+++ b/_docker-images/gruntwork-amazon-linux-test/Dockerfile
@@ -14,7 +14,7 @@ RUN yum update -y && \
         tar \
         vim \
         wget && \
-        yum clean all
+        yum clean all && rm -rf /var/cache/yum
 
 # Installing pip with yum doesn't actually put it in the PATH, so we use easy_install instead. Pip will now be placed
 # in /usr/local/bin, but amazonlinux's sudo uses a sanitzed PATH that does not include /usr/local/bin, so we symlink pip.
@@ -25,3 +25,9 @@ RUN curl https://bootstrap.pypa.io/ez_setup.py | sudo /usr/bin/python && \
 
 # Install the AWSCLI (which apparently does not come pre-bundled with Amazon Linux!)
 RUN pip install awscli --upgrade
+
+# Ideally, we'd install the latest version of Docker to avoid a conflict between the Docker client in this container
+# and the Docker API on your local host, but installing the latest version of Docker yields the error "Requires:
+# container-selinux >= 2.9", whch indicates that a newer Linux kernel version is required than what comes with Amazon Linux.
+# So we settle for the Amazon Linux supported version for now.
+RUN yum install -y docker

--- a/_docker-images/gruntwork-centos-test/Dockerfile
+++ b/_docker-images/gruntwork-centos-test/Dockerfile
@@ -13,7 +13,7 @@ RUN yum update -y && \
         sudo \
         vim \
         wget && \
-        yum clean all
+        yum clean all && rm -rf /var/cache/yum
 
 # Install jq. Oddly, there's no RPM for jq, so we install the binary directly. https://serverfault.com/a/768061/199943
 RUN wget -O jq https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 && \
@@ -24,6 +24,11 @@ RUN wget -O jq https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux6
 RUN pip install --upgrade pip && \
     pip install --upgrade setuptools && \
     pip install awscli --upgrade
+
+# Install the latest version of Docker, Consumer Edition
+RUN yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo && \
+    yum -y install docker-ce && \
+    yum clean all
 
 # We run systemd as our container process. Systemd can spawn other forks as necessary to help us simulate a real-world
 # CentOS systemd environment.

--- a/_docker-images/gruntwork-ubuntu-test/Dockerfile
+++ b/_docker-images/gruntwork-ubuntu-test/Dockerfile
@@ -4,22 +4,37 @@ FROM ubuntu:16.04
 # - dnsutils: Install handy DNS checking tools like dig
 # - libcrypt-hcesha-perl: Install shasum
 # - software-properties-common: Install add-apt-repository
-RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install --no-install-recommends -y \
-    ca-certificates \
-    curl \
-    dnsutils \
-    jq \
-    libcrypt-hcesha-perl \
-    python-pip \
-    rsyslog \
-    software-properties-common \
-    sudo \
-    vim \
-    wget && \
-    rm -rf /var/lib/apt/lists/*
+RUN DEBIAN_FRONTEND=noninteractive \
+    apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install --no-install-recommends -y \
+        ca-certificates \
+        curl \
+        dnsutils \
+        jq \
+        libcrypt-hcesha-perl \
+        python-pip \
+        rsyslog \
+        software-properties-common \
+        sudo \
+        vim \
+        wget && \
+        rm -rf /var/lib/apt/lists/*
 
 # Install the AWS CLI per https://docs.aws.amazon.com/cli/latest/userguide/installing.html. The last line upgrades pip
 # to the latest version.
 RUN pip install --upgrade setuptools && \
     pip install --upgrade pip && \
     pip install awscli --upgrade
+
+# Install the latest version of Docker, Consumer Edition
+RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - && \
+    apt-get update && \
+    apt-get -y install apt-transport-https && \
+    add-apt-repository \
+       "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
+       $(lsb_release -cs) \
+       stable" && \
+    apt-get update && \
+    apt-get -y install docker-ce && \
+    rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
This PR adds some additional tools I discovered I needed in Docker containers while working in package-kafka:

- `shasum`: In package-kafka, I verify a checksum of Kafka using `shasum`, which is not installed by default in any of the Docker images
- `docker`: In package-kafka, I need the ability to get the current container name from within the container. You can use a few tricks to get the container ID, but the only way to get the container name is to use `docker inspect`. Therefore, I install `docker` in each Docker image so that a container can be mounted with `-v /var/run/docker.sock:/var/run/docker.sock` and then directly query itself with `docker inspect $(cat /proc/1/cgroup | grep 'docker/' | tail -1 | sed 's/^.*\///')` (the latter part is a way to get the container ID).

Note that I have already pushed these Docker images live, however I will leave this PR open until I finish my active work in case I have any additional tools to add to the Docker images.