### PR TITLE
Add methods to fetch files from servers over SSH

### DIFF
--- a/examples/terraform-redeploy-example/main.tf
+++ b/examples/terraform-redeploy-example/main.tf
@@ -136,6 +136,15 @@ resource "aws_security_group_rule" "web_server_allow_http_inbound" {
   cidr_blocks       = ["0.0.0.0/0"]
 }
 
+resource "aws_security_group_rule" "web_server_allow_ssh_inbound" {
+  type              = "ingress"
+  from_port         = "${var.ssh_port}"
+  to_port           = "${var.ssh_port}"
+  protocol          = "tcp"
+  security_group_id = "${aws_security_group.web_server.id}"
+  cidr_blocks       = ["0.0.0.0/0"]
+}
+
 resource "aws_security_group_rule" "web_server_allow_all_outbound" {
   type              = "egress"
   from_port         = 0

--- a/examples/terraform-redeploy-example/main.tf
+++ b/examples/terraform-redeploy-example/main.tf
@@ -60,6 +60,7 @@ resource "aws_launch_configuration" "web_servers" {
   instance_type   = "t2.micro"
   security_groups = ["${aws_security_group.web_server.id}"]
   user_data       = "${data.template_file.user_data.rendered}"
+  key_name        = "${var.key_pair_name}"
 
   # When used with an aws_autoscaling_group resource, the aws_launch_configuration must set create_before_destroy to
   # true. Note: as soon as you set create_before_destroy = true in one resource, you must also set it in every resource

--- a/examples/terraform-redeploy-example/variables.tf
+++ b/examples/terraform-redeploy-example/variables.tf
@@ -32,6 +32,11 @@ variable "instance_port" {
   default     = 8080
 }
 
+variable "ssh_port" {
+  description = "The port each EC2 Instance should listen on for SSH requests."
+  default     = 22
+}
+
 variable "instance_text" {
   description = "The text each EC2 Instance should return when it gets an HTTP request."
   default     = "Hello, World!"

--- a/examples/terraform-redeploy-example/variables.tf
+++ b/examples/terraform-redeploy-example/variables.tf
@@ -41,3 +41,8 @@ variable "alb_port" {
   description = "The port the ALB should listen on for HTTP requests"
   default     = 80
 }
+
+variable "key_pair_name" {
+  description = "The EC2 Key Pair to associate with the EC2 Instance for SSH access."
+  default     = ""
+}

--- a/modules/aws/ec2-files.go
+++ b/modules/aws/ec2-files.go
@@ -1,0 +1,134 @@
+package aws
+
+import (
+	"testing"
+	"github.com/gruntwork-io/terratest/modules/ssh"
+)
+
+// FetchContentsOfFileFromInstance looks up the public IP address of the EC2 Instance with the given ID, connects to
+// the Instance via SSH using the given username and Key Pair, fetches the contents of the file at the given path
+// (using sudo if useSudo is true), and returns the contents of that file as a string.
+func FetchContentsOfFileFromInstance(t *testing.T, awsRegion string, sshUserName string, keyPair *Ec2Keypair, instanceID string, useSudo bool, filePath string) string {
+	out, err := FetchContentsOfFileFromInstanceE(t, awsRegion, sshUserName, keyPair, instanceID, useSudo, filePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return out
+}
+
+// FetchContentsOfFileFromInstanceE looks up the public IP address of the EC2 Instance with the given ID, connects to
+// the Instance via SSH using the given username and Key Pair, fetches the contents of the file at the given path
+// (using sudo if useSudo is true), and returns the contents of that file as a string.
+func FetchContentsOfFileFromInstanceE(t *testing.T, awsRegion string, sshUserName string, keyPair *Ec2Keypair, instanceID string, useSudo bool, filePath string) (string, error) {
+	publicIp, err := GetPublicIpOfEc2InstanceE(t, instanceID, awsRegion)
+	if err != nil {
+		return "", err
+	}
+
+	host := ssh.Host{
+		SshUserName: sshUserName,
+		SshKeyPair: keyPair.KeyPair,
+		Hostname: publicIp,
+	}
+
+	return ssh.FetchContentsOfFileE(t, host, useSudo, filePath)
+}
+
+// FetchContentsOfFilesFromInstance looks up the public IP address of the EC2 Instance with the given ID, connects to
+// the Instance via SSH using the given username and Key Pair, fetches the contents of the files at the given paths
+// (using sudo if useSudo is true), and returns a map from file path to the contents of that file as a string.
+func FetchContentsOfFilesFromInstance(t *testing.T, awsRegion string, sshUserName string, keyPair *Ec2Keypair, instanceID string, useSudo bool, filePaths ...string) map[string]string {
+	out, err := FetchContentsOfFilesFromInstanceE(t, awsRegion, sshUserName, keyPair, instanceID, useSudo, filePaths...)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return out
+}
+
+// FetchContentsOfFilesFromInstanceE looks up the public IP address of the EC2 Instance with the given ID, connects to
+// the Instance via SSH using the given username and Key Pair, fetches the contents of the files at the given paths
+// (using sudo if useSudo is true), and returns a map from file path to the contents of that file as a string.
+func FetchContentsOfFilesFromInstanceE(t *testing.T, awsRegion string, sshUserName string, keyPair *Ec2Keypair, instanceID string, useSudo bool, filePaths ...string) (map[string]string, error) {
+	publicIp, err := GetPublicIpOfEc2InstanceE(t, instanceID, awsRegion)
+	if err != nil {
+		return nil, err
+	}
+
+	host := ssh.Host{
+		SshUserName: sshUserName,
+		SshKeyPair: keyPair.KeyPair,
+		Hostname: publicIp,
+	}
+
+	return ssh.FetchContentsOfFilesE(t, host, useSudo, filePaths...)
+}
+
+// FetchContentsOfFileFromAsg looks up the EC2 Instances in the given ASG, looks up the public IPs of those EC2
+// Instances, connects to each Instance via SSH using the given username and Key Pair, fetches the contents of the file
+// at the given path (using sudo if useSudo is true), and returns a map from Instance ID to the contents of that file
+// as a string.
+func FetchContentsOfFileFromAsg(t *testing.T, awsRegion string, sshUserName string, keyPair *Ec2Keypair, asgName string, useSudo bool, filePath string) map[string]string {
+	out, err := FetchContentsOfFileFromAsgE(t, awsRegion, sshUserName, keyPair, asgName, useSudo, filePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return out
+}
+
+// FetchContentsOfFileFromAsgE looks up the EC2 Instances in the given ASG, looks up the public IPs of those EC2
+// Instances, connects to each Instance via SSH using the given username and Key Pair, fetches the contents of the file
+// at the given path (using sudo if useSudo is true), and returns a map from Instance ID to the contents of that file
+// as a string.
+func FetchContentsOfFileFromAsgE(t *testing.T, awsRegion string, sshUserName string, keyPair *Ec2Keypair, asgName string, useSudo bool, filePath string) (map[string]string, error) {
+	instanceIDs, err := GetInstanceIdsForAsgE(t, asgName, awsRegion)
+	if err != nil {
+		return nil, err
+	}
+
+	instanceIdToContents := map[string]string{}
+
+	for _, instanceID := range instanceIDs {
+		contents, err := FetchContentsOfFileFromInstanceE(t, awsRegion, sshUserName, keyPair, instanceID, useSudo, filePath)
+		if err != nil {
+			return nil, err
+		}
+		instanceIdToContents[instanceID] = contents
+	}
+
+	return instanceIdToContents, err
+}
+
+// FetchContentsOfFilesFromAsg looks up the EC2 Instances in the given ASG, looks up the public IPs of those EC2
+// Instances, connects to each Instance via SSH using the given username and Key Pair, fetches the contents of the files
+// at the given paths (using sudo if useSudo is true), and returns a map from Instance ID to a map of file path to the
+// contents of that file as a string.
+func FetchContentsOfFilesFromAsg(t *testing.T, awsRegion string, sshUserName string, keyPair *Ec2Keypair, asgName string, useSudo bool, filePaths ...string) map[string]map[string]string {
+	out, err := FetchContentsOfFilesFromAsgE(t, awsRegion, sshUserName, keyPair, asgName, useSudo, filePaths...)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return out
+}
+
+// FetchContentsOfFilesFromAsgE looks up the EC2 Instances in the given ASG, looks up the public IPs of those EC2
+// Instances, connects to each Instance via SSH using the given username and Key Pair, fetches the contents of the files
+// at the given paths (using sudo if useSudo is true), and returns a map from Instance ID to a map of file path to the
+// contents of that file as a string.
+func FetchContentsOfFilesFromAsgE(t *testing.T, awsRegion string, sshUserName string, keyPair *Ec2Keypair, asgName string, useSudo bool, filePaths ...string) (map[string]map[string]string, error) {
+	instanceIDs, err := GetInstanceIdsForAsgE(t, asgName, awsRegion)
+	if err != nil {
+		return nil, err
+	}
+
+	instanceIdToFilePathToContents := map[string]map[string]string{}
+
+	for _, instanceID := range instanceIDs {
+		contents, err := FetchContentsOfFilesFromInstanceE(t, awsRegion, sshUserName, keyPair, instanceID, useSudo, filePaths...)
+		if err != nil {
+			return nil, err
+		}
+		instanceIdToFilePathToContents[instanceID] = contents
+	}
+
+	return instanceIdToFilePathToContents, err
+}

--- a/modules/aws/ec2-files.go
+++ b/modules/aws/ec2-files.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"testing"
+
 	"github.com/gruntwork-io/terratest/modules/ssh"
 )
 
@@ -27,8 +28,8 @@ func FetchContentsOfFileFromInstanceE(t *testing.T, awsRegion string, sshUserNam
 
 	host := ssh.Host{
 		SshUserName: sshUserName,
-		SshKeyPair: keyPair.KeyPair,
-		Hostname: publicIp,
+		SshKeyPair:  keyPair.KeyPair,
+		Hostname:    publicIp,
 	}
 
 	return ssh.FetchContentsOfFileE(t, host, useSudo, filePath)
@@ -56,8 +57,8 @@ func FetchContentsOfFilesFromInstanceE(t *testing.T, awsRegion string, sshUserNa
 
 	host := ssh.Host{
 		SshUserName: sshUserName,
-		SshKeyPair: keyPair.KeyPair,
-		Hostname: publicIp,
+		SshKeyPair:  keyPair.KeyPair,
+		Hostname:    publicIp,
 	}
 
 	return ssh.FetchContentsOfFilesE(t, host, useSudo, filePaths...)

--- a/modules/aws/ec2-syslog.go
+++ b/modules/aws/ec2-syslog.go
@@ -12,6 +12,8 @@ import (
 	"github.com/gruntwork-io/terratest/modules/retry"
 )
 
+// (Deprecated) See the FetchContentsOfFileFromInstance method for a more powerful solution.
+//
 // GetSyslogForInstance gets the syslog for the Instance with the given ID in the given region. This should be available ~1 minute after an
 // Instance boots and is very useful for debugging boot-time issues, such as an error in User Data.
 func GetSyslogForInstance(t *testing.T, instanceID string, awsRegion string) string {
@@ -22,6 +24,8 @@ func GetSyslogForInstance(t *testing.T, instanceID string, awsRegion string) str
 	return out
 }
 
+// (Deprecated) See the FetchContentsOfFileFromInstanceE method for a more powerful solution.
+//
 // GetSyslogForInstanceE gets the syslog for the Instance with the given ID in the given region. This should be available ~1 minute after an
 // Instance boots and is very useful for debugging boot-time issues, such as an error in User Data.
 func GetSyslogForInstanceE(t *testing.T, instanceID string, region string) (string, error) {
@@ -66,6 +70,8 @@ func GetSyslogForInstanceE(t *testing.T, instanceID string, region string) (stri
 	return string(syslogBytes), nil
 }
 
+// (Deprecated) See the FetchContentsOfFilesFromAsg method for a more powerful solution.
+//
 // GetSyslogForInstancesInAsg gets the syslog for each of the Instances in the given ASG in the given region. These logs should be available ~1
 // minute after the Instance boots and are very useful for debugging boot-time issues, such as an error in User Data.
 // Returns a map of Instance Id -> Syslog for that Instance.
@@ -77,6 +83,8 @@ func GetSyslogForInstancesInAsg(t *testing.T, asgName string, awsRegion string) 
 	return out
 }
 
+// (Deprecated) See the FetchContentsOfFilesFromAsgE method for a more powerful solution.
+//
 // GetSyslogForInstancesInAsgE gets the syslog for each of the Instances in the given ASG in the given region. These logs should be available ~1
 // minute after the Instance boots and are very useful for debugging boot-time issues, such as an error in User Data.
 // Returns a map of Instance Id -> Syslog for that Instance.

--- a/modules/ssh/ssh.go
+++ b/modules/ssh/ssh.go
@@ -365,4 +365,3 @@ func sendScpCommandsToCopyFile(mode os.FileMode, fileName, contents string) func
 		fmt.Fprint(input, "\x00")
 	}
 }
-

--- a/test/ssh_agent.go
+++ b/test/ssh_agent.go
@@ -1,10 +1,11 @@
 package test
 
 import (
-	"net"
 	"fmt"
 	"io"
+	"net"
 	"os"
+
 	"golang.org/x/crypto/ssh/agent"
 )
 

--- a/test/ssh_agent.go
+++ b/test/ssh_agent.go
@@ -1,0 +1,71 @@
+package test
+
+import (
+	"net"
+	"fmt"
+	"io"
+	"os"
+	"golang.org/x/crypto/ssh/agent"
+)
+
+type SSHAgent struct {
+	stop       chan bool
+	stopped    chan bool
+	socketDir  string
+	socketFile string
+	agent      agent.Agent
+	ln         net.Listener
+}
+
+// Create SSH agent, start it in background and returns control back to the main thread
+func NewSSHAgent(socketDir string, socketFile string) (*SSHAgent, error) {
+	var err error
+	s := &SSHAgent{make(chan bool), make(chan bool), socketDir, socketFile, agent.NewKeyring(), nil}
+	s.ln, err = net.Listen("unix", s.socketFile)
+	if err != nil {
+		return nil, err
+	}
+	go s.run()
+	return s, nil
+}
+
+// SSH Agent listner and handler
+func (s *SSHAgent) run() {
+	defer close(s.stopped)
+	for {
+		select {
+		case <-s.stop:
+			return
+		default:
+			c, err := s.ln.Accept()
+			if err != nil {
+				select {
+				// When s.Stop() closes the listner, s.ln.Accept() returns an error that can be ignored
+				// since the agent is in stopping process
+				case <-s.stop:
+					return
+					// When s.ln.Accept() returns a legit error, we print it and continue accepting further requests
+				default:
+					fmt.Errorf("Could not accept connection to agent %v", err)
+					continue
+				}
+			} else {
+				defer c.Close()
+				go func(c io.ReadWriter) {
+					err := agent.ServeAgent(s.agent, c)
+					if err != nil {
+						fmt.Errorf("Could not serve ssh agent %v", err)
+					}
+				}(c)
+			}
+		}
+	}
+}
+
+// Stop and clean up SSH agent
+func (s *SSHAgent) Stop() {
+	close(s.stop)
+	s.ln.Close()
+	<-s.stopped
+	os.RemoveAll(s.socketDir)
+}

--- a/test/terraform_redeploy_example_test.go
+++ b/test/terraform_redeploy_example_test.go
@@ -172,7 +172,7 @@ func fetchSyslogForAsg(t *testing.T, awsRegion string, workingDir string) {
 const syslogPathUbuntu = "/var/log/syslog"
 
 // Default location where the User Data script generates an index.html on Ubuntu
-const indexHtmlUbuntu = "/home/ubuntu/index.html"
+const indexHtmlUbuntu = "/index.html"
 
 // This size is configured in the terraform-redeploy-example itself
 const asgSize = 3

--- a/test/terraform_redeploy_example_test.go
+++ b/test/terraform_redeploy_example_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 	"time"
 
+	"strings"
+
 	"github.com/gruntwork-io/terratest/modules/aws"
 	"github.com/gruntwork-io/terratest/modules/http-helper"
 	"github.com/gruntwork-io/terratest/modules/logger"
@@ -14,7 +16,6 @@ import (
 	"github.com/gruntwork-io/terratest/modules/test-structure"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"strings"
 )
 
 // An example of how to test the Terraform module in examples/terraform-redeploy-example using Terratest. We deploy the

--- a/test/terraform_redeploy_example_test.go
+++ b/test/terraform_redeploy_example_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/gruntwork-io/terratest/modules/retry"
 	"github.com/gruntwork-io/terratest/modules/terraform"
 	"github.com/gruntwork-io/terratest/modules/test-structure"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // An example of how to test the Terraform module in examples/terraform-redeploy-example using Terratest. We deploy the
@@ -37,10 +39,11 @@ func TestTerraformRedeployExample(t *testing.T) {
 		terraform.Destroy(t, terraformOptions)
 	})
 
-	// At the end of the test, fetch the most recent syslog entries from each Instance. This can be useful for
+	// At the end of the test, fetch the logs from each Instance. This can be useful for
 	// debugging issues without having to manually SSH to the server.
 	defer test_structure.RunTestStage(t, "logs", func() {
 		fetchSyslogForAsg(t, awsRegion, workingDir)
+		fetchFilesFromAsg(t, awsRegion, workingDir)
 	})
 
 	// Deploy the web app
@@ -65,6 +68,10 @@ func initialDeploy(t *testing.T, awsRegion string, workingDir string) {
 	// tests running in parallel
 	uniqueID := random.UniqueId()
 
+	// Create a KeyPair we can use later to SSH to each Instance
+	keyPair := aws.CreateAndImportEC2KeyPair(t, awsRegion, uniqueID)
+	test_structure.SaveEc2KeyPair(t, workingDir, keyPair)
+
 	// Give the ASG and other resources in the Terraform code a name with a unique ID so it doesn't clash
 	// with anything else in the AWS account.
 	name := fmt.Sprintf("redeploy-test-%s", uniqueID)
@@ -81,6 +88,7 @@ func initialDeploy(t *testing.T, awsRegion string, workingDir string) {
 			"aws_region":    awsRegion,
 			"instance_name": name,
 			"instance_text": text,
+			"key_pair_name": keyPair.Name,
 		},
 	}
 
@@ -142,6 +150,8 @@ func validateAsgRedeploy(t *testing.T, workingDir string) {
 	elbChecks.Done()
 }
 
+// (Deprecated) See the fetchFilesFromAsg method below for a more powerful solution.
+//
 // Fetch the most recent syslogs for the instances in the ASG. This is a handy way to see what happened on each
 // Instance as part of your test log output, without having to re-run the test and manually SSH to the Instances.
 func fetchSyslogForAsg(t *testing.T, awsRegion string, workingDir string) {
@@ -151,9 +161,40 @@ func fetchSyslogForAsg(t *testing.T, awsRegion string, workingDir string) {
 	asgName := terraform.OutputRequired(t, terraformOptions, "asg_name")
 	asgLogs := aws.GetSyslogForInstancesInAsg(t, asgName, awsRegion)
 
-	logger.Logf(t, "===== Syslog for instances in ASG %s =====\n\n", asgName)
+	logger.Logf(t, "===== First few hundred bytes of syslog for instances in ASG %s =====\n\n", asgName)
 
 	for instanceID, logs := range asgLogs {
 		logger.Logf(t, "Most recent syslog for Instance %s:\n\n%s\n", instanceID, logs)
+	}
+}
+
+// Default syslog location on Ubuntu
+const syslogPathUbuntu = "/var/log/syslog"
+
+// Default location where the User Data script generates an index.html on Ubuntu
+const indexHtmlUbuntu = "/home/ubuntu/index.html"
+
+func fetchFilesFromAsg(t *testing.T, awsRegion string, workingDir string) {
+	// Load the Terraform Options and Key Pair saved by the earlier deploy_terraform stage
+	terraformOptions := test_structure.LoadTerraformOptions(t, workingDir)
+	keyPair := test_structure.LoadEc2KeyPair(t, workingDir)
+
+	asgName := terraform.OutputRequired(t, terraformOptions, "asg_name")
+	instanceIdToFilePathToContents := aws.FetchContentsOfFilesFromAsg(t, awsRegion, "ubuntu", keyPair, asgName, true, syslogPathUbuntu, indexHtmlUbuntu)
+
+	// Check that the index.html file on each Instance contains the expected text
+	expectedText := terraformOptions.Vars["instance_text"]
+	for instanceID, filePathToContents := range instanceIdToFilePathToContents {
+		require.Contains(t, filePathToContents, indexHtmlUbuntu)
+		assert.Equal(t, expectedText, filePathToContents[indexHtmlUbuntu], "Expected %s on instance %s to contain %s", indexHtmlUbuntu, instanceID, expectedText)
+	}
+
+	logger.Logf(t, "===== Full contents of syslog for instances in ASG %s =====\n\n", asgName)
+
+	// Print out the FULL contents of syslog (unlike the deprecated GetSyslogForInstancesInAsg, which only returns the
+	// first few hundred bytes)
+	for instanceID, filePathToContents := range instanceIdToFilePathToContents {
+		require.Contains(t, filePathToContents, syslogPathUbuntu)
+		logger.Logf(t, "Full syslog for Instance %s:\n\n%s\n", instanceID, filePathToContents[syslogPathUbuntu])
 	}
 }

--- a/test/terraform_redeploy_example_test.go
+++ b/test/terraform_redeploy_example_test.go
@@ -174,6 +174,9 @@ const syslogPathUbuntu = "/var/log/syslog"
 // Default location where the User Data script generates an index.html on Ubuntu
 const indexHtmlUbuntu = "/home/ubuntu/index.html"
 
+// This size is configured in the terraform-redeploy-example itself
+const asgSize = 3
+
 func fetchFilesFromAsg(t *testing.T, awsRegion string, workingDir string) {
 	// Load the Terraform Options and Key Pair saved by the earlier deploy_terraform stage
 	terraformOptions := test_structure.LoadTerraformOptions(t, workingDir)
@@ -181,6 +184,8 @@ func fetchFilesFromAsg(t *testing.T, awsRegion string, workingDir string) {
 
 	asgName := terraform.OutputRequired(t, terraformOptions, "asg_name")
 	instanceIdToFilePathToContents := aws.FetchContentsOfFilesFromAsg(t, awsRegion, "ubuntu", keyPair, asgName, true, syslogPathUbuntu, indexHtmlUbuntu)
+
+	require.Len(t, instanceIdToFilePathToContents, asgSize)
 
 	// Check that the index.html file on each Instance contains the expected text
 	expectedText := terraformOptions.Vars["instance_text"]

--- a/test/terraform_redeploy_example_test.go
+++ b/test/terraform_redeploy_example_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gruntwork-io/terratest/modules/test-structure"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"strings"
 )
 
 // An example of how to test the Terraform module in examples/terraform-redeploy-example using Terratest. We deploy the
@@ -191,7 +192,7 @@ func fetchFilesFromAsg(t *testing.T, awsRegion string, workingDir string) {
 	expectedText := terraformOptions.Vars["instance_text"]
 	for instanceID, filePathToContents := range instanceIdToFilePathToContents {
 		require.Contains(t, filePathToContents, indexHtmlUbuntu)
-		assert.Equal(t, expectedText, filePathToContents[indexHtmlUbuntu], "Expected %s on instance %s to contain %s", indexHtmlUbuntu, instanceID, expectedText)
+		assert.Equal(t, expectedText, strings.TrimSpace(filePathToContents[indexHtmlUbuntu]), "Expected %s on instance %s to contain %s", indexHtmlUbuntu, instanceID, expectedText)
 	}
 
 	logger.Logf(t, "===== Full contents of syslog for instances in ASG %s =====\n\n", asgName)

--- a/test/terraform_ssh_example_test.go
+++ b/test/terraform_ssh_example_test.go
@@ -4,9 +4,7 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
-	"io"
 	"io/ioutil"
-	"net"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -208,7 +206,7 @@ func testSCPToPublicHost(t *testing.T, terraformOptions *terraform.Options, keyP
 			return "", err
 		}
 
-		actualText, err := ssh.CheckSshCommandE(t, publicHost, "cat /tmp/test.txt")
+		actualText, err := ssh.FetchContentsOfFileE(t, publicHost, false, "/tmp/test.txt")
 
 		if err != nil {
 			return "", err
@@ -396,64 +394,3 @@ func testSSHAgentToPrivateHost(t *testing.T, terraformOptions *terraform.Options
 	})
 }
 
-type SSHAgent struct {
-	stop       chan bool
-	stopped    chan bool
-	socketDir  string
-	socketFile string
-	agent      agent.Agent
-	ln         net.Listener
-}
-
-// Create SSH agent, start it in background and returns control back to the main thread
-func NewSSHAgent(socketDir string, socketFile string) (*SSHAgent, error) {
-	var err error
-	s := &SSHAgent{make(chan bool), make(chan bool), socketDir, socketFile, agent.NewKeyring(), nil}
-	s.ln, err = net.Listen("unix", s.socketFile)
-	if err != nil {
-		return nil, err
-	}
-	go s.run()
-	return s, nil
-}
-
-// SSH Agent listner and handler
-func (s *SSHAgent) run() {
-	defer close(s.stopped)
-	for {
-		select {
-		case <-s.stop:
-			return
-		default:
-			c, err := s.ln.Accept()
-			if err != nil {
-				select {
-				// When s.Stop() closes the listner, s.ln.Accept() returns an error that can be ignored
-				// since the agent is in stopping process
-				case <-s.stop:
-					return
-				// When s.ln.Accept() returns a legit error, we print it and continue accepting further requests
-				default:
-					fmt.Errorf("Could not accept connection to agent %v", err)
-					continue
-				}
-			} else {
-				defer c.Close()
-				go func(c io.ReadWriter) {
-					err := agent.ServeAgent(s.agent, c)
-					if err != nil {
-						fmt.Errorf("Could not serve ssh agent %v", err)
-					}
-				}(c)
-			}
-		}
-	}
-}
-
-// Stop and clean up SSH agent
-func (s *SSHAgent) Stop() {
-	close(s.stop)
-	s.ln.Close()
-	<-s.stopped
-	os.RemoveAll(s.socketDir)
-}

--- a/test/terraform_ssh_example_test.go
+++ b/test/terraform_ssh_example_test.go
@@ -393,4 +393,3 @@ func testSSHAgentToPrivateHost(t *testing.T, terraformOptions *terraform.Options
 		return "", nil
 	})
 }
-


### PR DESCRIPTION
This PR adds helper methods that can be used to fetch the contents of files from severs over SSH, as well as some wrapper methods designed specifically for use with EC2 Instances and ASGs. The main use case for this is to fetch the contents of log files (or any other files you need!) from EC2 Instances at the end of the test to make debugging a test failure 10x easier. 

I'm hitting a confusing, intermittent test failure in our Vault code, and I can't repro it locally, so having the test show me the logs of the Vault servers is going to be a huge help.