### PR TITLE
Fix output and retry handling

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,6 +41,17 @@ not delete or rename anything in a public API.
 If a backwards incompatible change cannot be avoided, please make sure to call that out when you submit a pull request,
 explaining why the change is absolutely necessary.
 
+Note that we use pre-commit hooks with this project. To ensure they run:
+
+1. Install [pre-commit](https://pre-commit.com/).
+1. Run `pre-commit install`.
+
+One of the pre-commit hooks we run is [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports). To prevent the
+hook from failing, make sure to :
+
+1. Install [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports)
+1. Run `goimports -w .`.
+
 ## Create a pull request
 
 [Create a pull request](https://help.github.com/articles/creating-a-pull-request/) with your changes. Please make sure

--- a/modules/retry/retry.go
+++ b/modules/retry/retry.go
@@ -60,24 +60,27 @@ func DoWithRetry(t *testing.T, actionDescription string, maxRetries int, sleepBe
 // immediately. If it returns any other type of error, sleep for sleepBetweenRetries and try again, up to a maximum of
 // maxRetries retries. If maxRetries is exceeded, return a MaxRetriesExceeded error.
 func DoWithRetryE(t *testing.T, actionDescription string, maxRetries int, sleepBetweenRetries time.Duration, action func() (string, error)) (string, error) {
+	var output string
+	var err error
+
 	for i := 0; i <= maxRetries; i++ {
 		logger.Log(t, actionDescription)
 
-		output, err := action()
+		output, err = action()
 		if err == nil {
 			return output, nil
 		}
 
 		if _, isFatalErr := err.(FatalError); isFatalErr {
 			logger.Logf(t, "Returning due to fatal error: %v", err)
-			return "", err
+			return output, err
 		}
 
 		logger.Logf(t, "%s returned an error: %s. Sleeping for %s and will try again.", actionDescription, err.Error(), sleepBetweenRetries)
 		time.Sleep(sleepBetweenRetries)
 	}
 
-	return "", MaxRetriesExceeded{Description: actionDescription, MaxRetries: maxRetries}
+	return output, MaxRetriesExceeded{Description: actionDescription, MaxRetries: maxRetries}
 }
 
 type Done struct {

--- a/modules/retry/retry_test.go
+++ b/modules/retry/retry_test.go
@@ -15,7 +15,7 @@ func TestDoWithRetry(t *testing.T) {
 	expectedError := fmt.Errorf("expected error")
 
 	actionAlwaysReturnsExpected := func() (string, error) { return expectedOutput, nil }
-	actionAlwaysReturnsError := func() (string, error) { return "", expectedError }
+	actionAlwaysReturnsError := func() (string, error) { return expectedOutput, expectedError }
 
 	createActionThatReturnsExpectedAfterFiveRetries := func() func() (string, error) {
 		count := 0
@@ -24,7 +24,7 @@ func TestDoWithRetry(t *testing.T) {
 			if count > 5 {
 				return expectedOutput, nil
 			} else {
-				return "", expectedError
+				return expectedOutput, expectedError
 			}
 		}
 	}
@@ -48,6 +48,7 @@ func TestDoWithRetry(t *testing.T) {
 			t.Parallel()
 
 			actualOutput, err := DoWithRetryE(t, testCase.description, testCase.maxRetries, 1*time.Millisecond, testCase.action)
+			assert.Equal(t, expectedOutput, actualOutput)
 			if testCase.expectedError != nil {
 				assert.Equal(t, testCase.expectedError, err)
 			} else {

--- a/modules/terraform/apply_test.go
+++ b/modules/terraform/apply_test.go
@@ -2,8 +2,9 @@ package terraform
 
 import (
 	"testing"
-	"github.com/stretchr/testify/assert"
+
 	"github.com/gruntwork-io/terratest/modules/files"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestApplyNoError(t *testing.T) {
@@ -51,7 +52,7 @@ func TestApplyWithErrorWithRetry(t *testing.T) {
 
 	options := &Options{
 		TerraformDir: testFolder,
-		MaxRetries: 1,
+		MaxRetries:   1,
 		RetryableTerraformErrors: map[string]string{
 			"This is the first run, exiting with an error": "Intentional failure in test fixture",
 		},

--- a/modules/terraform/apply_test.go
+++ b/modules/terraform/apply_test.go
@@ -1,0 +1,63 @@
+package terraform
+
+import (
+	"testing"
+	"github.com/stretchr/testify/assert"
+	"github.com/gruntwork-io/terratest/modules/files"
+)
+
+func TestApplyNoError(t *testing.T) {
+	t.Parallel()
+
+	testFolder, err := files.CopyTerraformFolderToTemp("../../test/fixtures/terraform-no-error", t.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	options := &Options{
+		TerraformDir: testFolder,
+	}
+
+	out := InitAndApply(t, options)
+
+	assert.Contains(t, out, "Hello, World")
+}
+
+func TestApplyWithErrorNoRetry(t *testing.T) {
+	t.Parallel()
+
+	testFolder, err := files.CopyTerraformFolderToTemp("../../test/fixtures/terraform-with-error", t.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	options := &Options{
+		TerraformDir: testFolder,
+	}
+
+	out, err := InitAndApplyE(t, options)
+
+	assert.Error(t, err)
+	assert.Contains(t, out, "This is the first run, exiting with an error")
+}
+
+func TestApplyWithErrorWithRetry(t *testing.T) {
+	t.Parallel()
+
+	testFolder, err := files.CopyTerraformFolderToTemp("../../test/fixtures/terraform-with-error", t.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	options := &Options{
+		TerraformDir: testFolder,
+		MaxRetries: 1,
+		RetryableTerraformErrors: map[string]string{
+			"This is the first run, exiting with an error": "Intentional failure in test fixture",
+		},
+	}
+
+	out := InitAndApply(t, options)
+
+	assert.Contains(t, out, "This is the first run, exiting with an error")
+}

--- a/modules/terraform/cmd.go
+++ b/modules/terraform/cmd.go
@@ -36,12 +36,12 @@ func RunTerraformCommandE(t *testing.T, options *Options, args ...string) (strin
 		}
 
 		for errorText, errorMessage := range options.RetryableTerraformErrors {
-			if strings.Contains(err.Error(), errorText) {
+			if strings.Contains(out, errorText) {
 				logger.Logf(t, "terraform failed with the error '%s' but this error was expected and warrants a retry. Further details: %s\n", errorText, errorMessage)
-				return "", err
+				return out, err
 			}
 		}
 
-		return "", retry.FatalError{Underlying: err}
+		return out, retry.FatalError{Underlying: err}
 	})
 }

--- a/test/fixtures/terraform-no-error/main.tf
+++ b/test/fixtures/terraform-no-error/main.tf
@@ -1,0 +1,3 @@
+output "test" {
+  value = "Hello, World"
+}

--- a/test/fixtures/terraform-with-error/main.tf
+++ b/test/fixtures/terraform-with-error/main.tf
@@ -1,5 +1,6 @@
 resource "null_resource" "fail_on_first_run" {
   provisioner "local-exec" {
     command = "if [[ -f terraform.tfstate.backup ]]; then echo 'This is not the first run, so exiting successfully' && exit 0; else echo 'This is the first run, exiting with an error' && exit 1; fi"
+    interpreter = ["/bin/bash", "-c"]
   }
 }

--- a/test/fixtures/terraform-with-error/main.tf
+++ b/test/fixtures/terraform-with-error/main.tf
@@ -1,0 +1,5 @@
+resource "null_resource" "fail_on_first_run" {
+  provisioner "local-exec" {
+    command = "if [[ -f terraform.tfstate.backup ]]; then echo 'This is not the first run, so exiting successfully' && exit 0; else echo 'This is the first run, exiting with an error' && exit 1; fi"
+  }
+}


### PR DESCRIPTION
Fix two bugs:

1. The `retry.DoWithRetryE` method did not always return stdout/stderr.
1. The retry mechanism in `terraform.Apply` was checking `err.Error()` instead of stdout/stderr. The former almost always just contains "exit status 1", so the latter is what we should actually be checking to determine if a retry is necessary.

To prevent these bugs in the future, I added automated tests that were failing before these fix and are now passing.