### PR TITLE
Terragrunt module

### DIFF
--- a/modules/shell/command.go
+++ b/modules/shell/command.go
@@ -20,6 +20,7 @@ type Command struct {
 	Args       []string          // The args to pass to the command
 	WorkingDir string            // The working directory
 	Env        map[string]string // Additional environment variables to set
+	WithStderr bool              // Include stderr in output
 }
 
 // RunCommand runs a shell command and redirects its stdout and stderr to the stdout of the atomic script itself.
@@ -71,7 +72,13 @@ func RunCommandAndGetOutputE(t *testing.T, command Command) (string, error) {
 		return "", err
 	}
 
-	output, err := readStdoutAndStderr(t, stdout, stderr)
+	var output string
+	if command.WithStderr != false {
+		output, err = readStdoutAndStderr(t, stdout, stderr)
+	} else {
+		output, err = readStdout(t, stdout)
+	}
+
 	if err != nil {
 		return output, err
 	}
@@ -81,6 +88,29 @@ func RunCommandAndGetOutputE(t *testing.T, command Command) (string, error) {
 	}
 
 	return output, nil
+}
+
+// This function captures stdout and stderr while still printing it to the stdout and stderr of this Go program
+func readStdout(t *testing.T, stdout io.ReadCloser) (string, error) {
+	allOutput := []string{}
+
+	stdoutScanner := bufio.NewScanner(stdout)
+
+	for {
+		if stdoutScanner.Scan() {
+			text := stdoutScanner.Text()
+			logger.Log(t, text)
+			allOutput = append(allOutput, text)
+		} else {
+			break
+		}
+	}
+
+	if err := stdoutScanner.Err(); err != nil {
+		return "", err
+	}
+
+	return strings.Join(allOutput, "\n"), nil
 }
 
 // This function captures stdout and stderr while still printing it to the stdout and stderr of this Go program

--- a/modules/terragrunt/apply.go
+++ b/modules/terragrunt/apply.go
@@ -1,0 +1,47 @@
+package terragrunt
+
+import (
+	"testing"
+)
+
+// InitAndApply runs terragrunt init and apply with the given options and return stdout/stderr from the apply command. Note that this
+// method does NOT call destroy and assumes the caller is responsible for cleaning up any resources created by running
+// apply.
+func InitAndApply(t *testing.T, options *Options) string {
+	out, err := InitAndApplyE(t, options)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return out
+}
+
+// InitAndApplyE runs terragrunt init and apply with the given options and return stdout/stderr from the apply command. Note that this
+// method does NOT call destroy and assumes the caller is responsible for cleaning up any resources created by running
+// apply.
+func InitAndApplyE(t *testing.T, options *Options) (string, error) {
+	if _, err := InitE(t, options); err != nil {
+		return "", err
+	}
+
+	if _, err := GetE(t, options); err != nil {
+		return "", err
+	}
+
+	return ApplyE(t, options)
+}
+
+// Apply runs terragrunt apply with the given options and return stdout/stderr. Note that this method does NOT call destroy and
+// assumes the caller is responsible for cleaning up any resources created by running apply.
+func Apply(t *testing.T, options *Options) string {
+	out, err := ApplyE(t, options)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return out
+}
+
+// ApplyE runs terragrunt apply with the given options and return stdout/stderr. Note that this method does NOT call destroy and
+// assumes the caller is responsible for cleaning up any resources created by running apply.
+func ApplyE(t *testing.T, options *Options) (string, error) {
+	return RunTerragruntCommandE(t, options, FormatArgs(options.Vars, "apply", "-input=false", "-lock=false", "-auto-approve")...)
+}

--- a/modules/terragrunt/cmd.go
+++ b/modules/terragrunt/cmd.go
@@ -8,7 +8,7 @@ import (
 	"github.com/gruntwork-io/terratest/modules/collections"
 	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/retry"
-	"github.com/gruntwork-io/terratest/modules/shell"
+	"github.com/kamsz/terratest/modules/shell"
 )
 
 // RunTerragruntCommand runs terragrunt with the given arguments and options and return stdout/stderr.
@@ -33,6 +33,7 @@ func RunTerragruntCommandE(t *testing.T, options *Options, args ...string) (stri
 			Args:       args,
 			WorkingDir: options.TerragruntDir,
 			Env:        options.EnvVars,
+			WithStderr: false,
 		}
 
 		out, err := shell.RunCommandAndGetOutputE(t, cmd)

--- a/modules/terragrunt/cmd.go
+++ b/modules/terragrunt/cmd.go
@@ -1,0 +1,52 @@
+package terragrunt
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/collections"
+	"github.com/gruntwork-io/terratest/modules/logger"
+	"github.com/gruntwork-io/terratest/modules/retry"
+	"github.com/gruntwork-io/terratest/modules/shell"
+)
+
+// RunTerragruntCommand runs terragrunt with the given arguments and options and return stdout/stderr.
+func RunTerragruntCommand(t *testing.T, options *Options, args ...string) string {
+	out, err := RunTerragruntCommandE(t, options, args...)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return out
+}
+
+// RunTerragruntCommandE runs terragrunt with the given arguments and options and return stdout/stderr.
+func RunTerragruntCommandE(t *testing.T, options *Options, args ...string) (string, error) {
+	if options.NoColor && !collections.ListContains(args, "-no-color") {
+		args = append(args, "-no-color")
+	}
+
+	description := fmt.Sprintf("Running terragrunt %v", args)
+	return retry.DoWithRetryE(t, description, options.MaxRetries, options.TimeBetweenRetries, func() (string, error) {
+		cmd := shell.Command{
+			Command:    "terragrunt",
+			Args:       args,
+			WorkingDir: options.TerragruntDir,
+			Env:        options.EnvVars,
+		}
+
+		out, err := shell.RunCommandAndGetOutputE(t, cmd)
+		if err == nil {
+			return out, nil
+		}
+
+		for errorText, errorMessage := range options.RetryableTerragruntErrors {
+			if strings.Contains(out, errorText) {
+				logger.Logf(t, "terragrunt failed with the error '%s' but this error was expected and warrants a retry. Further details: %s\n", errorText, errorMessage)
+				return out, err
+			}
+		}
+
+		return out, retry.FatalError{Underlying: err}
+	})
+}

--- a/modules/terragrunt/destroy.go
+++ b/modules/terragrunt/destroy.go
@@ -1,0 +1,19 @@
+package terragrunt
+
+import (
+	"testing"
+)
+
+// Destroy runs terragrunt destroy with the given options and return stdout/stderr.
+func Destroy(t *testing.T, options *Options) string {
+	out, err := DestroyE(t, options)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return out
+}
+
+// DestroyE runs terragrunt destroy with the given options and return stdout/stderr.
+func DestroyE(t *testing.T, options *Options) (string, error) {
+	return RunTerragruntCommandE(t, options, FormatArgs(options.Vars, "destroy", "-force", "-input=false", "-lock=false")...)
+}

--- a/modules/terragrunt/format.go
+++ b/modules/terragrunt/format.go
@@ -1,0 +1,148 @@
+package terragrunt
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+)
+
+// FormatArgs converts the inputs to a format palatable to terragrunt. This includes converting the given vars to the
+// format the Terragrunt CLI expects (-var key=value).
+func FormatArgs(customVars map[string]interface{}, args ...string) []string {
+	varsAsArgs := FormatTerragruntVarsAsArgs(customVars)
+	return append(args, varsAsArgs...)
+}
+
+// FormatTerragruntVarsAsArgs formats the given variables as command-line args for Terragrunt (e.g. of the format
+// -var key=value).
+func FormatTerragruntVarsAsArgs(vars map[string]interface{}) []string {
+	return formatTerragruntArgs(vars, "-var")
+}
+
+// FormatTerragruntBackendConfigAsArgs formats the given variables as backend config args for Terragrunt (e.g. of the
+// format -backend-config key=value).
+func FormatTerragruntBackendConfigAsArgs(vars map[string]interface{}) []string {
+	return formatTerragruntArgs(vars, "-backend-config")
+}
+
+// Format the given vars into 'Terragrunt' format, with each var being prefixed with the given prefix.
+func formatTerragruntArgs(vars map[string]interface{}, prefix string) []string {
+	var args []string
+
+	for key, value := range vars {
+		hclString := toHclString(value)
+		argValue := fmt.Sprintf("%s=%s", key, hclString)
+		args = append(args, prefix, argValue)
+	}
+
+	return args
+}
+
+// Terragrunt allows you to pass in command-line variables using HCL syntax (e.g. -var foo=[1,2,3]). Unfortunately,
+// while their golang hcl library can convert an HCL string to a Go type, they don't seem to offer a library to convert
+// arbitrary Go types to an HCL string. Therefore, this method is a simple implementation that correctly handles
+// ints, booleans, lists, and maps. Everything else is forced into a string using Sprintf. Hopefully, this approach is
+// good enough for the type of variables we deal with in Terratest.
+func toHclString(value interface{}) string {
+	// Ideally, we'd use a type switch here to identify slices and maps, but we can't do that, because Go doesn't
+	// support generics, and the type switch only matches concrete types. So we could match []interface{}, but if
+	// a user passes in []string{}, that would NOT match (the same logic applies to maps). Therefore, we have to
+	// use reflection and manually convert into []interface{} and map[string]interface{}.
+
+	if slice, isSlice := tryToConvertToGenericSlice(value); isSlice {
+		return sliceToHclString(slice)
+	} else if m, isMap := tryToConvertToGenericMap(value); isMap {
+		return mapToHclString(m)
+	} else {
+		return primitiveToHclString(value)
+	}
+}
+
+// Try to convert the given value to a generic slice. Return the slice and true if the underlying value itself was a
+// slice and an empty slice and false if it wasn't. This is necessary because Go is a shitty language that doesn't
+// have generics, nor useful utility methods built-in. For more info, see: http://stackoverflow.com/a/12754757/483528
+func tryToConvertToGenericSlice(value interface{}) ([]interface{}, bool) {
+	reflectValue := reflect.ValueOf(value)
+	if reflectValue.Kind() != reflect.Slice {
+		return []interface{}{}, false
+	}
+
+	genericSlice := make([]interface{}, reflectValue.Len())
+
+	for i := 0; i < reflectValue.Len(); i++ {
+		genericSlice[i] = reflectValue.Index(i).Interface()
+	}
+
+	return genericSlice, true
+}
+
+// Try to convert the given value to a generic map. Return the map and true if the underlying value itself was a
+// map and an empty map and false if it wasn't. This is necessary because Go is a shitty language that doesn't
+// have generics, nor useful utility methods built-in. For more info, see: http://stackoverflow.com/a/12754757/483528
+func tryToConvertToGenericMap(value interface{}) (map[string]interface{}, bool) {
+	reflectValue := reflect.ValueOf(value)
+	if reflectValue.Kind() != reflect.Map {
+		return map[string]interface{}{}, false
+	}
+
+	reflectType := reflect.TypeOf(value)
+	if reflectType.Key().Kind() != reflect.String {
+		return map[string]interface{}{}, false
+	}
+
+	genericMap := make(map[string]interface{}, reflectValue.Len())
+
+	mapKeys := reflectValue.MapKeys()
+	for _, key := range mapKeys {
+		genericMap[key.String()] = reflectValue.MapIndex(key).Interface()
+	}
+
+	return genericMap, true
+}
+
+// Convert a slice to an HCL string. See ToHclString for details.
+func sliceToHclString(slice []interface{}) string {
+	hclValues := []string{}
+
+	for _, value := range slice {
+		hclValue := toHclString(value)
+		hclValues = append(hclValues, hclValue)
+	}
+
+	return fmt.Sprintf("[%s]", strings.Join(hclValues, ", "))
+}
+
+// Convert a map to an HCL string. See ToHclString for details.
+func mapToHclString(m map[string]interface{}) string {
+	keyValuePairs := []string{}
+
+	for key, value := range m {
+		keyValuePair := fmt.Sprintf("%s = %s", key, toHclString(value))
+		keyValuePairs = append(keyValuePairs, keyValuePair)
+	}
+
+	return fmt.Sprintf("{%s}", strings.Join(keyValuePairs, ", "))
+}
+
+// Convert a primitive, such as a bool, int, or string, to an HCL string. If this isn't a primitive, force its value
+// using Sprintf. See ToHclString for details.
+func primitiveToHclString(value interface{}) string {
+	switch v := value.(type) {
+
+	// Terragrunt treats a boolean true as a 1 and a boolean false as a 0. It's best to convert to these ints when
+	// passing booleans as -var parameters. Moreover, due to a Terragrunt bug
+	// (https://github.com/hashicorp/terragrunt/issues/7962), all ints must be wrapped as strings.
+	case bool:
+		if v {
+			return "\"1\""
+		}
+		return "\"0\""
+
+	// Note: due to a Terragrunt bug (https://github.com/hashicorp/terragrunt/issues/7962), we can't use proper HCL
+	// syntax for ints have to wrap them as strings by falling through to the default case
+	//case int: return strconv.Itoa(v)
+
+	default:
+		return fmt.Sprintf("\"%v\"", v)
+	}
+}

--- a/modules/terragrunt/format_test.go
+++ b/modules/terragrunt/format_test.go
@@ -1,0 +1,217 @@
+package terragrunt
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFormatTerragruntVarsAsArgs(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		vars     map[string]interface{}
+		expected []string
+	}{
+		{map[string]interface{}{}, nil},
+		{map[string]interface{}{"foo": "bar"}, []string{"-var", "foo=\"bar\""}},
+		{map[string]interface{}{"foo": 123}, []string{"-var", "foo=\"123\""}},
+		{map[string]interface{}{"foo": true}, []string{"-var", "foo=\"1\""}},
+		{map[string]interface{}{"foo": []int{1, 2, 3}}, []string{"-var", "foo=[\"1\", \"2\", \"3\"]"}},
+		{map[string]interface{}{"foo": map[string]string{"baz": "blah"}}, []string{"-var", "foo={baz = \"blah\"}"}},
+		{
+			map[string]interface{}{"str": "bar", "int": -1, "bool": false, "list": []string{"foo", "bar", "baz"}, "map": map[string]int{"foo": 0}},
+			[]string{"-var", "str=\"bar\"", "-var", "int=\"-1\"", "-var", "bool=\"0\"", "-var", "list=[\"foo\", \"bar\", \"baz\"]", "-var", "map={foo = \"0\"}"},
+		},
+	}
+
+	for _, testCase := range testCases {
+		checkResultWithRetry(t, 100, testCase.expected, fmt.Sprintf("FormatTerragruntVarsAsArgs(%v)", testCase.vars), func() interface{} {
+			return FormatTerragruntVarsAsArgs(testCase.vars)
+		})
+	}
+}
+
+func TestPrimitiveToHclString(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		value    interface{}
+		expected string
+	}{
+		{"", "\"\""},
+		{"foo", "\"foo\""},
+		{"true", "\"true\""},
+		{true, "\"1\""},
+		{3, "\"3\""},
+		{[]int{1, 2, 3}, "\"[1 2 3]\""}, // Anything that isn't a primitive is forced into a string
+	}
+
+	for _, testCase := range testCases {
+		actual := primitiveToHclString(testCase.value)
+		assert.Equal(t, testCase.expected, actual, "Value: %v", testCase.value)
+	}
+}
+
+func TestMapToHclString(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		value    map[string]interface{}
+		expected string
+	}{
+		{map[string]interface{}{}, "{}"},
+		{map[string]interface{}{"key1": "value1"}, "{key1 = \"value1\"}"},
+		{map[string]interface{}{"key1": 123}, "{key1 = \"123\"}"},
+		{map[string]interface{}{"key1": true}, "{key1 = \"1\"}"},
+		{map[string]interface{}{"key1": []int{1, 2, 3}}, "{key1 = [\"1\", \"2\", \"3\"]}"}, // Any value that isn't a primitive is forced into a string
+		{map[string]interface{}{"key1": "value1", "key2": 0, "key3": false}, "{key1 = \"value1\", key2 = \"0\", key3 = \"0\"}"},
+	}
+
+	for _, testCase := range testCases {
+		checkResultWithRetry(t, 100, testCase.expected, fmt.Sprintf("mapToHclString(%v)", testCase.value), func() interface{} {
+			return mapToHclString(testCase.value)
+		})
+	}
+}
+
+// Some of our tests execute code that loops over a map to produce output. The problem is that the order of map
+// iteration is generally unpredictable and, to make it even more unpredictable, Go intentionally randomizes the
+// iteration order (https://blog.golang.org/go-maps-in-action#TOC_7). Therefore, the order of items in the output
+// is unpredictable, and doing a simple assert.Equals call will intermittently fail.
+//
+// We have a few unsatisfactory ways to solve this problem:
+//
+// 1. Enforce iteration order. This is easy to do in other languages, where you have built-in sorted maps. In Go, no
+//    such map exists, and if you create a custom one, you can't use the range keyword on it
+//    (http://stackoverflow.com/a/35810932/483528). As a result, we'd have to modify our implementation code to take
+//    iteration order into account which is a totally unnecessary feature that increases complexity.
+// 2. We could parse the output string and do an order-independent comparison. However, that adds a bunch of parsing
+//    logic into the test code which is a totally unnecessary feature that increases complexity.
+// 3. We accept that Go is a shitty language and, if the test fails, we re-run it a bunch of times in the hope that, if
+//    the bug is caused by key ordering, we will randomly get the proper order in a future run. The code being tested
+//    here is tiny & fast, so doing a hundred retries is still sub millisecond, so while ugly, this provides a very
+//    simple solution.
+//
+// Isn't it great that Go's designers built features into the language to prevent bugs that now force every Go
+// developer to write thousands of lines of extra code like this, which is of course likely to contain bugs itself?
+func checkResultWithRetry(t *testing.T, maxRetries int, expectedValue interface{}, description string, generateValue func() interface{}) {
+	for i := 0; i < maxRetries; i++ {
+		actualValue := generateValue()
+		if assert.ObjectsAreEqual(expectedValue, actualValue) {
+			return
+		}
+		t.Logf("Retry %d of %s failed: expected %v, got %v", i, description, expectedValue, actualValue)
+	}
+
+	assert.Fail(t, "checkResultWithRetry failed", "After %d retries, %s still not succeeding (see retries above)", description)
+}
+
+func TestSliceToHclString(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		value    []interface{}
+		expected string
+	}{
+		{[]interface{}{}, "[]"},
+		{[]interface{}{"foo"}, "[\"foo\"]"},
+		{[]interface{}{123}, "[\"123\"]"},
+		{[]interface{}{true}, "[\"1\"]"},
+		{[]interface{}{[]int{1, 2, 3}}, "[[\"1\", \"2\", \"3\"]]"}, // Any value that isn't a primitive is forced into a string
+		{[]interface{}{"foo", 0, false}, "[\"foo\", \"0\", \"0\"]"},
+		{[]interface{}{map[string]interface{}{"foo": "bar"}}, "[{foo = \"bar\"}]"},
+		{[]interface{}{map[string]interface{}{"foo": "bar"}, map[string]interface{}{"foo": "bar"}}, "[{foo = \"bar\"}, {foo = \"bar\"}]"},
+	}
+
+	for _, testCase := range testCases {
+		actual := sliceToHclString(testCase.value)
+		assert.Equal(t, testCase.expected, actual, "Value: %v", testCase.value)
+	}
+}
+
+func TestToHclString(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		value    interface{}
+		expected string
+	}{
+		{"", "\"\""},
+		{"foo", "\"foo\""},
+		{123, "\"123\""},
+		{true, "\"1\""},
+		{[]int{1, 2, 3}, "[\"1\", \"2\", \"3\"]"},
+		{[]string{"foo", "bar", "baz"}, "[\"foo\", \"bar\", \"baz\"]"},
+		{map[string]string{"key1": "value1"}, "{key1 = \"value1\"}"},
+		{map[string]int{"key1": 123}, "{key1 = \"123\"}"},
+	}
+
+	for _, testCase := range testCases {
+		actual := toHclString(testCase.value)
+		assert.Equal(t, testCase.expected, actual, "Value: %v", testCase.value)
+	}
+}
+
+func TestTryToConvertToGenericSlice(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		value           interface{}
+		expectedSlice   []interface{}
+		expectedIsSlice bool
+	}{
+		{"", []interface{}{}, false},
+		{"foo", []interface{}{}, false},
+		{true, []interface{}{}, false},
+		{531, []interface{}{}, false},
+		{map[string]string{"foo": "bar"}, []interface{}{}, false},
+		{[]string{}, []interface{}{}, true},
+		{[]int{}, []interface{}{}, true},
+		{[]bool{}, []interface{}{}, true},
+		{[]interface{}{}, []interface{}{}, true},
+		{[]string{"foo", "bar", "baz"}, []interface{}{"foo", "bar", "baz"}, true},
+		{[]int{1, 2, 3}, []interface{}{1, 2, 3}, true},
+		{[]bool{true, true, false}, []interface{}{true, true, false}, true},
+		{[]interface{}{"foo", "bar", "baz"}, []interface{}{"foo", "bar", "baz"}, true},
+	}
+
+	for _, testCase := range testCases {
+		actualSlice, actualIsSlice := tryToConvertToGenericSlice(testCase.value)
+		assert.Equal(t, testCase.expectedSlice, actualSlice, "Value: %v", testCase.value)
+		assert.Equal(t, testCase.expectedIsSlice, actualIsSlice, "Value: %v", testCase.value)
+	}
+}
+
+func TestTryToConvertToGenericMap(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		value         interface{}
+		expectedMap   map[string]interface{}
+		expectedIsMap bool
+	}{
+		{"", map[string]interface{}{}, false},
+		{"foo", map[string]interface{}{}, false},
+		{true, map[string]interface{}{}, false},
+		{531, map[string]interface{}{}, false},
+		{[]string{"foo", "bar"}, map[string]interface{}{}, false},
+		{map[int]int{}, map[string]interface{}{}, false},
+		{map[bool]string{}, map[string]interface{}{}, false},
+		{map[string]string{}, map[string]interface{}{}, true},
+		{map[string]int{}, map[string]interface{}{}, true},
+		{map[string]bool{}, map[string]interface{}{}, true},
+		{map[string]interface{}{}, map[string]interface{}{}, true},
+		{map[string]string{"key1": "value1", "key2": "value2"}, map[string]interface{}{"key1": "value1", "key2": "value2"}, true},
+		{map[string]int{"key1": 1, "key2": 2, "key3": 3}, map[string]interface{}{"key1": 1, "key2": 2, "key3": 3}, true},
+		{map[string]bool{"key1": true}, map[string]interface{}{"key1": true}, true},
+		{map[string]interface{}{"key1": "value1"}, map[string]interface{}{"key1": "value1"}, true},
+	}
+
+	for _, testCase := range testCases {
+		actualMap, actualIsMap := tryToConvertToGenericMap(testCase.value)
+		assert.Equal(t, testCase.expectedMap, actualMap, "Value: %v", testCase.value)
+		assert.Equal(t, testCase.expectedIsMap, actualIsMap, "Value: %v", testCase.value)
+	}
+}

--- a/modules/terragrunt/get.go
+++ b/modules/terragrunt/get.go
@@ -1,0 +1,19 @@
+package terragrunt
+
+import (
+	"testing"
+)
+
+// Get calls terragrunt get and return stdout/stderr.
+func Get(t *testing.T, options *Options) string {
+	out, err := GetE(t, options)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return out
+}
+
+// GetE calls terragrunt get and return stdout/stderr.
+func GetE(t *testing.T, options *Options) (string, error) {
+	return RunTerragruntCommandE(t, options, "get", "-update")
+}

--- a/modules/terragrunt/init.go
+++ b/modules/terragrunt/init.go
@@ -1,0 +1,22 @@
+package terragrunt
+
+import (
+	"fmt"
+	"testing"
+)
+
+// Init calls terragrunt init and return stdout/stderr.
+func Init(t *testing.T, options *Options) string {
+	out, err := InitE(t, options)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return out
+}
+
+// InitE calls terragrunt init and return stdout/stderr.
+func InitE(t *testing.T, options *Options) (string, error) {
+	args := []string{"init", fmt.Sprintf("-upgrade=%t", options.Upgrade)}
+	args = append(args, FormatTerragruntBackendConfigAsArgs(options.BackendConfig)...)
+	return RunTerragruntCommandE(t, options, args...)
+}

--- a/modules/terragrunt/init_test.go
+++ b/modules/terragrunt/init_test.go
@@ -1,0 +1,37 @@
+package terragrunt
+
+import (
+	"io/ioutil"
+	"path/filepath"
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/files"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInitBackendConfig(t *testing.T) {
+	t.Parallel()
+
+	stateDirectory, err := ioutil.TempDir("", t.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	remoteStateFile := filepath.Join(stateDirectory, "backend.tfstate")
+
+	testFolder, err := files.CopyTerragruntFolderToTemp("../../test/fixtures/terragrunt-backend", t.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	options := &Options{
+		TerragruntDir: testFolder,
+		BackendConfig: map[string]interface{}{
+			"path": remoteStateFile,
+		},
+	}
+
+	InitAndApply(t, options)
+
+	assert.FileExists(t, remoteStateFile)
+}

--- a/modules/terragrunt/options.go
+++ b/modules/terragrunt/options.go
@@ -1,0 +1,16 @@
+package terragrunt
+
+import "time"
+
+// Options for running Terragrunt commands
+type Options struct {
+	TerragruntDir             string                 // The path to the folder where the Terragrunt code is defined.
+	Vars                      map[string]interface{} // The vars to pass to Terragrunt commands using the -var option.
+	EnvVars                   map[string]string      // Environment variables to set when running Terragrunt
+	BackendConfig             map[string]interface{} // The vars to pass to the terragrunt init command for extra configuration for the backend
+	RetryableTerragruntErrors map[string]string      // If Terragrunt apply fails with one of these (transient) errors, retry. The keys are text to look for in the error and the message is what to display to a user if that error is found.
+	MaxRetries                int                    // Maximum number of times to retry errors matching RetryableTerragruntErrors
+	TimeBetweenRetries        time.Duration          // The amount of time to wait between retries
+	Upgrade                   bool                   // Whether the -upgrade flag of the terragrunt init command should be set to true or not
+	NoColor                   bool                   // Whether the -no-color flag will be set for any Terragrunt command or not
+}

--- a/modules/terragrunt/output.go
+++ b/modules/terragrunt/output.go
@@ -1,0 +1,57 @@
+package terragrunt
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// Output calls terragrunt output for the given variable and return its value.
+func Output(t *testing.T, options *Options, key string) string {
+	out, err := OutputE(t, options, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return out
+}
+
+// OutputE calls terragrunt output for the given variable and return its value.
+func OutputE(t *testing.T, options *Options, key string) (string, error) {
+	output, err := RunTerragruntCommandE(t, options, "output", "-no-color", key)
+
+	if err != nil {
+		return "", err
+	}
+
+	return strings.TrimSpace(output), nil
+}
+
+// OutputRequired calls terragrunt output for the given variable and return its value. If the value is empty, fail the test.
+func OutputRequired(t *testing.T, options *Options, key string) string {
+	out, err := OutputRequiredE(t, options, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return out
+}
+
+// OutputRequiredE calls terragrunt output for the given variable and return its value. If the value is empty, return an error.
+func OutputRequiredE(t *testing.T, options *Options, key string) (string, error) {
+	out, err := OutputE(t, options, key)
+
+	if err != nil {
+		return "", err
+	}
+	if out == "" {
+		return "", EmptyOutput(key)
+	}
+
+	return out, nil
+}
+
+// EmptyOutput is an error that occurs when an output is empty.
+type EmptyOutput string
+
+func (outputName EmptyOutput) Error() string {
+	return fmt.Sprintf("Required output %s was empty", string(outputName))
+}

--- a/modules/terragrunt/output.go
+++ b/modules/terragrunt/output.go
@@ -17,7 +17,7 @@ func Output(t *testing.T, options *Options, key string) string {
 
 // OutputE calls terragrunt output for the given variable and return its value.
 func OutputE(t *testing.T, options *Options, key string) (string, error) {
-	output, err := RunTerragruntCommandE(t, options, "output", "-no-color", key)
+	output, err := RunTerragruntCommandE(t, options, "output", "-no-color", key, "2>/dev/null")
 
 	if err != nil {
 		return "", err

--- a/modules/terragrunt/output.go
+++ b/modules/terragrunt/output.go
@@ -17,7 +17,7 @@ func Output(t *testing.T, options *Options, key string) string {
 
 // OutputE calls terragrunt output for the given variable and return its value.
 func OutputE(t *testing.T, options *Options, key string) (string, error) {
-	output, err := RunTerragruntCommandE(t, options, "output", "-no-color", key, "2>/dev/null")
+	output, err := RunTerragruntCommandE(t, options, "output", "-no-color", key)
 
 	if err != nil {
 		return "", err

--- a/modules/terragrunt/terraform.go
+++ b/modules/terragrunt/terraform.go
@@ -1,0 +1,2 @@
+// Package terragrunt allows to interact with Terragrunt.
+package terragrunt


### PR DESCRIPTION
This PR adds Terragrunt module (which is basically a copy of Terraform module).

It also adds an ability to disable stderr from shell commands. This is because Terragrunt prints alot of debug information to stderr, which completely mess up retrieving outputs.

Related to #122.