### PR TITLE
Fix README and CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,7 @@ jobs:
           paths: cmd/bin
 
       - run:
-          command: ./cmd/bin/terratest_log_parser_linux_amd64 -testlog /tmp/logs/test_output.log -outputdir /tmp/logs
+          command: ./cmd/bin/terratest_log_parser_linux_amd64 --testlog /tmp/logs/test_output.log --outputdir /tmp/logs
           when: always
 
       # Store test result and log artifacts for browsing purposes
@@ -72,6 +72,10 @@ jobs:
     machine: true
     steps:
       - checkout
+      - attach_workspace:
+          at: .
+      - run: echo 'export PATH=$HOME/.local/bin:$PATH' >> $BASH_ENV
+      - run: curl -Ls https://raw.githubusercontent.com/gruntwork-io/gruntwork-installer/master/bootstrap-gruntwork-installer.sh | bash /dev/stdin --version v0.0.21
       - run: gruntwork-install --module-name "gruntwork-module-circleci-helpers" --repo "https://github.com/gruntwork-io/module-ci" --tag "v0.13.2"
       - run: upload-github-release-assets cmd/bin/*
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,6 @@ jobs:
       - checkout
       - attach_workspace:
           at: .
-      - run: echo 'export PATH=$HOME/.local/bin:$PATH' >> $BASH_ENV
       - run: curl -Ls https://raw.githubusercontent.com/gruntwork-io/gruntwork-installer/master/bootstrap-gruntwork-installer.sh | bash /dev/stdin --version v0.0.21
       - run: gruntwork-install --module-name "gruntwork-module-circleci-helpers" --repo "https://github.com/gruntwork-io/module-ci" --tag "v0.13.2"
       - run: upload-github-release-assets cmd/bin/*

--- a/README.md
+++ b/README.md
@@ -325,11 +325,11 @@ provides for each build:
 
 - A test summary view showing you which tests failed:
 
-[CircleCI test summary](/_docs/images/circleci-test-summary.png)
+![CircleCI test summary](/_docs/images/circleci-test-summary.png)
 
 - A snapshot of all the logs broken out by test:
 
-[CircleCI logs](/_docs/images/circleci-logs.png)
+![CircleCI logs](/_docs/images/circleci-logs.png)
 
 You can download the compiled versions of the utility for your platform from the [Releases page](https://github.com/gruntwork-io/terratest/releases).
 

--- a/cmd/terratest_log_parser/main.go
+++ b/cmd/terratest_log_parser/main.go
@@ -58,7 +58,6 @@ Options:
                       (default: "info")
    --testlog value    Path to file containing test log. If unset will use stdin.
    --outputdir value  Path to directory to output test output to. If unset will use the current directory.
-                      (default: "/Users/yoriy/go/src/github.com/gruntwork-io/terratest/cmd/terratest_log_parser/out")
    --help, -h         show help
 `
 

--- a/test/terraform_gcp_example_test.go
+++ b/test/terraform_gcp_example_test.go
@@ -100,7 +100,8 @@ func TestSshAccessToComputeInstance(t *testing.T) {
 	// Setup values for our Terraform apply
 	projectID := gcp.GetGoogleProjectIDFromEnvVar(t)
 	randomValidGcpName := gcp.RandomValidGcpName()
-	zone := gcp.GetRandomZone(t, projectID, nil, nil, nil)
+	// On October 22, 2018, GCP launched the asia-east2 region, which promptly failed all our tests, so blacklist asia-east2.
+	zone := gcp.GetRandomZone(t, projectID, nil, nil, []string{"asia-east2"})
 
 	terraformOptions := &terraform.Options{
 		// The path to where our Terraform code is located


### PR DESCRIPTION
This makes a few minor adjustments to https://github.com/gruntwork-io/terratest/pull/179:

- `README` images were not rendered properly
- Help text awkwardly mentions my directory as a default
- Fixes circleci deployment config (you can see [error here](https://circleci.com/gh/gruntwork-io/terratest/567)). To verify the current config would do the right thing, [I ran a test config that ran `ls` on the directory instead of `upload-github-release-assets`](https://circleci.com/gh/gruntwork-io/terratest/570). You can see in the circleci build logs that it found the built binaries when running `ls`.