### PR TITLE
Implement a function for output list

### DIFF
--- a/modules/terraform/output.go
+++ b/modules/terraform/output.go
@@ -78,14 +78,13 @@ func OutputListE(t *testing.T, options *Options, key string) ([]string, error) {
 		return nil, fmt.Errorf("Output doesn't contain a value for the key %q", key)
 	}
 
-	var list []string
+	list := []string{}
 	switch t := value.(type) {
 	case []interface{}:
-		list = make([]string, len(t))
 		for i, item := range t {
 			list[i] = fmt.Sprintf("%v", item)
 		}
-	case interface{}:
+	default:
 		return nil, fmt.Errorf("Output value %q is not a list", value)
 	}
 

--- a/modules/terraform/output_test.go
+++ b/modules/terraform/output_test.go
@@ -1,0 +1,53 @@
+package terraform
+
+import (
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/files"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOutputList(t *testing.T) {
+	t.Parallel()
+
+	testFolder, err := files.CopyTerraformFolderToTemp("../../test/fixtures/terraform-output-list", t.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	options := &Options{
+		TerraformDir: testFolder,
+	}
+
+	InitAndApply(t, options)
+	out := OutputList(t, options, "giant_steps")
+
+	expectedLen := 4
+	expectedItem := "John Coltrane"
+
+	assert.Len(t, out, expectedLen, "Output should contain %d items", expectedLen)
+	assert.Contains(t, out, expectedItem, "Output should contain %q item", expectedItem)
+	assert.Equal(t, out[0], expectedItem, "First item should be %q, got %q", expectedItem, out[0])
+}
+
+func TestOutputNotList(t *testing.T) {
+	t.Parallel()
+
+	testFolder, err := files.CopyTerraformFolderToTemp("../../test/fixtures/terraform-output-list", t.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	options := &Options{
+		TerraformDir: testFolder,
+	}
+
+	InitAndApply(t, options)
+	out := OutputList(t, options, "not_a_list")
+
+	expectedLen := 1
+	expectedItem := "This is not a list."
+
+	assert.Len(t, out, expectedLen, "Output should contain %d items", expectedLen)
+	assert.Equal(t, out[0], expectedItem, "First item should be %q, got %q", expectedItem, out[0])
+}

--- a/modules/terraform/output_test.go
+++ b/modules/terraform/output_test.go
@@ -24,13 +24,15 @@ func TestOutputList(t *testing.T) {
 
 	expectedLen := 4
 	expectedItem := "John Coltrane"
+	expectedArray := []string{"John Coltrane", "Tommy Flanagan", "Paul Chambers", "Art Taylor"}
 
 	assert.Len(t, out, expectedLen, "Output should contain %d items", expectedLen)
 	assert.Contains(t, out, expectedItem, "Output should contain %q item", expectedItem)
 	assert.Equal(t, out[0], expectedItem, "First item should be %q, got %q", expectedItem, out[0])
+	assert.Equal(t, out, expectedArray, "Array %q should match %q", expectedArray, out)
 }
 
-func TestOutputNotList(t *testing.T) {
+func TestOutputNotListError(t *testing.T) {
 	t.Parallel()
 
 	testFolder, err := files.CopyTerraformFolderToTemp("../../test/fixtures/terraform-output-list", t.Name())
@@ -43,11 +45,7 @@ func TestOutputNotList(t *testing.T) {
 	}
 
 	InitAndApply(t, options)
-	out := OutputList(t, options, "not_a_list")
+	_, err = OutputListE(t, options, "not_a_list")
 
-	expectedLen := 1
-	expectedItem := "This is not a list."
-
-	assert.Len(t, out, expectedLen, "Output should contain %d items", expectedLen)
-	assert.Equal(t, out[0], expectedItem, "First item should be %q, got %q", expectedItem, out[0])
+	assert.Error(t, err)
 }

--- a/test/fixtures/terraform-output-list/output.tf
+++ b/test/fixtures/terraform-output-list/output.tf
@@ -1,0 +1,12 @@
+output "giant_steps" {
+  value = [
+    "John Coltrane",
+    "Tommy Flanagan",
+    "Paul Chambers",
+    "Art Taylor",
+  ]
+}
+
+output "not_a_list" {
+  value = "This is not a list."
+}


### PR DESCRIPTION
Related to #167 (output list)

A new function `OutputList` has been implemented and covered via unit tests. The function takes an output key as an argument and:

* either returns a multiple-items `[]string` if the value is a list,
* or returns a single item `[]string` if the value is not a list (i.e. a single value).

The output values are parsed from _Terraform_ JSON output obtained via `-json` switch.