### PR TITLE
Return ssh command output on error case

### DIFF
--- a/modules/ssh/ssh.go
+++ b/modules/ssh/ssh.go
@@ -433,7 +433,7 @@ func runSSHCommand(t *testing.T, sshSession *SshSession) (string, error) {
 
 	bytes, err := sshSession.Session.CombinedOutput(sshSession.Options.Command)
 	if err != nil {
-		return "", err
+		return string(bytes), err
 	}
 
 	return string(bytes), nil

--- a/test/terraform_ssh_example_test.go
+++ b/test/terraform_ssh_example_test.go
@@ -126,6 +126,27 @@ func testSSHToPublicHost(t *testing.T, terraformOptions *terraform.Options, keyP
 
 		return "", nil
 	})
+
+	// Run a command on the server that results in an error,
+	expectedText = "Hello, World"
+	command = fmt.Sprintf("echo -n '%s' && exit 1", expectedText)
+	description = fmt.Sprintf("SSH to public host %s with error command", publicInstanceIP)
+
+	// Verify that we can SSH to the Instance, run the command and see the output
+	retry.DoWithRetry(t, description, maxRetries, timeBetweenRetries, func() (string, error) {
+
+		actualText, err := ssh.CheckSshCommandE(t, publicHost, command)
+
+		if err == nil {
+			return "", fmt.Errorf("Expected SSH command to return an error but got none")
+		}
+
+		if strings.TrimSpace(actualText) != expectedText {
+			return "", fmt.Errorf("Expected SSH command to return '%s' but got '%s'", expectedText, actualText)
+		}
+
+		return "", nil
+	})
 }
 
 func testSSHToPrivateHost(t *testing.T, terraformOptions *terraform.Options, keyPair *aws.Ec2Keypair) {


### PR DESCRIPTION
The output of running ssh commands was being thrown away on error situations.
This PR fixes that. 