### PR TITLE
Add functions to return Terraform output as a map

### DIFF
--- a/modules/terraform/output_test.go
+++ b/modules/terraform/output_test.go
@@ -49,3 +49,50 @@ func TestOutputNotListError(t *testing.T) {
 
 	assert.Error(t, err)
 }
+
+func TestOutputMap(t *testing.T) {
+	t.Parallel()
+
+	testFolder, err := files.CopyTerraformFolderToTemp("../../test/fixtures/terraform-output-map", t.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	options := &Options{
+		TerraformDir: testFolder,
+	}
+
+	InitAndApply(t, options)
+	out := OutputMap(t, options, "mogwai")
+
+	t.Log(out)
+
+	expectedLen := 4
+	expectedMap := map[string]string{
+		"guitar_1": "Stuart Braithwaite",
+		"guitar_2": "Barry Burns",
+		"bass":     "Dominic Aitchison",
+		"drums":    "Martin Bulloch",
+	}
+
+	assert.Len(t, out, expectedLen, "Output should contain %d items", expectedLen)
+	assert.Equal(t, expectedMap, out, "Map %q should match %q", expectedMap, out)
+}
+
+func TestOutputNotMapError(t *testing.T) {
+	t.Parallel()
+
+	testFolder, err := files.CopyTerraformFolderToTemp("../../test/fixtures/terraform-output-map", t.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	options := &Options{
+		TerraformDir: testFolder,
+	}
+
+	InitAndApply(t, options)
+	_, err = OutputMapE(t, options, "not_a_map")
+
+	assert.Error(t, err)
+}

--- a/test/fixtures/terraform-output-map/output.tf
+++ b/test/fixtures/terraform-output-map/output.tf
@@ -1,0 +1,12 @@
+output "mogwai" {
+  value {
+    guitar_1 = "Stuart Braithwaite",
+    guitar_2 = "Barry Burns",
+    bass     = "Dominic Aitchison",
+    drums    = "Martin Bulloch",
+  }
+}
+
+output "not_a_map" {
+  value = "This is not a map."
+}


### PR DESCRIPTION
This PR fixes issue #175 (New OutputMap function for the Terraform module) and adds the following functions in the Terraform module:

* `OutputMap(t *testing.T, options *Options, key string) map[string]string`: Calls terraform output for the given variable and returns its value as a map. If the output value is not a map type, then it fails the test.
* `OutputMapE(t *testing.T, options *Options, key string) (map[string]string, error)`: Calls terraform output for the given variable and returns its value as a map. If the output value is not a map type, then it returns an error.

The output for the tests is [available as a gist](https://gist.github.com/jmfontaine/135b4d9291e14e8bfa41c30ee2222b04).

In order to keep implementation simple, the values are expected to be castable to string.

Supporting arbitrary types as `interface{}` is possible. I considered renaming the functions to `OutputMapString` and `OutputMapStringE` respectively, and add two `OutputMapInterface` and `OutputMapInterfaceE`. Is that something that we want now or do we want to wait until someone has a use case for that?
