### PR TITLE
Attempt to fix recent GCP test failures.

### DIFF
--- a/modules/gcp/compute_test.go
+++ b/modules/gcp/compute_test.go
@@ -83,7 +83,7 @@ func TestGetAndSetLabels(t *testing.T) {
 	instance.SetLabels(t, labelsToWrite)
 
 	// Now attempt to read the labels we just set.
-	maxRetries := 10
+	maxRetries := 30
 	sleepBetweenRetries := 3 * time.Second
 
 	retry.DoWithRetry(t, "Read newly set labels", maxRetries, sleepBetweenRetries, func() (string, error) {
@@ -118,7 +118,7 @@ func TestGetAndSetMetadata(t *testing.T) {
 	instance.SetMetadata(t, metadataToWrite)
 
 	// Now attempt to read the metadata we just set
-	maxRetries := 10
+	maxRetries := 30
 	sleepBetweenRetries := 3 * time.Second
 
 	retry.DoWithRetry(t, "Read newly set metadata", maxRetries, sleepBetweenRetries, func() (string, error) {

--- a/modules/gcp/compute_test.go
+++ b/modules/gcp/compute_test.go
@@ -68,7 +68,9 @@ func TestGetAndSetLabels(t *testing.T) {
 
 	instanceName := RandomValidGcpName()
 	projectID := GetGoogleProjectIDFromEnvVar(t)
-	zone := GetRandomZone(t, projectID, nil, nil, nil)
+
+	// On October 22, 2018, GCP launched the asia-east2 region, which promptly failed all our tests, so blacklist asia-east2.
+	zone := GetRandomZone(t, projectID, nil, nil, []string{"asia-east2"})
 
 	createComputeInstance(t, projectID, zone, instanceName)
 	defer deleteComputeInstance(t, projectID, zone, instanceName)
@@ -103,7 +105,9 @@ func TestGetAndSetMetadata(t *testing.T) {
 
 	projectID := GetGoogleProjectIDFromEnvVar(t)
 	instanceName := RandomValidGcpName()
-	zone := GetRandomZone(t, projectID, nil, nil, nil)
+
+	// On October 22, 2018, GCP launched the asia-east2 region, which promptly failed all our tests, so blacklist asia-east2.
+	zone := GetRandomZone(t, projectID, nil, nil, []string{"asia-east2"})
 
 	// Create a new Compute Instance
 	createComputeInstance(t, projectID, zone, instanceName)

--- a/modules/gcp/compute_test.go
+++ b/modules/gcp/compute_test.go
@@ -22,7 +22,7 @@ func TestGetPublicIpOfInstance(t *testing.T) {
 
 	instanceName := RandomValidGcpName()
 	projectID := GetGoogleProjectIDFromEnvVar(t)
-	zone := GetRandomZone(t, projectID, nil, nil)
+	zone := GetRandomZone(t, projectID, nil, nil, nil)
 
 	createComputeInstance(t, projectID, zone, instanceName)
 	defer deleteComputeInstance(t, projectID, zone, instanceName)
@@ -68,7 +68,7 @@ func TestGetAndSetLabels(t *testing.T) {
 
 	instanceName := RandomValidGcpName()
 	projectID := GetGoogleProjectIDFromEnvVar(t)
-	zone := GetRandomZone(t, projectID, nil, nil)
+	zone := GetRandomZone(t, projectID, nil, nil, nil)
 
 	createComputeInstance(t, projectID, zone, instanceName)
 	defer deleteComputeInstance(t, projectID, zone, instanceName)
@@ -103,7 +103,7 @@ func TestGetAndSetMetadata(t *testing.T) {
 
 	projectID := GetGoogleProjectIDFromEnvVar(t)
 	instanceName := RandomValidGcpName()
-	zone := GetRandomZone(t, projectID, nil, nil)
+	zone := GetRandomZone(t, projectID, nil, nil, nil)
 
 	// Create a new Compute Instance
 	createComputeInstance(t, projectID, zone, instanceName)

--- a/modules/gcp/region.go
+++ b/modules/gcp/region.go
@@ -2,7 +2,6 @@ package gcp
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"strings"
 	"testing"
@@ -10,7 +9,7 @@ import (
 	"github.com/gruntwork-io/terratest/modules/collections"
 	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/random"
-	compute "google.golang.org/api/compute/v1"
+	"google.golang.org/api/compute/v1"
 )
 
 // You can set this environment variable to force Terratest to use a specific Region rather than a random one. This is
@@ -102,18 +101,16 @@ func GetRandomZoneE(t *testing.T, projectID string, approvedZones []string, forb
 
 	zonesToPickFrom = collections.ListSubtract(zonesToPickFrom, forbiddenZones)
 
-	zone := ""
-	maxAttempts := 1000
-
-	for i := 0; i < maxAttempts; i++ {
-		zone = random.RandomString(zonesToPickFrom)
+	var zonesToPickFromFiltered []string
+	for _, zone := range zonesToPickFrom {
 		if !isInRegions(zone, forbiddenRegions) {
-			logger.Logf(t, "Using Zone %s", zone)
-			return zone, nil
+			zonesToPickFromFiltered = append(zonesToPickFromFiltered, zone)
 		}
 	}
 
-	return "", fmt.Errorf("Could not find a valid zone in %v given that the zone cannot be in %v or in regions %v", zonesToPickFrom, forbiddenZones, forbiddenRegions)
+	zone := random.RandomString(zonesToPickFromFiltered)
+
+	return zone, nil
 }
 
 // GetRandomZoneForRegion gets a randomly chosen GCP Zone in the given Region.

--- a/modules/gcp/region_test.go
+++ b/modules/gcp/region_test.go
@@ -21,7 +21,7 @@ func TestGetRandomZone(t *testing.T) {
 
 	projectID := GetGoogleProjectIDFromEnvVar(t)
 
-	randomZone := GetRandomZone(t, projectID, nil, nil)
+	randomZone := GetRandomZone(t, projectID, nil, nil, nil)
 	assertLooksLikeZoneName(t, randomZone)
 }
 
@@ -48,7 +48,7 @@ func TestGetRandomZoneExcludesForbiddenZones(t *testing.T) {
 	forbiddenZones := []string{"us-east1-a", "europe-west1-a", "europe-west2-a", "europe-west2-c"}
 
 	for i := 0; i < 1000; i++ {
-		randomZone := GetRandomZone(t, projectID, approvedZones, forbiddenZones)
+		randomZone := GetRandomZone(t, projectID, approvedZones, forbiddenZones, nil)
 		assert.NotContains(t, forbiddenZones, randomZone)
 	}
 }
@@ -99,6 +99,45 @@ func TestGetRandomZoneForRegion(t *testing.T) {
 		}
 
 		assert.True(t, strings.Contains(zone, region), "Expected zone %s to be in region %s", zone, region)
+	}
+}
+
+func TestGetInRegion(t *testing.T) {
+	t.Parallel()
+
+	testData := []struct {
+		zone     string
+		region   string
+		expected bool
+	}{
+		{"us-west2a", "us-west2", true},
+		{"us-west2b", "us-west2", true},
+		{"us-west2a", "us-east1", false},
+	}
+
+	for _, td := range testData {
+		actual := isInRegion(td.zone, td.region)
+		assert.Equal(t, td.expected, actual, "Expected %t for isInRegion(%s, %s) but got %t", td.expected, td.zone, td.region, actual)
+	}
+}
+
+func TestGetInRegions(t *testing.T) {
+	t.Parallel()
+
+	testData := []struct {
+		zone     string
+		regions  []string
+		expected bool
+	}{
+		{"us-west2a", []string{"us-west2", "us-east1"}, true},
+		{"us-west2b", []string{"us-west2", "us-east1"}, true},
+		{"us-west2a", []string{"us-west2", "us-east1"}, true},
+		{"us-west2a", []string{"us-east1", "europe-west1"}, false},
+	}
+
+	for _, td := range testData {
+		actual := isInRegions(td.zone, td.regions)
+		assert.Equal(t, td.expected, actual, "Expected %t for isInRegions(%s, %v) but got %t", td.expected, td.zone, td.regions, actual)
 	}
 }
 

--- a/modules/gcp/region_test.go
+++ b/modules/gcp/region_test.go
@@ -53,6 +53,23 @@ func TestGetRandomZoneExcludesForbiddenZones(t *testing.T) {
 	}
 }
 
+func TestGetRandomZoneExcludesForbiddenRegions(t *testing.T) {
+	t.Parallel()
+
+	projectID := GetGoogleProjectIDFromEnvVar(t)
+
+	approvedZones := []string{"us-east1-b", "us-east1-c", "us-east1-d", "us-east4-a", "us-east4-b", "us-east4-c", "us-west2-a", "us-west2-b", "us-west2-c", "us-central1-f", "europe-west2-b"}
+	forbiddenRegions := []string{"europe-west2"}
+
+	for i := 0; i < 1000; i++ {
+		randomZone := GetRandomZone(t, projectID, approvedZones, nil, forbiddenRegions)
+
+		for _, forbiddenRegion := range forbiddenRegions {
+			assert.True(t, !isInRegion(randomZone, forbiddenRegion), "Expected that selected zone %s would not be in region %s, but it is.", randomZone, forbiddenRegion)
+		}
+	}
+}
+
 func TestGetAllGcpRegions(t *testing.T) {
 	t.Parallel()
 

--- a/test/packer_gcp_basic_example_test.go
+++ b/test/packer_gcp_basic_example_test.go
@@ -15,7 +15,8 @@ func TestPackerGCPBasicExample(t *testing.T) {
 	projectID := gcp.GetGoogleProjectIDFromEnvVar(t)
 
 	// Pick a random GCP zone to test in. This helps ensure your code works in all regions.
-	zone := gcp.GetRandomZone(t, projectID, nil, nil)
+	// On October 22, 2018, GCP launched the asia-east2 region, which promptly failed all our tests, so blacklist asia-east2.
+	zone := gcp.GetRandomZone(t, projectID, nil, nil, []string{"asia-east2"})
 
 	packerOptions := &packer.Options{
 		// The path to where the Packer template is located

--- a/test/terraform_gcp_example_test.go
+++ b/test/terraform_gcp_example_test.go
@@ -100,7 +100,7 @@ func TestSshAccessToComputeInstance(t *testing.T) {
 	// Setup values for our Terraform apply
 	projectID := gcp.GetGoogleProjectIDFromEnvVar(t)
 	randomValidGcpName := gcp.RandomValidGcpName()
-	zone := gcp.GetRandomZone(t, projectID, nil, nil)
+	zone := gcp.GetRandomZone(t, projectID, nil, nil, nil)
 
 	terraformOptions := &terraform.Options{
 		// The path to where our Terraform code is located

--- a/test/terraform_gcp_ig_example_test.go
+++ b/test/terraform_gcp_ig_example_test.go
@@ -18,7 +18,10 @@ func TestTerraformGcpInstanceGroupExample(t *testing.T) {
 
 	// Setup values for our Terraform apply
 	projectId := gcp.GetGoogleProjectIDFromEnvVar(t)
-	region := gcp.GetRandomRegion(t, projectId, nil, nil)
+
+	// On October 22, 2018, GCP launched the asia-east2 region, which promptly failed all our tests, so blacklist asia-east2.
+	region := gcp.GetRandomRegion(t, projectId, nil, []string{"asia-east2"})
+
 	randomValidGcpName := gcp.RandomValidGcpName()
 	cluster_size := 3
 

--- a/test/terraform_gcp_ig_example_test.go
+++ b/test/terraform_gcp_ig_example_test.go
@@ -45,7 +45,7 @@ func TestTerraformGcpInstanceGroupExample(t *testing.T) {
 	instanceGroup := gcp.FetchRegionalInstanceGroup(t, projectId, region, instance_group_name)
 
 	// Validate that GetInstances() returns a non-zero number of Instances
-	maxRetries := 20
+	maxRetries := 40
 	sleepBetweenRetries := 3 * time.Second
 
 	retry.DoWithRetry(t, "Attempting to fetch Instances from Instance Group", maxRetries, sleepBetweenRetries, func() (string, error) {


### PR DESCRIPTION
Recent CircleCI test builds ([538](https://circleci.com/gh/gruntwork-io/terratest/538), [542](https://circleci.com/gh/gruntwork-io/terratest/542), [543](https://circleci.com/gh/gruntwork-io/terratest/543), [544](https://circleci.com/gh/gruntwork-io/terratest/544), [545](https://circleci.com/gh/gruntwork-io/terratest/545)) had multiple intermittent failures on the GCP tests. Because these tests passed consistently before, I wonder if the [recent GCP incident](https://status.cloud.google.com/incident/cloud-networking/18017) is relevant?

In either case, this is an initial attempt to fix GCP issues. Please do not merge until tests are passing consistently. Please do feel free to comment with feedback and ideas.

'cc @yorinasub17 

