### PR TITLE
lock pre-commit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ jobs:
 
       # Run pre-commit hooks and fail the build if any hook finds required changes.
       - run: go get golang.org/x/tools/cmd/goimports
-      - run: pip install pre-commit
+      - run: pip install pre-commit==1.11.2
       - run: pre-commit install
       - run: pre-commit run --all-files
 


### PR DESCRIPTION
It looks like `pre-commit` was recently updated, and there is a bug, so this PR locks it down to the last known working version.

[Build 545](https://circleci.com/gh/gruntwork-io/terratest/545) passed the precommit step with this version:

<img width="1322" alt="circleci" src="https://user-images.githubusercontent.com/430092/47428966-ad026580-d749-11e8-85aa-24438ec70d8d.png">

But both builds [547](https://circleci.com/gh/gruntwork-io/terratest/547) and [549](https://circleci.com/gh/gruntwork-io/terratest/549) did not pass the precommit step with a later version:

<img width="1328" alt="continuous_integration_and_deployment" src="https://user-images.githubusercontent.com/430092/47429049-f5218800-d749-11e8-8cb1-b950f624ff93.png">

It fails with an import error:

```
Traceback (most recent call last):
  File "/opt/circleci/.pyenv/versions/2.7.12/bin/pre-commit", line 7, in <module>
    from pre_commit.main import main
  File "/opt/circleci/.pyenv/versions/2.7.12/lib/python2.7/site-packages/pre_commit/main.py", line 11, in <module>
    from pre_commit import git
  File "/opt/circleci/.pyenv/versions/2.7.12/lib/python2.7/site-packages/pre_commit/git.py", line 7, in <module>
    from pre_commit.error_handler import FatalError
  File "/opt/circleci/.pyenv/versions/2.7.12/lib/python2.7/site-packages/pre_commit/error_handler.py", line 12, in <module>
    from pre_commit import output
  File "/opt/circleci/.pyenv/versions/2.7.12/lib/python2.7/site-packages/pre_commit/output.py", line 7, in <module>
    from pre_commit.util import noop_context
  File "/opt/circleci/.pyenv/versions/2.7.12/lib/python2.7/site-packages/pre_commit/util.py", line 22, in <module>
    from importlib_resources import open_binary
ImportError: No module named importlib_resources
Exited with code 1
```

cc @josh-padnick @eak12913 