### PR TITLE
Replace function in redeploy example

### DIFF
--- a/test/terraform_redeploy_example_test.go
+++ b/test/terraform_redeploy_example_test.go
@@ -33,7 +33,8 @@ func TestTerraformRedeployExample(t *testing.T) {
 
 	// At the end of the test, clean up all the resources we created
 	defer test_structure.RunTestStage(t, "teardown", func() {
-		undeployUsingTerraform(t, workingDir)
+		terraformOptions := test_structure.LoadTerraformOptions(t, workingDir)
+		terraform.Destroy(t, terraformOptions)
 	})
 
 	// At the end of the test, fetch the most recent syslog entries from each Instance. This can be useful for


### PR DESCRIPTION
In redeploy test example, a function named "undeployUsingTerraform" is used. However, it is defined in packer test example, which means that if I use this redeploy test only, this function will be regarded as undefined.

Nevertheless, I think all examples should be separated and not related to each other. As a result, I removed this function and replaced it with "LoadTerraformOptions" and "Destroy", just as other examples (for instance, ssh test example) do.

Although this modification is really tiny and I did not do any specific test, I hope it will be an enhancement. Thanks a lot!