### PR TITLE
Add an environment variable to use aws role auth instead of access keys

### DIFF
--- a/examples/terraform-aws-example/README.md
+++ b/examples/terraform-aws-example/README.md
@@ -25,7 +25,7 @@ it should be free, but you are completely responsible for all AWS charges.
 1. Sign up for [AWS](https://aws.amazon.com/).
 1. Configure your AWS credentials using one of the [supported methods for AWS CLI
    tools](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html), such as setting the
-   `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables.
+   `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables. If you're using the `~/.aws/config` file for profiles then export `AWS_SDK_LOAD_CONFIG` as "True".
 1. Set the AWS region you want to use as the environment variable `AWS_DEFAULT_REGION`.
 1. Install [Terraform](https://www.terraform.io/) and make sure it's on your `PATH`.
 1. Run `terraform init`.
@@ -40,7 +40,7 @@ it should be free, but you are completely responsible for all AWS charges.
 1. Sign up for [AWS](https://aws.amazon.com/).
 1. Configure your AWS credentials using one of the [supported methods for AWS CLI
    tools](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html), such as setting the
-   `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables.
+   `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables. If you're using the `~/.aws/config` file for profiles then export `AWS_SDK_LOAD_CONFIG` as "True".
 1. Install [Terraform](https://www.terraform.io/) and make sure it's on your `PATH`.
 1. Install [Golang](https://golang.org/) and make sure this code is checked out into your `GOPATH`.
 1. `cd test`

--- a/examples/terraform-http-example/README.md
+++ b/examples/terraform-http-example/README.md
@@ -26,7 +26,7 @@ it should be free, but you are completely responsible for all AWS charges.
 1. Sign up for [AWS](https://aws.amazon.com/).
 1. Configure your AWS credentials using one of the [supported methods for AWS CLI
    tools](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html), such as setting the
-   `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables.
+   `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables. If you're using the `~/.aws/config` file for profiles then export `AWS_SDK_LOAD_CONFIG` as "True".
 1. Install [Terraform](https://www.terraform.io/) and make sure it's on your `PATH`.
 1. Run `terraform init`.
 1. Run `terraform apply`.
@@ -41,7 +41,7 @@ it should be free, but you are completely responsible for all AWS charges.
 1. Sign up for [AWS](https://aws.amazon.com/).
 1. Configure your AWS credentials using one of the [supported methods for AWS CLI
    tools](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html), such as setting the
-   `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables.
+   `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables. If you're using the `~/.aws/config` file for profiles then export `AWS_SDK_LOAD_CONFIG` as "True".
 1. Install [Terraform](https://www.terraform.io/) and make sure it's on your `PATH`.
 1. Install [Golang](https://golang.org/) and make sure this code is checked out into your `GOPATH`.
 1. `cd test`

--- a/examples/terraform-packer-example/README.md
+++ b/examples/terraform-packer-example/README.md
@@ -28,7 +28,7 @@ it should be free, but you are completely responsible for all AWS charges.
 1. Sign up for [AWS](https://aws.amazon.com/).
 1. Configure your AWS credentials using one of the [supported methods for AWS CLI
    tools](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html), such as setting the
-   `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables.
+   `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables. If you're using the `~/.aws/config` file for profiles then export `AWS_SDK_LOAD_CONFIG` as "True".
 1. Install [Terraform](https://www.terraform.io/) and make sure it's on your `PATH`.
 1. Install [Packer](https://www.packer.io/) and make sure it's on your `PATH`.
 1. Follow the instructions in [packer-docker-example](/examples/packer-docker-example) to build an AMI. Note down the
@@ -47,7 +47,7 @@ it should be free, but you are completely responsible for all AWS charges.
 1. Sign up for [AWS](https://aws.amazon.com/).
 1. Configure your AWS credentials using one of the [supported methods for AWS CLI
    tools](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html), such as setting the
-   `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables.
+   `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables. If you're using the `~/.aws/config` file for profiles then export `AWS_SDK_LOAD_CONFIG` as "True".
 1. Install [Terraform](https://www.terraform.io/) and make sure it's on your `PATH`.
 1. Install [Packer](https://www.packer.io/) and make sure it's on your `PATH`.
 1. Install [Golang](https://golang.org/) and make sure this code is checked out into your `GOPATH`.

--- a/examples/terraform-redeploy-example/README.md
+++ b/examples/terraform-redeploy-example/README.md
@@ -28,7 +28,7 @@ it should be free, but you are completely responsible for all AWS charges.
 1. Sign up for [AWS](https://aws.amazon.com/).
 1. Configure your AWS credentials using one of the [supported methods for AWS CLI
    tools](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html), such as setting the
-   `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables.
+   `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables. If you're using the `~/.aws/config` file for profiles then export `AWS_SDK_LOAD_CONFIG` as "True".
 1. Install [Terraform](https://www.terraform.io/) and make sure it's on your `PATH`.
 1. Run `terraform init`.
 1. Run `terraform apply`.
@@ -43,7 +43,7 @@ it should be free, but you are completely responsible for all AWS charges.
 1. Sign up for [AWS](https://aws.amazon.com/).
 1. Configure your AWS credentials using one of the [supported methods for AWS CLI
    tools](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html), such as setting the
-   `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables.
+   `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables. If you're using the `~/.aws/config` file for profiles then export `AWS_SDK_LOAD_CONFIG` as "True".
 1. Install [Terraform](https://www.terraform.io/) and make sure it's on your `PATH`.
 1. Install [Golang](https://golang.org/) and make sure this code is checked out into your `GOPATH`.
 1. `cd test`

--- a/examples/terraform-ssh-example/README.md
+++ b/examples/terraform-ssh-example/README.md
@@ -25,7 +25,7 @@ it should be free, but you are completely responsible for all AWS charges.
 1. Sign up for [AWS](https://aws.amazon.com/).
 1. Configure your AWS credentials using one of the [supported methods for AWS CLI
    tools](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html), such as setting the
-   `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables.
+   `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables. If you're using the `~/.aws/config` file for profiles then export `AWS_SDK_LOAD_CONFIG` as "True".
 1. Install [Terraform](https://www.terraform.io/) and make sure it's on your `PATH`.
 1. Run `terraform init`.
 1. Run `terraform apply`.
@@ -39,7 +39,7 @@ it should be free, but you are completely responsible for all AWS charges.
 1. Sign up for [AWS](https://aws.amazon.com/).
 1. Configure your AWS credentials using one of the [supported methods for AWS CLI
    tools](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html), such as setting the
-   `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables.
+   `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables. If you're using the `~/.aws/config` file for profiles then export `AWS_SDK_LOAD_CONFIG` as "True".
 1. Install [Terraform](https://www.terraform.io/) and make sure it's on your `PATH`.
 1. Install [Golang](https://golang.org/) and make sure this code is checked out into your `GOPATH`.
 1. `cd test`

--- a/modules/aws/ami.go
+++ b/modules/aws/ami.go
@@ -26,7 +26,7 @@ func DeleteAmiAndAllSnapshots(t *testing.T, region string, ami string) {
 	}
 }
 
-// DeleteAmiAndAllSnapshots will delete the given AMI along with all EBS snapshots that backed that AMI
+// DeleteAmiAndAllSnapshotsE will delete the given AMI along with all EBS snapshots that backed that AMI
 func DeleteAmiAndAllSnapshotsE(t *testing.T, region string, ami string) error {
 	snapshots, err := GetEbsSnapshotsForAmiE(t, region, ami)
 	if err != nil {


### PR DESCRIPTION
[Issue](https://github.com/gruntwork-io/terratest/issues/112)
[Tests](https://gist.github.com/Briansbum/450553b11f33bf567c39596ce6d095fe)

Currently there's no way to use AWS role based authentication to get a session and then use that session in other functions in terratest. This allows you to set the variable "AWS_ROLE_ARN" in your environment and this will override any session made with access keys.