### PR TITLE
Add ScpDirFrom and ScpFileFrom

### DIFF
--- a/modules/customerrors/multierror.go
+++ b/modules/customerrors/multierror.go
@@ -1,0 +1,36 @@
+package customerrors
+
+import (
+	"fmt"
+	"strings"
+)
+
+type MultiError struct {
+	Errors []error
+}
+
+func NewMultiError(errs ...error) error {
+	nilsRemoved := make([]error, 0, len(errs))
+	for _, item := range errs {
+		if item != nil {
+			nilsRemoved = append(nilsRemoved, item)
+		}
+	}
+
+	if len(nilsRemoved) == 0 {
+		return nil
+	}
+
+	return MultiError{Errors: nilsRemoved}
+}
+
+func (errs MultiError) Error() string {
+	errorMessages := []string{}
+	for _, err := range errs.Errors {
+		if err != nil {
+			errorMessages = append(errorMessages, err.Error())
+		}
+	}
+
+	return fmt.Sprintf("Hit multiple errors:\n%s", strings.Join(errorMessages, "\n"))
+}

--- a/modules/ssh/ssh.go
+++ b/modules/ssh/ssh.go
@@ -334,14 +334,6 @@ func listFileInRemoteDir(t *testing.T, sshSession *SshSession, options ScpDownlo
 
 	var result []string
 
-	if err := setUpSSHClient(sshSession); err != nil {
-		return result, err
-	}
-
-	if err := setUpSSHSession(sshSession); err != nil {
-		return result, err
-	}
-
 	findCommand := fmt.Sprintf("find %s -type f", options.RemoteDir)
 
 	if options.FileNameFilter != "" {
@@ -352,14 +344,7 @@ func listFileInRemoteDir(t *testing.T, sshSession *SshSession, options ScpDownlo
 		findCommand = fmt.Sprintf("%s -size -%dM", findCommand, options.MaxFileSizeMB)
 	}
 
-	r, err := sshSession.Session.Output(findCommand)
-
-	if err != nil {
-		return result, err
-	}
-	defer sshSession.Session.Close()
-
-	resultString := string(r)
+	resultString := CheckSshCommand(t, options.RemoteHost, findCommand)
 	// The last character returned is `\n` this results in an extra "" array
 	// member when we do the split below. Cut off the last character to avoid
 	// having to remove the blank entry in the array.

--- a/modules/ssh/ssh.go
+++ b/modules/ssh/ssh.go
@@ -14,10 +14,11 @@ import (
 
 	"path/filepath"
 
+	"strings"
+
 	"github.com/gruntwork-io/terratest/modules/logger"
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/agent"
-	"strings"
 )
 
 // Host is a host on AWS.
@@ -32,11 +33,11 @@ type Host struct {
 }
 
 type ScpDownloadOptions struct {
-	FileNameFilter	string //bash style match string for files
-	MaxFileSizeMB		int //Don't grab any files > MaxFileSizeMB
-	RemoteDir 		string //Copy this directory on the remote machine
-	LocalDir   		string //Copy RemoteDir to this directory on the local machine
-	RemoteHost 		Host //Connection information for the remote machine
+	FileNameFilter string //bash style match string for files
+	MaxFileSizeMB  int    //Don't grab any files > MaxFileSizeMB
+	RemoteDir      string //Copy this directory on the remote machine
+	LocalDir       string //Copy RemoteDir to this directory on the local machine
+	RemoteHost     Host   //Connection information for the remote machine
 }
 
 // ScpFileToE uploads the contents using SCP to the given host and fails the test if the connection fails.

--- a/modules/ssh/ssh.go
+++ b/modules/ssh/ssh.go
@@ -78,6 +78,15 @@ func ScpFileToE(t *testing.T, host Host, mode os.FileMode, remotePath, contents 
 	return err
 }
 
+// ScpFileFromE downloads the file from remotePath on the given host using SCP.
+func ScpFileFrom(t *testing.T, host Host, remotePath string, localDestination *os.File) {
+	err := ScpFileFromE(t, host, remotePath, localDestination)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
 // ScpFileFromE downloads the file from remotePath on the given host using SCP and returns an error if the process fails.
 func ScpFileFromE(t *testing.T, host Host, remotePath string, localDestination *os.File) error {
 	authMethods, err := createAuthMethodsForHost(host)
@@ -103,6 +112,15 @@ func ScpFileFromE(t *testing.T, host Host, remotePath string, localDestination *
 
 	err = copyFileFromRemote(t, sshSession, localDestination, remotePath)
 	return err
+}
+
+// ScpFileFromE downloads all the files from remotePath on the given host using SCP.
+func ScpDirFrom(t *testing.T, options ScpDownloadOptions) {
+	err := ScpDirFromE(t, options)
+
+	if err != nil {
+		t.Fatal(err)
+	}
 }
 
 // ScpFileFromE downloads all the files from remotePath on the given host using SCP and returns an error if the process fails.

--- a/test/packer_oci_example_test.go
+++ b/test/packer_oci_example_test.go
@@ -15,8 +15,8 @@ func TestPackerOciExample(t *testing.T) {
 
 	// The Terratest CI environment does not yet have CI creds set up, so we skip these tests for now
 	// https://github.com/gruntwork-io/terratest/issues/160
-	if os.Getenv("SKIP_OCI_TESTS") != "" {
-		t.Skip("The SKIP_OCI_TESTS environment variable is set, so skipping OCI tests.")
+	if os.Getenv("CIRCLECI") != "" {
+		t.Skip("The build is running on CircleCI, so skipping OCI tests.")
 	}
 
 	compartmentID := oci.GetRootCompartmentID(t)

--- a/test/terraform_ssh_example_test.go
+++ b/test/terraform_ssh_example_test.go
@@ -9,6 +9,8 @@ import (
 
 	"io/ioutil"
 
+	"path/filepath"
+
 	"github.com/gruntwork-io/terratest/modules/aws"
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/gruntwork-io/terratest/modules/retry"
@@ -154,8 +156,8 @@ func testScpDirFromHost(t *testing.T, terraformOptions *terraform.Options, keyPa
 	timeBetweenRetries := 5 * time.Second
 	description := fmt.Sprintf("SSH to public host %s", publicInstanceIP)
 	remoteTempFolder := "/tmp/testFolder"
-	remoteTempFilePath := fmt.Sprintf("%s/test.foo", remoteTempFolder)
-	remoteTempFilePath2 := fmt.Sprintf("%s/test.baz", remoteTempFolder)
+	remoteTempFilePath := filepath.Join(remoteTempFolder, "test.foo")
+	remoteTempFilePath2 := filepath.Join(remoteTempFolder, "test.baz")
 	randomData := random.UniqueId()
 
 	// Verify that we can SSH to the Instance and run commands
@@ -241,7 +243,7 @@ func testScpFromHost(t *testing.T, terraformOptions *terraform.Options, keyPair 
 	timeBetweenRetries := 5 * time.Second
 	description := fmt.Sprintf("SSH to public host %s", publicInstanceIP)
 	remoteTempFolder := "/tmp/testFolder"
-	remoteTempFilePath := fmt.Sprintf("%s/test.out", remoteTempFolder)
+	remoteTempFilePath := filepath.Join(remoteTempFolder, "test.out")
 	randomData := random.UniqueId()
 
 	// Verify that we can SSH to the Instance and run commands

--- a/test/terraform_ssh_example_test.go
+++ b/test/terraform_ssh_example_test.go
@@ -7,13 +7,14 @@ import (
 	"testing"
 	"time"
 
+	"io/ioutil"
+
 	"github.com/gruntwork-io/terratest/modules/aws"
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/gruntwork-io/terratest/modules/retry"
 	"github.com/gruntwork-io/terratest/modules/ssh"
 	"github.com/gruntwork-io/terratest/modules/terraform"
 	"github.com/gruntwork-io/terratest/modules/test-structure"
-	"io/ioutil"
 )
 
 // An example of how to test the Terraform module in examples/terraform-ssh-example using Terratest. The test also
@@ -100,7 +101,6 @@ func TestTerraformScpExample(t *testing.T) {
 		testScpFromHost(t, terraformOptions, keyPair)
 	})
 
-
 	// Make sure we can SCP all files in a given remote dir from an EC2 instance to our local box
 	test_structure.RunTestStage(t, "validate_dir", func() {
 		terraformOptions := test_structure.LoadTerraformOptions(t, exampleFolder)
@@ -165,7 +165,7 @@ func testScpDirFromHost(t *testing.T, terraformOptions *terraform.Options, keyPa
 
 	// Verify that we can SSH to the Instance and run commands
 	retry.DoWithRetry(t, description, maxRetries, timeBetweenRetries, func() (string, error) {
-		_, err :=ssh.CheckSshCommandE(t, publicHost, fmt.Sprintf("mkdir -p %s && touch %s && touch %s && echo \"%s\" >> %s", remoteTempFolder, remoteTempFilePath, remoteTempFilePath2, randomData, remoteTempFilePath))
+		_, err := ssh.CheckSshCommandE(t, publicHost, fmt.Sprintf("mkdir -p %s && touch %s && touch %s && echo \"%s\" >> %s", remoteTempFolder, remoteTempFilePath, remoteTempFilePath2, randomData, remoteTempFilePath))
 
 		if err != nil {
 			return "", err
@@ -176,7 +176,7 @@ func testScpDirFromHost(t *testing.T, terraformOptions *terraform.Options, keyPa
 
 	// clean up the remote folder as we want may want to run another test case
 	defer retry.DoWithRetry(t, description, maxRetries, timeBetweenRetries, func() (string, error) {
-		_, err :=ssh.CheckSshCommandE(t,
+		_, err := ssh.CheckSshCommandE(t,
 			publicHost,
 			fmt.Sprintf("rm -rf %s", remoteTempFolder))
 
@@ -189,16 +189,16 @@ func testScpDirFromHost(t *testing.T, terraformOptions *terraform.Options, keyPa
 
 	localDestDir := "/tmp/tempFolder"
 
-	var testcases = []struct{
-		options		ssh.ScpDownloadOptions
+	var testcases = []struct {
+		options       ssh.ScpDownloadOptions
 		expectedFiles int
-	} {
+	}{
 		{
-			ssh.ScpDownloadOptions{RemoteHost:publicHost, RemoteDir:remoteTempFolder, LocalDir:localDestDir},
+			ssh.ScpDownloadOptions{RemoteHost: publicHost, RemoteDir: remoteTempFolder, LocalDir: localDestDir},
 			2,
 		},
 		{
-			ssh.ScpDownloadOptions{RemoteHost:publicHost, RemoteDir:remoteTempFolder, LocalDir:localDestDir, FileNameFilter:"*.baz"},
+			ssh.ScpDownloadOptions{RemoteHost: publicHost, RemoteDir: remoteTempFolder, LocalDir: localDestDir, FileNameFilter: "*.baz"},
 			1,
 		},
 	}
@@ -251,7 +251,7 @@ func testScpFromHost(t *testing.T, terraformOptions *terraform.Options, keyPair 
 
 	// Verify that we can SSH to the Instance and run commands
 	retry.DoWithRetry(t, description, maxRetries, timeBetweenRetries, func() (string, error) {
-		_, err :=ssh.CheckSshCommandE(t,
+		_, err := ssh.CheckSshCommandE(t,
 			publicHost,
 			fmt.Sprintf("mkdir -p %s && touch %s && echo \"%s\" >> %s && touch /tmp/testFolder/bar.baz", remoteTempFolder, remoteTempFilePath, randomData, remoteTempFilePath))
 
@@ -264,7 +264,7 @@ func testScpFromHost(t *testing.T, terraformOptions *terraform.Options, keyPair 
 
 	// clean up the remote folder as we want may want to run another test case
 	defer retry.DoWithRetry(t, description, maxRetries, timeBetweenRetries, func() (string, error) {
-		_, err :=ssh.CheckSshCommandE(t,
+		_, err := ssh.CheckSshCommandE(t,
 			publicHost,
 			fmt.Sprintf("rm -rf %s", remoteTempFolder))
 

--- a/test/terraform_ssh_example_test.go
+++ b/test/terraform_ssh_example_test.go
@@ -63,11 +63,6 @@ func TestTerraformSshExample(t *testing.T) {
 }
 
 func TestTerraformScpExample(t *testing.T) {
-	os.Setenv("SKIP_setup", "true")
-	//os.Setenv("SKIP_validate_file", "true")
-	//os.Setenv("SKIP_validate_dir", "true")
-	os.Setenv("SKIP_teardown", "true")
-
 	t.Parallel()
 
 	exampleFolder := "../examples/terraform-ssh-example"
@@ -296,7 +291,7 @@ func testScpFromHost(t *testing.T, terraformOptions *terraform.Options, keyPair 
 	localFileContents := string(buf)
 
 	if !strings.Contains(localFileContents, randomData) {
-		t.Fatalf("Error: unable to find %s in the local file.")
+		t.Fatalf("Error: unable to find %s in the local file. Local file's contents were: %s", randomData, localFileContents)
 	}
 }
 

--- a/test/terraform_ssh_example_test.go
+++ b/test/terraform_ssh_example_test.go
@@ -24,7 +24,7 @@ import (
 func TestTerraformSshExample(t *testing.T) {
 	t.Parallel()
 
-	exampleFolder := "../examples/terraform-ssh-example"
+	exampleFolder := test_structure.CopyTerraformFolderToTemp(t, "../", "examples/terraform-ssh-example")
 
 	// At the end of the test, run `terraform destroy` to clean up any resources that were created
 	defer test_structure.RunTestStage(t, "teardown", func() {
@@ -65,7 +65,7 @@ func TestTerraformSshExample(t *testing.T) {
 func TestTerraformScpExample(t *testing.T) {
 	t.Parallel()
 
-	exampleFolder := "../examples/terraform-ssh-example"
+	exampleFolder := test_structure.CopyTerraformFolderToTemp(t, "../", "examples/terraform-ssh-example")
 
 	// At the end of the test, run `terraform destroy` to clean up any resources that were created
 	defer test_structure.RunTestStage(t, "teardown", func() {


### PR DESCRIPTION
- Added ScpDirFrom - a helper method that will transfer many/all (can be controlled via ScpDownloadOptions) files from a remote dir to a local dir
    - ScpDownloadOptions allows user to specify a filename filter to grab only files matching the filter
    - ScpDownloadOptions allows user to specify a max size (MB) filter to only grab files smaller than XMB
- Added ScpFileFrom - a helper method that will transfer a remote file to your local machine
- Added new test cases to validate functionality