### PR TITLE
Expose k8s node api without test

### DIFF
--- a/modules/k8s/client.go
+++ b/modules/k8s/client.go
@@ -9,14 +9,8 @@ import (
 	"github.com/gruntwork-io/terratest/modules/logger"
 )
 
-// GetKubernetesClientE returns a Kubernetes API client that can be used to make requests.
-func GetKubernetesClientE(t *testing.T) (*kubernetes.Clientset, error) {
-	kubeConfigPath, err := GetKubeConfigPathE(t)
-	if err != nil {
-		return nil, err
-	}
-
-	logger.Logf(t, "Configuring kubectl using config file %s", kubeConfigPath)
+// GetKubernetesClientFromFileE returns a Kubernetes API client given the kubernetes config file path.
+func GetKubernetesClientFromFileE(kubeConfigPath string) (*kubernetes.Clientset, error) {
 	// Load API config (instead of more low level ClientConfig)
 	config, err := clientcmd.BuildConfigFromFlags("", kubeConfigPath)
 	if err != nil {
@@ -29,4 +23,15 @@ func GetKubernetesClientE(t *testing.T) (*kubernetes.Clientset, error) {
 	}
 
 	return clientset, nil
+}
+
+// GetKubernetesClientE returns a Kubernetes API client that can be used to make requests.
+func GetKubernetesClientE(t *testing.T) (*kubernetes.Clientset, error) {
+	kubeConfigPath, err := GetKubeConfigPathE(t)
+	if err != nil {
+		return nil, err
+	}
+
+	logger.Logf(t, "Configuring kubectl using config file %s", kubeConfigPath)
+	return GetKubernetesClientFromFileE(kubeConfigPath)
 }

--- a/modules/k8s/client.go
+++ b/modules/k8s/client.go
@@ -4,15 +4,14 @@ import (
 	"testing"
 
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/gruntwork-io/terratest/modules/logger"
 )
 
 // GetKubernetesClientFromFileE returns a Kubernetes API client given the kubernetes config file path.
-func GetKubernetesClientFromFileE(kubeConfigPath string) (*kubernetes.Clientset, error) {
+func GetKubernetesClientFromFileE(kubeConfigPath string, contextName string) (*kubernetes.Clientset, error) {
 	// Load API config (instead of more low level ClientConfig)
-	config, err := clientcmd.BuildConfigFromFlags("", kubeConfigPath)
+	config, err := LoadApiClientConfig(kubeConfigPath, contextName)
 	if err != nil {
 		return nil, err
 	}
@@ -33,5 +32,5 @@ func GetKubernetesClientE(t *testing.T) (*kubernetes.Clientset, error) {
 	}
 
 	logger.Logf(t, "Configuring kubectl using config file %s", kubeConfigPath)
-	return GetKubernetesClientFromFileE(kubeConfigPath)
+	return GetKubernetesClientFromFileE(kubeConfigPath, "")
 }

--- a/modules/k8s/config.go
+++ b/modules/k8s/config.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	homedir "github.com/mitchellh/go-homedir"
+	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/clientcmd/api"
 
@@ -21,6 +22,19 @@ func LoadConfigFromPath(path string) clientcmd.ClientConfig {
 		&clientcmd.ClientConfigLoadingRules{ExplicitPath: path},
 		&clientcmd.ConfigOverrides{})
 	return config
+}
+
+// LoadApiClientConfig will load a ClientConfig object from a file path that points to a location on disk containing a
+// kubectl config, with the requested context loaded.
+func LoadApiClientConfig(path string, context string) (*restclient.Config, error) {
+	overrides := clientcmd.ConfigOverrides{}
+	if context != "" {
+		overrides.CurrentContext = context
+	}
+	config := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+		&clientcmd.ClientConfigLoadingRules{ExplicitPath: path},
+		&overrides)
+	return config.ClientConfig()
 }
 
 // DeleteConfigContextE will remove the context specified at the provided name, and remove any clusters and authinfos

--- a/modules/k8s/node.go
+++ b/modules/k8s/node.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gruntwork-io/terratest/modules/retry"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 )
 
 // GetNodes queries Kubernetes for information about the worker nodes registered to the cluster. If anything goes wrong,
@@ -28,7 +29,12 @@ func GetNodesE(t *testing.T) ([]corev1.Node, error) {
 	if err != nil {
 		return nil, err
 	}
+	return GetNodesByClientE(clientset)
+}
 
+// GetNodesByClientE queries Kubernetes for information about the worker nodes registered to the cluster, given a
+// clientset.
+func GetNodesByClientE(clientset *kubernetes.Clientset) ([]corev1.Node, error) {
 	nodes, err := clientset.CoreV1().Nodes().List(metav1.ListOptions{})
 	if err != nil {
 		return nil, err

--- a/modules/k8s/node.go
+++ b/modules/k8s/node.go
@@ -29,13 +29,13 @@ func GetNodesE(t *testing.T) ([]corev1.Node, error) {
 	if err != nil {
 		return nil, err
 	}
-	return GetNodesByClientE(clientset)
+	return GetNodesByClientE(clientset, metav1.ListOptions{})
 }
 
 // GetNodesByClientE queries Kubernetes for information about the worker nodes registered to the cluster, given a
 // clientset.
-func GetNodesByClientE(clientset *kubernetes.Clientset) ([]corev1.Node, error) {
-	nodes, err := clientset.CoreV1().Nodes().List(metav1.ListOptions{})
+func GetNodesByClientE(clientset *kubernetes.Clientset, options metav1.ListOptions) ([]corev1.Node, error) {
+	nodes, err := clientset.CoreV1().Nodes().List(options)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
I wanted to reuse some of the functions i wrote here in a non-test context, so reorganized some of the functions so that logging can happen outside of core functionality.