### PR TITLE
Add ability to SSH into GCP Compute Instances

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -162,6 +162,18 @@
   version = "v1.8.0"
 
 [[projects]]
+  digest = "1:c8d00f8d5b900f252da7f4a2cf618043bd1c833333d210281e21a69121cc87d0"
+  name = "github.com/oracle/oci-go-sdk"
+  packages = [
+    "common",
+    "core",
+    "identity",
+  ]
+  pruneopts = "UT"
+  revision = "37ec848b9622efd149232580c77a7a168f0f35ef"
+  version = "v2.6.0"
+
+[[projects]]
   digest = "1:0028cb19b2e4c3112225cd871870f2d9cf49b9b4276531f03438a88e94be86fe"
   name = "github.com/pmezard/go-difflib"
   packages = ["difflib"]
@@ -295,7 +307,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:a124d2ef8b444eee0f0bf419136052570947651dd738cf220b1cd1cea669ddc6"
+  digest = "1:43867bae2f0dac0e62e6fb220f7e56dba3edba4f605bbe9f0b59e01fc3d13bc6"
   name = "google.golang.org/api"
   packages = [
     "compute/v1",
@@ -404,6 +416,9 @@
     "github.com/go-sql-driver/mysql",
     "github.com/google/uuid",
     "github.com/magiconair/properties/assert",
+    "github.com/oracle/oci-go-sdk/common",
+    "github.com/oracle/oci-go-sdk/core",
+    "github.com/oracle/oci-go-sdk/identity",
     "github.com/pquerna/otp/totp",
     "github.com/stretchr/testify/assert",
     "github.com/stretchr/testify/require",

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -307,7 +307,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:43867bae2f0dac0e62e6fb220f7e56dba3edba4f605bbe9f0b59e01fc3d13bc6"
+  digest = "1:a124d2ef8b444eee0f0bf419136052570947651dd738cf220b1cd1cea669ddc6"
   name = "google.golang.org/api"
   packages = [
     "compute/v1",

--- a/examples/terraform-gcp-example/main.tf
+++ b/examples/terraform-gcp-example/main.tf
@@ -1,12 +1,15 @@
+
+
 # ---------------------------------------------------------------------------------------------------------------------
 # DEPLOY A CLOUD INSTANCE RUNNING UBUNTU
 # See test/terraform_gcp_example_test.go for how to write automated tests for this code.
 # ---------------------------------------------------------------------------------------------------------------------
 
 resource "google_compute_instance" "example" {
-  name         = "${var.instance_name}"
+  project = "${var.gcp_project_id}"
+  name = "${var.instance_name}"
   machine_type = "${var.machine_type}"
-  zone         = "${var.zone}"
+  zone = "${var.zone}"
 
   boot_disk {
     initialize_params {
@@ -16,6 +19,7 @@ resource "google_compute_instance" "example" {
 
   network_interface {
     network = "default"
+    access_config {}
   }
 }
 
@@ -24,6 +28,7 @@ resource "google_compute_instance" "example" {
 # ---------------------------------------------------------------------------------------------------------------------
 
 resource "google_storage_bucket" "example_bucket" {
-  name     = "${var.bucket_name}"
+  project = "${var.gcp_project_id}"
+  name = "${var.bucket_name}"
   location = "${var.bucket_location}"
 }

--- a/examples/terraform-gcp-example/outputs.tf
+++ b/examples/terraform-gcp-example/outputs.tf
@@ -2,6 +2,10 @@ output "instance_id" {
   value = "${google_compute_instance.example.id}"
 }
 
+output "public_ip" {
+  value = "${google_compute_instance.example.network_interface.0.access_config.0.nat_ip}"
+}
+
 output "bucket_url" {
   value = "${google_storage_bucket.example_bucket.url}"
 }

--- a/examples/terraform-gcp-example/variables.tf
+++ b/examples/terraform-gcp-example/variables.tf
@@ -6,8 +6,10 @@
 # GOOGLE_CREDENTIALS
 # or
 # GOOGLE_APPLICATION_CREDENTIALS
-# and
-# GOOGLE_CLOUD_PROJECT
+
+variable "gcp_project_id" {
+  description = "The ID of the GCP project in which these resources will be created."
+}
 
 # ---------------------------------------------------------------------------------------------------------------------
 # REQUIRED PARAMETERS

--- a/modules/gcp/compute.go
+++ b/modules/gcp/compute.go
@@ -514,3 +514,11 @@ func NewInstancesServiceE(t *testing.T) (*compute.InstancesService, error) {
 
 	return service.Instances, nil
 }
+
+// Return a random, valid name for GCP Compute Instances. Note that GCP requires Instance names to use lowercase letters only.
+func UniqueGcpInstanceName() string {
+	id := strings.ToLower(random.UniqueId())
+	instanceName := fmt.Sprintf("terratest-%s", id)
+
+	return instanceName
+}

--- a/modules/gcp/compute.go
+++ b/modules/gcp/compute.go
@@ -225,10 +225,12 @@ func (i *Instance) SetLabelsE(t *testing.T, labels map[string]string) error {
 	return nil
 }
 
+// GetMetadata gets the given Compute Instance's metadata
 func (i *Instance) GetMetadata(t *testing.T) []*compute.MetadataItems {
 	return i.Metadata.Items
 }
 
+// SetMetadata sets the given Compute Instance's metadata
 func (i *Instance) SetMetadata(t *testing.T, metadata map[string]string) {
 	err := i.SetMetadataE(t, metadata)
 	if err != nil {
@@ -236,7 +238,7 @@ func (i *Instance) SetMetadata(t *testing.T, metadata map[string]string) {
 	}
 }
 
-// SetLabelsE adds the tags to the given Compute Instance.
+// SetLabelsE adds the given metadata map to the existing metadata of the given Compute Instance.
 func (i *Instance) SetMetadataE(t *testing.T, metadata map[string]string) error {
 	logger.Logf(t, "Adding metadata to instance %s in zone %s", i.Name, i.Zone)
 
@@ -256,7 +258,7 @@ func (i *Instance) SetMetadataE(t *testing.T, metadata map[string]string) error 
 }
 
 // newMetadata takes in a Compute Instance's existing metadata plus a new set of key-value pairs and returns an updated
-// metadata object
+// metadata object.
 func newMetadata(t *testing.T, oldMetadata *compute.Metadata, kvs map[string]string) *compute.Metadata {
 	items := []*compute.MetadataItems{}
 
@@ -277,7 +279,7 @@ func newMetadata(t *testing.T, oldMetadata *compute.Metadata, kvs map[string]str
 	return newMetadata
 }
 
-// Add the given public SSH key to the Compute Instance. Users can login with the given username.
+// Add the given public SSH key to the Compute Instance. Users can SSH in with the given username.
 func (i *Instance) AddSshKey(t *testing.T, username string, publicKey string) {
 	err := i.AddSshKeyE(t, username, publicKey)
 	if err != nil {
@@ -285,9 +287,9 @@ func (i *Instance) AddSshKey(t *testing.T, username string, publicKey string) {
 	}
 }
 
-// Add the given public SSH key to the Compute Instance. Users can login with the given username.
+// Add the given public SSH key to the Compute Instance. Users can SSH in with the given username.
 func (i *Instance) AddSshKeyE(t *testing.T, username string, publicKey string) error {
-	logger.Logf(t, "Adding SSH Key to Compute Instance %s for username %s\n\n", i.Name, username)
+	logger.Logf(t, "Adding SSH Key to Compute Instance %s for username %s\n", i.Name, username)
 
 	publicKeyFormatted := strings.TrimSpace(publicKey)
 	sshKeyFormatted := fmt.Sprintf("%s:%s %s", username, publicKeyFormatted, username)
@@ -502,7 +504,7 @@ func NewInstancesService(t *testing.T) *compute.InstancesService {
 	return client
 }
 
-// NewComputeServiceE creates a new InstancesService service, which is used to make a subset of GCE API calls.
+// NewInstancesServiceE creates a new InstancesService service, which is used to make a subset of GCE API calls.
 func NewInstancesServiceE(t *testing.T) (*compute.InstancesService, error) {
 	service, err := NewComputeServiceE(t)
 	if err != nil {

--- a/modules/gcp/compute.go
+++ b/modules/gcp/compute.go
@@ -515,8 +515,8 @@ func NewInstancesServiceE(t *testing.T) (*compute.InstancesService, error) {
 	return service.Instances, nil
 }
 
-// Return a random, valid name for GCP Compute Instances. Note that GCP requires Instance names to use lowercase letters only.
-func UniqueGcpInstanceName() string {
+// Return a random, valid name for GCP resources. Many resources in GCP requires lowercase letters only.
+func RandomValidGcpName() string {
 	id := strings.ToLower(random.UniqueId())
 	instanceName := fmt.Sprintf("terratest-%s", id)
 

--- a/modules/gcp/compute.go
+++ b/modules/gcp/compute.go
@@ -291,6 +291,7 @@ func (i *Instance) AddSshKey(t *testing.T, username string, publicKey string) {
 func (i *Instance) AddSshKeyE(t *testing.T, username string, publicKey string) error {
 	logger.Logf(t, "Adding SSH Key to Compute Instance %s for username %s\n", i.Name, username)
 
+	// We represent the key in the format required per GCP docs (https://cloud.google.com/compute/docs/instances/adding-removing-ssh-keys)
 	publicKeyFormatted := strings.TrimSpace(publicKey)
 	sshKeyFormatted := fmt.Sprintf("%s:%s %s", username, publicKeyFormatted, username)
 

--- a/modules/gcp/compute.go
+++ b/modules/gcp/compute.go
@@ -224,7 +224,7 @@ func (i *Instance) SetLabelsE(t *testing.T, labels map[string]string) error {
 	return nil
 }
 
-func (i *Instance) GetMetadata(t *testing.T) interface{} {
+func (i *Instance) GetMetadata(t *testing.T) []*compute.MetadataItems {
 	return i.Metadata.Items
 }
 
@@ -239,13 +239,17 @@ func (i *Instance) SetMetadata(t *testing.T, metadata map[string]string) {
 func (i *Instance) SetMetadataE(t *testing.T, metadata map[string]string) error {
 	logger.Logf(t, "Adding metadata to instance %s in zone %s", i.Name, i.Zone)
 
+	ctx := context.Background()
 	service, err := NewInstancesServiceE(t)
 	if err != nil {
 		return err
 	}
 
 	metadataItems := newMetadata(t, i.Metadata, metadata)
-	service.SetMetadata(i.projectID, i.Zone, i.Name, metadataItems)
+	req := service.SetMetadata(i.projectID, i.GetZone(t), i.Name, metadataItems)
+	if _, err := req.Context(ctx).Do(); err != nil {
+		return fmt.Errorf("Instances.SetMetadata(%s) got error: %v", i.Name, err)
+	}
 
 	return nil
 }

--- a/modules/gcp/compute_test.go
+++ b/modules/gcp/compute_test.go
@@ -135,6 +135,8 @@ func TestGetAndSetMetadata(t *testing.T) {
 			}
 		}
 
+		fmt.Printf("Metadata to write: %+v\nMetadata from read: %+v\n", metadataToWrite, metadataFromRead)
+
 		return "", fmt.Errorf("Metadata that was written was not found in metadata that was read. Retrying.\n")
 	})
 }

--- a/modules/gcp/compute_test.go
+++ b/modules/gcp/compute_test.go
@@ -109,11 +109,11 @@ func TestGetAndSetMetadata(t *testing.T) {
 	instanceName := uniqueGcpInstanceName()
 	zone := GetRandomZone(t, projectID, nil, nil)
 
+	// Create a new Compute Instance
 	createComputeInstance(t, projectID, zone, instanceName)
 	defer deleteComputeInstance(t, projectID, zone, instanceName)
 
-	// Now that our Instance is launched, set the metadata. Note that in GCP label keys and values can only contain
-	// lowercase letters, numeric characters, underscores and dashes.
+	// Set the metadata
 	instance := FetchInstance(t, projectID, instanceName)
 
 	metadataToWrite := map[string]string{
@@ -121,7 +121,7 @@ func TestGetAndSetMetadata(t *testing.T) {
 	}
 	instance.SetMetadata(t, metadataToWrite)
 
-	// Now attempt to read the labels we just set.
+	// Now attempt to read the metadata we just set
 	maxRetries := 10
 	sleepBetweenRetries := 3 * time.Second
 

--- a/modules/gcp/compute_test.go
+++ b/modules/gcp/compute_test.go
@@ -20,7 +20,7 @@ const DEFAULT_IMAGE_FAMILY_NAME = "family/ubuntu-1804-lts"
 func TestGetPublicIpOfInstance(t *testing.T) {
 	t.Parallel()
 
-	instanceName := UniqueGcpInstanceName()
+	instanceName := RandomValidGcpName()
 	projectID := GetGoogleProjectIDFromEnvVar(t)
 	zone := GetRandomZone(t, projectID, nil, nil)
 
@@ -66,7 +66,7 @@ func TestZoneUrlToZone(t *testing.T) {
 func TestGetAndSetLabels(t *testing.T) {
 	t.Parallel()
 
-	instanceName := UniqueGcpInstanceName()
+	instanceName := RandomValidGcpName()
 	projectID := GetGoogleProjectIDFromEnvVar(t)
 	zone := GetRandomZone(t, projectID, nil, nil)
 
@@ -102,7 +102,7 @@ func TestGetAndSetMetadata(t *testing.T) {
 	t.Parallel()
 
 	projectID := GetGoogleProjectIDFromEnvVar(t)
-	instanceName := UniqueGcpInstanceName()
+	instanceName := RandomValidGcpName()
 	zone := GetRandomZone(t, projectID, nil, nil)
 
 	// Create a new Compute Instance

--- a/modules/gcp/compute_test.go
+++ b/modules/gcp/compute_test.go
@@ -138,7 +138,9 @@ func TestGetAndSetMetadata(t *testing.T) {
 	})
 }
 
-// Helper function to launch a Compute Instance.
+// Helper function to launch a Compute Instance. This function is useful for quickly iterating on automated tests. But
+// if you're writing a test that resembles real-world code that Terratest users may write, you should create a Compute
+// Instance using a Terraform apply, similar to the tests in /test.
 func createComputeInstance(t *testing.T, projectID string, zone string, name string) {
 	t.Logf("Launching new Compute Instance %s\n", name)
 

--- a/modules/gcp/compute_test.go
+++ b/modules/gcp/compute_test.go
@@ -9,10 +9,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gruntwork-io/terratest/modules/ssh"
-
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/gruntwork-io/terratest/modules/retry"
+	"github.com/gruntwork-io/terratest/modules/ssh"
 	"github.com/magiconair/properties/assert"
 	"google.golang.org/api/compute/v1"
 )

--- a/test/terraform_gcp_example_test.go
+++ b/test/terraform_gcp_example_test.go
@@ -94,7 +94,7 @@ func TestSshAccessToComputeInstance(t *testing.T) {
 
 	// Setup values for our Terraform apply
 	projectID := gcp.GetGoogleProjectIDFromEnvVar(t)
-	instanceName := gcp.UniqueGcpInstanceName()
+	randomValidGcpName := gcp.RandomValidGcpName()
 	zone := gcp.GetRandomZone(t, projectID, nil, nil)
 
 	terraformOptions := &terraform.Options{
@@ -104,7 +104,8 @@ func TestSshAccessToComputeInstance(t *testing.T) {
 		// Variables to pass to our Terraform code using -var options
 		Vars: map[string]interface{}{
 			"gcp_project_id": projectID,
-			"instance_name":  instanceName,
+			"instance_name":  randomValidGcpName,
+			"bucket_name":    randomValidGcpName,
 			"zone":           zone,
 		},
 	}
@@ -119,7 +120,7 @@ func TestSshAccessToComputeInstance(t *testing.T) {
 	publicIp := terraform.Output(t, terraformOptions, "public_ip")
 
 	// Attempt to SSH and execute the command
-	instance := gcp.FetchInstance(t, projectID, instanceName)
+	instance := gcp.FetchInstance(t, projectID, randomValidGcpName)
 
 	sampleText := "Hello World"
 	sshUsername := "terratest"

--- a/test/terraform_gcp_example_test.go
+++ b/test/terraform_gcp_example_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gruntwork-io/terratest/modules/gcp"
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/gruntwork-io/terratest/modules/retry"
+	"github.com/gruntwork-io/terratest/modules/ssh"
 	"github.com/gruntwork-io/terratest/modules/terraform"
 	"github.com/stretchr/testify/assert"
 )
@@ -34,9 +35,10 @@ func TestTerraformGcpExample(t *testing.T) {
 
 		// Variables to pass to our Terraform code using -var options
 		Vars: map[string]interface{}{
-			"zone":          zone,
-			"instance_name": expectedInstanceName,
-			"bucket_name":   expectedBucketName,
+			"gcp_project_id": projectId,
+			"zone":           zone,
+			"instance_name":  expectedInstanceName,
+			"bucket_name":    expectedBucketName,
 		},
 	}
 
@@ -80,6 +82,68 @@ func TestTerraformGcpExample(t *testing.T) {
 
 		if actualText != expectedText {
 			return "", fmt.Errorf("Expeced GetLabelsForComputeInstanceE to return '%s' but got '%s'", expectedText, actualText)
+		}
+
+		return "", nil
+	})
+}
+
+// Create a Compute Instance, and attempt to SSH in and run a command.
+func TestSshAccessToComputeInstance(t *testing.T) {
+	t.Parallel()
+
+	// Setup values for our Terraform apply
+	projectID := gcp.GetGoogleProjectIDFromEnvVar(t)
+	instanceName := gcp.UniqueGcpInstanceName()
+	zone := gcp.GetRandomZone(t, projectID, nil, nil)
+
+	terraformOptions := &terraform.Options{
+		// The path to where our Terraform code is located
+		TerraformDir: "../examples/terraform-gcp-example",
+
+		// Variables to pass to our Terraform code using -var options
+		Vars: map[string]interface{}{
+			"gcp_project_id": projectID,
+			"instance_name":  instanceName,
+			"zone":           zone,
+		},
+	}
+
+	// At the end of the test, run `terraform destroy` to clean up any resources that were created
+	defer terraform.Destroy(t, terraformOptions)
+
+	// This will run `terraform init` and `terraform apply` and fail the test if there are any errors
+	terraform.InitAndApply(t, terraformOptions)
+
+	// Run `terraform output` to get the value of an output variable
+	publicIp := terraform.Output(t, terraformOptions, "public_ip")
+
+	// Attempt to SSH and execute the command
+	instance := gcp.FetchInstance(t, projectID, instanceName)
+
+	sampleText := "Hello World"
+	sshUsername := "terratest"
+
+	keyPair := ssh.GenerateRSAKeyPair(t, 2048)
+	instance.AddSshKey(t, sshUsername, keyPair.PublicKey)
+
+	host := ssh.Host{
+		Hostname:    publicIp,
+		SshKeyPair:  keyPair,
+		SshUserName: sshUsername,
+	}
+
+	maxRetries := 20
+	sleepBetweenRetries := 3 * time.Second
+
+	retry.DoWithRetry(t, "Attempting to SSH", maxRetries, sleepBetweenRetries, func() (string, error) {
+		output, err := ssh.CheckSshCommandE(t, host, fmt.Sprintf("echo '%s'", sampleText))
+		if err != nil {
+			return "", err
+		}
+
+		if strings.TrimSpace(sampleText) != strings.TrimSpace(output) {
+			return "", fmt.Errorf("Expected: %s. Got: %s\n", sampleText, output)
 		}
 
 		return "", nil


### PR DESCRIPTION
As part of adding automated tests for Vault GCP, we needed the ability to SSH into a GCP Compute Instance and run commands. This PR adds that functionality. As part of the implementation, I added the ability to get and set Compute Instance metadata.

Assuming tests pass, this is ready to merge.