### PR TITLE
Found and fixed two issues

### DIFF
--- a/modules/aws/ec2-files.go
+++ b/modules/aws/ec2-files.go
@@ -218,21 +218,15 @@ func FetchFilesFromAsgsE(t *testing.T, awsRegion string, spec RemoteFileSpecific
 
 			instanceIDs, err := GetInstanceIdsForAsgE(t, curAsg, awsRegion)
 			if err != nil {
-				return err
-			}
-
-			for _, instanceID := range instanceIDs {
-				err = FetchFilesFromInstanceE(t, awsRegion, spec.SshUser, spec.KeyPair, instanceID, spec.UseSudo, curRemoteDir, spec.LocalDestinationDir, fileFilters)
-
-				if err != nil {
-					errorsOccurred = append(errorsOccurred, err)
-					err = nil // since we reuse err, make sure not to double add the same error if this loop exits
-				}
-			}
-
-			if err != nil {
 				errorsOccurred = append(errorsOccurred, err)
-				err = nil
+			} else {
+				for _, instanceID := range instanceIDs {
+					err = FetchFilesFromInstanceE(t, awsRegion, spec.SshUser, spec.KeyPair, instanceID, spec.UseSudo, curRemoteDir, spec.LocalDestinationDir, fileFilters)
+
+					if err != nil {
+						errorsOccurred = append(errorsOccurred, err)
+					}
+				}
 			}
 		}
 	}

--- a/modules/aws/ec2-files.go
+++ b/modules/aws/ec2-files.go
@@ -221,18 +221,18 @@ func FetchFilesFromAsgsE(t *testing.T, awsRegion string, spec RemoteFileSpecific
 				return err
 			}
 
-			errorsOccurred := []error{}
-
 			for _, instanceID := range instanceIDs {
 				err = FetchFilesFromInstanceE(t, awsRegion, spec.SshUser, spec.KeyPair, instanceID, spec.UseSudo, curRemoteDir, spec.LocalDestinationDir, fileFilters)
 
 				if err != nil {
 					errorsOccurred = append(errorsOccurred, err)
+					err = nil // since we reuse err, make sure not to double add the same error if this loop exits
 				}
 			}
 
 			if err != nil {
 				errorsOccurred = append(errorsOccurred, err)
+				err = nil
 			}
 		}
 	}

--- a/modules/ssh/ssh.go
+++ b/modules/ssh/ssh.go
@@ -350,8 +350,8 @@ func listFileInRemoteDir(t *testing.T, sshSession *SshSession, options ScpDownlo
 
 		findCommandArgs = append(findCommandArgs, "\\(")
 		for i, curFilter := range options.FileNameFilters {
-			// due to inconsistent bash behavior we need to wrap the wildcard if it
-			// is just on its own.
+			// due to inconsistent bash behavior we need to wrap the
+			// filter in single quotes
 			curFilter = fmt.Sprintf("'%s'", curFilter)
 			findCommandArgs = append(findCommandArgs, "-name", curFilter)
 

--- a/modules/ssh/ssh.go
+++ b/modules/ssh/ssh.go
@@ -350,6 +350,9 @@ func listFileInRemoteDir(t *testing.T, sshSession *SshSession, options ScpDownlo
 
 		findCommandArgs = append(findCommandArgs, "\\(")
 		for i, curFilter := range options.FileNameFilters {
+			// due to inconsistent bash behavior we need to wrap the wildcard if it
+			// is just on its own.
+			curFilter = fmt.Sprintf("'%s'", curFilter)
 			findCommandArgs = append(findCommandArgs, "-name", curFilter)
 
 			// only add the or flag if we're not the last element
@@ -364,7 +367,8 @@ func listFileInRemoteDir(t *testing.T, sshSession *SshSession, options ScpDownlo
 		findCommandArgs = append(findCommandArgs, "-size", fmt.Sprintf("-%dM", options.MaxFileSizeMB))
 	}
 
-	resultString, err := CheckSshCommandE(t, options.RemoteHost, strings.Join(findCommandArgs, " "))
+	finalCommandString := strings.Join(findCommandArgs, " ")
+	resultString, err := CheckSshCommandE(t, options.RemoteHost, finalCommandString)
 
 	if err != nil {
 		return result, err

--- a/test/terraform_scp_example_test.go
+++ b/test/terraform_scp_example_test.go
@@ -134,6 +134,11 @@ func testScpDirFromHost(t *testing.T, terraformOptions *terraform.Options, keyPa
 			2,
 		},
 		{
+			"GrabAllFilesExplicit",
+			ssh.ScpDownloadOptions{RemoteHost: publicHost, RemoteDir: remoteTempFolder, LocalDir: filepath.Join(localDestDir, random.UniqueId()), FileNameFilters: []string{"*"}},
+			2,
+		},
+		{
 			"GrabFilesWithFilter",
 			ssh.ScpDownloadOptions{RemoteHost: publicHost, RemoteDir: remoteTempFolder, LocalDir: filepath.Join(localDestDir, random.UniqueId()), FileNameFilters: []string{"*.baz"}},
 			1,


### PR DESCRIPTION
1. There was an issue propagating errors out of ssh.go. There was an erroneous declaration of the errors array that would clobber any existing errors that were in there. The result was that some kinds of errors would not be propagated to the calling functions as expected.
2. There was a problem in some bash versions when calling the find command with the "*" filter. The solution turned out that we have to wrap in single quotes, but _only_ if the filter is just for "*" (https://stackoverflow.com/questions/6495501/find-paths-must-precede-expression-how-do-i-specify-a-recursive-search-that)