### PR TITLE
OCI delete image

### DIFF
--- a/examples/packer-basic-example/README.md
+++ b/examples/packer-basic-example/README.md
@@ -61,13 +61,9 @@ Terratest. For slightly more complicated, real-world examples of Packer template
 1. Sign up for [OCI](https://cloud.oracle.com/cloud-infrastructure).
 1. Configure your OCI credentials via [CLI Configuration
    Information](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/sdkconfig.htm).
-1. Create following [Packer-required](https://www.packer.io/docs/builders/oracle-oci.html#required)
-   resources in your tenancy:
-   1. [Compartment](https://docs.cloud.oracle.com/iaas/Content/GSG/Tasks/choosingcompartments.htm)
-   1. [VCN](https://docs.cloud.oracle.com/iaas/Content/GSG/Tasks/creatingnetwork.htm) and subnet
-1. Create following environment properties:
-   1. `TF_VAR_compartment_ocid` with the OCID of the previously created compartment.
-   1. `TF_VAR_pass_phrase` with the pass phrase for decrypting of the OCI [API signing
+1. Create [VCN](https://docs.cloud.oracle.com/iaas/Content/GSG/Tasks/creatingnetwork.htm) and subnet 
+   resources in your tenancy (a.k.a. a root compartment).
+1. (Optional) Create `TF_VAR_pass_phrase` environment property with the pass phrase for decrypting of the OCI [API signing
       key](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/apisigningkey.htm) (can be omitted
       if the key is not protected).
 1. Install [Packer](https://www.packer.io/) and make sure it's on your `PATH`.

--- a/examples/packer-basic-example/README.md
+++ b/examples/packer-basic-example/README.md
@@ -38,3 +38,26 @@ Terratest. For slightly more complicated, real-world examples of Packer template
 1. `cd test`
 1. `dep ensure`
 1. `go test -v -run TestPackerBasicExample`
+
+
+
+
+## Running automated tests against this Packer template for the OCI builder
+
+1. Sign up for [OCI](https://cloud.oracle.com/cloud-infrastructure).
+1. Configure your OCI credentials via [CLI Configuration
+   Information](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/sdkconfig.htm).
+1. Create following [Packer-required](https://www.packer.io/docs/builders/oracle-oci.html#required)
+   resources in your tenancy:
+   1. [Compartment](https://docs.cloud.oracle.com/iaas/Content/GSG/Tasks/choosingcompartments.htm)
+   1. [VCN](https://docs.cloud.oracle.com/iaas/Content/GSG/Tasks/creatingnetwork.htm) and subnet
+1. Create following environment properties:
+   1. `TF_VAR_compartment_ocid` with the OCID of the previously created compartment.
+   1. `TF_VAR_pass_phrase` with the pass phrase for decrypting of the OCI [API signing
+      key](https://docs.cloud.oracle.com/iaas/Content/API/Concepts/apisigningkey.htm) (can be omitted
+      if the key is not protected).
+1. Install [Packer](https://www.packer.io/) and make sure it's on your `PATH`.
+1. Install [Golang](https://golang.org/) and make sure this code is checked out into your `GOPATH`.
+1. `cd test`
+1. `dep ensure`
+1. `go test -v -run TestPackerOciExample`

--- a/examples/packer-basic-example/README.md
+++ b/examples/packer-basic-example/README.md
@@ -42,6 +42,20 @@ Terratest. For slightly more complicated, real-world examples of Packer template
 
 
 
+## Running automated tests against this Packer template for the GCP builder
+
+1. Sign up for [GCP](https://cloud.google.com/).
+1. Configure your GCP credentials using one of the
+   [Authentication](https://www.packer.io/docs/builders/googlecompute.html#authentication) methods.
+1. Install [Packer](https://www.packer.io/) and make sure it's on your `PATH`.
+1. Install [Golang](https://golang.org/) and make sure this code is checked out into your `GOPATH`.
+1. `cd test`
+1. `dep ensure`
+1. `go test -v -run TestPackerGCPBasicExample`
+
+
+
+
 ## Running automated tests against this Packer template for the OCI builder
 
 1. Sign up for [OCI](https://cloud.oracle.com/cloud-infrastructure).

--- a/examples/packer-basic-example/build.json
+++ b/examples/packer-basic-example/build.json
@@ -7,9 +7,8 @@
     "oci_availability_domain": "",
     "oci_base_image_ocid": "",
     "oci_compartment_ocid": "",
-    "oci_subnet_ocid": "",
-    "oci_key_file": "",
-    "oci_pass_phrase": ""
+    "oci_pass_phrase": "",
+    "oci_subnet_ocid": ""
   },
   "builders": [{
     "type": "amazon-ebs",
@@ -44,7 +43,6 @@
     "availability_domain": "{{user `oci_availability_domain`}}",
     "base_image_ocid": "{{user `oci_base_image_ocid`}}",
     "compartment_ocid": "{{user `oci_compartment_ocid`}}",
-    "key_file": "{{user `oci_key_file`}}",
     "pass_phrase": "{{user `oci_pass_phrase`}}",
     "shape": "VM.Standard2.1",
     "ssh_username": "ubuntu",

--- a/examples/packer-basic-example/build.json
+++ b/examples/packer-basic-example/build.json
@@ -3,7 +3,13 @@
   "variables": {
     "aws_region": "us-east-1",
     "gcp_project_id": "",
-    "gcp_zone": "us-central1-a"
+    "gcp_zone": "us-central1-a",
+    "oci_availability_domain": "",
+    "oci_base_image_ocid": "",
+    "oci_compartment_ocid": "",
+    "oci_subnet_ocid": "",
+    "oci_key_file": "",
+    "oci_pass_phrase": ""
   },
   "builders": [{
     "type": "amazon-ebs",
@@ -32,6 +38,17 @@
     "source_image_family": "ubuntu-1604-lts",
     "zone": "{{user `gcp_zone`}}",
     "ssh_username": "ubuntu"
+  }, {
+    "type": "oracle-oci",
+    "image_name": "terratest-packer-example-{{isotime}}",
+    "availability_domain": "{{user `oci_availability_domain`}}",
+    "base_image_ocid": "{{user `oci_base_image_ocid`}}",
+    "compartment_ocid": "{{user `oci_compartment_ocid`}}",
+    "key_file": "{{user `oci_key_file`}}",
+    "pass_phrase": "{{user `oci_pass_phrase`}}",
+    "shape": "VM.Standard2.1",
+    "ssh_username": "ubuntu",
+    "subnet_ocid": "{{user `oci_subnet_ocid`}}"
   }],
   "provisioners": [{
     "type": "shell",

--- a/modules/oci/compute.go
+++ b/modules/oci/compute.go
@@ -1,0 +1,31 @@
+package oci
+
+import (
+	"context"
+	"github.com/gruntwork-io/terratest/modules/logger"
+	"github.com/oracle/oci-go-sdk/common"
+	"github.com/oracle/oci-go-sdk/core"
+	"testing"
+)
+
+// DeleteImage deletes a custom image with given OCID.
+func DeleteImage(t *testing.T, ocid string) {
+	err := DeleteImageE(t, ocid)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+// DeleteImageE deletes a custom image with given OCID.
+func DeleteImageE(t *testing.T, ocid string)  error {
+	logger.Logf(t, "Deleting image with OCID %s", ocid)
+
+	configProvider := common.DefaultConfigProvider()
+	computeClient, err := core.NewComputeClientWithConfigurationProvider(configProvider)
+	if err != nil {
+		return err
+	}
+
+	_, err = computeClient.DeleteImage(context.Background(), core.DeleteImageRequest{ImageId: &ocid})
+	return err
+}

--- a/modules/oci/compute.go
+++ b/modules/oci/compute.go
@@ -24,49 +24,48 @@ func DeleteImageE(t *testing.T, ocid string) error {
 	logger.Logf(t, "Deleting image with OCID %s", ocid)
 
 	configProvider := common.DefaultConfigProvider()
-	computeClient, err := core.NewComputeClientWithConfigurationProvider(configProvider)
+	client, err := core.NewComputeClientWithConfigurationProvider(configProvider)
 	if err != nil {
 		return err
 	}
 
-	_, err = computeClient.DeleteImage(context.Background(), core.DeleteImageRequest{ImageId: &ocid})
+	_, err = client.DeleteImage(context.Background(), core.DeleteImageRequest{ImageId: &ocid})
 	return err
 }
 
-// BaseImageOcid gets the OCID of the most recent image in the given compartment that has the given OS name and version.
-func BaseImageOcid(t *testing.T, compartmentOcid string, osName string, osVersion string) string {
-	ocid, err := BaseImageOcidE(t, compartmentOcid, osName, osVersion)
+// GetMostRecentImageID gets the OCID of the most recent image in the given compartment that has the given OS name and version.
+func GetMostRecentImageID(t *testing.T, compartmentID string, osName string, osVersion string) string {
+	ocid, err := GetMostRecentImageIDE(t, compartmentID, osName, osVersion)
 	if err != nil {
 		t.Fatal(err)
 	}
 	return ocid
 }
 
-// BaseImageOcidE gets the OCID of the most recent image in the given compartment that has the given OS name and version.
-func BaseImageOcidE(t *testing.T, compartmentOcid string, osName string, osVersion string) (string, error) {
+// GetMostRecentImageIDE gets the OCID of the most recent image in the given compartment that has the given OS name and version.
+func GetMostRecentImageIDE(t *testing.T, compartmentID string, osName string, osVersion string) (string, error) {
 	configProvider := common.DefaultConfigProvider()
-	computeClient, err := core.NewComputeClientWithConfigurationProvider(configProvider)
+	client, err := core.NewComputeClientWithConfigurationProvider(configProvider)
 	if err != nil {
 		return "", err
 	}
 
 	request := core.ListImagesRequest{
-		CompartmentId:          &compartmentOcid,
+		CompartmentId:          &compartmentID,
 		OperatingSystem:        &osName,
 		OperatingSystemVersion: &osVersion,
 	}
-	response, err := computeClient.ListImages(context.Background(), request)
+	response, err := client.ListImages(context.Background(), request)
 	if err != nil {
 		return "", err
 	}
 
 	if len(response.Items) == 0 {
-		return "", fmt.Errorf("No %s %s images found in the %s compartment", osName, osVersion, compartmentOcid)
+		return "", fmt.Errorf("No %s %s images found in the %s compartment", osName, osVersion, compartmentID)
 	}
 
 	mostRecentImage := mostRecentImage(response.Items)
 	return *mostRecentImage.Id, nil
-
 }
 
 // Image sorting code borrowed from: https://github.com/hashicorp/packer/blob/7f4112ba229309cfc0ebaa10ded2abdfaf1b22c8/builder/amazon/common/step_source_ami_info.go

--- a/modules/oci/compute.go
+++ b/modules/oci/compute.go
@@ -2,10 +2,11 @@ package oci
 
 import (
 	"context"
+	"testing"
+
 	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/oracle/oci-go-sdk/common"
 	"github.com/oracle/oci-go-sdk/core"
-	"testing"
 )
 
 // DeleteImage deletes a custom image with given OCID.
@@ -17,7 +18,7 @@ func DeleteImage(t *testing.T, ocid string) {
 }
 
 // DeleteImageE deletes a custom image with given OCID.
-func DeleteImageE(t *testing.T, ocid string)  error {
+func DeleteImageE(t *testing.T, ocid string) error {
 	logger.Logf(t, "Deleting image with OCID %s", ocid)
 
 	configProvider := common.DefaultConfigProvider()

--- a/modules/oci/compute.go
+++ b/modules/oci/compute.go
@@ -2,6 +2,8 @@ package oci
 
 import (
 	"context"
+	"fmt"
+	"sort"
 	"testing"
 
 	"github.com/gruntwork-io/terratest/modules/logger"
@@ -29,4 +31,58 @@ func DeleteImageE(t *testing.T, ocid string) error {
 
 	_, err = computeClient.DeleteImage(context.Background(), core.DeleteImageRequest{ImageId: &ocid})
 	return err
+}
+
+// BaseImageOcid gets the OCID of the most recent image in the given compartment that has the given OS name and version.
+func BaseImageOcid(t *testing.T, compartmentOcid string, osName string, osVersion string) string {
+	ocid, err := BaseImageOcidE(t, compartmentOcid, osName, osVersion)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return ocid
+}
+
+// BaseImageOcidE gets the OCID of the most recent image in the given compartment that has the given OS name and version.
+func BaseImageOcidE(t *testing.T, compartmentOcid string, osName string, osVersion string) (string, error) {
+	configProvider := common.DefaultConfigProvider()
+	computeClient, err := core.NewComputeClientWithConfigurationProvider(configProvider)
+	if err != nil {
+		return "", err
+	}
+
+	request := core.ListImagesRequest{
+		CompartmentId:          &compartmentOcid,
+		OperatingSystem:        &osName,
+		OperatingSystemVersion: &osVersion,
+	}
+	response, err := computeClient.ListImages(context.Background(), request)
+	if err != nil {
+		return "", err
+	}
+
+	if len(response.Items) == 0 {
+		return "", fmt.Errorf("No %s %s images found in the %s compartment", osName, osVersion, compartmentOcid)
+	}
+
+	mostRecentImage := mostRecentImage(response.Items)
+	return *mostRecentImage.Id, nil
+
+}
+
+// Image sorting code borrowed from: https://github.com/hashicorp/packer/blob/7f4112ba229309cfc0ebaa10ded2abdfaf1b22c8/builder/amazon/common/step_source_ami_info.go
+type imageSort []core.Image
+
+func (a imageSort) Len() int      { return len(a) }
+func (a imageSort) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
+func (a imageSort) Less(i, j int) bool {
+	iTime := a[i].TimeCreated.Unix()
+	jTime := a[j].TimeCreated.Unix()
+	return iTime < jTime
+}
+
+// mostRecentImage returns the most recent image out of a slice of images.
+func mostRecentImage(images []core.Image) core.Image {
+	sortedImages := images
+	sort.Sort(imageSort(sortedImages))
+	return sortedImages[len(sortedImages)-1]
 }

--- a/modules/oci/compute.go
+++ b/modules/oci/compute.go
@@ -29,7 +29,8 @@ func DeleteImageE(t *testing.T, ocid string) error {
 		return err
 	}
 
-	_, err = client.DeleteImage(context.Background(), core.DeleteImageRequest{ImageId: &ocid})
+	request := core.DeleteImageRequest{ImageId: &ocid}
+	_, err = client.DeleteImage(context.Background(), request)
 	return err
 }
 

--- a/modules/oci/identity.go
+++ b/modules/oci/identity.go
@@ -1,0 +1,84 @@
+package oci
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/random"
+
+	"github.com/gruntwork-io/terratest/modules/logger"
+	"github.com/oracle/oci-go-sdk/common"
+	"github.com/oracle/oci-go-sdk/identity"
+)
+
+// You can set this environment variable to force Terratest to use a specific availability domain
+// rather than a random one. This is convenient when iterating locally.
+const availabilityDomainOverrideEnvVarName = "TF_VAR_AD"
+
+// TODO Guido: document this
+func GetRandomAvailabilityDomain(t *testing.T, compartmentID string) string {
+	ad, err := GetRandomAvailabilityDomainE(t, compartmentID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return ad
+}
+
+// TODO Guido: document this
+func GetRandomAvailabilityDomainE(t *testing.T, compartmentID string) (string, error) {
+	adFromEnvVar := os.Getenv(availabilityDomainOverrideEnvVarName)
+	if adFromEnvVar != "" {
+		logger.Logf(t, "Using availability domain %s from environment variable %s", adFromEnvVar, availabilityDomainOverrideEnvVarName)
+		return adFromEnvVar, nil
+	}
+
+	allADs, err := GetAllADsE(t, compartmentID)
+	if err != nil {
+		return "", err
+	}
+
+	ad := random.RandomString(allADs)
+
+	logger.Logf(t, "Using availability domain %s", ad)
+	return ad, nil
+}
+
+// TODO Guido: document this
+func GetAllADs(t *testing.T, compartmentID string) []string {
+	ads, err := GetAllADsE(t, compartmentID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return ads
+}
+
+// TODO Guido: document this
+func GetAllADsE(t *testing.T, compartmentID string) ([]string, error) {
+	configProvider := common.DefaultConfigProvider()
+	client, err := identity.NewIdentityClientWithConfigurationProvider(configProvider)
+	if err != nil {
+		return nil, err
+	}
+
+	request := identity.ListAvailabilityDomainsRequest{CompartmentId: &compartmentID}
+	response, err := client.ListAvailabilityDomains(context.Background(), request)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(response.Items) == 0 {
+		return nil, fmt.Errorf("No availability domains found in the %s compartment", compartmentID)
+	}
+
+	return adNames(response.Items), nil
+}
+
+func adNames(ads []identity.AvailabilityDomain) []string {
+	names := []string{}
+	for _, ad := range ads {
+		names = append(names, *ad.Name)
+	}
+	return names
+}

--- a/modules/oci/identity.go
+++ b/modules/oci/identity.go
@@ -13,6 +13,9 @@ import (
 	"github.com/oracle/oci-go-sdk/identity"
 )
 
+// You can set this environment variable to force Terratest to use a specific compartment.
+const compartmentIDOverrideEnvVarName = "TF_VAR_compartment_ocid"
+
 // You can set this environment variable to force Terratest to use a specific availability domain
 // rather than a random one. This is convenient when iterating locally.
 const availabilityDomainOverrideEnvVarName = "TF_VAR_AD"
@@ -73,6 +76,14 @@ func GetAllADsE(t *testing.T, compartmentID string) ([]string, error) {
 	}
 
 	return adNames(response.Items), nil
+}
+
+// GetCompartmentIDFromEnvVar returns the Compartment for use with testing.
+func GetCompartmentIDFromEnvVar() string {
+	if compartmentID := os.Getenv(compartmentIDOverrideEnvVarName); compartmentID != "" {
+		return compartmentID
+	}
+	return ""
 }
 
 func adNames(ads []identity.AvailabilityDomain) []string {

--- a/modules/oci/network.go
+++ b/modules/oci/network.go
@@ -1,0 +1,101 @@
+package oci
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/logger"
+	"github.com/gruntwork-io/terratest/modules/random"
+	"github.com/oracle/oci-go-sdk/common"
+	"github.com/oracle/oci-go-sdk/core"
+)
+
+// GetRandomSubnetID gets a randomly chosen subnet OCID in the given availability domain.
+// The returned value can be overridden by of the environment variable TF_VAR_subnet_ocid.
+func GetRandomSubnetID(t *testing.T, compartmentID string, availabilityDomain string) string {
+	ocid, err := GetRandomSubnetIDE(t, compartmentID, availabilityDomain)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return ocid
+}
+
+// GetRandomSubnetIDE gets a randomly chosen subnet OCID in the given availability domain.
+// The returned value can be overridden by of the environment variable TF_VAR_subnet_ocid.
+func GetRandomSubnetIDE(t *testing.T, compartmentID string, availabilityDomain string) (string, error) {
+	configProvider := common.DefaultConfigProvider()
+	client, err := core.NewVirtualNetworkClientWithConfigurationProvider(configProvider)
+	if err != nil {
+		return "", err
+	}
+
+	vcnIDs, err := GetAllVcnIDsE(t, compartmentID)
+	if err != nil {
+		return "", err
+	}
+
+	allSubnetIDs := map[string][]string{}
+	for _, vcnID := range vcnIDs {
+		request := core.ListSubnetsRequest{
+			CompartmentId: &compartmentID,
+			VcnId:         &vcnID,
+		}
+		response, err := client.ListSubnets(context.Background(), request)
+		if err != nil {
+			return "", err
+		}
+
+		mapSubnetsByAvailabilityDomain(allSubnetIDs, response.Items)
+	}
+
+	subnetID := random.RandomString(allSubnetIDs[availabilityDomain])
+
+	logger.Logf(t, "Using subnet with OCID %s", subnetID)
+	return subnetID, nil
+}
+
+// GetAllVcnIDs gets the list of VCNs available in the given compartment.
+func GetAllVcnIDs(t *testing.T, compartmentID string) []string {
+	vcnIDS, err := GetAllVcnIDsE(t, compartmentID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return vcnIDS
+}
+
+// GetAllVcnIDsE gets the list of VCNs available in the given compartment.
+func GetAllVcnIDsE(t *testing.T, compartmentID string) ([]string, error) {
+	configProvider := common.DefaultConfigProvider()
+	client, err := core.NewVirtualNetworkClientWithConfigurationProvider(configProvider)
+	if err != nil {
+		return nil, err
+	}
+
+	request := core.ListVcnsRequest{CompartmentId: &compartmentID}
+	response, err := client.ListVcns(context.Background(), request)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(response.Items) == 0 {
+		return nil, fmt.Errorf("No VCNs found in the %s compartment", compartmentID)
+	}
+
+	return vcnsIDs(response.Items), nil
+}
+
+func mapSubnetsByAvailabilityDomain(allSubnets map[string][]string, subnets []core.Subnet) map[string][]string {
+	for _, subnet := range subnets {
+		allSubnets[*subnet.AvailabilityDomain] = append(allSubnets[*subnet.AvailabilityDomain], *subnet.Id)
+	}
+	return allSubnets
+}
+
+func vcnsIDs(vcns []core.Vcn) []string {
+	ids := []string{}
+	for _, vcn := range vcns {
+		ids = append(ids, *vcn.Id)
+	}
+	return ids
+}

--- a/modules/oci/provider.go
+++ b/modules/oci/provider.go
@@ -1,6 +1,11 @@
 package oci
 
-import "os"
+import (
+	"os"
+	"testing"
+
+	"github.com/oracle/oci-go-sdk/common"
+)
 
 // You can set this environment variable to force Terratest to use a specific compartment.
 const compartmentIDEnvVar = "TF_VAR_compartment_ocid"
@@ -14,6 +19,25 @@ const subnetIDEnvVar = "TF_VAR_subnet_ocid"
 
 // You can set this environment variable to force Terratest to use a pass phrase.
 const passPhraseEnvVar = "TF_VAR_pass_phrase"
+
+// GetRootComparmentID gets an OCID of the root compartment (a.k.a. tenancy OCID).
+func GetRootCompartmentID(t *testing.T) string {
+	tenancyID, err := GetRootCompartmentIDE(t)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return tenancyID
+}
+
+// GetRootComparmentIDE gets an OCID of the root compartment (a.k.a. tenancy OCID).
+func GetRootCompartmentIDE(t *testing.T) (string, error) {
+	configProvider := common.DefaultConfigProvider()
+	tenancyID, err := configProvider.TenancyOCID()
+	if err != nil {
+		return "", err
+	}
+	return tenancyID, nil
+}
 
 // GetCompartmentIDFromEnvVar returns the compartment OCID for use with testing.
 func GetCompartmentIDFromEnvVar() string {

--- a/modules/oci/provider.go
+++ b/modules/oci/provider.go
@@ -1,0 +1,40 @@
+package oci
+
+import "os"
+
+// You can set this environment variable to force Terratest to use a specific compartment.
+const compartmentIDEnvVar = "TF_VAR_compartment_ocid"
+
+// You can set this environment variable to force Terratest to use a specific availability domain
+// rather than a random one. This is convenient when iterating locally.
+const availabilityDomainEnvVar = "TF_VAR_availability_domain"
+
+// You can set this environment variable to force Terratest to use a specific subnet.
+const subnetIDEnvVar = "TF_VAR_subnet_ocid"
+
+// You can set this environment variable to force Terratest to use a pass phrase.
+const passPhraseEnvVar = "TF_VAR_pass_phrase"
+
+// GetCompartmentIDFromEnvVar returns the compartment OCID for use with testing.
+func GetCompartmentIDFromEnvVar() string {
+	if compartmentID := os.Getenv(compartmentIDEnvVar); compartmentID != "" {
+		return compartmentID
+	}
+	return ""
+}
+
+// GetSubnetIDFromEnvVar returns the subnet OCID for use with testing.
+func GetSubnetIDFromEnvVar() string {
+	if subnetID := os.Getenv(subnetIDEnvVar); subnetID != "" {
+		return subnetID
+	}
+	return ""
+}
+
+// GetPassPhraseFromEnvVar returns the pass phrase for use with testing.
+func GetPassPhraseFromEnvVar() string {
+	if passPhrase := os.Getenv(passPhraseEnvVar); passPhrase != "" {
+		return passPhrase
+	}
+	return ""
+}

--- a/modules/oci/provider.go
+++ b/modules/oci/provider.go
@@ -17,24 +17,15 @@ const passPhraseEnvVar = "TF_VAR_pass_phrase"
 
 // GetCompartmentIDFromEnvVar returns the compartment OCID for use with testing.
 func GetCompartmentIDFromEnvVar() string {
-	if compartmentID := os.Getenv(compartmentIDEnvVar); compartmentID != "" {
-		return compartmentID
-	}
-	return ""
+	return os.Getenv(compartmentIDEnvVar)
 }
 
 // GetSubnetIDFromEnvVar returns the subnet OCID for use with testing.
 func GetSubnetIDFromEnvVar() string {
-	if subnetID := os.Getenv(subnetIDEnvVar); subnetID != "" {
-		return subnetID
-	}
-	return ""
+	return os.Getenv(subnetIDEnvVar)
 }
 
 // GetPassPhraseFromEnvVar returns the pass phrase for use with testing.
 func GetPassPhraseFromEnvVar() string {
-	if passPhrase := os.Getenv(passPhraseEnvVar); passPhrase != "" {
-		return passPhrase
-	}
-	return ""
+	return os.Getenv(passPhraseEnvVar)
 }

--- a/test/packer_oci_example_test.go
+++ b/test/packer_oci_example_test.go
@@ -5,17 +5,17 @@ import (
 	"os"
 	"testing"
 
-	"github.com/gruntwork-io/terratest/modules/oci"
 	"github.com/gruntwork-io/terratest/modules/packer"
+	"github.com/sw-samuraj/terratest/modules/oci"
 )
-
-const compartmentOcid = "ocid1.compartment.oc1..aaaaaaaa"
 
 // An example of how to test the Packer template in examples/packer-basic-example using Terratest.
 func TestPackerOciExample(t *testing.T) {
 	t.Parallel()
 
-	baseImageOcid := oci.BaseImageOcid(t, compartmentOcid, "Canonical Ubuntu", "18.04")
+	compartmentID := "ocid1.compartment.oc1..aaaaaaaa"
+	baseImageID := oci.GetMostRecentImageID(t, compartmentID, "Canonical Ubuntu", "18.04")
+	availabilityDomain := oci.GetRandomAvailabilityDomain(t, compartmentID)
 
 	packerOptions := &packer.Options{
 		// The path to where the Packer template is located
@@ -23,9 +23,9 @@ func TestPackerOciExample(t *testing.T) {
 
 		// Variables to pass to our Packer build using -var options
 		Vars: map[string]string{
-			"oci_base_image_ocid":     baseImageOcid,
-			"oci_compartment_ocid":    compartmentOcid,
-			"oci_availability_domain": "YHQr:PHX-AD-1",
+			"oci_base_image_ocid":     baseImageID,
+			"oci_compartment_ocid":    compartmentID,
+			"oci_availability_domain": availabilityDomain,
 			"oci_subnet_ocid":         "ocid1.subnet.oc1.phx.aaaaaaaa",
 			"oci_key_file":            fmt.Sprintf("%s/.oci/oci_api_key.pem", os.Getenv("HOME")),
 			"oci_pass_phrase":         "my-secret-pass-phrase",

--- a/test/packer_oci_example_test.go
+++ b/test/packer_oci_example_test.go
@@ -1,12 +1,10 @@
 package test
 
 import (
-	"fmt"
-	"os"
 	"testing"
 
+	"github.com/gruntwork-io/terratest/modules/oci"
 	"github.com/gruntwork-io/terratest/modules/packer"
-	"github.com/sw-samuraj/terratest/modules/oci"
 )
 
 // An example of how to test the Packer template in examples/packer-basic-example using Terratest.
@@ -16,6 +14,8 @@ func TestPackerOciExample(t *testing.T) {
 	compartmentID := oci.GetCompartmentIDFromEnvVar()
 	baseImageID := oci.GetMostRecentImageID(t, compartmentID, "Canonical Ubuntu", "18.04")
 	availabilityDomain := oci.GetRandomAvailabilityDomain(t, compartmentID)
+	subnetID := oci.GetRandomSubnetID(t, compartmentID, availabilityDomain)
+	passPhrase := oci.GetPassPhraseFromEnvVar()
 
 	packerOptions := &packer.Options{
 		// The path to where the Packer template is located
@@ -26,9 +26,8 @@ func TestPackerOciExample(t *testing.T) {
 			"oci_compartment_ocid":    compartmentID,
 			"oci_base_image_ocid":     baseImageID,
 			"oci_availability_domain": availabilityDomain,
-			"oci_subnet_ocid":         "ocid1.subnet.oc1.phx.aaaaaaaa",
-			"oci_key_file":            fmt.Sprintf("%s/.oci/oci_api_key.pem", os.Getenv("HOME")),
-			"oci_pass_phrase":         "my-secret-pass-phrase",
+			"oci_subnet_ocid":         subnetID,
+			"oci_pass_phrase":         passPhrase,
 		},
 
 		// Only build an OCI image

--- a/test/packer_oci_example_test.go
+++ b/test/packer_oci_example_test.go
@@ -1,0 +1,43 @@
+package test
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/oci"
+	"github.com/gruntwork-io/terratest/modules/packer"
+)
+
+const compartmentOcid = "ocid1.compartment.oc1..aaaaaaaa"
+
+// An example of how to test the Packer template in examples/packer-basic-example using Terratest.
+func TestPackerOciExample(t *testing.T) {
+	t.Parallel()
+
+	baseImageOcid := oci.BaseImageOcid(t, compartmentOcid, "Canonical Ubuntu", "18.04")
+
+	packerOptions := &packer.Options{
+		// The path to where the Packer template is located
+		Template: "../examples/packer-basic-example/build.json",
+
+		// Variables to pass to our Packer build using -var options
+		Vars: map[string]string{
+			"oci_base_image_ocid":     baseImageOcid,
+			"oci_compartment_ocid":    compartmentOcid,
+			"oci_availability_domain": "YHQr:PHX-AD-1",
+			"oci_subnet_ocid":         "ocid1.subnet.oc1.phx.aaaaaaaa",
+			"oci_key_file":            fmt.Sprintf("%s/.oci/oci_api_key.pem", os.Getenv("HOME")),
+			"oci_pass_phrase":         "my-secret-pass-phrase",
+		},
+
+		// Only build an OCI image
+		Only: "oracle-oci",
+	}
+
+	// Make sure the Packer build completes successfully
+	ocid := packer.BuildArtifact(t, packerOptions)
+
+	// Delete the OCI image after we're done
+	defer oci.DeleteImage(t, ocid)
+}

--- a/test/packer_oci_example_test.go
+++ b/test/packer_oci_example_test.go
@@ -11,7 +11,7 @@ import (
 func TestPackerOciExample(t *testing.T) {
 	t.Parallel()
 
-	compartmentID := oci.GetCompartmentIDFromEnvVar()
+	compartmentID := oci.GetRootCompartmentID(t)
 	baseImageID := oci.GetMostRecentImageID(t, compartmentID, "Canonical Ubuntu", "18.04")
 	availabilityDomain := oci.GetRandomAvailabilityDomain(t, compartmentID)
 	subnetID := oci.GetRandomSubnetID(t, compartmentID, availabilityDomain)

--- a/test/packer_oci_example_test.go
+++ b/test/packer_oci_example_test.go
@@ -13,7 +13,7 @@ import (
 func TestPackerOciExample(t *testing.T) {
 	t.Parallel()
 
-	compartmentID := "ocid1.compartment.oc1..aaaaaaaa"
+	compartmentID := oci.GetCompartmentIDFromEnvVar()
 	baseImageID := oci.GetMostRecentImageID(t, compartmentID, "Canonical Ubuntu", "18.04")
 	availabilityDomain := oci.GetRandomAvailabilityDomain(t, compartmentID)
 
@@ -23,8 +23,8 @@ func TestPackerOciExample(t *testing.T) {
 
 		// Variables to pass to our Packer build using -var options
 		Vars: map[string]string{
-			"oci_base_image_ocid":     baseImageID,
 			"oci_compartment_ocid":    compartmentID,
+			"oci_base_image_ocid":     baseImageID,
 			"oci_availability_domain": availabilityDomain,
 			"oci_subnet_ocid":         "ocid1.subnet.oc1.phx.aaaaaaaa",
 			"oci_key_file":            fmt.Sprintf("%s/.oci/oci_api_key.pem", os.Getenv("HOME")),


### PR DESCRIPTION
Related to #158 (Add support for OCI)

Developing a new product build on top of OCI, our team needs to write a test suite of integration/provisioning/e2e tests. I've already started to use _Terratest_ for this epic.

I would like to incrementally add new OCI testing and helper functions, but for now, **I just add a simple function for deleting of the custom OCI image** which was previously created via `packer.BuildArtifact()` function.

The very basic test case:

```go
func TestPackerControlPlane(t *testing.T) {
	t.Parallel()

	packerOptions := &packer.Options{
		Template: "../delivery/oci/packer.json",
		Only:     "oracle-oci",
		Vars: map[string]string{
			// Packer variables
		},
	}

	ocid := packer.BuildArtifact(t, packerOptions)

	defer oci.DeleteImage(t, ocid)
}
```

It produces following output:
```
TestPackerControlPlane 2018-09-21T13:57:20+02:00 packer.go:33: Running Packer to generate a custom artifact for template ../delivery/oci/packer.json
TestPackerControlPlane 2018-09-21T13:57:20+02:00 command.go:52: Running command packer with args [build -machine-readable -var image_name=BDSQL-CP-terratest -only=oracle-oci ../delivery/oci/packer.json]
TestPackerControlPlane 2018-09-21T13:57:20+02:00 command.go:96: 1537531040,,ui,say,==> oracle-oci: Creating temporary ssh key for instance...
TestPackerControlPlane 2018-09-21T13:57:21+02:00 command.go:96: 1537531041,,ui,say,==> oracle-oci: Creating instance...
TestPackerControlPlane 2018-09-21T13:57:24+02:00 command.go:96: 1537531044,,ui,say,==> oracle-oci: Created instance (ocid1.instance.oc1.phx.abyhqljrc5jqaa3hsz3gofxmfme47xqzzq6jklccp2qpavhddq2pplpaismq).
TestPackerControlPlane 2018-09-21T13:57:24+02:00 command.go:96: 1537531044,,ui,say,==> oracle-oci: Waiting for instance to enter 'RUNNING' state...
TestPackerControlPlane 2018-09-21T13:58:27+02:00 command.go:96: 1537531107,,ui,say,==> oracle-oci: Instance 'RUNNING'.
TestPackerControlPlane 2018-09-21T13:58:28+02:00 command.go:96: 1537531108,,ui,say,==> oracle-oci: Instance has IP: 129.146.161.20.
TestPackerControlPlane 2018-09-21T13:58:28+02:00 command.go:96: 1537531108,,ui,say,==> oracle-oci: Waiting for SSH to become available...
TestPackerControlPlane 2018-09-21T13:59:01+02:00 command.go:96: 1537531141,,ui,say,==> oracle-oci: Connected to SSH!
TestPackerControlPlane 2018-09-21T13:59:01+02:00 command.go:96: 1537531141,,ui,say,==> oracle-oci: Provisioning with shell script: /tmp/packer-shell108054499
.
.
.
TestPackerControlPlane 2018-09-21T14:00:10+02:00 command.go:96: 1537531210,,ui,say,==> oracle-oci: Creating image from instance...
TestPackerControlPlane 2018-09-21T14:01:57+02:00 command.go:96: 1537531317,,ui,say,==> oracle-oci: Image created.
TestPackerControlPlane 2018-09-21T14:01:57+02:00 command.go:96: 1537531317,,ui,say,==> oracle-oci: Terminating instance (ocid1.instance.oc1.phx.abyhqljrc5jqaa3hsz3gofxmfme47xqzzq6jklccp2qpavhddq2pplpaismq)...
TestPackerControlPlane 2018-09-21T14:03:12+02:00 command.go:96: 1537531392,,ui,say,==> oracle-oci: Terminated instance.
TestPackerControlPlane 2018-09-21T14:03:12+02:00 command.go:96: 1537531392,,ui,say,Build 'oracle-oci' finished.
TestPackerControlPlane 2018-09-21T14:03:12+02:00 command.go:96: 1537531392,,ui,say,\n==> Builds finished. The artifacts of successful builds are:
TestPackerControlPlane 2018-09-21T14:03:12+02:00 command.go:96: 1537531392,oracle-oci,artifact-count,1
TestPackerControlPlane 2018-09-21T14:03:12+02:00 command.go:96: 1537531392,oracle-oci,artifact,0,builder-id,packer.oracle.oci
TestPackerControlPlane 2018-09-21T14:03:12+02:00 command.go:96: 1537531392,oracle-oci,artifact,0,id,ocid1.image.oc1.phx.aaaaaaaaf3t66udxprdsczj5fv2havhrv5jmoj5e7h6tyvao4og2dqf2d2uq
TestPackerControlPlane 2018-09-21T14:03:12+02:00 command.go:96: 1537531392,oracle-oci,artifact,0,string,An image was created: 'BDSQL-CP-terratest' (OCID: ocid1.image.oc1.phx.aaaaaaaaf3t66udxprdsczj5fv2havhrv5jmoj5e7h6tyvao4og2dqf2d2uq) in region 'us-phoenix-1'
TestPackerControlPlane 2018-09-21T14:03:12+02:00 command.go:96: 1537531392,oracle-oci,artifact,0,files-count,0
TestPackerControlPlane 2018-09-21T14:03:12+02:00 command.go:96: 1537531392,oracle-oci,artifact,0,end
TestPackerControlPlane 2018-09-21T14:03:12+02:00 command.go:96: 1537531392,,ui,say,--> oracle-oci: An image was created: 'BDSQL-CP-terratest' (OCID: ocid1.image.oc1.phx.aaaaaaaaf3t66udxprdsczj5fv2havhrv5jmoj5e7h6tyvao4og2dqf2d2uq) in region 'us-phoenix-1'
TestPackerControlPlane 2018-09-21T14:03:13+02:00 compute.go:21: Deleting image with OCID ocid1.image.oc1.phx.aaaaaaaaf3t66udxprdsczj5fv2havhrv5jmoj5e7h6tyvao4og2dqf2d2uq
PASS
ok  	orahub.oraclecorp.com/cloud-bigdata-dev/bdsql-control-plane/tests/terratest	353.750s
```