### PR TITLE
Save test data immediately after creation

### DIFF
--- a/modules/aws/region.go
+++ b/modules/aws/region.go
@@ -51,7 +51,10 @@ func GetRandomRegionE(t *testing.T, approvedRegions []string, forbiddenRegions [
 	}
 
 	regionsToPickFrom = collections.ListSubtract(regionsToPickFrom, forbiddenRegions)
-	return random.RandomString(regionsToPickFrom), nil
+	region := random.RandomString(regionsToPickFrom)
+
+	logger.Logf(t, "Using region %s", region)
+	return region, nil
 }
 
 // Get the list of AWS regions available in this account

--- a/test/terraform_packer_example_test.go
+++ b/test/terraform_packer_example_test.go
@@ -74,12 +74,14 @@ func buildAmi(t *testing.T, awsRegion string, workingDir string) {
 		},
 	}
 
+	// Save the Packer Options so future test stages can use them
+	test_structure.SavePackerOptions(t, workingDir, packerOptions)
+
 	// Build the AMI
 	amiId := packer.BuildAmi(t, packerOptions)
 
-	// Save the AMI ID and Packer Options so future test stages can use them
+	// Save the AMI ID so future test stages can use them
 	test_structure.SaveAmiId(t, workingDir, amiId)
-	test_structure.SavePackerOptions(t, workingDir, packerOptions)
 }
 
 // Delete the AMI
@@ -119,11 +121,11 @@ func deployUsingTerraform(t *testing.T, awsRegion string, workingDir string) {
 		},
 	}
 
-	// This will run `terraform init` and `terraform apply` and fail the test if there are any errors
-	terraform.InitAndApply(t, terraformOptions)
-
 	// Save the Terraform Options struct, instance name, and instance text so future test stages can use it
 	test_structure.SaveTerraformOptions(t, workingDir, terraformOptions)
+
+	// This will run `terraform init` and `terraform apply` and fail the test if there are any errors
+	terraform.InitAndApply(t, terraformOptions)
 }
 
 // Undeploy the terraform-packer-example using Terraform

--- a/test/terraform_redeploy_example_test.go
+++ b/test/terraform_redeploy_example_test.go
@@ -82,11 +82,11 @@ func initialDeploy(t *testing.T, awsRegion string, workingDir string) {
 		},
 	}
 
-	// This will run `terraform init` and `terraform apply` and fail the test if there are any errors
-	terraform.InitAndApply(t, terraformOptions)
-
 	// Save the Terraform Options struct so future test stages can use it
 	test_structure.SaveTerraformOptions(t, workingDir, terraformOptions)
+
+	// This will run `terraform init` and `terraform apply` and fail the test if there are any errors
+	terraform.InitAndApply(t, terraformOptions)
 }
 
 // Validate the ASG has been deployed and is working
@@ -120,6 +120,9 @@ func validateAsgRedeploy(t *testing.T, workingDir string) {
 	newText := fmt.Sprintf("%s-redeploy", originalText)
 	terraformOptions.Vars["instance_text"] = newText
 
+	// Save the updated Terraform Options struct
+	test_structure.SaveTerraformOptions(t, workingDir, terraformOptions)
+
 	// Run `terraform output` to get the value of an output variable
 	url := terraform.Output(t, terraformOptions, "url")
 
@@ -135,9 +138,6 @@ func validateAsgRedeploy(t *testing.T, workingDir string) {
 
 	// Stop checking the ELB
 	elbChecks.Done()
-
-	// Save the updated Terraform Options struct
-	test_structure.SaveTerraformOptions(t, workingDir, terraformOptions)
 }
 
 // Fetch the most recent syslogs for the instances in the ASG. This is a handy way to see what happened on each

--- a/test/terraform_ssh_example_test.go
+++ b/test/terraform_ssh_example_test.go
@@ -33,11 +33,14 @@ func TestTerraformSshExample(t *testing.T) {
 
 	// Deploy the example
 	test_structure.RunTestStage(t, "setup", func() {
-		terraformOptions, keyPair := deploy(t, exampleFolder)
+		terraformOptions, keyPair := configureTerraformOptions(t, exampleFolder)
 
 		// Save the options and key pair so later test stages can use them
 		test_structure.SaveTerraformOptions(t, exampleFolder, terraformOptions)
 		test_structure.SaveEc2KeyPair(t, exampleFolder, keyPair)
+
+		// This will run `terraform init` and `terraform apply` and fail the test if there are any errors
+		terraform.InitAndApply(t, terraformOptions)
 	})
 
 	// Make sure we can SSH to the public Instance directly from the public Internet and the private Instance by using
@@ -52,7 +55,7 @@ func TestTerraformSshExample(t *testing.T) {
 
 }
 
-func deploy(t *testing.T, exampleFolder string) (*terraform.Options, *aws.Ec2Keypair) {
+func configureTerraformOptions(t *testing.T, exampleFolder string) (*terraform.Options, *aws.Ec2Keypair) {
 	// A unique ID we can use to namespace resources so we don't clash with anything already in the AWS account or
 	// tests running in parallel
 	uniqueId := random.UniqueId()
@@ -79,9 +82,6 @@ func deploy(t *testing.T, exampleFolder string) (*terraform.Options, *aws.Ec2Key
 			"key_pair_name": keyPairName,
 		},
 	}
-
-	// This will run `terraform init` and `terraform apply` and fail the test if there are any errors
-	terraform.InitAndApply(t, terraformOptions)
 
 	return terraformOptions, keyPair
 }


### PR DESCRIPTION
If we wait too long to save it, some other part of the test may fail
first, so the save never happens. Then, when the test goes to clean up,
the saved data is not there.