### PR TITLE
Fix grub config prompt issue

### DIFF
--- a/examples/packer-basic-example/build.json
+++ b/examples/packer-basic-example/build.json
@@ -52,8 +52,8 @@
   "provisioners": [{
     "type": "shell",
     "inline": [
-      "DEBIAN_FRONTEND=noninteractive sudo apt-get update",
-      "DEBIAN_FRONTEND=noninteractive sudo apt-get upgrade -y"
+      "sudo DEBIAN_FRONTEND=noninteractive apt-get update",
+      "sudo DEBIAN_FRONTEND=noninteractive apt-get upgrade -y"
     ]
   }]
 }


### PR DESCRIPTION
The vars should apply after entering sudo shell, not before as they are wiped when the new shell environment is entered with sudo.