### PR TITLE
Stream stdout and stderr better

### DIFF
--- a/modules/shell/command.go
+++ b/modules/shell/command.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"sync"
 	"syscall"
 	"testing"
 
@@ -90,19 +91,12 @@ func readStdoutAndStderr(t *testing.T, stdout io.ReadCloser, stderr io.ReadClose
 	stdoutScanner := bufio.NewScanner(stdout)
 	stderrScanner := bufio.NewScanner(stderr)
 
-	for {
-		if stdoutScanner.Scan() {
-			text := stdoutScanner.Text()
-			logger.Log(t, text)
-			allOutput = append(allOutput, text)
-		} else if stderrScanner.Scan() {
-			text := stderrScanner.Text()
-			logger.Log(t, text)
-			allOutput = append(allOutput, text)
-		} else {
-			break
-		}
-	}
+	wg := &sync.WaitGroup{}
+	mutex := &sync.Mutex{}
+	wg.Add(2)
+	go readData(t, stdoutScanner, wg, mutex, &allOutput)
+	go readData(t, stderrScanner, wg, mutex, &allOutput)
+	wg.Wait()
 
 	if err := stdoutScanner.Err(); err != nil {
 		return "", err
@@ -113,6 +107,17 @@ func readStdoutAndStderr(t *testing.T, stdout io.ReadCloser, stderr io.ReadClose
 	}
 
 	return strings.Join(allOutput, "\n"), nil
+}
+
+func readData(t *testing.T, scanner *bufio.Scanner, wg *sync.WaitGroup, mutex *sync.Mutex, allOutput *[]string) {
+	defer wg.Done()
+	for scanner.Scan() {
+		text := scanner.Text()
+		logger.Log(t, text)
+		mutex.Lock()
+		*allOutput = append(*allOutput, text)
+		mutex.Unlock()
+	}
 }
 
 // GetExitCodeForRunCommandError tries to read the exit code for the error object returned from running a shell command. This is a bit tricky to do

--- a/modules/shell/command.go
+++ b/modules/shell/command.go
@@ -112,12 +112,15 @@ func readStdoutAndStderr(t *testing.T, stdout io.ReadCloser, stderr io.ReadClose
 func readData(t *testing.T, scanner *bufio.Scanner, wg *sync.WaitGroup, mutex *sync.Mutex, allOutput *[]string) {
 	defer wg.Done()
 	for scanner.Scan() {
-		text := scanner.Text()
-		logger.Log(t, text)
-		mutex.Lock()
-		*allOutput = append(*allOutput, text)
-		mutex.Unlock()
+		logTextAndAppendToOutput(t, mutex, scanner.Text(), allOutput)
 	}
+}
+
+func logTextAndAppendToOutput(t *testing.T, mutex *sync.Mutex, text string, allOutput *[]string) {
+	defer mutex.Unlock()
+	logger.Log(t, text)
+	mutex.Lock()
+	*allOutput = append(*allOutput, text)
 }
 
 // GetExitCodeForRunCommandError tries to read the exit code for the error object returned from running a shell command. This is a bit tricky to do

--- a/modules/shell/command_test.go
+++ b/modules/shell/command_test.go
@@ -64,14 +64,14 @@ func TestRunCommandAndGetOutputConcurrency(t *testing.T) {
 
 	bashCode := fmt.Sprintf(`
 echo_stderr(){
-	sleep .$[ ( $RANDOM %% 10 ) + 1 ]s
+	sleep .0$[ ( $RANDOM %% 10 ) + 1 ]s
 	(>&2 echo "%s")
 }
 echo_stdout(){
-	sleep .$[ ( $RANDOM %% 10 ) + 1 ]s
+	sleep .0$[ ( $RANDOM %% 10 ) + 1 ]s
 	echo "%s"
 }
-for i in {1..5}
+for i in {1..500}
 do
 	echo_stderr &
 	echo_stdout &
@@ -89,6 +89,6 @@ wait
 	out := RunCommandAndGetOutput(t, cmd)
 	stdoutReg := regexp.MustCompile(uniqueStdout)
 	stderrReg := regexp.MustCompile(uniqueStderr)
-	assert.Equal(t, len(stdoutReg.FindAllString(out, -1)), 5)
-	assert.Equal(t, len(stderrReg.FindAllString(out, -1)), 5)
+	assert.Equal(t, len(stdoutReg.FindAllString(out, -1)), 500)
+	assert.Equal(t, len(stderrReg.FindAllString(out, -1)), 500)
 }

--- a/modules/shell/command_test.go
+++ b/modules/shell/command_test.go
@@ -29,15 +29,27 @@ func TestRunCommandAndGetOutputOrder(t *testing.T) {
 
 	stderrText := "Hello, Error"
 	stdoutText := "Hello, World"
-	expectedText := "Hello, Error\nHello, World"
-	pythonCode := fmt.Sprintf(
-		"from __future__ import print_function; import sys, time; print('%s', file=sys.stderr); sys.stderr.flush(); time.sleep(1); print('%s', file=sys.stdout); sys.stdout.flush()",
+	expectedText := "Hello, Error\nHello, World\nHello, Error\nHello, World\nHello, Error\nHello, Error"
+	bashCode := fmt.Sprintf(`
+echo_stderr(){
+	(>&2 echo "%s")
+}
+echo_stdout(){
+	echo "%s"
+}
+echo_stderr
+echo_stdout
+echo_stderr
+echo_stdout
+echo_stderr
+echo_stderr
+`,
 		stderrText,
 		stdoutText,
 	)
 	cmd := Command{
-		Command: "python",
-		Args:    []string{"-c", pythonCode},
+		Command: "bash",
+		Args:    []string{"-c", bashCode},
 	}
 
 	out := RunCommandAndGetOutput(t, cmd)

--- a/modules/shell/command_test.go
+++ b/modules/shell/command_test.go
@@ -2,10 +2,13 @@ package shell
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/gruntwork-io/terratest/modules/random"
 )
 
 func TestRunCommandAndGetOutput(t *testing.T) {
@@ -28,7 +31,7 @@ func TestRunCommandAndGetOutputOrder(t *testing.T) {
 	stdoutText := "Hello, World"
 	expectedText := "Hello, Error\nHello, World"
 	pythonCode := fmt.Sprintf(
-		"from __future__ import print_function; import sys; print('%s', file=sys.stderr); sys.stderr.flush(); print('%s', file=sys.stdout); sys.stdout.flush()",
+		"from __future__ import print_function; import sys, time; print('%s', file=sys.stderr); sys.stderr.flush(); time.sleep(1); print('%s', file=sys.stdout); sys.stdout.flush()",
 		stderrText,
 		stdoutText,
 	)
@@ -39,4 +42,41 @@ func TestRunCommandAndGetOutputOrder(t *testing.T) {
 
 	out := RunCommandAndGetOutput(t, cmd)
 	assert.Equal(t, strings.TrimSpace(out), expectedText)
+}
+
+func TestRunCommandAndGetOutputConcurrency(t *testing.T) {
+	t.Parallel()
+
+	uniqueStderr := random.UniqueId()
+	uniqueStdout := random.UniqueId()
+
+	bashCode := fmt.Sprintf(`
+echo_stderr(){
+	sleep .$[ ( $RANDOM %% 10 ) + 1 ]s
+	(>&2 echo "%s")
+}
+echo_stdout(){
+	sleep .$[ ( $RANDOM %% 10 ) + 1 ]s
+	echo "%s"
+}
+for i in {1..5}
+do
+	echo_stderr &
+	echo_stdout &
+done
+wait
+`,
+		uniqueStderr,
+		uniqueStdout,
+	)
+	cmd := Command{
+		Command: "bash",
+		Args:    []string{"-c", bashCode},
+	}
+
+	out := RunCommandAndGetOutput(t, cmd)
+	stdoutReg := regexp.MustCompile(uniqueStdout)
+	stderrReg := regexp.MustCompile(uniqueStderr)
+	assert.Equal(t, len(stdoutReg.FindAllString(out, -1)), 5)
+	assert.Equal(t, len(stderrReg.FindAllString(out, -1)), 5)
 }

--- a/modules/shell/command_test.go
+++ b/modules/shell/command_test.go
@@ -24,11 +24,11 @@ func TestRunCommandAndGetOutput(t *testing.T) {
 func TestRunCommandAndGetOutputOrder(t *testing.T) {
 	t.Parallel()
 
-	stdoutText := "Hello, Error"
-	stderrText := "Hello, World"
+	stderrText := "Hello, Error"
+	stdoutText := "Hello, World"
 	expectedText := "Hello, Error\nHello, World"
 	pythonCode := fmt.Sprintf(
-		"from __future__ import print_function; import sys; print('%s', file=sys.stderr); print('%s', file=sys.stdout)",
+		"from __future__ import print_function; import sys; print('%s', file=sys.stderr, flush=True); print('%s', file=sys.stdout, flush=True)",
 		stderrText,
 		stdoutText,
 	)

--- a/modules/shell/command_test.go
+++ b/modules/shell/command_test.go
@@ -28,7 +28,7 @@ func TestRunCommandAndGetOutputOrder(t *testing.T) {
 	stdoutText := "Hello, World"
 	expectedText := "Hello, Error\nHello, World"
 	pythonCode := fmt.Sprintf(
-		"from __future__ import print_function; import sys; print('%s', file=sys.stderr, flush=True); print('%s', file=sys.stdout, flush=True)",
+		"from __future__ import print_function; import sys; print('%s', file=sys.stderr); sys.stderr.flush(); print('%s', file=sys.stdout); sys.stdout.flush()",
 		stderrText,
 		stdoutText,
 	)

--- a/modules/shell/command_test.go
+++ b/modules/shell/command_test.go
@@ -1,6 +1,7 @@
 package shell
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -18,4 +19,24 @@ func TestRunCommandAndGetOutput(t *testing.T) {
 
 	out := RunCommandAndGetOutput(t, cmd)
 	assert.Equal(t, text, strings.TrimSpace(out))
+}
+
+func TestRunCommandAndGetOutputOrder(t *testing.T) {
+	t.Parallel()
+
+	stdoutText := "Hello, Error"
+	stderrText := "Hello, World"
+	expectedText := "Hello, Error\nHello, World"
+	pythonCode := fmt.Sprintf(
+		"from __future__ import print_function; import sys; print('%s', file=sys.stderr); print('%s', file=sys.stdout)",
+		stderrText,
+		stdoutText,
+	)
+	cmd := Command{
+		Command: "python",
+		Args:    []string{"-c", pythonCode},
+	}
+
+	out := RunCommandAndGetOutput(t, cmd)
+	assert.Equal(t, strings.TrimSpace(out), expectedText)
 }


### PR DESCRIPTION
The current method will not interleave stdout and stderr. Additionally, if a command only outputs to stderr, then this will not emit any logs until the command finishes, because it will block on `stdoutScanner.Scan()`.

The solution proposed here is to use goroutines for reading the data from each output and wait until they terminate.