### PR TITLE
Add support for saving and loading arbitrary string values.

### DIFF
--- a/test-structure/test_structure.go
+++ b/test-structure/test_structure.go
@@ -90,7 +90,13 @@ func formatRandomResourceCollectionPath(testFolder string) string {
 // Serialize and save a uniquely named string value into the given folder. This allows you to create one or more string
 // values during one stage -- each with a unique name -- and to reuse those values during later stages.
 func SaveString(t *testing.T, testFolder string, name string, val string, logger *log.Logger) {
-	SaveTestData(t, formatNamedTestDataPath(testFolder, name), val, logger)
+	path := formatNamedTestDataPath(testFolder, name)
+
+	if IsTestDataPresent(t, path, logger) {
+		logger.Printf("[WARNING] Test data already exists for named string \"%s\" at path %s. The upcoming save operation will overwrite existing data.\n.", name, path)
+	}
+
+	SaveTestData(t, path, val, logger)
 }
 
 // Serialize and save an AMI ID into the given folder. This allows you to build an AMI during setup and to reuse that
@@ -174,22 +180,17 @@ func LoadTestData(t *testing.T, path string, value interface{}, logger *log.Logg
 
 // Return true if a file exists at $path and the test data there is non-empty.
 func IsTestDataPresent(t *testing.T, path string, logger *log.Logger) bool {
-	logger.Printf("Testing whether test data exists at %s", path)
-
 	bytes, err := ioutil.ReadFile(path)
 	if err != nil && strings.Contains(err.Error(), "no such file or directory") {
-		logger.Printf("No test data was found at %s", path)
 		return false
 	} else if err != nil {
 		t.Fatalf("Failed to load test data from %s due to unexpected error: %v", path, err)
 	}
 
 	if isEmptyJson(t, bytes) {
-		logger.Printf("No test data was found at %s", path)
 		return false
 	}
 
-	logger.Printf("Non-empty test data found at %s", path)
 	return true
 }
 

--- a/test-structure/test_structure_test.go
+++ b/test-structure/test_structure_test.go
@@ -199,3 +199,25 @@ func TestSaveAndLoadNamedTestData(t *testing.T) {
 	assert.False(t, files.FileExists(formatNamedTestDataPath(tmpFolder, name1)))
 	assert.False(t, files.FileExists(formatNamedTestDataPath(tmpFolder, name2)))
 }
+
+func TestSaveDuplicateTestData(t *testing.T) {
+	t.Parallel()
+
+	logger := terralog.NewLogger("TestSaveAndLoadAmiId")
+
+	tmpFolder, err := ioutil.TempDir("", "save-and-load-ami-id")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+
+	name := "hello-world"
+	val1 := "hello world"
+	val2 := "buenos dias, mundo"
+
+	SaveString(t, tmpFolder, name, val1, logger)
+	SaveString(t, tmpFolder, name, val2, logger)
+
+	actualVal := LoadString(t, tmpFolder, name, logger)
+
+	assert.Equal(t, val2, actualVal, "Actual test data should use overwritten values")
+}


### PR DESCRIPTION
While working with the Confluent and Kafka tests, I had to build in some cases up to 3 separate AMIs to run a single test, however the previous test_structucture code only allowed for saving and loading a single AMI. This pR adds a backwards-compatible way of saving and loading multiple AMIs in a single test run.

It occurs to me that there is nothing AMI-specific about this code, so I'll refactor now to support generic saving and loading of strings.