### PR TITLE
Fix for extractAmiId function returning docker sha256

### DIFF
--- a/packer/packer_test.go
+++ b/packer/packer_test.go
@@ -1,8 +1,8 @@
 package packer
 
 import (
-	"testing"
 	"fmt"
+	"testing"
 )
 
 func TestExtractAmiIdFromOneLine(t *testing.T) {
@@ -60,4 +60,24 @@ func TestExtractAmiIdNoIdPresent(t *testing.T) {
 		t.Error("Expected to get an error when extracting an AMI ID from text with no AMI in it, but got nil")
 	}
 
+}
+
+func TestExtractAmiIdFromMultipleArtifacts(t *testing.T) {
+	t.Parallel()
+
+	expectedAmiId := "ami-b481b3de"
+	text := fmt.Sprintf(`
+	1524229039,ubuntu-docker,artifact,0,id,sha256:e8c89d46fcc8d9e81a25fd0e1157b0de79d4547dfea9142ca0d46f7fb05eb446
+	1456332887,amazon-ebs,artifact,0,id,us-east-1:%s
+	`, expectedAmiId)
+
+	actualAmiId, err := extractAmiId(text)
+
+	if err != nil {
+		t.Errorf("Did not expect to get an error when extracting a valid AMI ID: %s", err)
+	}
+
+	if actualAmiId != expectedAmiId {
+		t.Errorf("Did not get expected AMI ID. Expected: %s. Actual: %s.", expectedAmiId, actualAmiId)
+	}
 }


### PR DESCRIPTION
Fixed an issue where a docker image sha256 id could be returned instead of an AWS ami_id
Added test that would have caught this
Formatted code

**Important Note**
This function and that whole helper method is only designed to work with packer templates that only build one AMI at a time. Right now, it will ignore the docker ids, but will still return only the first non-docker id that it finds.