### PR TITLE
Implement a function for workspace selection, or creation

### DIFF
--- a/modules/terraform/workspace.go
+++ b/modules/terraform/workspace.go
@@ -1,12 +1,15 @@
 package terraform
 
 import (
+	"fmt"
+	"regexp"
 	"strings"
 	"testing"
 )
 
-// WorkspaceSelectOrNew runs terraform workspace with the given options and returns workspace name.
-// It tries to select a workspace with the given name, or it creates a new one if it doesn't exist.
+// WorkspaceSelectOrNew runs terraform workspace with the given options and the workspace name
+// and returns a name of the current workspace. It tries to select a workspace with the given
+// name, or it creates a new one if it doesn't exist.
 func WorkspaceSelectOrNew(t *testing.T, options *Options, name string) string {
 	out, err := WorkspaceSelectOrNewE(t, options, name)
 	if err != nil {
@@ -15,22 +18,38 @@ func WorkspaceSelectOrNew(t *testing.T, options *Options, name string) string {
 	return out
 }
 
-// WorkspaceSelectOrNewE runs terraform workspace with the given options and returns workspace name.
-// It tries to select a workspace with the given name, or it creates a new one if it doesn't exist.
+// WorkspaceSelectOrNewE runs terraform workspace with the given options and the workspace name
+// and returns a name of the current workspace. It tries to select a workspace with the given
+// name, or it creates a new one if it doesn't exist.
 func WorkspaceSelectOrNewE(t *testing.T, options *Options, name string) (string, error) {
 	out, err := RunTerraformCommandE(t, options, "workspace", "list")
 	if err != nil {
-		return out, nil
+		return "", err
 	}
 
-	if strings.Contains(out, name) {
+	if isExistingWorkspace(out, name) {
 		_, err = RunTerraformCommandE(t, options, "workspace", "select", name)
 	} else {
 		_, err = RunTerraformCommandE(t, options, "workspace", "new", name)
 	}
 	if err != nil {
-		return out, nil
+		return "", err
 	}
 
 	return RunTerraformCommandE(t, options, "workspace", "show")
+}
+
+func isExistingWorkspace(out string, name string) bool {
+	workspaces := strings.Split(out, "\n")
+	for _, ws := range workspaces {
+		if nameMatchesWorkspace(name, ws) {
+			return true
+		}
+	}
+	return false
+}
+
+func nameMatchesWorkspace(name string, workspace string) bool {
+	match, _ := regexp.MatchString(fmt.Sprintf("^\\*?\\s*%s$", name), workspace)
+	return match
 }

--- a/modules/terraform/workspace.go
+++ b/modules/terraform/workspace.go
@@ -50,6 +50,12 @@ func isExistingWorkspace(out string, name string) bool {
 }
 
 func nameMatchesWorkspace(name string, workspace string) bool {
+	// Regex for matching workspace should match for strings with optional leading asterisk "*"
+	// following optional white spaces following the workspace name.
+	// E.g. for the given name "terratest", following strings will match:
+	//
+	//    "* terratest"
+	//    "  terratest"
 	match, _ := regexp.MatchString(fmt.Sprintf("^\\*?\\s*%s$", name), workspace)
 	return match
 }

--- a/modules/terraform/workspace.go
+++ b/modules/terraform/workspace.go
@@ -1,0 +1,36 @@
+package terraform
+
+import (
+	"strings"
+	"testing"
+)
+
+// WorkspaceSelectOrNew runs terraform workspace with the given options and returns workspace name.
+// It tries to select a workspace with the given name, or it creates a new one if it doesn't exist.
+func WorkspaceSelectOrNew(t *testing.T, options *Options, name string) string {
+	out, err := WorkspaceSelectOrNewE(t, options, name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return out
+}
+
+// WorkspaceSelectOrNewE runs terraform workspace with the given options and returns workspace name.
+// It tries to select a workspace with the given name, or it creates a new one if it doesn't exist.
+func WorkspaceSelectOrNewE(t *testing.T, options *Options, name string) (string, error) {
+	out, err := RunTerraformCommandE(t, options, "workspace", "list")
+	if err != nil {
+		return out, nil
+	}
+
+	if strings.Contains(out, name) {
+		_, err = RunTerraformCommandE(t, options, "workspace", "select", name)
+	} else {
+		_, err = RunTerraformCommandE(t, options, "workspace", "new", name)
+	}
+	if err != nil {
+		return out, nil
+	}
+
+	return RunTerraformCommandE(t, options, "workspace", "show")
+}

--- a/modules/terraform/workspace_test.go
+++ b/modules/terraform/workspace_test.go
@@ -21,7 +21,25 @@ func TestWorkspaceNew(t *testing.T) {
 
 	out := WorkspaceSelectOrNew(t, options, "terratest")
 
-	assert.Contains(t, out, "terratest")
+	assert.Equal(t, "terratest", out)
+}
+
+func TestWorkspaceIllegalName(t *testing.T) {
+	t.Parallel()
+
+	testFolder, err := files.CopyTerraformFolderToTemp("../../test/fixtures/terraform-workspace", t.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	options := &Options{
+		TerraformDir: testFolder,
+	}
+
+	out, err := WorkspaceSelectOrNewE(t, options, "###@@@&&&")
+
+	assert.Error(t, err)
+	assert.Equal(t, "", out, "%q should be an empty string", out)
 }
 
 func TestWorkspaceSelect(t *testing.T) {
@@ -37,10 +55,10 @@ func TestWorkspaceSelect(t *testing.T) {
 	}
 
 	out := WorkspaceSelectOrNew(t, options, "terratest")
-	assert.Contains(t, out, "terratest")
+	assert.Equal(t, "terratest", out)
 
 	out = WorkspaceSelectOrNew(t, options, "default")
-	assert.Contains(t, out, "default")
+	assert.Equal(t, "default", out)
 }
 
 func TestWorkspaceApply(t *testing.T) {
@@ -59,4 +77,56 @@ func TestWorkspaceApply(t *testing.T) {
 	out := InitAndApply(t, options)
 
 	assert.Contains(t, out, "Hello, Terratest")
+}
+
+func TestIsExistingWorkspace(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		out      string
+		name     string
+		expected bool
+	}{
+		{"  default\n* foo\n", "default", true},
+		{"* default\n  foo\n", "default", true},
+		{"  foo\n* default\n", "default", true},
+		{"* foo\n  default\n", "default", true},
+		{"  foo\n* bar\n", "default", false},
+		{"* foo\n  bar\n", "default", false},
+		{"  default\n* foobar\n", "foo", false},
+		{"* default\n  foobar\n", "foo", false},
+		{"  default\n* foo\n", "foobar", false},
+		{"* default\n  foo\n", "foobar", false},
+		{"* default\n  foo\n", "foo", true},
+	}
+
+	for _, testCase := range testCases {
+		actual := isExistingWorkspace(testCase.out, testCase.name)
+		assert.Equal(t, testCase.expected, actual, "Out: %q, Name: %q", testCase.out, testCase.name)
+	}
+}
+
+func TestNameMatchesWorkspace(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name      string
+		workspace string
+		expected  bool
+	}{
+		{"default", "  default", true},
+		{"default", "* default", true},
+		{"default", "", false},
+		{"foo", "  foobar", false},
+		{"foo", "* foobar", false},
+		{"foobar", "  foo", false},
+		{"foobar", "* foo", false},
+		{"foo", "  foo", true},
+		{"foo", "* foo", true},
+	}
+
+	for _, testCase := range testCases {
+		actual := nameMatchesWorkspace(testCase.name, testCase.workspace)
+		assert.Equal(t, testCase.expected, actual, "Name: %q, Workspace: %q", testCase.name, testCase.workspace)
+	}
 }

--- a/modules/terraform/workspace_test.go
+++ b/modules/terraform/workspace_test.go
@@ -1,0 +1,62 @@
+package terraform
+
+import (
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/files"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWorkspaceNew(t *testing.T) {
+	t.Parallel()
+
+	testFolder, err := files.CopyTerraformFolderToTemp("../../test/fixtures/terraform-workspace", t.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	options := &Options{
+		TerraformDir: testFolder,
+	}
+
+	out := WorkspaceSelectOrNew(t, options, "terratest")
+
+	assert.Contains(t, out, "terratest")
+}
+
+func TestWorkspaceSelect(t *testing.T) {
+	t.Parallel()
+
+	testFolder, err := files.CopyTerraformFolderToTemp("../../test/fixtures/terraform-workspace", t.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	options := &Options{
+		TerraformDir: testFolder,
+	}
+
+	out := WorkspaceSelectOrNew(t, options, "terratest")
+	assert.Contains(t, out, "terratest")
+
+	out = WorkspaceSelectOrNew(t, options, "default")
+	assert.Contains(t, out, "default")
+}
+
+func TestWorkspaceApply(t *testing.T) {
+	t.Parallel()
+
+	testFolder, err := files.CopyTerraformFolderToTemp("../../test/fixtures/terraform-workspace", t.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	options := &Options{
+		TerraformDir: testFolder,
+	}
+
+	WorkspaceSelectOrNew(t, options, "Terratest")
+	out := InitAndApply(t, options)
+
+	assert.Contains(t, out, "Hello, Terratest")
+}

--- a/test/fixtures/terraform-workspace/main.tf
+++ b/test/fixtures/terraform-workspace/main.tf
@@ -1,0 +1,3 @@
+output "test" {
+  value = "Hello, ${terraform.workspace}"
+}


### PR DESCRIPTION
Related to #163 (Terraform workspace support)

A new function `WorkspaceSelectOrNew` has been implemented and covered via three unit tests. The function takes a workspace name as an argument and:

* either select the given workspace, if it already exists,
* or creates a new workspace with the given name.