### PR TITLE
Added packer multi artifact parallel build

### DIFF
--- a/examples/packer-basic-example/build.json
+++ b/examples/packer-basic-example/build.json
@@ -12,7 +12,7 @@
   },
   "builders": [{
     "type": "amazon-ebs",
-    "ami_name": "terratest-packer-example-{{isotime | clean_ami_name}}",
+    "ami_name": "terratest-packer-example-{{user `aws_region`}}-{{isotime | clean_ami_name}}",
     "ami_description": "An example of how to create a custom AMI on top of Ubuntu",
     "instance_type": "t2.micro",
     "region": "{{user `aws_region`}}",

--- a/examples/packer-basic-example/build.json
+++ b/examples/packer-basic-example/build.json
@@ -2,6 +2,7 @@
   "min_packer_version": "1.0.4",
   "variables": {
     "aws_region": "us-east-1",
+    "ami_base_name": "",
     "gcp_project_id": "",
     "gcp_zone": "us-central1-a",
     "oci_availability_domain": "",
@@ -12,7 +13,7 @@
   },
   "builders": [{
     "type": "amazon-ebs",
-    "ami_name": "terratest-packer-example-{{user `aws_region`}}-{{isotime | clean_ami_name}}",
+    "ami_name": "{{user `ami_base_name`}}-terratest-packer-example",
     "ami_description": "An example of how to create a custom AMI on top of Ubuntu",
     "instance_type": "t2.micro",
     "region": "{{user `aws_region`}}",

--- a/modules/packer/packer.go
+++ b/modules/packer/packer.go
@@ -34,6 +34,8 @@ func BuildArtifactsE(t *testing.T, artifactNameToOptions map[string]*Options) (m
 	errorsOccurred := []error{}
 
 	for artifactName, curOptions := range artifactNameToOptions {
+		// The following is necessary to make sure testCase's values don't
+		// get updated due to concurrency within the scope of t.Run(..) below
 		artifactName := artifactName
 		curOptions := curOptions
 		go func() {

--- a/modules/packer/packer.go
+++ b/modules/packer/packer.go
@@ -21,6 +21,20 @@ type Options struct {
 	Env      map[string]string // Custom environment variables to set when running Packer
 }
 
+// BuildArtifacts can take a map of identifierName <-> Options and then parallelize
+// the packer builds. Once all the packer builds have completed a map of identifierName <-> generated identifier
+// is returned. The identifierName can be anything you want, it is only used so that you can
+// know which generated artifact is which.
+func BuildArtifacts(t *testing.T, artifactNameToOptions map[string]*Options) map[string]string {
+	result, err := BuildArtifactsE(t, artifactNameToOptions)
+
+	if err != nil {
+		t.Fatalf("Error building artifacts: %s", err.Error())
+	}
+
+	return result
+}
+
 // BuildArtifactsE can take a map of identifierName <-> Options and then parallelize
 // the packer builds. Once all the packer builds have completed a map of identifierName <-> generated identifier
 // is returned. If any artifact fails to build, the errors are accumulated and returned

--- a/modules/packer/packer.go
+++ b/modules/packer/packer.go
@@ -48,7 +48,7 @@ func BuildArtifactsE(t *testing.T, artifactNameToOptions map[string]*Options) (m
 	errorsOccurred := []error{}
 
 	for artifactName, curOptions := range artifactNameToOptions {
-		// The following is necessary to make sure testCase's values don't
+		// The following is necessary to make sure artifactName and curOptions don't
 		// get updated due to concurrency within the scope of t.Run(..) below
 		artifactName := artifactName
 		curOptions := curOptions

--- a/test/packer_basic_example_test.go
+++ b/test/packer_basic_example_test.go
@@ -54,13 +54,12 @@ func TestPackerBasicExample(t *testing.T) {
 
 func TestPackerMultipleConcurrentAmis(t *testing.T) {
 	t.Parallel()
-	i := 0
 
 	// Build a map of 3 randomId <-> packer.Options, in 3 random AWS Regions
 	// then build all of these AMIs in parallel and make sure that there are
 	// no errors.
 	var identifierToOptions = map[string]*packer.Options{}
-	for i < 3 {
+	for i := 0; i < 3; i++ {
 		// Pick a random AWS region to test in. This helps ensure your code works in all regions.
 		awsRegion := terratest_aws.GetRandomRegion(t, nil, nil)
 
@@ -70,7 +69,8 @@ func TestPackerMultipleConcurrentAmis(t *testing.T) {
 
 			// Variables to pass to our Packer build using -var options
 			Vars: map[string]string{
-				"aws_region": awsRegion,
+				"aws_region":    awsRegion,
+				"ami_base_name": random.UniqueId(),
 			},
 
 			// Only build the AWS AMI
@@ -78,8 +78,6 @@ func TestPackerMultipleConcurrentAmis(t *testing.T) {
 		}
 
 		identifierToOptions[random.UniqueId()] = packerOptions
-
-		i += 1
 	}
 
 	resultMap, err := packer.BuildArtifactsE(t, identifierToOptions)

--- a/test/packer_basic_example_test.go
+++ b/test/packer_basic_example_test.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -70,7 +71,7 @@ func TestPackerMultipleConcurrentAmis(t *testing.T) {
 			// Variables to pass to our Packer build using -var options
 			Vars: map[string]string{
 				"aws_region":    awsRegion,
-				"ami_base_name": random.UniqueId(),
+				"ami_base_name": fmt.Sprintf("%s-terratest-packer", random.UniqueId()),
 			},
 
 			// Only build the AWS AMI

--- a/test/packer_basic_example_test.go
+++ b/test/packer_basic_example_test.go
@@ -80,11 +80,7 @@ func TestPackerMultipleConcurrentAmis(t *testing.T) {
 		identifierToOptions[random.UniqueId()] = packerOptions
 	}
 
-	resultMap, err := packer.BuildArtifactsE(t, identifierToOptions)
-
-	if err != nil {
-		t.Fatalf("Unexpected errors encounterd while building AMI: %s", err.Error())
-	}
+	resultMap := packer.BuildArtifacts(t, identifierToOptions)
 
 	// Clean up the AMIs after we're done
 	for key, amiId := range resultMap {


### PR DESCRIPTION
Added: function: BuildArtifactsE can take a map of identifierName <-> Options and then parallelize the packer builds. Once all the packer builds have completed a map of identifierName <-> generated identifier is returned. If any artifact fails to build, the errors are accumulated and returned as a MultiError. The identifierName can be anything you want, it is only used so that you can know which generated artifact is which.

Added test to verify functionality.