### PR TITLE
Add GetInstances() and GetPublicIps() to GCP Instance Groups

### DIFF
--- a/examples/terraform-gcp-ig-example/README.md
+++ b/examples/terraform-gcp-ig-example/README.md
@@ -7,12 +7,13 @@ https://cloud.google.com/compute/docs/instance-groups/).
 Check out [test/terraform_gcp_ig_example_test.go](/test/terraform_gcp_ig_example_test.go) to see how you can write
 automated tests for this module.
 
-Note that the Instance Group in this module doesn't actually do anything; it just runs a Vanilla Ubuntu 16.04 Image for demonstration purposes. For slightly more complicated, real-world examples of Terraform modules, see
+Note that the Instance Group in this module doesn't actually do anything; it just runs a cluster of vanilla Ubuntu 16.04
+Images for demonstration purposes. For slightly more complicated, real-world examples of Terraform modules, see
 [terraform-http-example](/examples/terraform-http-example) and [terraform-ssh-example](/examples/terraform-ssh-example).
 
 **WARNING**: This module and the automated tests for it deploy real resources into your GCP account which can cost you
-money. The resources are all part of the [GCP Free Tier](https://cloud.google.com/free/), so if you haven't used that up,
-it should be free, but you are completely responsible for all GCP charges.
+money. By launching multiple Instances as part of an Instance Group, these resources may go beyond the [GCP Free Tier](
+https://cloud.google.com/free/). Naturally, you are completely responsible for all GCP charges.
 
 ## Running this module manually
 

--- a/examples/terraform-gcp-ig-example/README.md
+++ b/examples/terraform-gcp-ig-example/README.md
@@ -1,15 +1,13 @@
-# Terraform GCP Example
+# Terraform GCP Managed Instance Group Example
 
-This folder contains a simple Terraform module that deploys resources in [GCP](https://cloud.google.com/) to demonstrate
-how you can use Terratest to write automated tests for your GCP Terraform code. This module deploys a [Compute
-Instance](https://cloud.google.com/compute/) and gives that Instance a `Name` with the value specified in the
-`instance_name` variable. It also creates a Cloud Storage Bucket using the `bucket_name` and `bucket_location` variables.
+This folder contains a simple Terraform configuration that deploys resources in [GCP](https://cloud.google.com/) to demonstrate
+how you can use Terratest to write automated tests for your GCP Terraform code. This module deploys an [Instance Group](
+https://cloud.google.com/compute/docs/instance-groups/).
 
-Check out [test/terraform_gcp_example_test.go](/test/terraform_gcp_example_test.go) to see how you can write
+Check out [test/terraform_gcp_ig_example_test.go](/test/terraform_gcp_ig_example_test.go) to see how you can write
 automated tests for this module.
 
-Note that the Compute Instance in this module doesn't actually do anything; it just runs a Vanilla Ubuntu 16.04 Image for
-demonstration purposes. For slightly more complicated, real-world examples of Terraform modules, see
+Note that the Instance Group in this module doesn't actually do anything; it just runs a Vanilla Ubuntu 16.04 Image for demonstration purposes. For slightly more complicated, real-world examples of Terraform modules, see
 [terraform-http-example](/examples/terraform-http-example) and [terraform-ssh-example](/examples/terraform-ssh-example).
 
 **WARNING**: This module and the automated tests for it deploy real resources into your GCP account which can cost you
@@ -37,4 +35,4 @@ it should be free, but you are completely responsible for all GCP charges.
 1. Set `GOOGLE_CLOUD_PROJECT` environment variable to your project name.
 1. `cd test`
 1. `dep ensure`
-1. `go test -v -run TestTerraformGcpExample`
+1. `go test -v -run TestTerraformGcpInstanceGroupExample`

--- a/examples/terraform-gcp-ig-example/main.tf
+++ b/examples/terraform-gcp-ig-example/main.tf
@@ -6,11 +6,11 @@
 # Create a Regional Managed Instance Group
 resource "google_compute_region_instance_group_manager" "example" {
   project = "${var.gcp_project_id}"
-  region = "${var.gcp_region}"
+  region  = "${var.gcp_region}"
 
-  name = "${var.cluster_name}-ig"
+  name               = "${var.cluster_name}-ig"
   base_instance_name = "${var.cluster_name}"
-  instance_template = "${google_compute_instance_template.example.self_link}"
+  instance_template  = "${google_compute_instance_template.example.self_link}"
 
   target_size = "${var.cluster_size}"
 }
@@ -19,23 +19,24 @@ resource "google_compute_region_instance_group_manager" "example" {
 resource "google_compute_instance_template" "example" {
   project = "${var.gcp_project_id}"
 
-  name_prefix = "${var.cluster_name}"
+  name_prefix  = "${var.cluster_name}"
   machine_type = "${var.machine_type}"
 
   scheduling {
-    automatic_restart = true
+    automatic_restart   = true
     on_host_maintenance = "MIGRATE"
-    preemptible = false
+    preemptible         = false
   }
 
   disk {
-    boot = true
-    auto_delete = true
+    boot         = true
+    auto_delete  = true
     source_image = "ubuntu-os-cloud/ubuntu-1604-lts"
   }
 
   network_interface {
     network = "default"
+
     # The presence of this property assigns a public IP address to each Compute Instance. We intentionally leave it
     # blank so that an external IP address is selected automatically.
     access_config {}

--- a/examples/terraform-gcp-ig-example/main.tf
+++ b/examples/terraform-gcp-ig-example/main.tf
@@ -1,0 +1,43 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# DEPLOY A REGIONAL MANAGED INSTANCE GROUP
+# See test/terraform_gcp_ig_example_test.go for how to write automated tests for this code.
+# ---------------------------------------------------------------------------------------------------------------------
+
+# Create a Regional Managed Instance Group
+resource "google_compute_region_instance_group_manager" "example" {
+  project = "${var.gcp_project_id}"
+  region = "${var.gcp_region}"
+
+  name = "${var.cluster_name}-ig"
+  base_instance_name = "${var.cluster_name}"
+  instance_template = "${google_compute_instance_template.example.self_link}"
+
+  target_size = "${var.cluster_size}"
+}
+
+# Create the Instance Template that will be used to populate the Managed Instance Group.
+resource "google_compute_instance_template" "example" {
+  project = "${var.gcp_project_id}"
+
+  name_prefix = "${var.cluster_name}"
+  machine_type = "${var.machine_type}"
+
+  scheduling {
+    automatic_restart = true
+    on_host_maintenance = "MIGRATE"
+    preemptible = false
+  }
+
+  disk {
+    boot = true
+    auto_delete = true
+    source_image = "ubuntu-os-cloud/ubuntu-1604-lts"
+  }
+
+  network_interface {
+    network = "default"
+    # The presence of this property assigns a public IP address to each Compute Instance. We intentionally leave it
+    # blank so that an external IP address is selected automatically.
+    access_config {}
+  }
+}

--- a/examples/terraform-gcp-ig-example/outputs.tf
+++ b/examples/terraform-gcp-ig-example/outputs.tf
@@ -1,0 +1,3 @@
+output "instance_group_name" {
+  value = "${google_compute_region_instance_group_manager.example.id}"
+}

--- a/examples/terraform-gcp-ig-example/variables.tf
+++ b/examples/terraform-gcp-ig-example/variables.tf
@@ -17,7 +17,7 @@ variable "gcp_project_id" {
 }
 
 variable "gcp_region" {
-  description = "The region in which all GCP resources will be created. "
+  description = "The region in which all GCP resources will be created."
 }
 
 # ---------------------------------------------------------------------------------------------------------------------
@@ -36,6 +36,6 @@ variable "cluster_size" {
 }
 
 variable "machine_type" {
-  description = "The Machine Type to use for the Cloud Instance."
+  description = "The Machine Type to use for the Compute Instances."
   default     = "f1-micro"
 }

--- a/examples/terraform-gcp-ig-example/variables.tf
+++ b/examples/terraform-gcp-ig-example/variables.tf
@@ -1,0 +1,41 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# ENVIRONMENT VARIABLES
+# You must define the following environment variables.
+# ---------------------------------------------------------------------------------------------------------------------
+
+# GOOGLE_CREDENTIALS
+# or
+# GOOGLE_APPLICATION_CREDENTIALS
+
+# ---------------------------------------------------------------------------------------------------------------------
+# REQUIRED PARAMETERS
+# You must provide a value for each of these parameters.
+# ---------------------------------------------------------------------------------------------------------------------
+
+variable "gcp_project_id" {
+  description = "The ID of the GCP project in which these resources will be created."
+}
+
+variable "gcp_region" {
+  description = "The region in which all GCP resources will be created. "
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# OPTIONAL PARAMETERS
+# These parameters have reasonable defaults.
+# ---------------------------------------------------------------------------------------------------------------------
+
+variable "cluster_name" {
+  description = "The unique identifier for the resources created by this Terraform configuration."
+  default = "terratest-example"
+}
+
+variable "cluster_size" {
+  description = "The number of Compute Instances to run in the Managed Instance Group."
+  default = 3
+}
+
+variable "machine_type" {
+  description = "The Machine Type to use for the Cloud Instance."
+  default     = "f1-micro"
+}

--- a/examples/terraform-gcp-ig-example/variables.tf
+++ b/examples/terraform-gcp-ig-example/variables.tf
@@ -27,12 +27,12 @@ variable "gcp_region" {
 
 variable "cluster_name" {
   description = "The unique identifier for the resources created by this Terraform configuration."
-  default = "terratest-example"
+  default     = "terratest-example"
 }
 
 variable "cluster_size" {
   description = "The number of Compute Instances to run in the Managed Instance Group."
-  default = 3
+  default     = 3
 }
 
 variable "machine_type" {

--- a/modules/gcp/compute.go
+++ b/modules/gcp/compute.go
@@ -424,8 +424,28 @@ func (ig *RegionalInstanceGroup) GetInstanceIdsE(t *testing.T) ([]string, error)
 }
 
 // Return a collection of Instance structs from the given Instance Groups
+func (ig *ZonalInstanceGroup) GetInstances(t *testing.T, projectId string) []*Instance {
+	return getInstances(t, ig, projectId)
+}
+
+// Return a collection of Instance structs from the given Instance Groups
+func (ig *ZonalInstanceGroup) GetInstancesE(t *testing.T, projectId string) ([]*Instance, error) {
+	return getInstancesE(t, ig, projectId)
+}
+
+// Return a collection of Instance structs from the given Instance Groups
 func (ig *RegionalInstanceGroup) GetInstances(t *testing.T, projectId string) []*Instance {
-	instances, err := ig.GetInstancesE(t, projectId)
+	return getInstances(t, ig, projectId)
+}
+
+// Return a collection of Instance structs from the given Instance Groups
+func (ig *RegionalInstanceGroup) GetInstancesE(t *testing.T, projectId string) ([]*Instance, error) {
+	return getInstancesE(t, ig, projectId)
+}
+
+// getInstancesE returns a collection of Instance structs from the given Instance Groups
+func getInstances(t *testing.T, ig InstanceGroup, projectId string) []*Instance {
+	instances, err := getInstancesE(t, ig, projectId)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -433,8 +453,8 @@ func (ig *RegionalInstanceGroup) GetInstances(t *testing.T, projectId string) []
 	return instances
 }
 
-// Return a collection of Instance structs from the given Instance Groups
-func (ig *RegionalInstanceGroup) GetInstancesE(t *testing.T, projectId string) ([]*Instance, error) {
+// getInstancesE returns a collection of Instance structs from the given Instance Groups
+func getInstancesE(t *testing.T, ig InstanceGroup, projectId string) ([]*Instance, error) {
 	instanceIds, err := ig.GetInstanceIdsE(t)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to get Instance Group IDs: %s", err)
@@ -454,9 +474,29 @@ func (ig *RegionalInstanceGroup) GetInstancesE(t *testing.T, projectId string) (
 	return instances, nil
 }
 
-// Return a slice of the public IPs from the given Instance Group
+// GetPublicIps returns a slice of the public IPs from the given Instance Group
+func (ig *ZonalInstanceGroup) GetPublicIps(t *testing.T, projectId string) []string {
+	return getPublicIps(t, ig, projectId)
+}
+
+// GetPublicIpsE returns a slice of the public IPs from the given Instance Group
+func (ig *ZonalInstanceGroup) GetPublicIpsE(t *testing.T, projectId string) ([]string, error) {
+	return getPublicIpsE(t, ig, projectId)
+}
+
+// GetPublicIps returns a slice of the public IPs from the given Instance Group
 func (ig *RegionalInstanceGroup) GetPublicIps(t *testing.T, projectId string) []string {
-	ips, err := ig.GetPublicIpsE(t, projectId)
+	return getPublicIps(t, ig, projectId)
+}
+
+// GetPublicIpsE returns a slice of the public IPs from the given Instance Group
+func (ig *RegionalInstanceGroup) GetPublicIpsE(t *testing.T, projectId string) ([]string, error) {
+	return getPublicIpsE(t, ig, projectId)
+}
+
+// getPublicIps a slice of the public IPs from the given Instance Group
+func getPublicIps(t *testing.T, ig InstanceGroup, projectId string) []string {
+	ips, err := getPublicIpsE(t, ig, projectId)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -464,9 +504,9 @@ func (ig *RegionalInstanceGroup) GetPublicIps(t *testing.T, projectId string) []
 	return ips
 }
 
-// Return a slice of the public IPs from the given Instance Group
-func (ig *RegionalInstanceGroup) GetPublicIpsE(t *testing.T, projectId string) ([]string, error) {
-	instances, err := ig.GetInstancesE(t, projectId)
+// getPublicIpsE a slice of the public IPs from the given Instance Group
+func getPublicIpsE(t *testing.T, ig InstanceGroup, projectId string) ([]string, error) {
+	instances, err := getInstancesE(t, ig, projectId)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to get Compute Instances from Instance Group: %s", err)
 	}

--- a/modules/gcp/compute.go
+++ b/modules/gcp/compute.go
@@ -423,6 +423,64 @@ func (ig *RegionalInstanceGroup) GetInstanceIdsE(t *testing.T) ([]string, error)
 	return instanceIDs, nil
 }
 
+// Return a collection of Instance structs from the given Instance Groups
+func (ig *RegionalInstanceGroup) GetInstances(t *testing.T, projectId string) []*Instance {
+	instances, err := ig.GetInstancesE(t, projectId)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return instances
+}
+
+// Return a collection of Instance structs from the given Instance Groups
+func (ig *RegionalInstanceGroup) GetInstancesE(t *testing.T, projectId string) ([]*Instance, error) {
+	instanceIds, err := ig.GetInstanceIdsE(t)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to get Instance Group IDs: %s", err)
+	}
+
+	var instances []*Instance
+
+	for _, instanceId := range instanceIds {
+		instance, err := FetchInstanceE(t, projectId, instanceId)
+		if err != nil {
+			return nil, fmt.Errorf("Failed to get Instance: %s", err)
+		}
+
+		instances = append(instances, instance)
+	}
+
+	return instances, nil
+}
+
+// Return a slice of the public IPs from the given Instance Group
+func (ig *RegionalInstanceGroup) GetPublicIps(t *testing.T, projectId string) []string {
+	ips, err := ig.GetPublicIpsE(t, projectId)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return ips
+}
+
+// Return a slice of the public IPs from the given Instance Group
+func (ig *RegionalInstanceGroup) GetPublicIpsE(t *testing.T, projectId string) ([]string, error) {
+	instances, err := ig.GetInstancesE(t, projectId)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to get Compute Instances from Instance Group: %s", err)
+	}
+
+	var ips []string
+
+	for _, instance := range instances {
+		ip := instance.GetPublicIp(t)
+		ips = append(ips, ip)
+	}
+
+	return ips, nil
+}
+
 // getRandomInstance returns a randomly selected Instance from the Regional Instance Group
 func (ig *ZonalInstanceGroup) GetRandomInstance(t *testing.T) *Instance {
 	return getRandomInstance(t, ig, ig.Name, ig.Region, ig.Size, ig.projectID)

--- a/modules/gcp/compute.go
+++ b/modules/gcp/compute.go
@@ -423,27 +423,27 @@ func (ig *RegionalInstanceGroup) GetInstanceIdsE(t *testing.T) ([]string, error)
 	return instanceIDs, nil
 }
 
-// Return a collection of Instance structs from the given Instance Groups
+// Return a collection of Instance structs from the given Instance Group
 func (ig *ZonalInstanceGroup) GetInstances(t *testing.T, projectId string) []*Instance {
 	return getInstances(t, ig, projectId)
 }
 
-// Return a collection of Instance structs from the given Instance Groups
+// Return a collection of Instance structs from the given Instance Group
 func (ig *ZonalInstanceGroup) GetInstancesE(t *testing.T, projectId string) ([]*Instance, error) {
 	return getInstancesE(t, ig, projectId)
 }
 
-// Return a collection of Instance structs from the given Instance Groups
+// Return a collection of Instance structs from the given Instance Group
 func (ig *RegionalInstanceGroup) GetInstances(t *testing.T, projectId string) []*Instance {
 	return getInstances(t, ig, projectId)
 }
 
-// Return a collection of Instance structs from the given Instance Groups
+// Return a collection of Instance structs from the given Instance Group
 func (ig *RegionalInstanceGroup) GetInstancesE(t *testing.T, projectId string) ([]*Instance, error) {
 	return getInstancesE(t, ig, projectId)
 }
 
-// getInstancesE returns a collection of Instance structs from the given Instance Groups
+// getInstancesE returns a collection of Instance structs from the given Instance Group
 func getInstances(t *testing.T, ig InstanceGroup, projectId string) []*Instance {
 	instances, err := getInstancesE(t, ig, projectId)
 	if err != nil {
@@ -453,7 +453,7 @@ func getInstances(t *testing.T, ig InstanceGroup, projectId string) []*Instance 
 	return instances
 }
 
-// getInstancesE returns a collection of Instance structs from the given Instance Groups
+// getInstancesE returns a collection of Instance structs from the given Instance Group
 func getInstancesE(t *testing.T, ig InstanceGroup, projectId string) ([]*Instance, error) {
 	instanceIds, err := ig.GetInstanceIdsE(t)
 	if err != nil {

--- a/test/terraform_gcp_example_test.go
+++ b/test/terraform_gcp_example_test.go
@@ -11,11 +11,14 @@ import (
 	"github.com/gruntwork-io/terratest/modules/retry"
 	"github.com/gruntwork-io/terratest/modules/ssh"
 	"github.com/gruntwork-io/terratest/modules/terraform"
+	"github.com/gruntwork-io/terratest/modules/test-structure"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestTerraformGcpExample(t *testing.T) {
 	t.Parallel()
+
+	exampleDir := test_structure.CopyTerraformFolderToTemp(t, "../", "examples/terraform-gcp-example")
 
 	// Get the Project Id to use
 	projectId := gcp.GetGoogleProjectIDFromEnvVar(t)
@@ -31,7 +34,7 @@ func TestTerraformGcpExample(t *testing.T) {
 
 	terraformOptions := &terraform.Options{
 		// The path to where our Terraform code is located
-		TerraformDir: "../examples/terraform-gcp-example",
+		TerraformDir: exampleDir,
 
 		// Variables to pass to our Terraform code using -var options
 		Vars: map[string]interface{}{
@@ -92,6 +95,8 @@ func TestTerraformGcpExample(t *testing.T) {
 func TestSshAccessToComputeInstance(t *testing.T) {
 	t.Parallel()
 
+	exampleDir := test_structure.CopyTerraformFolderToTemp(t, "../", "examples/terraform-gcp-example")
+
 	// Setup values for our Terraform apply
 	projectID := gcp.GetGoogleProjectIDFromEnvVar(t)
 	randomValidGcpName := gcp.RandomValidGcpName()
@@ -99,7 +104,7 @@ func TestSshAccessToComputeInstance(t *testing.T) {
 
 	terraformOptions := &terraform.Options{
 		// The path to where our Terraform code is located
-		TerraformDir: "../examples/terraform-gcp-example",
+		TerraformDir: exampleDir,
 
 		// Variables to pass to our Terraform code using -var options
 		Vars: map[string]interface{}{
@@ -149,13 +154,4 @@ func TestSshAccessToComputeInstance(t *testing.T) {
 
 		return "", nil
 	})
-
-	// This test was repeatedly failing with the following error during the Terraform destroy portion of the test:
-	//
-	// * google_compute_instance.example (destroy): 1 error(s) occurred:
-	// * google_compute_instance.example: The resource 'projects/terratest-214610/zones/us-east1-b/instances/terratest-gcp-example-tx6omj' was not found
-	//
-	// I suspect the problem was that Terraform was attempting to destroy the Compute Instance too soon after creating it,
-	// so put a cowardly, arbitrary sleep to mitigate.
-	time.Sleep(45 * time.Second)
 }

--- a/test/terraform_gcp_example_test.go
+++ b/test/terraform_gcp_example_test.go
@@ -149,4 +149,13 @@ func TestSshAccessToComputeInstance(t *testing.T) {
 
 		return "", nil
 	})
+
+	// This test was repeatedly failing with the following error during the Terraform destroy portion of the test:
+	//
+	// * google_compute_instance.example (destroy): 1 error(s) occurred:
+	// * google_compute_instance.example: The resource 'projects/terratest-214610/zones/us-east1-b/instances/terratest-gcp-example-tx6omj' was not found
+	//
+	// I suspect the problem was that Terraform was attempting to destroy the Compute Instance too soon after creating it,
+	// so put a cowardly, arbitrary sleep to mitigate.
+	time.Sleep(45 * time.Second)
 }

--- a/test/terraform_gcp_ig_example_test.go
+++ b/test/terraform_gcp_ig_example_test.go
@@ -1,0 +1,74 @@
+package test
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/gruntwork-io/terratest/modules/gcp"
+	"github.com/gruntwork-io/terratest/modules/retry"
+	"github.com/gruntwork-io/terratest/modules/terraform"
+)
+
+func TestTerraformGcpInstanceGroupExample(t *testing.T) {
+	t.Parallel()
+
+	// Setup values for our Terraform apply
+	projectId := gcp.GetGoogleProjectIDFromEnvVar(t)
+	region := gcp.GetRandomRegion(t, projectId, nil, nil)
+	randomValidGcpName := gcp.RandomValidGcpName()
+	cluster_size := 3
+
+	terraformOptions := &terraform.Options{
+		// The path to where our Terraform code instances located
+		TerraformDir: "../examples/terraform-gcp-ig-example",
+
+		// Variables to pass to our Terraform code using -var options
+		Vars: map[string]interface{}{
+			"gcp_project_id": projectId,
+			"gcp_region":     region,
+			"cluster_name":   randomValidGcpName,
+		},
+	}
+
+	// At the end of the test, run `terraform destroy` to clean up any resources that were created
+	defer terraform.Destroy(t, terraformOptions)
+
+	// This will run `terraform init` and `terraform apply` and fail the test if there are any errors
+	terraform.InitAndApply(t, terraformOptions)
+
+	instance_group_name := terraform.Output(t, terraformOptions, "instance_group_name")
+
+	instanceGroup := gcp.FetchRegionalInstanceGroup(t, projectId, region, instance_group_name)
+
+	// Validate that GetInstances() returns a non-zero number of Instances
+	maxRetries := 20
+	sleepBetweenRetries := 3 * time.Second
+
+	retry.DoWithRetry(t, "Attempting to fetch Instances from Instance Group", maxRetries, sleepBetweenRetries, func() (string, error) {
+		instances, err := instanceGroup.GetInstancesE(t, projectId)
+		if err != nil {
+			return "", fmt.Errorf("Failed to get Instances: %s", err)
+		}
+
+		if len(instances) != cluster_size {
+			return "", fmt.Errorf("Expected to find exactly %d Compute Instances in Instance Group but found %d.", cluster_size, len(instances))
+		}
+
+		return "", nil
+	})
+
+	// Validate that we get the right number of IP addresses
+	retry.DoWithRetry(t, "Attempting to fetch Public IP addresses from Instance Group", maxRetries, sleepBetweenRetries, func() (string, error) {
+		ips, err := instanceGroup.GetPublicIpsE(t, projectId)
+		if err != nil {
+			return "", fmt.Errorf("Failed to get public IPs from Instance Group")
+		}
+
+		if len(ips) != cluster_size {
+			return "", fmt.Errorf("Expected to get exactly %d public IP addresses but found %d.", cluster_size, len(ips))
+		}
+
+		return "", nil
+	})
+}

--- a/test/terraform_gcp_ig_example_test.go
+++ b/test/terraform_gcp_ig_example_test.go
@@ -8,10 +8,13 @@ import (
 	"github.com/gruntwork-io/terratest/modules/gcp"
 	"github.com/gruntwork-io/terratest/modules/retry"
 	"github.com/gruntwork-io/terratest/modules/terraform"
+	"github.com/gruntwork-io/terratest/modules/test-structure"
 )
 
 func TestTerraformGcpInstanceGroupExample(t *testing.T) {
 	t.Parallel()
+
+	exampleDir := test_structure.CopyTerraformFolderToTemp(t, "../", "examples/terraform-gcp-ig-example")
 
 	// Setup values for our Terraform apply
 	projectId := gcp.GetGoogleProjectIDFromEnvVar(t)
@@ -21,7 +24,7 @@ func TestTerraformGcpInstanceGroupExample(t *testing.T) {
 
 	terraformOptions := &terraform.Options{
 		// The path to where our Terraform code instances located
-		TerraformDir: "../examples/terraform-gcp-ig-example",
+		TerraformDir: exampleDir,
 
 		// Variables to pass to our Terraform code using -var options
 		Vars: map[string]interface{}{


### PR DESCRIPTION
With AWS, Terraform resources output a full collection of properties. For example, the [aws_autoscaling_group](https://www.terraform.io/docs/providers/aws/r/autoscaling_group.html#attributes-reference) outputs over 10 properties like `min_size`, `max_size`, etc.

But with GCP, Terraform outputs a surprisingly few number of properties. In particular, the [google_compute_region_instance_group_manager](https://www.terraform.io/docs/providers/google/r/compute_region_instance_group_manager.html#attributes-reference) includes just 3 properties. Therefore, nearly every user of Terratest that uses [Instance Groups](https://cloud.google.com/compute/docs/instance-groups/) will need functionality in Terratest to get public IPs and other instance properties.

In that spirit, this PR adds:

- `instanceGroup.GetInstances()`
- `instanceGroup.GetPublicIps()`

Please hold off on merging this for now, as I may add more functions here as I work through GCP tests in Vault.