### PR TITLE
Reorder defers in examples

### DIFF
--- a/test/packer_docker_example_test.go
+++ b/test/packer_docker_example_test.go
@@ -41,11 +41,11 @@ func TestPackerDockerExampleLocal(t *testing.T)  {
 		},
 	}
 
-	// Run Docker Compose to fire up the web app. We run it in the background (-d) so it doesn't block this test.
-	docker.RunDockerCompose(t, dockerOptions, "up", "-d")
-
 	// Make sure to shut down the Docker container at the end of the test
 	defer docker.RunDockerCompose(t, dockerOptions, "down")
+
+	// Run Docker Compose to fire up the web app. We run it in the background (-d) so it doesn't block this test.
+	docker.RunDockerCompose(t, dockerOptions, "up", "-d")
 
 	// It can take a few seconds for the Docker container boot up, so retry a few times
 	maxRetries := 5

--- a/test/terraform_aws_example_test.go
+++ b/test/terraform_aws_example_test.go
@@ -31,11 +31,11 @@ func TestTerraformAwsExample(t *testing.T) {
 		},
 	}
 
-	// This will run `terraform init` and `terraform apply` and fail the test if there are any errors
-	terraform.InitAndApply(t, terraformOptions)
-
 	// At the end of the test, run `terraform destroy` to clean up any resources that were created
 	defer terraform.Destroy(t, terraformOptions)
+
+	// This will run `terraform init` and `terraform apply` and fail the test if there are any errors
+	terraform.InitAndApply(t, terraformOptions)
 
 	// Run `terraform output` to get the value of an output variable
 	instanceId := terraform.Output(t, terraformOptions, "instance_id")

--- a/test/terraform_basic_example_test.go
+++ b/test/terraform_basic_example_test.go
@@ -22,11 +22,11 @@ func TestTerraformBasicExample(t *testing.T) {
 		},
 	}
 
-	// This will run `terraform init` and `terraform apply` and fail the test if there are any errors
-	terraform.InitAndApply(t, terraformOptions)
-
 	// At the end of the test, run `terraform destroy` to clean up any resources that were created
 	defer terraform.Destroy(t, terraformOptions)
+
+	// This will run `terraform init` and `terraform apply` and fail the test if there are any errors
+	terraform.InitAndApply(t, terraformOptions)
 
 	// Run `terraform output` to get the value of an output variable
 	actualText := terraform.Output(t, terraformOptions, "example")

--- a/test/terraform_http_example_test.go
+++ b/test/terraform_http_example_test.go
@@ -40,11 +40,11 @@ func TestTerraformHttpExample(t *testing.T) {
 		},
 	}
 
-	// This will run `terraform init` and `terraform apply` and fail the test if there are any errors
-	terraform.InitAndApply(t, terraformOptions)
-
 	// At the end of the test, run `terraform destroy` to clean up any resources that were created
 	defer terraform.Destroy(t, terraformOptions)
+
+	// This will run `terraform init` and `terraform apply` and fail the test if there are any errors
+	terraform.InitAndApply(t, terraformOptions)
 
 	// Run `terraform output` to get the value of an output variable
 	instanceUrl := terraform.Output(t, terraformOptions, "instance_url")

--- a/test/terraform_packer_example_test.go
+++ b/test/terraform_packer_example_test.go
@@ -37,11 +37,6 @@ func TestTerraformPackerExample(t *testing.T)  {
 		deleteAmi(t, awsRegion, workingDir)
 	})
 
-	// Deploy the web app using Terraform
-	test_structure.RunTestStage(t, "deploy_terraform", func() {
-		deployUsingTerraform(t, awsRegion, workingDir)
-	})
-
 	// At the end of the test, undeploy the web app using Terraform
 	defer test_structure.RunTestStage(t, "cleanup_terraform", func() {
 		undeployUsingTerraform(t, workingDir)
@@ -51,6 +46,11 @@ func TestTerraformPackerExample(t *testing.T)  {
 	// debugging issues without having to manually SSH to the server.
 	defer test_structure.RunTestStage(t, "logs", func() {
 		fetchSyslogForInstance(t, awsRegion, workingDir)
+	})
+
+	// Deploy the web app using Terraform
+	test_structure.RunTestStage(t, "deploy_terraform", func() {
+		deployUsingTerraform(t, awsRegion, workingDir)
 	})
 
 	// Validate that the web app deployed and is responding to HTTP requests

--- a/test/terraform_redeploy_example_test.go
+++ b/test/terraform_redeploy_example_test.go
@@ -30,11 +30,6 @@ func TestTerraformRedeployExample(t *testing.T) {
 	// The folder where we have our Terraform code
 	workingDir := "../examples/terraform-redeploy-example"
 
-	// Deploy the web app
-	test_structure.RunTestStage(t, "deploy_initial", func() {
-		initialDeploy(t, awsRegion, workingDir)
-	})
-
 	// At the end of the test, clean up all the resources we created
 	defer test_structure.RunTestStage(t, "teardown", func() {
 		undeployUsingTerraform(t, workingDir)
@@ -42,8 +37,13 @@ func TestTerraformRedeployExample(t *testing.T) {
 
 	// At the end of the test, fetch the most recent syslog entries from each Instance. This can be useful for
 	// debugging issues without having to manually SSH to the server.
-	 defer test_structure.RunTestStage(t, "logs", func() {
+	defer test_structure.RunTestStage(t, "logs", func() {
 		fetchSyslogForAsg(t, awsRegion, workingDir)
+	})
+
+	// Deploy the web app
+	test_structure.RunTestStage(t, "deploy_initial", func() {
+		initialDeploy(t, awsRegion, workingDir)
 	})
 
 	// Validate that the ASG deployed and is responding to HTTP requests

--- a/test/terraform_ssh_example_test.go
+++ b/test/terraform_ssh_example_test.go
@@ -22,15 +22,6 @@ func TestTerraformSshExample(t *testing.T) {
 
 	exampleFolder := "../examples/terraform-ssh-example"
 
-	// Deploy the example
-	test_structure.RunTestStage(t, "setup", func() {
-		terraformOptions, keyPair := deploy(t, exampleFolder)
-
-		// Save the options and key pair so later test stages can use them
-		test_structure.SaveTerraformOptions(t, exampleFolder, terraformOptions)
-		test_structure.SaveEc2KeyPair(t, exampleFolder, keyPair)
-	})
-
 	// At the end of the test, run `terraform destroy` to clean up any resources that were created
 	defer test_structure.RunTestStage(t, "teardown", func() {
 		terraformOptions := test_structure.LoadTerraformOptions(t, exampleFolder)
@@ -38,6 +29,15 @@ func TestTerraformSshExample(t *testing.T) {
 
 		keyPair := test_structure.LoadEc2KeyPair(t, exampleFolder)
 		aws.DeleteEC2KeyPair(t, keyPair)
+	})
+
+	// Deploy the example
+	test_structure.RunTestStage(t, "setup", func() {
+		terraformOptions, keyPair := deploy(t, exampleFolder)
+
+		// Save the options and key pair so later test stages can use them
+		test_structure.SaveTerraformOptions(t, exampleFolder, terraformOptions)
+		test_structure.SaveEc2KeyPair(t, exampleFolder, keyPair)
 	})
 
 	// Make sure we can SSH to the public Instance directly from the public Internet and the private Instance by using


### PR DESCRIPTION
This ensures that the cleanup code always runs, even if something went wrong in the earlier steps