### PR TITLE
Remove broken symlink from fixtures

### DIFF
--- a/modules/files/files_test.go
+++ b/modules/files/files_test.go
@@ -74,6 +74,19 @@ func TestCopyFolderContentsWithSymLinks(t *testing.T) {
 func TestCopyFolderContentsWithBrokenSymLinks(t *testing.T) {
 	t.Parallel()
 
+	// Creating broken symlink
+	pathToFile := filepath.Join(copyFolderContentsFixtureRoot, "symlinks-broken/nonexistent-folder/bar.txt")
+	pathToSymlink := filepath.Join(copyFolderContentsFixtureRoot, "symlinks-broken/bar.txt")
+	defer func() {
+		if err := os.Remove(pathToSymlink); err != nil {
+			t.Fatal(fmt.Errorf("Failed to remove link: %+v", err))
+		}
+	}()
+	if err := os.Symlink(pathToFile, pathToSymlink); err != nil {
+		t.Fatal(fmt.Errorf("Failed to create broken link for test: %+v", err))
+	}
+
+	// Test copying folder
 	originalDir := filepath.Join(copyFolderContentsFixtureRoot, "symlinks-broken")
 	tmpDir, err := ioutil.TempDir("", "TestCopyFolderContentsWithFilter")
 	assert.NoError(t, err)

--- a/test/fixtures/copy-folder-contents/symlinks-broken/bar.txt
+++ b/test/fixtures/copy-folder-contents/symlinks-broken/bar.txt
@@ -1,1 +1,0 @@
-nonexistent-folder/bar.txt


### PR DESCRIPTION
Fixture was causing errors on packer builds that copy terratest folder.
Replaced by creating the test file on the go during test.