### PR TITLE
Design of key-pair loading

### DIFF
--- a/modules/ssh/key_pair.go
+++ b/modules/ssh/key_pair.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
+	"io/ioutil"
 	"testing"
 
 	"github.com/gruntwork-io/terratest/modules/logger"
@@ -54,4 +55,31 @@ func GenerateRSAKeyPairE(t *testing.T, keySize int) (*KeyPair, error) {
 
 	// Return
 	return &KeyPair{PublicKey: sshPubKeyStr, PrivateKey: keyPem}, nil
+}
+
+// TODO Vit: document this
+func LoadRSAKeyPair(t *testing.T, privateKeyPath string, publicKeyPath string) *KeyPair {
+	keyPair, err := LoadRSAKeyPairE(t, privateKeyPath, publicKeyPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return keyPair
+}
+
+// TODO Vit: document this
+func LoadRSAKeyPairE(t *testing.T, publicKeyPath string, privateKeyPath string) (*KeyPair, error) {
+	publicKey, err := ioutil.ReadFile(publicKeyPath)
+	if err != nil {
+		return nil, err
+	}
+
+	privateKey, err := ioutil.ReadFile(privateKeyPath)
+	if err != nil {
+		return nil, err
+	}
+
+	return &KeyPair{
+		PublicKey:  string(publicKey),
+		PrivateKey: string(privateKey),
+	}, nil
 }


### PR DESCRIPTION
Related to #170 

This is a first draft of the _key-pair loading_ functionality. **It's intended for a design discussion**, not for merge (yet).

Possible extension could be a function
```go
func LoadDefaultRSAKeyPair(t *testing.T) *KeyPair
```

which loads a key-pair from some default location, e.g. `~/.ssh`. Maybe the default location could be driven via some environment variable.

For now, an _encrypted_ private key is omitted from the design, but after solving of this topic, the next function could be

```go
func LoadRSAEncryptedKeyPair(t *testing.T, publicKeyPath string, privateKeyPath string, passPhrase string) *KeyPair
```

where the `passPhrase` would be providede via environment variable, e.g. `TF_VAR_pass_phrase`.