### PR TITLE
Fix variable coercion

### DIFF
--- a/modules/terraform/format.go
+++ b/modules/terraform/format.go
@@ -6,14 +6,15 @@ import (
 	"strings"
 )
 
-// FormatArgs converts the inputs to a format palatable to terraform. This includes converting the given vars to the format the
-// Terraform CLI expects (-var key=value).
+// FormatArgs converts the inputs to a format palatable to terraform. This includes converting the given vars to the
+// format the Terraform CLI expects (-var key=value).
 func FormatArgs(customVars map[string]interface{}, args ...string) []string {
 	varsAsArgs := FormatTerraformVarsAsArgs(customVars)
 	return append(args, varsAsArgs...)
 }
 
-// FormatTerraformVarsAsArgs formats the given variables as command-line args for Terraform (e.g. of the format -var key=value).
+// FormatTerraformVarsAsArgs formats the given variables as command-line args for Terraform (e.g. of the format
+// -var key=value).
 func FormatTerraformVarsAsArgs(vars map[string]interface{}) []string {
 	args := []string{}
 
@@ -28,9 +29,9 @@ func FormatTerraformVarsAsArgs(vars map[string]interface{}) []string {
 
 // Terraform allows you to pass in command-line variables using HCL syntax (e.g. -var foo=[1,2,3]). Unfortunately,
 // while their golang hcl library can convert an HCL string to a Go type, they don't seem to offer a library to convert
-// arbitrary Go types to an HCL string. Therefore, this method is a VERY simple implementation that correctly handles
-// ints, booleans, non-nested lists, and non-nested maps. Everything else is forced into a string using Sprintf.
-// Hopefully, this approach is good enough for the type of variables we deal with in terratest.
+// arbitrary Go types to an HCL string. Therefore, this method is a simple implementation that correctly handles
+// ints, booleans, lists, and maps. Everything else is forced into a string using Sprintf. Hopefully, this approach is
+// good enough for the type of variables we deal with in Terratest.
 func toHclString(value interface{}) string {
 	// Ideally, we'd use a type switch here to identify slices and maps, but we can't do that, because Go doesn't
 	// support generics, and the type switch only matches concrete types. So we could match []interface{}, but if
@@ -88,24 +89,24 @@ func tryToConvertToGenericMap(value interface{}) (map[string]interface{}, bool) 
 	return genericMap, true
 }
 
-// Convert a non-nested slice to an HCL string. See ToHclString for details.
+// Convert a slice to an HCL string. See ToHclString for details.
 func sliceToHclString(slice []interface{}) string {
 	hclValues := []string{}
 
 	for _, value := range slice {
-		hclValue := primitiveToHclString(value)
+		hclValue := toHclString(value)
 		hclValues = append(hclValues, hclValue)
 	}
 
 	return fmt.Sprintf("[%s]", strings.Join(hclValues, ", "))
 }
 
-// Convert a non-nested map to an HCL string. See ToHclString for details.
+// Convert a map to an HCL string. See ToHclString for details.
 func mapToHclString(m map[string]interface{}) string {
 	keyValuePairs := []string{}
 
 	for key, value := range m {
-		keyValuePair := fmt.Sprintf("%s = %s", key, primitiveToHclString(value))
+		keyValuePair := fmt.Sprintf("%s = %s", key, toHclString(value))
 		keyValuePairs = append(keyValuePairs, keyValuePair)
 	}
 

--- a/modules/terraform/format.go
+++ b/modules/terraform/format.go
@@ -116,10 +116,19 @@ func mapToHclString(m map[string]interface{}) string {
 // using Sprintf. See ToHclString for details.
 func primitiveToHclString(value interface{}) string {
 	switch v := value.(type) {
-	// Note: due to a Terraform bug, we can't use proper HCL syntax for ints and booleans and instead have
-	// to treat EVERYTHING as a string. For more info, see: https://github.com/hashicorp/terraform/issues/7962
+
+	// Terraform treats a boolean true as a 1 and a boolean false as a 0. It's best to convert to these ints when
+	// passing booleans as -var parameters. Moreover, due to a Terraform bug
+	// (https://github.com/hashicorp/terraform/issues/7962), all ints must be wrapped as strings.
+	case bool:
+		if v {
+			return "\"1\""
+		}
+		return "\"0\""
+
+	// Note: due to a Terraform bug (https://github.com/hashicorp/terraform/issues/7962), we can't use proper HCL
+	// syntax for ints have to wrap them as strings by falling through to the default case
 	//case int: return strconv.Itoa(v)
-	//case bool: return strconv.FormatBool(v)
 
 	default:
 		return fmt.Sprintf("\"%v\"", v)

--- a/modules/terraform/format_test.go
+++ b/modules/terraform/format_test.go
@@ -17,12 +17,12 @@ func TestFormatTerraformVarsAsArgs(t *testing.T) {
 		{map[string]interface{}{}, []string{}},
 		{map[string]interface{}{"foo": "bar"}, []string{"-var", "foo=\"bar\""}},
 		{map[string]interface{}{"foo": 123}, []string{"-var", "foo=\"123\""}},
-		{map[string]interface{}{"foo": true}, []string{"-var", "foo=\"true\""}},
+		{map[string]interface{}{"foo": true}, []string{"-var", "foo=\"1\""}},
 		{map[string]interface{}{"foo": []int{1, 2, 3}}, []string{"-var", "foo=[\"1\", \"2\", \"3\"]"}},
 		{map[string]interface{}{"foo": map[string]string{"baz": "blah"}}, []string{"-var", "foo={baz = \"blah\"}"}},
 		{
 			map[string]interface{}{"str": "bar", "int": -1, "bool": false, "list": []string{"foo", "bar", "baz"}, "map": map[string]int{"foo": 0}},
-			[]string{"-var", "str=\"bar\"", "-var", "int=\"-1\"", "-var", "bool=\"false\"", "-var", "list=[\"foo\", \"bar\", \"baz\"]", "-var", "map={foo = \"0\"}"},
+			[]string{"-var", "str=\"bar\"", "-var", "int=\"-1\"", "-var", "bool=\"0\"", "-var", "list=[\"foo\", \"bar\", \"baz\"]", "-var", "map={foo = \"0\"}"},
 		},
 	}
 
@@ -43,7 +43,7 @@ func TestPrimitiveToHclString(t *testing.T) {
 		{"", "\"\""},
 		{"foo", "\"foo\""},
 		{"true", "\"true\""},
-		{true, "\"true\""},
+		{true, "\"1\""},
 		{3, "\"3\""},
 		{[]int{1, 2, 3}, "\"[1 2 3]\""}, // Anything that isn't a primitive is forced into a string
 	}
@@ -64,9 +64,9 @@ func TestMapToHclString(t *testing.T) {
 		{map[string]interface{}{}, "{}"},
 		{map[string]interface{}{"key1": "value1"}, "{key1 = \"value1\"}"},
 		{map[string]interface{}{"key1": 123}, "{key1 = \"123\"}"},
-		{map[string]interface{}{"key1": true}, "{key1 = \"true\"}"},
+		{map[string]interface{}{"key1": true}, "{key1 = \"1\"}"},
 		{map[string]interface{}{"key1": []int{1, 2, 3}}, "{key1 = \"[1 2 3]\"}"}, // Any value that isn't a primitive is forced into a string
-		{map[string]interface{}{"key1": "value1", "key2": 0, "key3": false}, "{key1 = \"value1\", key2 = \"0\", key3 = \"false\"}"},
+		{map[string]interface{}{"key1": "value1", "key2": 0, "key3": false}, "{key1 = \"value1\", key2 = \"0\", key3 = \"0\"}"},
 	}
 
 	for _, testCase := range testCases {
@@ -118,9 +118,9 @@ func TestSliceToHclString(t *testing.T) {
 		{[]interface{}{}, "[]"},
 		{[]interface{}{"foo"}, "[\"foo\"]"},
 		{[]interface{}{123}, "[\"123\"]"},
-		{[]interface{}{true}, "[\"true\"]"},
+		{[]interface{}{true}, "[\"1\"]"},
 		{[]interface{}{[]int{1, 2, 3}}, "[\"[1 2 3]\"]"}, // Any value that isn't a primitive is forced into a string
-		{[]interface{}{"foo", 0, false}, "[\"foo\", \"0\", \"false\"]"},
+		{[]interface{}{"foo", 0, false}, "[\"foo\", \"0\", \"0\"]"},
 	}
 
 	for _, testCase := range testCases {
@@ -139,7 +139,7 @@ func TestToHclString(t *testing.T) {
 		{"", "\"\""},
 		{"foo", "\"foo\""},
 		{123, "\"123\""},
-		{true, "\"true\""},
+		{true, "\"1\""},
 		{[]int{1, 2, 3}, "[\"1\", \"2\", \"3\"]"},
 		{[]string{"foo", "bar", "baz"}, "[\"foo\", \"bar\", \"baz\"]"},
 		{map[string]string{"key1": "value1"}, "{key1 = \"value1\"}"},

--- a/modules/terraform/format_test.go
+++ b/modules/terraform/format_test.go
@@ -65,7 +65,7 @@ func TestMapToHclString(t *testing.T) {
 		{map[string]interface{}{"key1": "value1"}, "{key1 = \"value1\"}"},
 		{map[string]interface{}{"key1": 123}, "{key1 = \"123\"}"},
 		{map[string]interface{}{"key1": true}, "{key1 = \"1\"}"},
-		{map[string]interface{}{"key1": []int{1, 2, 3}}, "{key1 = \"[1 2 3]\"}"}, // Any value that isn't a primitive is forced into a string
+		{map[string]interface{}{"key1": []int{1, 2, 3}}, "{key1 = [\"1\", \"2\", \"3\"]}"}, // Any value that isn't a primitive is forced into a string
 		{map[string]interface{}{"key1": "value1", "key2": 0, "key3": false}, "{key1 = \"value1\", key2 = \"0\", key3 = \"0\"}"},
 	}
 
@@ -119,8 +119,10 @@ func TestSliceToHclString(t *testing.T) {
 		{[]interface{}{"foo"}, "[\"foo\"]"},
 		{[]interface{}{123}, "[\"123\"]"},
 		{[]interface{}{true}, "[\"1\"]"},
-		{[]interface{}{[]int{1, 2, 3}}, "[\"[1 2 3]\"]"}, // Any value that isn't a primitive is forced into a string
+		{[]interface{}{[]int{1, 2, 3}}, "[[\"1\", \"2\", \"3\"]]"}, // Any value that isn't a primitive is forced into a string
 		{[]interface{}{"foo", 0, false}, "[\"foo\", \"0\", \"0\"]"},
+		{[]interface{}{map[string]interface{}{"foo": "bar", "baz": "blah"}}, "[{foo = \"bar\", baz = \"blah\"}]"},
+		{[]interface{}{map[string]interface{}{"foo": "bar", "baz": "blah"}, map[string]interface{}{"foo": "bar", "baz": "blah"}}, "[{foo = \"bar\", baz = \"blah\"}, {foo = \"bar\", baz = \"blah\"}]"},
 	}
 
 	for _, testCase := range testCases {


### PR DESCRIPTION
This PR fixes two bugs with how Terratest coerces variables passed via `-var` arguments:

1. Convert booleans to `"1"` and `"0"` instead of `true` and `false`. There seems to be some Terraform bug where `-var 'foo = true'` is not parsed properly.

1. Handle nested maps and lists. We used to ignore these and simply convert them to strings, but now Terratest attempts to properly convert lists and maps that contain other nested lists and maps.