### PR TITLE
Prevent possible resource leakage in packer example

### DIFF
--- a/test/terraform_packer_example_test.go
+++ b/test/terraform_packer_example_test.go
@@ -22,19 +22,20 @@ import (
 func TestTerraformPackerExample(t *testing.T) {
 	t.Parallel()
 
-	// Pick a random AWS region to test in. This helps ensure your code works in all regions.
-	awsRegion := aws.GetRandomRegion(t, nil, nil)
-
 	// The folder where we have our Terraform code
 	workingDir := "../examples/terraform-packer-example"
 
 	// Build the AMI for the web app
 	test_structure.RunTestStage(t, "build_ami", func() {
+		// Pick a random AWS region to test in. This helps ensure your code works in all regions.
+		awsRegion := aws.GetRandomRegion(t, nil, nil)
+		test_structure.SaveString(t, workingDir, "awsRegion", awsRegion)
 		buildAMI(t, awsRegion, workingDir)
 	})
 
 	// At the end of the test, delete the AMI
 	defer test_structure.RunTestStage(t, "cleanup_ami", func() {
+		awsRegion := test_structure.LoadString(t, workingDir, "awsRegion")
 		deleteAMI(t, awsRegion, workingDir)
 	})
 
@@ -46,11 +47,13 @@ func TestTerraformPackerExample(t *testing.T) {
 	// At the end of the test, fetch the most recent syslog entries from each Instance. This can be useful for
 	// debugging issues without having to manually SSH to the server.
 	defer test_structure.RunTestStage(t, "logs", func() {
+		awsRegion := test_structure.LoadString(t, workingDir, "awsRegion")
 		fetchSyslogForInstance(t, awsRegion, workingDir)
 	})
 
 	// Deploy the web app using Terraform
 	test_structure.RunTestStage(t, "deploy_terraform", func() {
+		awsRegion := test_structure.LoadString(t, workingDir, "awsRegion")
 		deployUsingTerraform(t, awsRegion, workingDir)
 	})
 


### PR DESCRIPTION
As it was previously, if one were to use `SKIP_*` env variables, it could potentially generate a different `awsRegion` each iteration and fail and/or leak AWS resources. To correct, I've saved the random `awsRegion` in the first step using `test_structure.SaveString` and loaded it as needed in the subsequent steps using `test_structure.LoadString`.

(This particular example caused me some confusion when I was first learning the `test_structure` module last week. It made me wrongly assume `test_structure` was doing something more magical. )