### PR TITLE
k8s enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,8 +124,10 @@ such as:
 1.  [Terraform Packer Example](/examples/terraform-packer-example): A more complicated example that shows how to use
     Packer to build an AMI with a web server installed and deploy that AMI in AWS using Terraform.
 1.  [Terraform GCP Example](/examples/terraform-gcp-example): A simple Terraform configuration that creates a GCP Compute Instance and Storage Bucket.
-1.  [Terraform remote-exec Example](/examples/terraform-remote-exec-example): A terraform configuration that creates and 
+1.  [Terraform remote-exec Example](/examples/terraform-remote-exec-example): A terraform configuration that creates and
     AWS instance and then uses `remote-exec` to provision it.
+1.  [Basic Kubernetes Example](/examples/kubernetes-basic-example): A minimal Kubernetes resource that deploys an
+    addressable nginx instance.
 
 Next, head over to the [test folder](/test) to see how you can use Terraform to test each of these examples:
 
@@ -148,6 +150,9 @@ Next, head over to the [test folder](/test) to see how you can use Terraform to 
 1.  [terraform_scp_example_test.go](/test/terraform_scp_example_test.go): Use Terratest to simplify copying resources
     like config files and logs from deployed EC2 Instances. This is especially useful for getting a snapshot of the
     state of a deployment when a test fails.
+1.  [kubernetes_basic_example_test.go](/test/kubernetes_basic_example_test.go): Use Terratest to run `kubectl apply`
+    apply a Kubernetes resource file, verify resources are created using the Kubernetes API, and then run `kubectl
+    delete` to delete the resources at the end of the test.
     
 
 Finally, to see some real-world examples of Terratest in action, check out some of our open source infrastructure

--- a/examples/kubernetes-basic-example/README.md
+++ b/examples/kubernetes-basic-example/README.md
@@ -1,0 +1,40 @@
+# Kubernetes Basic Example
+
+This folder contains a minimal Kubernetes resource config file to demonstrate how you can use Terratest to write
+automated tests for Kubernetes.
+
+This resource file deploys an nginx container as a single pod deployment with a node port service attached to it.
+
+See the corresponding terratest code for an example of how to test this resource config:
+- [kubernetes_basic_example_test.go](../test/kubernetes_basic_example_test.go) for the most basic verification
+- [kubernetes_basic_example_service_check_test.go](../test/kubernetes_basic_example_service_check_test.go) for a more
+  advanced version of checking the service.
+
+
+## Deploying the Kubernetes resource
+
+1. Setup a Kubernetes cluster. We recommend using a local version:
+    - [minikube](https://github.com/kubernetes/minikube)
+    - [Kubernetes on Docker For Mac](https://docs.docker.com/docker-for-mac/kubernetes/)
+    - [Kubernetes on Docker For Windows](https://docs.docker.com/docker-for-windows/kubernetes/)
+
+1. Install and setup [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) to talk to the deployed
+   Kubernetes cluster.
+1. Run `kubectl apply -f nginx-deployment.yml`
+
+
+## Running automated tests against this Kubernetes deployment
+
+1. Setup a Kubernetes cluster. We recommend using a local version:
+    - [minikube](https://github.com/kubernetes/minikube)
+    - [Kubernetes on Docker For Mac](https://docs.docker.com/docker-for-mac/kubernetes/)
+    - [Kubernetes on Docker For Windows](https://docs.docker.com/docker-for-windows/kubernetes/)
+
+1. Install and setup [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) to talk to the deployed
+   Kubernetes cluster.
+1. Install and setup [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/).
+1. Install [Golang](https://golang.org/) and make sure this code is checked out into your `GOPATH`.
+1. `cd test`
+1. `dep ensure`
+1. `go test -v -run TestKubernetesBasicExample`
+1. You can also run `TestKubernetesBasicExampleServiceCheck`

--- a/examples/kubernetes-basic-example/nginx-deployment.yml
+++ b/examples/kubernetes-basic-example/nginx-deployment.yml
@@ -1,0 +1,33 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+spec:
+  selector:
+    matchLabels:
+      app: nginx
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.15.7
+        ports:
+        - containerPort: 80
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: nginx-service
+spec:
+  selector:
+    app: nginx
+  ports:
+  - protocol: TCP
+    targetPort: 80
+    port: 80
+  type: NodePort

--- a/modules/aws/ec2.go
+++ b/modules/aws/ec2.go
@@ -46,11 +46,6 @@ func GetPublicIpsOfEc2Instances(t *testing.T, instanceIDs []string, awsRegion st
 // GetPublicIpsOfEc2InstancesE gets the public IP address of the given EC2 Instance in the given region. Returns a map of instance ID to IP address.
 func GetPublicIpsOfEc2InstancesE(t *testing.T, instanceIDs []string, awsRegion string) (map[string]string, error) {
 	ec2Client := NewEc2Client(t, awsRegion)
-	return GetPublicIpsOfEc2InstancesFromClientE(ec2Client, instanceIDs, awsRegion)
-}
-
-// GetPublicIpsOfEc2InstancesFromClientE is the same as GetPublicIpsOfEc2InstancesE, but can be used outside of tests
-func GetPublicIpsOfEc2InstancesFromClientE(ec2Client *ec2.EC2, instanceIDs []string, awsRegion string) (map[string]string, error) {
 	input := ec2.DescribeInstancesInput{InstanceIds: aws.StringSlice(instanceIDs)}
 	output, err := ec2Client.DescribeInstances(&input)
 	if err != nil {

--- a/modules/aws/ec2.go
+++ b/modules/aws/ec2.go
@@ -46,7 +46,11 @@ func GetPublicIpsOfEc2Instances(t *testing.T, instanceIDs []string, awsRegion st
 // GetPublicIpsOfEc2InstancesE gets the public IP address of the given EC2 Instance in the given region. Returns a map of instance ID to IP address.
 func GetPublicIpsOfEc2InstancesE(t *testing.T, instanceIDs []string, awsRegion string) (map[string]string, error) {
 	ec2Client := NewEc2Client(t, awsRegion)
+	return GetPublicIpsOfEc2InstancesFromClientE(ec2Client, instanceIDs, awsRegion)
+}
 
+// GetPublicIpsOfEc2InstancesFromClientE is the same as GetPublicIpsOfEc2InstancesE, but can be used outside of tests
+func GetPublicIpsOfEc2InstancesFromClientE(ec2Client *ec2.EC2, instanceIDs []string, awsRegion string) (map[string]string, error) {
 	input := ec2.DescribeInstancesInput{InstanceIds: aws.StringSlice(instanceIDs)}
 	output, err := ec2Client.DescribeInstances(&input)
 	if err != nil {

--- a/modules/aws/keypair_test.go
+++ b/modules/aws/keypair_test.go
@@ -14,7 +14,7 @@ import (
 func TestCreateImportAndDeleteEC2KeyPair(t *testing.T) {
 	t.Parallel()
 
-	region := GetRandomRegion(t, nil, nil)
+	region := GetRandomStableRegion(t, nil, nil)
 	uniqueID := random.UniqueId()
 	name := fmt.Sprintf("test-key-pair-%s", uniqueID)
 

--- a/modules/aws/region.go
+++ b/modules/aws/region.go
@@ -44,8 +44,13 @@ var stableRegions = []string{
 // those that have been around for at least 1 year.
 // Note that regions in the approvedRegions list that are not considered stable are ignored.
 func GetRandomStableRegion(t *testing.T, approvedRegions []string, forbiddenRegions []string) string {
-	regionsToPickFrom := collections.ListIntersection(stableRegions, approvedRegions)
-	regionsToPickFrom = collections.ListSubtract(regionsToPickFrom, forbiddenRegions)
+	regionsToPickFrom := stableRegions
+	if len(approvedRegions) > 0 {
+		regionsToPickFrom = collections.ListIntersection(regionsToPickFrom, approvedRegions)
+	}
+	if len(forbiddenRegions) > 0 {
+		regionsToPickFrom = collections.ListSubtract(regionsToPickFrom, forbiddenRegions)
+	}
 	return GetRandomRegion(t, regionsToPickFrom, nil)
 }
 

--- a/modules/aws/region.go
+++ b/modules/aws/region.go
@@ -20,6 +20,35 @@ const regionOverrideEnvVarName = "TERRATEST_REGION"
 // this region as a default.
 const defaultRegion = "us-east-1"
 
+// Reference for launch dates: https://aws.amazon.com/about-aws/global-infrastructure/
+var stableRegions = []string{
+	"us-east-1",      // Launched 2006
+	"us-east-2",      // Launched 2016
+	"us-west-1",      // Launched 2009
+	"us-west-2",      // Launched 2011
+	"ca-central-1",   // Launched 2016
+	"sa-east-1",      // Launched 2011
+	"eu-west-1",      // Launched 2007
+	"eu-west-2",      // Launched 2016
+	"eu-west-3",      // Launched 2017
+	"eu-central-1",   // Launched 2014
+	"ap-southeast-1", // Launched 2010
+	"ap-southeast-2", // Launched 2012
+	"ap-northeast-1", // Launched 2011
+	"ap-northeast-2", // Launched 2016
+	"ap-south-1",     // Launched 2016
+}
+
+// GetStableRandomRegion gets a randomly chosen AWS region that is considered stable. Like GetRandomRegion, you can
+// further restrict the stable region list using approvedRegions and forbiddenRegions. We consider stable regions to be
+// those that have been around for at least 1 year.
+// Note that regions in the approvedRegions list that are not considered stable are ignored.
+func GetRandomStableRegion(t *testing.T, approvedRegions []string, forbiddenRegions []string) string {
+	regionsToPickFrom := collections.ListIntersection(stableRegions, approvedRegions)
+	regionsToPickFrom = collections.ListSubtract(regionsToPickFrom, forbiddenRegions)
+	return GetRandomRegion(t, regionsToPickFrom, nil)
+}
+
 // GetRandomRegion gets a randomly chosen AWS region. If approvedRegions is not empty, this will be a region from the approvedRegions
 // list; otherwise, this method will fetch the latest list of regions from the AWS APIs and pick one of those. If
 // forbiddenRegions is not empty, this method will make sure the returned region is not in the forbiddenRegions list.

--- a/modules/aws/region_test.go
+++ b/modules/aws/region_test.go
@@ -45,7 +45,7 @@ func assertLooksLikeRegionName(t *testing.T, regionName string) {
 func TestGetAvailabilityZones(t *testing.T) {
 	t.Parallel()
 
-	randomRegion := GetRandomRegion(t, nil, nil)
+	randomRegion := GetRandomStableRegion(t, nil, nil)
 	azs := GetAvailabilityZones(t, randomRegion)
 
 	// Every AWS account has access to different AZs, so he best we can do is make sure we get at least one back

--- a/modules/aws/s3_test.go
+++ b/modules/aws/s3_test.go
@@ -19,7 +19,7 @@ import (
 func TestCreateAndDestroyS3Bucket(t *testing.T) {
 	t.Parallel()
 
-	region := GetRandomRegion(t, nil, nil)
+	region := GetRandomStableRegion(t, nil, nil)
 	id := random.UniqueId()
 	logger.Logf(t, "Random values selected. Region = %s, Id = %s\n", region, id)
 
@@ -32,7 +32,7 @@ func TestCreateAndDestroyS3Bucket(t *testing.T) {
 func TestAssertS3BucketExistsNoFalseNegative(t *testing.T) {
 	t.Parallel()
 
-	region := GetRandomRegion(t, nil, nil)
+	region := GetRandomStableRegion(t, nil, nil)
 	s3BucketName := "gruntwork-terratest-" + strings.ToLower(random.UniqueId())
 	logger.Logf(t, "Random values selected. Region = %s, s3BucketName = %s\n", region, s3BucketName)
 
@@ -45,7 +45,7 @@ func TestAssertS3BucketExistsNoFalseNegative(t *testing.T) {
 func TestAssertS3BucketExistsNoFalsePositive(t *testing.T) {
 	t.Parallel()
 
-	region := GetRandomRegion(t, nil, nil)
+	region := GetRandomStableRegion(t, nil, nil)
 	s3BucketName := "gruntwork-terratest-" + strings.ToLower(random.UniqueId())
 	logger.Logf(t, "Random values selected. Region = %s, s3BucketName = %s\n", region, s3BucketName)
 
@@ -61,7 +61,7 @@ func TestAssertS3BucketExistsNoFalsePositive(t *testing.T) {
 func TestEmptyS3Bucket(t *testing.T) {
 	t.Parallel()
 
-	// region := GetRandomRegion(t, nil, nil)
+	// region := GetRandomStableRegion(t, nil, nil)
 	region := "us-east-1"
 	id := random.UniqueId()
 	logger.Logf(t, "Random values selected. Region = %s, Id = %s\n", region, id)
@@ -82,7 +82,7 @@ func TestEmptyS3Bucket(t *testing.T) {
 func TestEmptyS3BucketVersioned(t *testing.T) {
 	t.Parallel()
 
-	region := GetRandomRegion(t, nil, nil)
+	region := GetRandomStableRegion(t, nil, nil)
 
 	id := random.UniqueId()
 	logger.Logf(t, "Random values selected. Region = %s, Id = %s\n", region, id)

--- a/modules/aws/sns_test.go
+++ b/modules/aws/sns_test.go
@@ -14,7 +14,7 @@ import (
 func TestCreateAndDeleteSnsTopic(t *testing.T) {
 	t.Parallel()
 
-	region := GetRandomRegion(t, nil, nil)
+	region := GetRandomStableRegion(t, nil, nil)
 	uniqueID := random.UniqueId()
 	name := fmt.Sprintf("test-sns-topic-%s", uniqueID)
 

--- a/modules/aws/sqs_test.go
+++ b/modules/aws/sqs_test.go
@@ -14,7 +14,7 @@ import (
 func TestSqsQueueMethods(t *testing.T) {
 	t.Parallel()
 
-	region := GetRandomRegion(t, nil, nil)
+	region := GetRandomStableRegion(t, nil, nil)
 	uniqueID := random.UniqueId()
 	namePrefix := fmt.Sprintf("sqs-queue-test-%s", uniqueID)
 

--- a/modules/aws/vpc_test.go
+++ b/modules/aws/vpc_test.go
@@ -9,7 +9,7 @@ import (
 func TestGetDefaultVpc(t *testing.T) {
 	t.Parallel()
 
-	region := GetRandomRegion(t, nil, nil)
+	region := GetRandomStableRegion(t, nil, nil)
 	vpc := GetDefaultVpc(t, region)
 
 	assert.NotEmpty(t, vpc.Name)

--- a/modules/collections/lists.go
+++ b/modules/collections/lists.go
@@ -1,5 +1,20 @@
 package collections
 
+// ListIntersection returns all the items in both list1 and list2. Note that this will dedup the items so that the
+// output is more predictable. Otherwise, the end list depends on which list was used as the base.
+func ListIntersection(list1 []string, list2 []string) []string {
+	out := []string{}
+
+	// Only need to iterate list1, because we want items in both lists, not union.
+	for _, item := range list1 {
+		if ListContains(list2, item) && !ListContains(out, item) {
+			out = append(out, item)
+		}
+	}
+
+	return out
+}
+
 // ListSubtract removes all the items in list2 from list1.
 func ListSubtract(list1 []string, list2 []string) []string {
 	out := []string{}

--- a/modules/collections/lists_test.go
+++ b/modules/collections/lists_test.go
@@ -59,3 +59,31 @@ func TestSubtract(t *testing.T) {
 		})
 	}
 }
+
+func TestIntersection(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		description string
+		list1       []string
+		list2       []string
+		expected    []string
+	}{
+		{"empty list, empty list", []string{}, []string{}, []string{}},
+		{"empty list, non-empty list", []string{}, []string{"foo"}, []string{}},
+		{"non-empty list, empty list", []string{"foo"}, []string{}, []string{}},
+		{"list with 1 item, list with no matches", []string{"foo"}, []string{"bar"}, []string{}},
+		{"list with 1 item, list with 1 match", []string{"foo"}, []string{"foo"}, []string{"foo"}},
+		{"list with 1 item, list with multiple matches and non-matches", []string{"foo"}, []string{"foo", "bar", "foo"}, []string{"foo"}},
+		{"list with multiple items, list with no matches", []string{"foo", "bar", "baz"}, []string{"abc", "def"}, []string{}},
+		{"list with multiple items, list with 1 match", []string{"foo", "bar", "baz"}, []string{"abc", "foo", "def"}, []string{"foo"}},
+		{"list with multiple items, list with multiple matches", []string{"foo", "bar", "baz", "foo", "bar", "baz"}, []string{"abc", "foo", "baz"}, []string{"foo", "baz"}},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.description, func(t *testing.T) {
+			actual := ListIntersection(testCase.list1, testCase.list2)
+			assert.Equal(t, testCase.expected, actual)
+		})
+	}
+}

--- a/modules/http-helper/continuous.go
+++ b/modules/http-helper/continuous.go
@@ -29,8 +29,12 @@ func ContinuouslyCheckUrl(
 				statusCode, body, err := HttpGetE(t, url)
 				logger.Logf(t, "Got response %d and err %v from URL at %s", statusCode, err, url)
 				if err != nil {
+					// We use Errorf instead of Fatalf here because Fatalf is not goroutine safe, while Errorf is. Refer
+					// to the docs on `T`: https://godoc.org/testing#T
 					t.Errorf("Failed to make HTTP request to the URL at %s: %s\n", url, err.Error())
 				} else if statusCode != 200 {
+					// We use Errorf instead of Fatalf here because Fatalf is not goroutine safe, while Errorf is. Refer
+					// to the docs on `T`: https://godoc.org/testing#T
 					t.Errorf("Got a non-200 response (%d) from the URL at %s, which means there was downtime! Response body: %s", statusCode, url, body)
 				}
 			}

--- a/modules/http-helper/continuous.go
+++ b/modules/http-helper/continuous.go
@@ -8,18 +8,27 @@ import (
 	"github.com/gruntwork-io/terratest/modules/logger"
 )
 
+type GetResponse struct {
+	StatusCode int
+	Body       string
+}
+
 // Continuously check the given URL every 1 second until the stopChecking channel receives a signal to stop.
-// This function will return a sync.WaitGroup that can be used to wait for the checking to stop.
+// This function will return a sync.WaitGroup that can be used to wait for the checking to stop, and a read only channel
+// to stream the responses for each check.
+// Note that the channel has a buffer of 1000, after which it will start to drop the send events
 func ContinuouslyCheckUrl(
 	t *testing.T,
 	url string,
 	stopChecking <-chan bool,
 	sleepBetweenChecks time.Duration,
-) *sync.WaitGroup {
+) (*sync.WaitGroup, <-chan GetResponse) {
 	var wg sync.WaitGroup
 	wg.Add(1)
+	responses := make(chan GetResponse, 1000)
 	go func() {
 		defer wg.Done()
+		defer close(responses)
 		for {
 			select {
 			case <-stopChecking:
@@ -27,6 +36,13 @@ func ContinuouslyCheckUrl(
 				return
 			case <-time.After(sleepBetweenChecks):
 				statusCode, body, err := HttpGetE(t, url)
+				// Nonblocking send, defaulting to logging a warning if there is no channel reader
+				select {
+				case responses <- GetResponse{StatusCode: statusCode, Body: body}:
+					// do nothing since all we want to do is send the response
+				default:
+					logger.Logf(t, "WARNING: ContinuouslyCheckUrl responses channel buffer is full")
+				}
 				logger.Logf(t, "Got response %d and err %v from URL at %s", statusCode, err, url)
 				if err != nil {
 					// We use Errorf instead of Fatalf here because Fatalf is not goroutine safe, while Errorf is. Refer
@@ -40,5 +56,5 @@ func ContinuouslyCheckUrl(
 			}
 		}
 	}()
-	return &wg
+	return &wg, responses
 }

--- a/modules/http-helper/continuous.go
+++ b/modules/http-helper/continuous.go
@@ -1,0 +1,29 @@
+package http_helper
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gruntwork-io/terratest/modules/logger"
+)
+
+// Continuously check the given URL every 1 second until the stopChecking channel receives a signal to stop.
+func ContinuouslyCheckUrl(t *testing.T, url string, stopChecking <-chan bool, sleepBetweenChecks time.Duration) {
+	go func() {
+		for {
+			select {
+			case <-stopChecking:
+				logger.Logf(t, "Got signal to stop downtime checks for URL %s.\n", url)
+				return
+			case <-time.After(sleepBetweenChecks):
+				statusCode, body, err := HttpGetE(t, url)
+				logger.Logf(t, "Got response %d and err %v from URL at %s", statusCode, err, url)
+				if err != nil {
+					t.Fatalf("Failed to make HTTP request to the URL at %s: %s\n", url, err.Error())
+				} else if statusCode != 200 {
+					t.Fatalf("Got a non-200 response (%d) from the URL at %s, which means there was downtime! Response body: %s", statusCode, url, body)
+				}
+			}
+		}
+	}()
+}

--- a/modules/http-helper/dummy_server.go
+++ b/modules/http-helper/dummy_server.go
@@ -28,7 +28,9 @@ func RunDummyServer(t *testing.T, text string) (net.Listener, int) {
 func RunDummyServerE(t *testing.T, text string) (net.Listener, int, error) {
 	port := getNextPort()
 
-	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+	// Create new serve mux so that multiple handlers can be created
+	server := http.NewServeMux()
+	server.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintf(w, text)
 	})
 
@@ -39,7 +41,7 @@ func RunDummyServerE(t *testing.T, text string) (net.Listener, int, error) {
 		return nil, 0, fmt.Errorf("error listening: %s", err)
 	}
 
-	go http.Serve(listener, nil)
+	go http.Serve(listener, server)
 
 	return listener, port, err
 }

--- a/modules/http-helper/dummy_server_test.go
+++ b/modules/http-helper/dummy_server_test.go
@@ -36,7 +36,7 @@ func TestContinuouslyCheck(t *testing.T) {
 	wg := ContinuouslyCheckUrl(t, url, stopChecking, 1*time.Second)
 	defer func() {
 		stopChecking <- true
-		wg.Done()
+		wg.Wait()
 		shutDownServer(t, listener)
 	}()
 	time.Sleep(5 * time.Second)

--- a/modules/k8s/client.go
+++ b/modules/k8s/client.go
@@ -15,14 +15,14 @@ func GetKubernetesClientE(t *testing.T) (*kubernetes.Clientset, error) {
 		return nil, err
 	}
 
-	logger.Logf(t, "Configuring kubectl using config file %s", kubeConfigPath)
-	return GetKubernetesClientFromFileE(kubeConfigPath, "")
+	return GetKubernetesClientFromFileE(t, kubeConfigPath, "")
 }
 
 // GetKubernetesClientFromFileE returns a Kubernetes API client given the kubernetes config file path.
-func GetKubernetesClientFromFileE(kubeConfigPath string, contextName string) (*kubernetes.Clientset, error) {
+func GetKubernetesClientFromFileE(t *testing.T, kubeConfigPath string, contextName string) (*kubernetes.Clientset, error) {
+	logger.Logf(t, "Configuring kubectl using config file %s with context %s", kubeConfigPath, contextName)
 	// Load API config (instead of more low level ClientConfig)
-	config, err := LoadApiClientConfig(kubeConfigPath, contextName)
+	config, err := LoadApiClientConfigE(kubeConfigPath, contextName)
 	if err != nil {
 		return nil, err
 	}

--- a/modules/k8s/client.go
+++ b/modules/k8s/client.go
@@ -8,6 +8,17 @@ import (
 	"github.com/gruntwork-io/terratest/modules/logger"
 )
 
+// GetKubernetesClientE returns a Kubernetes API client that can be used to make requests.
+func GetKubernetesClientE(t *testing.T) (*kubernetes.Clientset, error) {
+	kubeConfigPath, err := GetKubeConfigPathE(t)
+	if err != nil {
+		return nil, err
+	}
+
+	logger.Logf(t, "Configuring kubectl using config file %s", kubeConfigPath)
+	return GetKubernetesClientFromFileE(kubeConfigPath, "")
+}
+
 // GetKubernetesClientFromFileE returns a Kubernetes API client given the kubernetes config file path.
 func GetKubernetesClientFromFileE(kubeConfigPath string, contextName string) (*kubernetes.Clientset, error) {
 	// Load API config (instead of more low level ClientConfig)
@@ -22,15 +33,4 @@ func GetKubernetesClientFromFileE(kubeConfigPath string, contextName string) (*k
 	}
 
 	return clientset, nil
-}
-
-// GetKubernetesClientE returns a Kubernetes API client that can be used to make requests.
-func GetKubernetesClientE(t *testing.T) (*kubernetes.Clientset, error) {
-	kubeConfigPath, err := GetKubeConfigPathE(t)
-	if err != nil {
-		return nil, err
-	}
-
-	logger.Logf(t, "Configuring kubectl using config file %s", kubeConfigPath)
-	return GetKubernetesClientFromFileE(kubeConfigPath, "")
 }

--- a/modules/k8s/client.go
+++ b/modules/k8s/client.go
@@ -9,14 +9,8 @@ import (
 	"github.com/gruntwork-io/terratest/modules/logger"
 )
 
-// GetKubernetesClientE returns a Kubernetes API client that can be used to make requests.
-func GetKubernetesClientE(t *testing.T) (*kubernetes.Clientset, error) {
-	kubeConfigPath, err := GetKubeConfigPathE(t)
-	if err != nil {
-		return nil, err
-	}
-
-	logger.Logf(t, "Configuring kubectl using config file %s", kubeConfigPath)
+// GetKubernetesClientFromFileE returns a Kubernetes API client given the kubernetes config file path.
+func GetKubernetesClientFromFileE(kubeConfigPath string) (*kubernetes.Clientset, error) {
 	// Load API config (instead of more low level ClientConfig)
 	config, err := clientcmd.BuildConfigFromFlags("", kubeConfigPath)
 	if err != nil {
@@ -29,4 +23,15 @@ func GetKubernetesClientE(t *testing.T) (*kubernetes.Clientset, error) {
 	}
 
 	return clientset, nil
+}
+
+// GetKubernetesClientE returns a Kubernetes API client that can be used to make requests.
+func GetKubernetesClientE(t *testing.T) (*kubernetes.Clientset, error) {
+	kubeConfigPath, err := GetKubeConfigPathE(t)
+	if err != nil {
+		return nil, err
+	}
+
+	logger.Logf(t, "Configuring kubectl using config file %s", kubeConfigPath)
+	return GetKubernetesClientFromFileE(kubeConfigPath)
 }

--- a/modules/k8s/client.go
+++ b/modules/k8s/client.go
@@ -15,14 +15,26 @@ func GetKubernetesClientE(t *testing.T) (*kubernetes.Clientset, error) {
 		return nil, err
 	}
 
-	return GetKubernetesClientFromFileE(t, kubeConfigPath, "")
+	options := NewKubectlOptions("", kubeConfigPath)
+	return GetKubernetesClientFromOptionsE(t, options)
 }
 
-// GetKubernetesClientFromFileE returns a Kubernetes API client given the kubernetes config file path.
-func GetKubernetesClientFromFileE(t *testing.T, kubeConfigPath string, contextName string) (*kubernetes.Clientset, error) {
-	logger.Logf(t, "Configuring kubectl using config file %s with context %s", kubeConfigPath, contextName)
+// GetKubernetesClientFromOptionsE returns a Kubernetes API client given a configured KubectlOptions object.
+func GetKubernetesClientFromOptionsE(t *testing.T, options *KubectlOptions) (*kubernetes.Clientset, error) {
+	var err error
+
+	// We have to give an actual configpath for LoadApiClientConfigE to work
+	kubeConfigPath := options.ConfigPath
+	if kubeConfigPath == "" {
+		kubeConfigPath, err = GetKubeConfigPathE(t)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	logger.Logf(t, "Configuring kubectl using config file %s with context %s", kubeConfigPath, options.ContextName)
 	// Load API config (instead of more low level ClientConfig)
-	config, err := LoadApiClientConfigE(kubeConfigPath, contextName)
+	config, err := LoadApiClientConfigE(kubeConfigPath, options.ContextName)
 	if err != nil {
 		return nil, err
 	}

--- a/modules/k8s/client.go
+++ b/modules/k8s/client.go
@@ -4,15 +4,14 @@ import (
 	"testing"
 
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/gruntwork-io/terratest/modules/logger"
 )
 
 // GetKubernetesClientFromFileE returns a Kubernetes API client given the kubernetes config file path.
-func GetKubernetesClientFromFileE(kubeConfigPath string) (*kubernetes.Clientset, error) {
+func GetKubernetesClientFromFileE(kubeConfigPath string, contextName string) (*kubernetes.Clientset, error) {
 	// Load API config (instead of more low level ClientConfig)
-	config, err := clientcmd.BuildConfigFromFlags("", kubeConfigPath)
+	config, err := LoadApiClientConfig(kubeConfigPath, contextName)
 	if err != nil {
 		return nil, err
 	}
@@ -33,5 +32,5 @@ func GetKubernetesClientE(t *testing.T) (*kubernetes.Clientset, error) {
 	}
 
 	logger.Logf(t, "Configuring kubectl using config file %s", kubeConfigPath)
-	return GetKubernetesClientFromFileE(kubeConfigPath)
+	return GetKubernetesClientFromFileE(kubeConfigPath, "")
 }

--- a/modules/k8s/config.go
+++ b/modules/k8s/config.go
@@ -26,13 +26,13 @@ func LoadConfigFromPath(path string) clientcmd.ClientConfig {
 
 // LoadApiClientConfig will load a ClientConfig object from a file path that points to a location on disk containing a
 // kubectl config, with the requested context loaded.
-func LoadApiClientConfigE(path string, context string) (*restclient.Config, error) {
+func LoadApiClientConfigE(configPath string, contextName string) (*restclient.Config, error) {
 	overrides := clientcmd.ConfigOverrides{}
-	if context != "" {
-		overrides.CurrentContext = context
+	if contextName != "" {
+		overrides.CurrentContext = contextName
 	}
 	config := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
-		&clientcmd.ClientConfigLoadingRules{ExplicitPath: path},
+		&clientcmd.ClientConfigLoadingRules{ExplicitPath: configPath},
 		&overrides)
 	return config.ClientConfig()
 }

--- a/modules/k8s/config.go
+++ b/modules/k8s/config.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	homedir "github.com/mitchellh/go-homedir"
+	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/clientcmd/api"
 
@@ -21,6 +22,19 @@ func LoadConfigFromPath(path string) clientcmd.ClientConfig {
 		&clientcmd.ClientConfigLoadingRules{ExplicitPath: path},
 		&clientcmd.ConfigOverrides{})
 	return config
+}
+
+// LoadApiClientConfig will load a ClientConfig object from a file path that points to a location on disk containing a
+// kubectl config, with the requested context loaded.
+func LoadApiClientConfig(path string, context string) (*restclient.Config, error) {
+	overrides := clientcmd.ConfigOverrides{}
+	if context != "" {
+		overrides.CurrentContext = context
+	}
+	config := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+		&clientcmd.ClientConfigLoadingRules{ExplicitPath: path},
+		&overrides)
+	return config.ClientConfig()
 }
 
 // DeleteConfigContextE will remove the context specified at the provided name, and remove any clusters and authinfos

--- a/modules/k8s/config.go
+++ b/modules/k8s/config.go
@@ -26,7 +26,7 @@ func LoadConfigFromPath(path string) clientcmd.ClientConfig {
 
 // LoadApiClientConfig will load a ClientConfig object from a file path that points to a location on disk containing a
 // kubectl config, with the requested context loaded.
-func LoadApiClientConfig(path string, context string) (*restclient.Config, error) {
+func LoadApiClientConfigE(path string, context string) (*restclient.Config, error) {
 	overrides := clientcmd.ConfigOverrides{}
 	if context != "" {
 		overrides.CurrentContext = context

--- a/modules/k8s/config_test.go
+++ b/modules/k8s/config_test.go
@@ -2,7 +2,6 @@ package k8s
 
 import (
 	"io/ioutil"
-	"net/url"
 	"os"
 	"testing"
 
@@ -14,7 +13,7 @@ import (
 func TestDeleteConfigContext(t *testing.T) {
 	t.Parallel()
 
-	path := storeConfigToTempFile(t, BASIC_CONFIG_WITH_EXTRA_CONTEXT)
+	path := StoreConfigToTempFile(t, BASIC_CONFIG_WITH_EXTRA_CONTEXT)
 	defer os.Remove(path)
 
 	err := DeleteConfigContextWithPathE(t, path, "extra_minikube")
@@ -29,7 +28,7 @@ func TestDeleteConfigContext(t *testing.T) {
 func TestDeleteConfigContextWithAnotherContextRemaining(t *testing.T) {
 	t.Parallel()
 
-	path := storeConfigToTempFile(t, BASIC_CONFIG_WITH_EXTRA_CONTEXT_NO_GARBAGE)
+	path := StoreConfigToTempFile(t, BASIC_CONFIG_WITH_EXTRA_CONTEXT_NO_GARBAGE)
 	defer os.Remove(path)
 
 	err := DeleteConfigContextWithPathE(t, path, "extra_minikube")
@@ -72,7 +71,7 @@ func TestRemoveOrphanedClusterAndAuthInfoConfig(t *testing.T) {
 }
 
 func removeOrphanedClusterAndAuthInfoConfigTestFunc(t *testing.T, inputConfig string, expectedOutputConfig string) {
-	path := storeConfigToTempFile(t, inputConfig)
+	path := StoreConfigToTempFile(t, inputConfig)
 	defer os.Remove(path)
 
 	config := LoadConfigFromPath(path)
@@ -85,17 +84,6 @@ func removeOrphanedClusterAndAuthInfoConfigTestFunc(t *testing.T, inputConfig st
 	require.NoError(t, err)
 	storedConfig := string(data)
 	assert.Equal(t, storedConfig, expectedOutputConfig)
-}
-
-func storeConfigToTempFile(t *testing.T, configData string) string {
-	escapedTestName := url.PathEscape(t.Name())
-	tmpfile, err := ioutil.TempFile("", escapedTestName)
-	require.NoError(t, err)
-	defer tmpfile.Close()
-
-	_, err = tmpfile.WriteString(configData)
-	require.NoError(t, err)
-	return tmpfile.Name()
 }
 
 // Various example configs used in testing the config manipulation functions

--- a/modules/k8s/errors.go
+++ b/modules/k8s/errors.go
@@ -1,5 +1,9 @@
 package k8s
 
+import (
+	"fmt"
+)
+
 type KubernetesError struct {
 	message string
 }
@@ -8,6 +12,6 @@ func (err KubernetesError) Error() string {
 	return err.message
 }
 
-func NewKubernetesError(message string) KubernetesError {
-	return KubernetesError{message}
+func NewKubernetesError(message string, args ...interface{}) KubernetesError {
+	return KubernetesError{fmt.Sprintf(message, args...)}
 }

--- a/modules/k8s/errors.go
+++ b/modules/k8s/errors.go
@@ -2,16 +2,83 @@ package k8s
 
 import (
 	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
 )
 
-type KubernetesError struct {
-	message string
+// ServiceNotAvailable is returned when a Kubernetes service is not yet available to accept traffic.
+type ServiceNotAvailable struct {
+	service *corev1.Service
 }
 
-func (err KubernetesError) Error() string {
-	return err.message
+func (err ServiceNotAvailable) Error() string {
+	return fmt.Sprintf("Service %s is not available", err.service.Name)
 }
 
-func NewKubernetesError(message string, args ...interface{}) KubernetesError {
-	return KubernetesError{fmt.Sprintf(message, args...)}
+func NewServiceNotAvailableError(service *corev1.Service) ServiceNotAvailable {
+	return ServiceNotAvailable{service}
+}
+
+// UnknownServiceType is returned when a Kubernetes service has a type that is not yet handled by the test functions.
+type UnknownServiceType struct {
+	service *corev1.Service
+}
+
+func (err UnknownServiceType) Error() string {
+	return fmt.Sprintf("Service %s has an unknown service type", err.service.Name)
+}
+
+func NewUnknownServiceTypeError(service *corev1.Service) UnknownServiceType {
+	return UnknownServiceType{service}
+}
+
+// UnknownServicePort is returned when the given service port is not an exported port of the service.
+type UnknownServicePort struct {
+	service *corev1.Service
+	port    int32
+}
+
+func (err UnknownServicePort) Error() string {
+	return fmt.Sprintf("Port %d is not a part of the service %s", err.port, err.service.Name)
+}
+
+func NewUnknownServicePortError(service *corev1.Service, port int32) UnknownServicePort {
+	return UnknownServicePort{service, port}
+}
+
+// NoNodesInKubernetes is returned when the Kubernetes cluster has no nodes registered.
+type NoNodesInKubernetes struct{}
+
+func (err NoNodesInKubernetes) Error() string {
+	return "There are no nodes in the Kubernetes cluster"
+}
+
+func NewNoNodesInKubernetesError() NoNodesInKubernetes {
+	return NoNodesInKubernetes{}
+}
+
+// NodeHasNoHostname is returned when a Kubernetes node has no discernible hostname
+type NodeHasNoHostname struct {
+	node *corev1.Node
+}
+
+func (err NodeHasNoHostname) Error() string {
+	return fmt.Sprintf("Node %s has no hostname", err.node.Name)
+}
+
+func NewNodeHasNoHostnameError(node *corev1.Node) NodeHasNoHostname {
+	return NodeHasNoHostname{node}
+}
+
+// MalformedNodeID is returned when a Kubernetes node has a malformed node id scheme
+type MalformedNodeID struct {
+	node *corev1.Node
+}
+
+func (err MalformedNodeID) Error() string {
+	return fmt.Sprintf("Node %s has malformed ID %s", err.node.Name, err.node.Spec.ProviderID)
+}
+
+func NewMalformedNodeIDError(node *corev1.Node) MalformedNodeID {
+	return MalformedNodeID{node}
 }

--- a/modules/k8s/errors.go
+++ b/modules/k8s/errors.go
@@ -1,0 +1,13 @@
+package k8s
+
+type KubernetesError struct {
+	message string
+}
+
+func (err KubernetesError) Error() string {
+	return err.message
+}
+
+func NewKubernetesError(message string) KubernetesError {
+	return KubernetesError{message}
+}

--- a/modules/k8s/kubectl.go
+++ b/modules/k8s/kubectl.go
@@ -34,6 +34,7 @@ func RunKubectlAndGetOutputE(t *testing.T, options *KubectlOptions, args ...stri
 	command := shell.Command{
 		Command: "kubectl",
 		Args:    cmdArgs,
+		Env:     options.Env,
 	}
 	return shell.RunCommandAndGetOutputE(t, command)
 }

--- a/modules/k8s/kubectl.go
+++ b/modules/k8s/kubectl.go
@@ -1,0 +1,39 @@
+package k8s
+
+import (
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/shell"
+)
+
+// RunKubectl will call kubectl using the provided options and args, failing the test on error.
+func RunKubectl(t *testing.T, options *KubectlOptions, args ...string) {
+	err := RunKubectlE(t, options, args...)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+// RunKubectlE will call kubectl using the provided options and args.
+func RunKubectlE(t *testing.T, options *KubectlOptions, args ...string) error {
+	_, err := RunKubectlAndGetOutputE(t, options, args...)
+	return err
+}
+
+// RunKubectlAndGetOutputE will call kubectl using the provided options and args, returning the output of stdout and
+// stderr.
+func RunKubectlAndGetOutputE(t *testing.T, options *KubectlOptions, args ...string) (string, error) {
+	cmdArgs := []string{}
+	if options.ContextName != "" {
+		cmdArgs = append(cmdArgs, "--context", options.ContextName)
+	}
+	if options.ConfigPath != "" {
+		cmdArgs = append(cmdArgs, "--kubeconfig", options.ConfigPath)
+	}
+	cmdArgs = append(cmdArgs, args...)
+	command := shell.Command{
+		Command: "kubectl",
+		Args:    cmdArgs,
+	}
+	return shell.RunCommandAndGetOutputE(t, command)
+}

--- a/modules/k8s/kubectl.go
+++ b/modules/k8s/kubectl.go
@@ -13,10 +13,7 @@ import (
 
 // RunKubectl will call kubectl using the provided options and args, failing the test on error.
 func RunKubectl(t *testing.T, options *KubectlOptions, args ...string) {
-	err := RunKubectlE(t, options, args...)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, RunKubectlE(t, options, args...))
 }
 
 // RunKubectlE will call kubectl using the provided options and args.

--- a/modules/k8s/kubectl.go
+++ b/modules/k8s/kubectl.go
@@ -32,6 +32,9 @@ func RunKubectlAndGetOutputE(t *testing.T, options *KubectlOptions, args ...stri
 	if options.ConfigPath != "" {
 		cmdArgs = append(cmdArgs, "--kubeconfig", options.ConfigPath)
 	}
+	if options.Namespace != "" {
+		cmdArgs = append(cmdArgs, "--namespace", options.Namespace)
+	}
 	cmdArgs = append(cmdArgs, args...)
 	command := shell.Command{
 		Command: "kubectl",
@@ -39,6 +42,17 @@ func RunKubectlAndGetOutputE(t *testing.T, options *KubectlOptions, args ...stri
 		Env:     options.Env,
 	}
 	return shell.RunCommandAndGetOutputE(t, command)
+}
+
+// KubectlDelete will take in a file path and delete it from the cluster targeted by KubectlOptions. If there are any
+// errors, fail the test immediately.
+func KubectlDelete(t *testing.T, options *KubectlOptions, configPath string) {
+	require.NoError(t, KubectlDeleteE(t, options, configPath))
+}
+
+// KubectlDeleteE will take in a file path and delete it from the cluster targeted by KubectlOptions.
+func KubectlDeleteE(t *testing.T, options *KubectlOptions, configPath string) error {
+	return RunKubectlE(t, options, "delete", "-f", configPath)
 }
 
 // KubectlDeleteFromString will take in a kubernetes resource config as a string and delete it on the cluster specified
@@ -55,7 +69,18 @@ func KubectlDeleteFromStringE(t *testing.T, options *KubectlOptions, configData 
 		return err
 	}
 	defer os.Remove(tmpfile)
-	return RunKubectlE(t, options, "delete", "-f", tmpfile)
+	return KubectlDeleteE(t, options, tmpfile)
+}
+
+// KubectlApply will take in a file path and apply it to the cluster targeted by KubectlOptions. If there are any
+// errors, fail the test immediately.
+func KubectlApply(t *testing.T, options *KubectlOptions, configPath string) {
+	require.NoError(t, KubectlApplyE(t, options, configPath))
+}
+
+// KubectlApplyE will take in a file path and apply it to the cluster targeted by KubectlOptions.
+func KubectlApplyE(t *testing.T, options *KubectlOptions, configPath string) error {
+	return RunKubectlE(t, options, "apply", "-f", configPath)
 }
 
 // KubectlApplyFromString will take in a kubernetes resource config as a string and apply it on the cluster specified
@@ -72,7 +97,7 @@ func KubectlApplyFromStringE(t *testing.T, options *KubectlOptions, configData s
 		return err
 	}
 	defer os.Remove(tmpfile)
-	return RunKubectlE(t, options, "apply", "-f", tmpfile)
+	return KubectlApplyE(t, options, tmpfile)
 }
 
 // StoreConfigToTempFile will store the provided config data to a temporary file created on the os and return the

--- a/modules/k8s/kubectl_options.go
+++ b/modules/k8s/kubectl_options.go
@@ -1,0 +1,14 @@
+package k8s
+
+// Represents common options necessary to specify for all Kubectl calls
+type KubectlOptions struct {
+	ContextName string
+	ConfigPath  string
+}
+
+func NewKubectlOptions(contextName string, configPath string) *KubectlOptions {
+	return &KubectlOptions{
+		ContextName: contextName,
+		ConfigPath:  configPath,
+	}
+}

--- a/modules/k8s/kubectl_options.go
+++ b/modules/k8s/kubectl_options.go
@@ -4,6 +4,7 @@ package k8s
 type KubectlOptions struct {
 	ContextName string
 	ConfigPath  string
+	Namespace   string
 	Env         map[string]string
 }
 

--- a/modules/k8s/kubectl_options.go
+++ b/modules/k8s/kubectl_options.go
@@ -4,6 +4,7 @@ package k8s
 type KubectlOptions struct {
 	ContextName string
 	ConfigPath  string
+	Env         map[string]string
 }
 
 func NewKubectlOptions(contextName string, configPath string) *KubectlOptions {

--- a/modules/k8s/kubectl_test.go
+++ b/modules/k8s/kubectl_test.go
@@ -1,0 +1,15 @@
+package k8s
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Test that RunKubectlAndGetOutputE will run kubectl and return the output by running a can-i command call.
+func TestRunKubectlAndGetOutputReturnsOutput(t *testing.T) {
+	options := NewKubectlOptions("", "")
+	output, err := RunKubectlAndGetOutputE(t, options, "auth", "can-i", "get", "pods")
+	require.NoError(t, err)
+	require.Equal(t, output, "yes")
+}

--- a/modules/k8s/namespace.go
+++ b/modules/k8s/namespace.go
@@ -1,0 +1,66 @@
+package k8s
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// CreateNamespace will create a new Kubernetes namespace on the cluster targeted by the provided options. This will
+// fail the test if there is an error in creating the namespace.
+func CreateNamespace(t *testing.T, options *KubectlOptions, namespaceName string) {
+	require.NoError(t, CreateNamespaceE(t, options, namespaceName))
+}
+
+// CreateNamespaceE will create a new Kubernetes namespace on the cluster targeted by the provided options.
+func CreateNamespaceE(t *testing.T, options *KubectlOptions, namespaceName string) error {
+	clientset, err := GetKubernetesClientFromOptionsE(t, options)
+	if err != nil {
+		return err
+	}
+
+	namespace := corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: namespaceName,
+		},
+	}
+	_, err = clientset.CoreV1().Namespaces().Create(&namespace)
+	return err
+}
+
+// GetNamespace will query the Kubernetes cluster targeted by the provided options for the requested namespace. This will
+// fail the test if there is an error in creating the namespace.
+func GetNamespace(t *testing.T, options *KubectlOptions, namespaceName string) corev1.Namespace {
+	namespace, err := GetNamespaceE(t, options, namespaceName)
+	require.NoError(t, err)
+	return namespace
+}
+
+// GetNamespaceE will query the Kubernetes cluster targeted by the provided options for the requested namespace.
+func GetNamespaceE(t *testing.T, options *KubectlOptions, namespaceName string) (corev1.Namespace, error) {
+	clientset, err := GetKubernetesClientFromOptionsE(t, options)
+	if err != nil {
+		return corev1.Namespace{}, err
+	}
+
+	namespace, err := clientset.CoreV1().Namespaces().Get(namespaceName, metav1.GetOptions{})
+	return *namespace, err
+}
+
+// DeleteNamespace will delete the requested namespace from the Kubernetes cluster targeted by the provided options. This will
+// fail the test if there is an error in creating the namespace.
+func DeleteNamespace(t *testing.T, options *KubectlOptions, namespaceName string) {
+	require.NoError(t, DeleteNamespaceE(t, options, namespaceName))
+}
+
+// DeleteNamespaceE will delete the requested namespace from the Kubernetes cluster targeted by the provided options.
+func DeleteNamespaceE(t *testing.T, options *KubectlOptions, namespaceName string) error {
+	clientset, err := GetKubernetesClientFromOptionsE(t, options)
+	if err != nil {
+		return err
+	}
+
+	return clientset.CoreV1().Namespaces().Delete(namespaceName, &metav1.DeleteOptions{})
+}

--- a/modules/k8s/namespace_test.go
+++ b/modules/k8s/namespace_test.go
@@ -1,0 +1,28 @@
+package k8s
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/gruntwork-io/terratest/modules/random"
+)
+
+func TestNamespaces(t *testing.T) {
+	t.Parallel()
+
+	uniqueId := random.UniqueId()
+	namespaceName := strings.ToLower(uniqueId)
+	options := NewKubectlOptions("", "")
+	CreateNamespace(t, options, namespaceName)
+	defer func() {
+		DeleteNamespace(t, options, namespaceName)
+		namespace := GetNamespace(t, options, namespaceName)
+		require.Equal(t, namespace.Status.Phase, corev1.NamespaceTerminating)
+	}()
+
+	namespace := GetNamespace(t, options, namespaceName)
+	require.Equal(t, namespace.Name, namespaceName)
+}

--- a/modules/k8s/node.go
+++ b/modules/k8s/node.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gruntwork-io/terratest/modules/retry"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 )
 
 // GetNodes queries Kubernetes for information about the worker nodes registered to the cluster. If anything goes wrong,
@@ -28,7 +29,12 @@ func GetNodesE(t *testing.T) ([]corev1.Node, error) {
 	if err != nil {
 		return nil, err
 	}
+	return GetNodesByClientE(clientset)
+}
 
+// GetNodesByClientE queries Kubernetes for information about the worker nodes registered to the cluster, given a
+// clientset.
+func GetNodesByClientE(clientset *kubernetes.Clientset) ([]corev1.Node, error) {
 	nodes, err := clientset.CoreV1().Nodes().List(metav1.ListOptions{})
 	if err != nil {
 		return nil, err

--- a/modules/k8s/node.go
+++ b/modules/k8s/node.go
@@ -9,7 +9,6 @@ import (
 	"github.com/gruntwork-io/terratest/modules/retry"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
 )
 
 // GetNodes queries Kubernetes for information about the worker nodes registered to the cluster. If anything goes wrong,
@@ -29,13 +28,8 @@ func GetNodesE(t *testing.T) ([]corev1.Node, error) {
 	if err != nil {
 		return nil, err
 	}
-	return GetNodesByClientE(clientset, metav1.ListOptions{})
-}
 
-// GetNodesByClientE queries Kubernetes for information about the worker nodes registered to the cluster, given a
-// clientset.
-func GetNodesByClientE(clientset *kubernetes.Clientset, options metav1.ListOptions) ([]corev1.Node, error) {
-	nodes, err := clientset.CoreV1().Nodes().List(options)
+	nodes, err := clientset.CoreV1().Nodes().List(metav1.ListOptions{})
 	if err != nil {
 		return nil, err
 	}

--- a/modules/k8s/node.go
+++ b/modules/k8s/node.go
@@ -29,13 +29,13 @@ func GetNodesE(t *testing.T) ([]corev1.Node, error) {
 	if err != nil {
 		return nil, err
 	}
-	return GetNodesByClientE(clientset)
+	return GetNodesByClientE(clientset, metav1.ListOptions{})
 }
 
 // GetNodesByClientE queries Kubernetes for information about the worker nodes registered to the cluster, given a
 // clientset.
-func GetNodesByClientE(clientset *kubernetes.Clientset) ([]corev1.Node, error) {
-	nodes, err := clientset.CoreV1().Nodes().List(metav1.ListOptions{})
+func GetNodesByClientE(clientset *kubernetes.Clientset, options metav1.ListOptions) ([]corev1.Node, error) {
+	nodes, err := clientset.CoreV1().Nodes().List(options)
 	if err != nil {
 		return nil, err
 	}

--- a/modules/k8s/service.go
+++ b/modules/k8s/service.go
@@ -19,23 +19,23 @@ import (
 
 // GetService returns a Kubernetes service resource in the provided namespace with the given name. This will
 // fail the test if there is an error.
-func GetService(t *testing.T, namespace string, serviceName string) *corev1.Service {
-	service, err := GetServiceE(t, namespace, serviceName)
+func GetService(t *testing.T, options *KubectlOptions, serviceName string) *corev1.Service {
+	service, err := GetServiceE(t, options, serviceName)
 	require.NoError(t, err)
 	return service
 }
 
 // GetServiceE returns a Kubernetes service resource in the provided namespace with the given name.
-func GetServiceE(t *testing.T, namespace string, serviceName string) (*corev1.Service, error) {
-	clientset, err := GetKubernetesClientE(t)
+func GetServiceE(t *testing.T, options *KubectlOptions, serviceName string) (*corev1.Service, error) {
+	clientset, err := GetKubernetesClientFromOptionsE(t, options)
 	if err != nil {
 		return nil, err
 	}
-	return clientset.CoreV1().Services(namespace).Get(serviceName, metav1.GetOptions{})
+	return clientset.CoreV1().Services(options.Namespace).Get(serviceName, metav1.GetOptions{})
 }
 
 // WaitUntilServiceAvailable waits until the service endpoint is ready to accept traffic.
-func WaitUntilServiceAvailable(t *testing.T, namespace string, serviceName string, retries int, sleepBetweenRetries time.Duration) {
+func WaitUntilServiceAvailable(t *testing.T, options *KubectlOptions, serviceName string, retries int, sleepBetweenRetries time.Duration) {
 	statusMsg := fmt.Sprintf("Wait for service %s to be provisioned.", serviceName)
 	message := retry.DoWithRetry(
 		t,
@@ -43,7 +43,7 @@ func WaitUntilServiceAvailable(t *testing.T, namespace string, serviceName strin
 		retries,
 		sleepBetweenRetries,
 		func() (string, error) {
-			service, err := GetServiceE(t, namespace, serviceName)
+			service, err := GetServiceE(t, options, serviceName)
 			if err != nil {
 				return "", err
 			}

--- a/modules/k8s/service.go
+++ b/modules/k8s/service.go
@@ -2,14 +2,18 @@ package k8s
 
 import (
 	"fmt"
+	"net/url"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
+	"github.com/gruntwork-io/terratest/modules/aws"
 	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/retry"
 )
@@ -72,25 +76,20 @@ func IsServiceAvailable(service *corev1.Service) bool {
 
 // GetServiceEndpoint will return the service access point. If the service endpoint is not ready, will fail the test
 // immediately.
-func GetServiceEndpoint(t *testing.T, service *corev1.Service, servicePort int) string {
-	endpoint, err := GetServiceEndpointE(service, servicePort)
+func GetServiceEndpoint(t *testing.T, clientset *kubernetes.Clientset, service *corev1.Service, servicePort int) string {
+	endpoint, err := GetServiceEndpointE(clientset, service, servicePort)
 	require.NoError(t, err)
 	return endpoint
 }
 
 // GetServiceEndpointE will return the service access point
-func GetServiceEndpointE(service *corev1.Service, servicePort int) (string, error) {
+func GetServiceEndpointE(clientset *kubernetes.Clientset, service *corev1.Service, servicePort int) (string, error) {
 	switch service.Spec.Type {
 	case corev1.ServiceTypeClusterIP:
 		// ClusterIP service type will map directly to service port
 		return fmt.Sprintf("%s:%d", service.Spec.ClusterIP, servicePort), nil
 	case corev1.ServiceTypeNodePort:
-		// NodePort type needs to find the right port mapped to the service port
-		nodePort, err := findNodePort(service, int32(servicePort))
-		if err != nil {
-			return "", err
-		}
-		return fmt.Sprintf("%s:%d", service.Spec.ExternalIPs[0], nodePort), nil
+		return findEndpointForNodePortService(clientset, service, int32(servicePort))
 	case corev1.ServiceTypeLoadBalancer:
 		ingress := service.Status.LoadBalancer.Ingress
 		if len(ingress) == 0 {
@@ -103,11 +102,102 @@ func GetServiceEndpointE(service *corev1.Service, servicePort int) (string, erro
 	}
 }
 
+// Extracts a endpoint that can be reached outside the kubernetes cluster. NodePort type needs to find the right
+// allocated node port mapped to the service port, as well as find out the externally reachable ip (if available).
+func findEndpointForNodePortService(
+	clientset *kubernetes.Clientset,
+	service *corev1.Service,
+	servicePort int32,
+) (string, error) {
+	nodePort, err := findNodePort(service, int32(servicePort))
+	if err != nil {
+		return "", err
+	}
+	node, err := pickRandomNode(clientset)
+	if err != nil {
+		return "", err
+	}
+	nodeHostname, err := findNodeHostname(node)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%s:%d", nodeHostname, nodePort), nil
+}
+
+// Given the desired servicePort, return the allocated nodeport
 func findNodePort(service *corev1.Service, servicePort int32) (int32, error) {
 	for _, port := range service.Spec.Ports {
 		if port.Port == servicePort {
 			return port.NodePort, nil
 		}
 	}
-	return -1, NewKubernetesError(fmt.Sprintf("Port %d is not a part of the service %s", servicePort, service.Name))
+	return -1, NewKubernetesError("Port %d is not a part of the service %s", servicePort, service.Name)
+}
+
+// pickRandomNode will pick a random node in the kubernetes cluster
+func pickRandomNode(clientset *kubernetes.Clientset) (corev1.Node, error) {
+	nodes, err := GetNodesByClientE(clientset, metav1.ListOptions{})
+	if err != nil {
+		return corev1.Node{}, err
+	}
+	if len(nodes) == 0 {
+		return corev1.Node{}, NewKubernetesError("There are no nodes in the cluster")
+	}
+	// TODO: randomly pick one
+	return nodes[0], nil
+}
+
+// Given a node, return the ip address, preferring the external IP
+func findNodeHostname(node corev1.Node) (string, error) {
+	nodeIDUri, err := url.Parse(node.Spec.ProviderID)
+	if err != nil {
+		return "", err
+	}
+	switch nodeIDUri.Scheme {
+	case "aws":
+		return findAwsNodeHostname(node, nodeIDUri)
+	default:
+		return findDefaultNodeHostname(node)
+	}
+}
+
+// findAwsNodeHostname will return the public ip of the node, assuming the node is an AWS EC2 instance.
+// If the instance does not have a public IP, will return the internal hostname as recorded on the Kubernetes node
+// object.
+func findAwsNodeHostname(node corev1.Node, awsIDUri *url.URL) (string, error) {
+	// Path is /AVAILABILITY_ZONE/INSTANCE_ID
+	parts := strings.Split(awsIDUri.Path, "/")
+	instanceID := parts[2]
+	availabilityZone := parts[1]
+	// Availability Zone name is known to be region code + 1 letter
+	// https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html
+	region := availabilityZone[:len(availabilityZone)-1]
+
+	sess, err := aws.NewAuthenticatedSession(region)
+	if err != nil {
+		return "", err
+	}
+	ec2Client := ec2.New(sess)
+
+	ipMap, err := aws.GetPublicIpsOfEc2InstancesFromClientE(ec2Client, []string{instanceID}, region)
+	if err != nil {
+		return "", err
+	}
+
+	publicIp, containsIp := ipMap[instanceID]
+	if !containsIp {
+		// return default hostname
+		return findDefaultNodeHostname(node)
+	}
+	return publicIp, nil
+}
+
+// findDefaultNodeHostname returns the hostname recorded on the Kubernetes node object.
+func findDefaultNodeHostname(node corev1.Node) (string, error) {
+	for _, address := range node.Status.Addresses {
+		if address.Type == corev1.NodeHostName {
+			return address.Address, nil
+		}
+	}
+	return "", NewKubernetesError("Node %s has no hostname", node.Name)
 }

--- a/modules/k8s/service.go
+++ b/modules/k8s/service.go
@@ -11,7 +11,6 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
 
 	"github.com/gruntwork-io/terratest/modules/aws"
 	"github.com/gruntwork-io/terratest/modules/logger"
@@ -22,43 +21,39 @@ import (
 // GetService returns a Kubernetes service resource in the provided namespace with the given name. This will
 // fail the test if there is an error.
 func GetService(t *testing.T, namespace string, serviceName string) *corev1.Service {
-	clientset, err := GetKubernetesClientE(t)
-	require.NoError(t, err)
-	service, err := GetServiceFromClientE(clientset, namespace, serviceName)
+	service, err := GetServiceE(t, namespace, serviceName)
 	require.NoError(t, err)
 	return service
 }
 
 // GetServiceFromClientE returns a Kubernetes service resource in the provided namespace with the given name.
-func GetServiceFromClientE(clientset *kubernetes.Clientset, namespace string, serviceName string) (*corev1.Service, error) {
+func GetServiceE(t *testing.T, namespace string, serviceName string) (*corev1.Service, error) {
+	clientset, err := GetKubernetesClientE(t)
+	if err != nil {
+		return nil, err
+	}
 	return clientset.CoreV1().Services(namespace).Get(serviceName, metav1.GetOptions{})
 }
 
 // WaitUntilServiceAvailable waits until the service endpoint is ready to accept traffic.
 func WaitUntilServiceAvailable(t *testing.T, namespace string, serviceName string, retries int, sleepBetweenRetries time.Duration) {
-	clientset, err := GetKubernetesClientE(t)
-	require.NoError(t, err)
 	statusMsg := fmt.Sprintf("Wait for service %s to be provisioned.", serviceName)
-	message, err := retry.DoWithRetryE(
+	message := retry.DoWithRetry(
 		t,
 		statusMsg,
 		retries,
 		sleepBetweenRetries,
 		func() (string, error) {
-			service, err := GetServiceFromClientE(clientset, namespace, serviceName)
+			service, err := GetServiceE(t, namespace, serviceName)
 			if err != nil {
 				return "", err
 			}
 			if !IsServiceAvailable(service) {
-				return "", NewKubernetesError("Service is not available")
+				return "", NewServiceNotAvailableError(service)
 			}
 			return "Service is now available", nil
 		},
 	)
-	if err != nil {
-		logger.Logf(t, "Error waiting for service %s to be available: %s", serviceName, err)
-		t.Fatal(err)
-	}
 	logger.Logf(t, message)
 }
 
@@ -78,54 +73,52 @@ func IsServiceAvailable(service *corev1.Service) bool {
 // GetServiceEndpoint will return the service access point. If the service endpoint is not ready, will fail the test
 // immediately.
 func GetServiceEndpoint(t *testing.T, service *corev1.Service, servicePort int) string {
-	clientset, err := GetKubernetesClientE(t)
-	require.NoError(t, err)
-	endpoint, err := GetServiceEndpointFromClientE(clientset, service, servicePort)
+	endpoint, err := GetServiceEndpointE(t, service, servicePort)
 	require.NoError(t, err)
 	return endpoint
 }
 
-// GetServiceEndpointFromClientE will return the service access point using the following logic:
+// GetServiceEndpointE will return the service access point using the following logic:
 // - For ClusterIP service type, return the URL that maps to ClusterIP and Service Port
 // - For NodePort service type, identify the public IP of the node (if it exists, otherwise return the bound hostname),
 //   and the assigned node port for the provided service port, and return the URL that maps to node ip and node port.
 // - For LoadBalancer service type, return the publicly accessible hostname of the load balancer.
 // - All other service types are not supported.
-func GetServiceEndpointFromClientE(clientset *kubernetes.Clientset, service *corev1.Service, servicePort int) (string, error) {
+func GetServiceEndpointE(t *testing.T, service *corev1.Service, servicePort int) (string, error) {
 	switch service.Spec.Type {
 	case corev1.ServiceTypeClusterIP:
 		// ClusterIP service type will map directly to service port
 		return fmt.Sprintf("%s:%d", service.Spec.ClusterIP, servicePort), nil
 	case corev1.ServiceTypeNodePort:
-		return findEndpointForNodePortService(clientset, service, int32(servicePort))
+		return findEndpointForNodePortService(t, service, int32(servicePort))
 	case corev1.ServiceTypeLoadBalancer:
 		ingress := service.Status.LoadBalancer.Ingress
 		if len(ingress) == 0 {
-			return "", NewKubernetesError("Load Balancer is not ready")
+			return "", NewServiceNotAvailableError(service)
 		}
 		// Load Balancer service type will map directly to service port
 		return fmt.Sprintf("%s:%d", ingress[0].Hostname, servicePort), nil
 	default:
-		return "", NewKubernetesError("Unknown service type")
+		return "", NewUnknownServiceTypeError(service)
 	}
 }
 
 // Extracts a endpoint that can be reached outside the kubernetes cluster. NodePort type needs to find the right
 // allocated node port mapped to the service port, as well as find out the externally reachable ip (if available).
 func findEndpointForNodePortService(
-	clientset *kubernetes.Clientset,
+	t *testing.T,
 	service *corev1.Service,
 	servicePort int32,
 ) (string, error) {
-	nodePort, err := findNodePort(service, int32(servicePort))
+	nodePort, err := findNodePortE(service, int32(servicePort))
 	if err != nil {
 		return "", err
 	}
-	node, err := pickRandomNode(clientset)
+	node, err := pickRandomNodeE(t)
 	if err != nil {
 		return "", err
 	}
-	nodeHostname, err := findNodeHostname(node)
+	nodeHostname, err := findNodeHostnameE(t, node)
 	if err != nil {
 		return "", err
 	}
@@ -133,48 +126,51 @@ func findEndpointForNodePortService(
 }
 
 // Given the desired servicePort, return the allocated nodeport
-func findNodePort(service *corev1.Service, servicePort int32) (int32, error) {
+func findNodePortE(service *corev1.Service, servicePort int32) (int32, error) {
 	for _, port := range service.Spec.Ports {
 		if port.Port == servicePort {
 			return port.NodePort, nil
 		}
 	}
-	return -1, NewKubernetesError("Port %d is not a part of the service %s", servicePort, service.Name)
+	return -1, NewUnknownServicePortError(service, servicePort)
 }
 
 // pickRandomNode will pick a random node in the kubernetes cluster
-func pickRandomNode(clientset *kubernetes.Clientset) (corev1.Node, error) {
-	nodes, err := GetNodesByClientE(clientset, metav1.ListOptions{})
+func pickRandomNodeE(t *testing.T) (corev1.Node, error) {
+	nodes, err := GetNodesE(t)
 	if err != nil {
 		return corev1.Node{}, err
 	}
 	if len(nodes) == 0 {
-		return corev1.Node{}, NewKubernetesError("There are no nodes in the cluster")
+		return corev1.Node{}, NewNoNodesInKubernetesError()
 	}
 	index := random.Random(0, len(nodes)-1)
 	return nodes[index], nil
 }
 
 // Given a node, return the ip address, preferring the external IP
-func findNodeHostname(node corev1.Node) (string, error) {
+func findNodeHostnameE(t *testing.T, node corev1.Node) (string, error) {
 	nodeIDUri, err := url.Parse(node.Spec.ProviderID)
 	if err != nil {
 		return "", err
 	}
 	switch nodeIDUri.Scheme {
 	case "aws":
-		return findAwsNodeHostname(node, nodeIDUri)
+		return findAwsNodeHostnameE(t, node, nodeIDUri)
 	default:
-		return findDefaultNodeHostname(node)
+		return findDefaultNodeHostnameE(node)
 	}
 }
 
 // findAwsNodeHostname will return the public ip of the node, assuming the node is an AWS EC2 instance.
 // If the instance does not have a public IP, will return the internal hostname as recorded on the Kubernetes node
 // object.
-func findAwsNodeHostname(node corev1.Node, awsIDUri *url.URL) (string, error) {
+func findAwsNodeHostnameE(t *testing.T, node corev1.Node, awsIDUri *url.URL) (string, error) {
 	// Path is /AVAILABILITY_ZONE/INSTANCE_ID
 	parts := strings.Split(awsIDUri.Path, "/")
+	if len(parts) != 3 {
+		return "", NewMalformedNodeIDError(&node)
+	}
 	instanceID := parts[2]
 	availabilityZone := parts[1]
 	// Availability Zone name is known to be region code + 1 letter
@@ -187,7 +183,7 @@ func findAwsNodeHostname(node corev1.Node, awsIDUri *url.URL) (string, error) {
 	}
 	ec2Client := ec2.New(sess)
 
-	ipMap, err := aws.GetPublicIpsOfEc2InstancesFromClientE(ec2Client, []string{instanceID}, region)
+	ipMap, err := aws.GetPublicIpsOfEc2InstancesE(t, []string{instanceID}, region)
 	if err != nil {
 		return "", err
 	}
@@ -195,17 +191,17 @@ func findAwsNodeHostname(node corev1.Node, awsIDUri *url.URL) (string, error) {
 	publicIp, containsIp := ipMap[instanceID]
 	if !containsIp {
 		// return default hostname
-		return findDefaultNodeHostname(node)
+		return findDefaultNodeHostnameE(node)
 	}
 	return publicIp, nil
 }
 
 // findDefaultNodeHostname returns the hostname recorded on the Kubernetes node object.
-func findDefaultNodeHostname(node corev1.Node) (string, error) {
+func findDefaultNodeHostnameE(node corev1.Node) (string, error) {
 	for _, address := range node.Status.Addresses {
 		if address.Type == corev1.NodeHostName {
 			return address.Address, nil
 		}
 	}
-	return "", NewKubernetesError("Node %s has no hostname", node.Name)
+	return "", NewNodeHasNoHostnameError(&node)
 }

--- a/modules/k8s/service.go
+++ b/modules/k8s/service.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/gruntwork-io/terratest/modules/aws"
 	"github.com/gruntwork-io/terratest/modules/logger"
+	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/gruntwork-io/terratest/modules/retry"
 )
 
@@ -150,8 +151,8 @@ func pickRandomNode(clientset *kubernetes.Clientset) (corev1.Node, error) {
 	if len(nodes) == 0 {
 		return corev1.Node{}, NewKubernetesError("There are no nodes in the cluster")
 	}
-	// TODO: randomly pick one
-	return nodes[0], nil
+	index := random.Random(0, len(nodes)-1)
+	return nodes[index], nil
 }
 
 // Given a node, return the ip address, preferring the external IP

--- a/modules/k8s/service.go
+++ b/modules/k8s/service.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -26,7 +25,7 @@ func GetService(t *testing.T, namespace string, serviceName string) *corev1.Serv
 	return service
 }
 
-// GetServiceFromClientE returns a Kubernetes service resource in the provided namespace with the given name.
+// GetServiceE returns a Kubernetes service resource in the provided namespace with the given name.
 func GetServiceE(t *testing.T, namespace string, serviceName string) (*corev1.Service, error) {
 	clientset, err := GetKubernetesClientE(t)
 	if err != nil {
@@ -176,12 +175,6 @@ func findAwsNodeHostnameE(t *testing.T, node corev1.Node, awsIDUri *url.URL) (st
 	// Availability Zone name is known to be region code + 1 letter
 	// https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html
 	region := availabilityZone[:len(availabilityZone)-1]
-
-	sess, err := aws.NewAuthenticatedSession(region)
-	if err != nil {
-		return "", err
-	}
-	ec2Client := ec2.New(sess)
 
 	ipMap, err := aws.GetPublicIpsOfEc2InstancesE(t, []string{instanceID}, region)
 	if err != nil {

--- a/modules/k8s/service.go
+++ b/modules/k8s/service.go
@@ -1,0 +1,113 @@
+package k8s
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/gruntwork-io/terratest/modules/logger"
+	"github.com/gruntwork-io/terratest/modules/retry"
+)
+
+// GetService returns a Kubernetes service resource in the provided namespace with the given name. This will
+// fail the test if there is an error.
+func GetService(t *testing.T, namespace string, serviceName string) *corev1.Service {
+	clientset, err := GetKubernetesClientE(t)
+	require.NoError(t, err)
+	service, err := GetServiceFromClientE(clientset, namespace, serviceName)
+	require.NoError(t, err)
+	return service
+}
+
+// GetServiceFromClientE returns a Kubernetes service resource in the provided namespace with the given name.
+func GetServiceFromClientE(clientset *kubernetes.Clientset, namespace string, serviceName string) (*corev1.Service, error) {
+	return clientset.CoreV1().Services(namespace).Get(serviceName, metav1.GetOptions{})
+}
+
+// WaitUntilServiceAvailable waits until the service endpoint is ready to accept traffic.
+func WaitUntilServiceAvailable(t *testing.T, namespace string, serviceName string, retries int, sleepBetweenRetries time.Duration) {
+	clientset, err := GetKubernetesClientE(t)
+	require.NoError(t, err)
+	statusMsg := fmt.Sprintf("Wait for service %s to be provisioned.", serviceName)
+	message, err := retry.DoWithRetryE(
+		t,
+		statusMsg,
+		retries,
+		sleepBetweenRetries,
+		func() (string, error) {
+			service, err := GetServiceFromClientE(clientset, namespace, serviceName)
+			if err != nil {
+				return "", err
+			}
+			if !IsServiceAvailable(service) {
+				return "", NewKubernetesError("Service is not available")
+			}
+			return "Service is now available", nil
+		},
+	)
+	if err != nil {
+		logger.Logf(t, "Error waiting for service %s to be available: %s", serviceName, err)
+		t.Fatal(err)
+	}
+	logger.Logf(t, message)
+}
+
+// IsServiceAvailable returns true if the service endpoint is ready to accept traffic.
+func IsServiceAvailable(service *corev1.Service) bool {
+	// Only the LoadBalancer type has a delay. All other service types are available if the resource exists.
+	switch service.Spec.Type {
+	case corev1.ServiceTypeLoadBalancer:
+		ingress := service.Status.LoadBalancer.Ingress
+		// The load balancer is ready if it has at least one ingress point
+		return len(ingress) > 0
+	default:
+		return true
+	}
+}
+
+// GetServiceEndpoint will return the service access point. If the service endpoint is not ready, will fail the test
+// immediately.
+func GetServiceEndpoint(t *testing.T, service *corev1.Service, servicePort int) string {
+	endpoint, err := GetServiceEndpointE(service, servicePort)
+	require.NoError(t, err)
+	return endpoint
+}
+
+// GetServiceEndpointE will return the service access point
+func GetServiceEndpointE(service *corev1.Service, servicePort int) (string, error) {
+	switch service.Spec.Type {
+	case corev1.ServiceTypeClusterIP:
+		// ClusterIP service type will map directly to service port
+		return fmt.Sprintf("%s:%d", service.Spec.ClusterIP, servicePort), nil
+	case corev1.ServiceTypeNodePort:
+		// NodePort type needs to find the right port mapped to the service port
+		nodePort, err := findNodePort(service, int32(servicePort))
+		if err != nil {
+			return "", err
+		}
+		return fmt.Sprintf("%s:%d", service.Spec.ExternalIPs[0], nodePort), nil
+	case corev1.ServiceTypeLoadBalancer:
+		ingress := service.Status.LoadBalancer.Ingress
+		if len(ingress) == 0 {
+			return "", NewKubernetesError("Load Balancer is not ready")
+		}
+		// Load Balancer service type will map directly to service port
+		return fmt.Sprintf("%s:%d", ingress[0].Hostname, servicePort), nil
+	default:
+		return "", NewKubernetesError("Unknown service type")
+	}
+}
+
+func findNodePort(service *corev1.Service, servicePort int32) (int32, error) {
+	for _, port := range service.Spec.Ports {
+		if port.Port == servicePort {
+			return port.NodePort, nil
+		}
+	}
+	return -1, NewKubernetesError(fmt.Sprintf("Port %d is not a part of the service %s", servicePort, service.Name))
+}

--- a/modules/k8s/service_test.go
+++ b/modules/k8s/service_test.go
@@ -58,8 +58,16 @@ func TestGetServiceEndpointEReturnsAccessibleEndpointForNodePort(t *testing.T) {
 
 	service := GetService(t, uniqueID, "nginx-service")
 	endpoint := GetServiceEndpoint(t, service, 80)
-	statusCode, _ := http_helper.HttpGet(t, fmt.Sprintf("http://%s", endpoint))
-	require.Equal(t, statusCode, 200)
+	// Test up to 5 minutes
+	http_helper.HttpGetWithRetryWithCustomValidation(
+		t,
+		fmt.Sprintf("http://%s", endpoint),
+		30,
+		10*time.Second,
+		func(statusCode int, body string) bool {
+			return statusCode == 200
+		},
+	)
 }
 
 const EXAMPLE_DEPLOYMENT_YAML_TEMPLATE = `---

--- a/modules/k8s/service_test.go
+++ b/modules/k8s/service_test.go
@@ -1,0 +1,47 @@
+package k8s
+
+import (
+	"testing"
+)
+
+func TestGetServiceFromClientEReturnsErrorForNonExistantService(t *testing.T) {
+	t.Parallel()
+
+	t.Fatal("Not implemented")
+}
+
+func TestGetServiceFromClientEReturnsCorrectServiceInCorrectNamespace(t *testing.T) {
+	t.Parallel()
+
+	t.Fatal("Not implemented")
+}
+
+func TestWaitUntilServiceAvailableReturnsSuccessfullyOnLoadBalancerType(t *testing.T) {
+	t.Parallel()
+
+	t.Fatal("Not implemented")
+}
+
+func TestWaitUntilServiceAvailableReturnsSuccessfullyOnNodePortType(t *testing.T) {
+	t.Parallel()
+
+	t.Fatal("Not implemented")
+}
+
+func TestGetServiceEndpointEReturnsErrorOnUnavailableLoadBalancer(t *testing.T) {
+	t.Parallel()
+
+	t.Fatal("Not implemented")
+}
+
+func TestGetServiceEndpointEReturnsEndpointForLoadBalancer(t *testing.T) {
+	t.Parallel()
+
+	t.Fatal("Not implemented")
+}
+
+func TestGetServiceEndpointEReturnsAccessibleEndpointForNodePort(t *testing.T) {
+	t.Parallel()
+
+	t.Fatal("Not implemented")
+}

--- a/modules/k8s/service_test.go
+++ b/modules/k8s/service_test.go
@@ -15,7 +15,8 @@ import (
 func TestGetServiceEReturnsErrorForNonExistantService(t *testing.T) {
 	t.Parallel()
 
-	_, err := GetServiceE(t, "default", "nginx-service")
+	options := NewKubectlOptions("", "")
+	_, err := GetServiceE(t, options, "nginx-service")
 	require.Error(t, err)
 }
 
@@ -24,11 +25,12 @@ func TestGetServiceEReturnsCorrectServiceInCorrectNamespace(t *testing.T) {
 
 	uniqueID := strings.ToLower(random.UniqueId())
 	options := NewKubectlOptions("", "")
+	options.Namespace = uniqueID
 	configData := fmt.Sprintf(EXAMPLE_DEPLOYMENT_YAML_TEMPLATE, uniqueID, uniqueID, uniqueID)
 	KubectlApplyFromString(t, options, configData)
 	defer KubectlDeleteFromString(t, options, configData)
 
-	service := GetService(t, uniqueID, "nginx-service")
+	service := GetService(t, options, "nginx-service")
 	require.Equal(t, service.Name, "nginx-service")
 	require.Equal(t, service.Namespace, uniqueID)
 }
@@ -38,11 +40,12 @@ func TestWaitUntilServiceAvailableReturnsSuccessfullyOnNodePortType(t *testing.T
 
 	uniqueID := strings.ToLower(random.UniqueId())
 	options := NewKubectlOptions("", "")
+	options.Namespace = uniqueID
 	configData := fmt.Sprintf(EXAMPLE_DEPLOYMENT_YAML_TEMPLATE, uniqueID, uniqueID, uniqueID)
 	KubectlApplyFromString(t, options, configData)
 	defer KubectlDeleteFromString(t, options, configData)
 
-	WaitUntilServiceAvailable(t, uniqueID, "nginx-service", 10, 1*time.Second)
+	WaitUntilServiceAvailable(t, options, "nginx-service", 10, 1*time.Second)
 }
 
 func TestGetServiceEndpointEReturnsAccessibleEndpointForNodePort(t *testing.T) {
@@ -50,11 +53,12 @@ func TestGetServiceEndpointEReturnsAccessibleEndpointForNodePort(t *testing.T) {
 
 	uniqueID := strings.ToLower(random.UniqueId())
 	options := NewKubectlOptions("", "")
+	options.Namespace = uniqueID
 	configData := fmt.Sprintf(EXAMPLE_DEPLOYMENT_YAML_TEMPLATE, uniqueID, uniqueID, uniqueID)
 	KubectlApplyFromString(t, options, configData)
 	defer KubectlDeleteFromString(t, options, configData)
 
-	service := GetService(t, uniqueID, "nginx-service")
+	service := GetService(t, options, "nginx-service")
 	endpoint := GetServiceEndpoint(t, service, 80)
 	// Test up to 5 minutes
 	http_helper.HttpGetWithRetryWithCustomValidation(

--- a/modules/k8s/service_test.go
+++ b/modules/k8s/service_test.go
@@ -15,9 +15,7 @@ import (
 func TestGetServiceFromClientEReturnsErrorForNonExistantService(t *testing.T) {
 	t.Parallel()
 
-	clientset, err := GetKubernetesClientE(t)
-	require.NoError(t, err)
-	_, err = GetServiceFromClientE(clientset, "default", "nginx-service")
+	_, err := GetServiceE(t, "default", "nginx-service")
 	require.Error(t, err)
 }
 

--- a/modules/k8s/service_test.go
+++ b/modules/k8s/service_test.go
@@ -1,47 +1,105 @@
 package k8s
 
 import (
+	"fmt"
+	"strings"
 	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	http_helper "github.com/gruntwork-io/terratest/modules/http-helper"
+	"github.com/gruntwork-io/terratest/modules/random"
 )
 
 func TestGetServiceFromClientEReturnsErrorForNonExistantService(t *testing.T) {
 	t.Parallel()
 
-	t.Fatal("Not implemented")
+	clientset, err := GetKubernetesClientE(t)
+	require.NoError(t, err)
+	_, err = GetServiceFromClientE(clientset, "default", "nginx-service")
+	require.Error(t, err)
 }
 
 func TestGetServiceFromClientEReturnsCorrectServiceInCorrectNamespace(t *testing.T) {
 	t.Parallel()
 
-	t.Fatal("Not implemented")
-}
+	uniqueID := strings.ToLower(random.UniqueId())
+	options := NewKubectlOptions("", "")
+	configData := fmt.Sprintf(EXAMPLE_DEPLOYMENT_YAML_TEMPLATE, uniqueID, uniqueID, uniqueID)
+	KubectlApplyFromString(t, options, configData)
+	defer KubectlDeleteFromString(t, options, configData)
 
-func TestWaitUntilServiceAvailableReturnsSuccessfullyOnLoadBalancerType(t *testing.T) {
-	t.Parallel()
-
-	t.Fatal("Not implemented")
+	service := GetService(t, uniqueID, "nginx-service")
+	require.Equal(t, service.Name, "nginx-service")
+	require.Equal(t, service.Namespace, uniqueID)
 }
 
 func TestWaitUntilServiceAvailableReturnsSuccessfullyOnNodePortType(t *testing.T) {
 	t.Parallel()
 
-	t.Fatal("Not implemented")
-}
+	uniqueID := strings.ToLower(random.UniqueId())
+	options := NewKubectlOptions("", "")
+	configData := fmt.Sprintf(EXAMPLE_DEPLOYMENT_YAML_TEMPLATE, uniqueID, uniqueID, uniqueID)
+	KubectlApplyFromString(t, options, configData)
+	defer KubectlDeleteFromString(t, options, configData)
 
-func TestGetServiceEndpointEReturnsErrorOnUnavailableLoadBalancer(t *testing.T) {
-	t.Parallel()
-
-	t.Fatal("Not implemented")
-}
-
-func TestGetServiceEndpointEReturnsEndpointForLoadBalancer(t *testing.T) {
-	t.Parallel()
-
-	t.Fatal("Not implemented")
+	WaitUntilServiceAvailable(t, uniqueID, "nginx-service", 10, 1*time.Second)
 }
 
 func TestGetServiceEndpointEReturnsAccessibleEndpointForNodePort(t *testing.T) {
 	t.Parallel()
 
-	t.Fatal("Not implemented")
+	uniqueID := strings.ToLower(random.UniqueId())
+	options := NewKubectlOptions("", "")
+	configData := fmt.Sprintf(EXAMPLE_DEPLOYMENT_YAML_TEMPLATE, uniqueID, uniqueID, uniqueID)
+	KubectlApplyFromString(t, options, configData)
+	defer KubectlDeleteFromString(t, options, configData)
+
+	service := GetService(t, uniqueID, "nginx-service")
+	endpoint := GetServiceEndpoint(t, service, 80)
+	statusCode, _ := http_helper.HttpGet(t, fmt.Sprintf("http://%s", endpoint))
+	require.Equal(t, statusCode, 200)
 }
+
+const EXAMPLE_DEPLOYMENT_YAML_TEMPLATE = `---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: %s
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+  namespace: %s
+spec:
+  selector:
+    matchLabels:
+      app: nginx
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.15.7
+        ports:
+        - containerPort: 80
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: nginx-service
+  namespace: %s
+spec:
+  selector:
+    app: nginx
+  ports:
+  - protocol: TCP
+    targetPort: 80
+    port: 80
+  type: NodePort
+`

--- a/modules/k8s/service_test.go
+++ b/modules/k8s/service_test.go
@@ -12,14 +12,14 @@ import (
 	"github.com/gruntwork-io/terratest/modules/random"
 )
 
-func TestGetServiceFromClientEReturnsErrorForNonExistantService(t *testing.T) {
+func TestGetServiceEReturnsErrorForNonExistantService(t *testing.T) {
 	t.Parallel()
 
 	_, err := GetServiceE(t, "default", "nginx-service")
 	require.Error(t, err)
 }
 
-func TestGetServiceFromClientEReturnsCorrectServiceInCorrectNamespace(t *testing.T) {
+func TestGetServiceEReturnsCorrectServiceInCorrectNamespace(t *testing.T) {
 	t.Parallel()
 
 	uniqueID := strings.ToLower(random.UniqueId())

--- a/modules/terraform/plan_test.go
+++ b/modules/terraform/plan_test.go
@@ -14,7 +14,7 @@ func TestPlanWithNoChanges(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	awsRegion := aws.GetRandomRegion(t, nil, nil)
+	awsRegion := aws.GetRandomStableRegion(t, nil, nil)
 	options := &Options{
 		TerraformDir: testFolder,
 
@@ -32,7 +32,7 @@ func TestPlanWithChanges(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	awsRegion := aws.GetRandomRegion(t, nil, nil)
+	awsRegion := aws.GetRandomStableRegion(t, nil, nil)
 	options := &Options{
 		TerraformDir: testFolder,
 

--- a/test/kubernetes_basic_example_service_check_test.go
+++ b/test/kubernetes_basic_example_service_check_test.go
@@ -1,0 +1,63 @@
+package test
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	http_helper "github.com/gruntwork-io/terratest/modules/http-helper"
+	"github.com/gruntwork-io/terratest/modules/k8s"
+	"github.com/gruntwork-io/terratest/modules/random"
+)
+
+// An example of how to do more expanded verification of the Kubernetes resource config in examples/kubernetes-basic-example using Terratest.
+func TestKubernetesBasicExampleServiceCheck(t *testing.T) {
+	t.Parallel()
+
+	// Path to the Kubernetes resource config we will test
+	kubeResourcePath, err := filepath.Abs("../examples/kubernetes-basic-example/nginx-deployment.yml")
+	require.NoError(t, err)
+
+	// Setup the kubectl config and context. Here we choose to use the defaults, which is:
+	// - HOME/.kube/config for the kubectl config file
+	// - Current context of the kubectl config file
+	options := k8s.NewKubectlOptions("", "")
+
+	// To ensure we can reuse the resource config on the same cluster to test different scenarios, we setup a unique
+	// namespace for the resources for this test.
+	// Note that namespaces must be lowercase.
+	namespaceName := strings.ToLower(random.UniqueId())
+	k8s.CreateNamespace(t, options, namespaceName)
+	// Make sure we set the namespace on the options
+	options.Namespace = namespaceName
+	// ... and make sure to delete the namespace at the end of the test
+	defer k8s.DeleteNamespace(t, options, namespaceName)
+
+	// At the end of the test, run `kubectl delete -f RESOURCE_CONFIG` to clean up any resources that were created.
+	defer k8s.KubectlDelete(t, options, kubeResourcePath)
+
+	// This will run `kubectl apply -f RESOURCE_CONFIG` and fail the test if there are any errors
+	k8s.KubectlApply(t, options, kubeResourcePath)
+
+	// This will wait up to 10 seconds for the service to become available, to ensure that we can access it.
+	k8s.WaitUntilServiceAvailable(t, options, "nginx-service", 10, 1*time.Second)
+
+	// Now we verify that the service will successfully boot and start serving requests
+	service := k8s.GetService(t, options, "nginx-service")
+	endpoint := k8s.GetServiceEndpoint(t, service, 80)
+	// Test the endpoint for up to 5 minutes. This will only fail if we timeout waiting for the service to return a 200
+	// response.
+	http_helper.HttpGetWithRetryWithCustomValidation(
+		t,
+		fmt.Sprintf("http://%s", endpoint),
+		30,
+		10*time.Second,
+		func(statusCode int, body string) bool {
+			return statusCode == 200
+		},
+	)
+}

--- a/test/kubernetes_basic_example_test.go
+++ b/test/kubernetes_basic_example_test.go
@@ -1,0 +1,47 @@
+package test
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gruntwork-io/terratest/modules/k8s"
+	"github.com/gruntwork-io/terratest/modules/random"
+)
+
+// An example of how to test the Kubernetes resource config in examples/kubernetes-basic-example using Terratest.
+func TestKubernetesBasicExample(t *testing.T) {
+	t.Parallel()
+
+	// Path to the Kubernetes resource config we will test
+	kubeResourcePath, err := filepath.Abs("../examples/kubernetes-basic-example/nginx-deployment.yml")
+	require.NoError(t, err)
+
+	// Setup the kubectl config and context. Here we choose to use the defaults, which is:
+	// - HOME/.kube/config for the kubectl config file
+	// - Current context of the kubectl config file
+	options := k8s.NewKubectlOptions("", "")
+
+	// To ensure we can reuse the resource config on the same cluster to test different scenarios, we setup a unique
+	// namespace for the resources for this test.
+	// Note that namespaces must be lowercase.
+	namespaceName := strings.ToLower(random.UniqueId())
+	k8s.CreateNamespace(t, options, namespaceName)
+	// Make sure we set the namespace on the options
+	options.Namespace = namespaceName
+	// ... and make sure to delete the namespace at the end of the test
+	defer k8s.DeleteNamespace(t, options, namespaceName)
+
+	// At the end of the test, run `kubectl delete -f RESOURCE_CONFIG` to clean up any resources that were created.
+	defer k8s.KubectlDelete(t, options, kubeResourcePath)
+
+	// This will run `kubectl apply -f RESOURCE_CONFIG` and fail the test if there are any errors
+	k8s.KubectlApply(t, options, kubeResourcePath)
+
+	// This will get the service resource and verify that it exists and was retrieved successfully. This function will
+	// fail the test if the there is an error retrieving the service resource from Kubernetes.
+	service := k8s.GetService(t, options, "nginx-service")
+	require.Equal(t, service.Name, "nginx-service")
+}

--- a/test/packer_basic_example_test.go
+++ b/test/packer_basic_example_test.go
@@ -17,7 +17,7 @@ func TestPackerBasicExample(t *testing.T) {
 	t.Parallel()
 
 	// Pick a random AWS region to test in. This helps ensure your code works in all regions.
-	awsRegion := terratest_aws.GetRandomRegion(t, nil, nil)
+	awsRegion := terratest_aws.GetRandomStableRegion(t, nil, nil)
 
 	packerOptions := &packer.Options{
 		// The path to where the Packer template is located
@@ -62,7 +62,7 @@ func TestPackerMultipleConcurrentAmis(t *testing.T) {
 	var identifierToOptions = map[string]*packer.Options{}
 	for i := 0; i < 3; i++ {
 		// Pick a random AWS region to test in. This helps ensure your code works in all regions.
-		awsRegion := terratest_aws.GetRandomRegion(t, nil, nil)
+		awsRegion := terratest_aws.GetRandomStableRegion(t, nil, nil)
 
 		packerOptions := &packer.Options{
 			// The path to where the Packer template is located

--- a/test/terraform_aws_example_test.go
+++ b/test/terraform_aws_example_test.go
@@ -19,7 +19,7 @@ func TestTerraformAwsExample(t *testing.T) {
 	expectedName := fmt.Sprintf("terratest-aws-example-%s", random.UniqueId())
 
 	// Pick a random AWS region to test in. This helps ensure your code works in all regions.
-	awsRegion := aws.GetRandomRegion(t, nil, nil)
+	awsRegion := aws.GetRandomStableRegion(t, nil, nil)
 
 	terraformOptions := &terraform.Options{
 		// The path to where our Terraform code is located

--- a/test/terraform_aws_rds_example_test.go
+++ b/test/terraform_aws_rds_example_test.go
@@ -23,7 +23,7 @@ func TestTerraformAwsRdsExample(t *testing.T) {
 	username := "username"
 	password := "password"
 	// Pick a random AWS region to test in. This helps ensure your code works in all regions.
-	awsRegion := aws.GetRandomRegion(t, nil, nil)
+	awsRegion := aws.GetRandomStableRegion(t, nil, nil)
 
 	terraformOptions := &terraform.Options{
 		// The path to where our Terraform code is located

--- a/test/terraform_http_example_test.go
+++ b/test/terraform_http_example_test.go
@@ -27,7 +27,7 @@ func TestTerraformHttpExample(t *testing.T) {
 	instanceText := fmt.Sprintf("Hello, %s!", uniqueID)
 
 	// Pick a random AWS region to test in. This helps ensure your code works in all regions.
-	awsRegion := aws.GetRandomRegion(t, nil, nil)
+	awsRegion := aws.GetRandomStableRegion(t, nil, nil)
 
 	terraformOptions := &terraform.Options{
 		// The path to where our Terraform code is located

--- a/test/terraform_packer_example_test.go
+++ b/test/terraform_packer_example_test.go
@@ -46,7 +46,7 @@ func TestTerraformPackerExample(t *testing.T) {
 	// Build the AMI for the web app
 	test_structure.RunTestStage(t, "build_ami", func() {
 		// Pick a random AWS region to test in. This helps ensure your code works in all regions.
-		awsRegion := aws.GetRandomRegion(t, nil, nil)
+		awsRegion := aws.GetRandomStableRegion(t, nil, nil)
 		test_structure.SaveString(t, workingDir, "awsRegion", awsRegion)
 		buildAMI(t, awsRegion, workingDir)
 	})

--- a/test/terraform_redeploy_example_test.go
+++ b/test/terraform_redeploy_example_test.go
@@ -29,7 +29,7 @@ func TestTerraformRedeployExample(t *testing.T) {
 	t.Parallel()
 
 	// Pick a random AWS region to test in. This helps ensure your code works in all regions.
-	awsRegion := aws.GetRandomRegion(t, nil, nil)
+	awsRegion := aws.GetRandomStableRegion(t, nil, nil)
 
 	// The folder where we have our Terraform code
 	workingDir := "../examples/terraform-redeploy-example"

--- a/test/terraform_remote_exec_example_test.go
+++ b/test/terraform_remote_exec_example_test.go
@@ -52,7 +52,7 @@ func TestTerraformRemoteExecExample(t *testing.T) {
 		instanceName := fmt.Sprintf("terratest-remote-exec-example-%s", uniqueID)
 
 		// Pick a random AWS region to test in. This helps ensure your code works in all regions.
-		awsRegion := aws.GetRandomRegion(t, nil, nil)
+		awsRegion := aws.GetRandomStableRegion(t, nil, nil)
 
 		// Create an EC2 KeyPair that we can use for SSH access
 		keyPairName := fmt.Sprintf("terratest-remote-exec-example-%s", uniqueID)

--- a/test/terraform_scp_example_test.go
+++ b/test/terraform_scp_example_test.go
@@ -80,7 +80,7 @@ func createTerraformOptions(t *testing.T, exampleFolder string) (*terraform.Opti
 	instanceName := fmt.Sprintf("terratest-asg-scp-example-%s", uniqueID)
 
 	// Pick a random AWS region to test in. This helps ensure your code works in all regions.
-	awsRegion := aws.GetRandomRegion(t, nil, nil)
+	awsRegion := aws.GetRandomStableRegion(t, nil, nil)
 
 	// Create an EC2 KeyPair that we can use for SSH access
 	keyPairName := fmt.Sprintf("terratest-asg-scp-example-%s", uniqueID)

--- a/test/terraform_ssh_example_test.go
+++ b/test/terraform_ssh_example_test.go
@@ -70,7 +70,7 @@ func configureTerraformOptions(t *testing.T, exampleFolder string) (*terraform.O
 	instanceName := fmt.Sprintf("terratest-ssh-example-%s", uniqueID)
 
 	// Pick a random AWS region to test in. This helps ensure your code works in all regions.
-	awsRegion := aws.GetRandomRegion(t, nil, nil)
+	awsRegion := aws.GetRandomStableRegion(t, nil, nil)
 
 	// Create an EC2 KeyPair that we can use for SSH access
 	keyPairName := fmt.Sprintf("terratest-ssh-example-%s", uniqueID)


### PR DESCRIPTION
More functions for https://github.com/gruntwork-io/terratest/issues/194

- Expose some functions that can be used without `testing.T` to not take in `testing.T` so that they can be used outside testing context.
    - `GetPublicIpsOfEc2InstancesFromClientE`
    - `GetKubernetesClientFromFileE`
    - `GetNodesByClientE`

- Migrate `ContinuouslyCheckUrl` from module-ecs
- Expose `StoreConfigToFile` from the k8s module tests, as that can be used for storing a kubernetes resource config to disk to be used with `kubectl apply`
- Introduce wrapper functions for calling kubectl:
     - `RunKubectl`, `RunKubectlE`, `RunKubectlAndGetOutputE`
     - `KubectlApplyFromString`, `KubectlApplyFromStringE`
     - `KubectlDeleteFromString`, `KubectlDeleteFromStringE`

- Introduce functions for interacting with Kubernetes Service resources.