### PR TITLE
Adding GetPrivateIpInstance(s) AWS helper functions

### DIFF
--- a/test/terraform_ssh_example_test.go
+++ b/test/terraform_ssh_example_test.go
@@ -154,7 +154,9 @@ func testSSHToPrivateHost(t *testing.T, terraformOptions *terraform.Options, key
 	publicInstanceIP := terraform.Output(t, terraformOptions, "public_instance_ip")
 
 	// Get IP of private instance from AWS helper function instead of Terraform output
-	privateInstanceIP := aws.GetPrivateIpOfEc2Instance(t, terraform.Output(t, terraformOptions, "private_instance_id"), terraformOptions.Vars["aws_region"].(string))
+	privateInstanceID := terraform.Output(t, terraformOptions, "private_instance_id")
+	deployedAWSRegion := terraformOptions.Vars["aws_region"].(string)
+	privateInstanceIP := aws.GetPrivateIpOfEc2Instance(t, privateInstanceID, deployedAWSRegion)
 
 	// We're going to try to SSH to the private instance using the public instance as a jump host. For both instances,
 	// we are using the Key Pair we created earlier, and the user "ubuntu", as we know the Instances are running an

--- a/test/terraform_ssh_example_test.go
+++ b/test/terraform_ssh_example_test.go
@@ -173,7 +173,7 @@ func testSSHToPrivateHost(t *testing.T, terraformOptions *terraform.Options, key
 	// It can take a minute or so for the Instance to boot up, so retry a few times
 	maxRetries := 30
 	timeBetweenRetries := 5 * time.Second
-	description := fmt.Sprintf("SSH to private host %s via public host %s", publicInstanceIP, privateInstanceIP)
+	description := fmt.Sprintf("SSH to private host %s via public host %s", privateInstanceIP, publicInstanceIP)
 
 	// Run a simple echo command on the server
 	expectedText := "Hello, World"
@@ -307,7 +307,7 @@ func testSSHAgentToPrivateHost(t *testing.T, terraformOptions *terraform.Options
 	// It can take a minute or so for the Instance to boot up, so retry a few times
 	maxRetries := 30
 	timeBetweenRetries := 5 * time.Second
-	description := fmt.Sprintf("SSH with Agent to private host %s via public host %s", publicInstanceIP, privateInstanceIP)
+	description := fmt.Sprintf("SSH with Agent to private host %s via public host %s", privateInstanceIP, publicInstanceIP)
 
 	// Run a simple echo command on the server
 	expectedText := "Hello, World"

--- a/test/terraform_ssh_example_test.go
+++ b/test/terraform_ssh_example_test.go
@@ -152,7 +152,9 @@ func testSSHToPublicHost(t *testing.T, terraformOptions *terraform.Options, keyP
 func testSSHToPrivateHost(t *testing.T, terraformOptions *terraform.Options, keyPair *aws.Ec2Keypair) {
 	// Run `terraform output` to get the value of an output variable
 	publicInstanceIP := terraform.Output(t, terraformOptions, "public_instance_ip")
-	privateInstanceIP := terraform.Output(t, terraformOptions, "private_instance_ip")
+
+	// Get IP of private instance from AWS helper function instead of Terraform output
+	privateInstanceIP := aws.GetPrivateIpOfEc2Instance(t, terraform.Output(t, terraformOptions, "private_instance_id"), terraformOptions.Vars["aws_region"].(string))
 
 	// We're going to try to SSH to the private instance using the public instance as a jump host. For both instances,
 	// we are using the Key Pair we created earlier, and the user "ubuntu", as we know the Instances are running an


### PR DESCRIPTION
Issue: https://github.com/gruntwork-io/terratest/issues/211
Test Pass Gist: https://gist.github.com/drmmarsunited/d95744bbc049d040b1b17b3c90eda796

This PR adds the following helper functions to the `ec2.go` file in the `aws` module:

- GetPrivateIpOfEc2Instance
- GetPrivateIpOfEc2InstanceE
- GetPrivateIpsOfEc2Instances
- GetPrivateIpsOfEc2InstancesE

It also updates the [existing tests](https://github.com/gruntwork-io/terratest/blob/master/test/terraform_ssh_example_test.go) for the basic SSH example to use the newly created `GetPrivateIpOfEc2Instance` function to grab the private instance's IP address, instead of using the output from Terraform.

There was also a reversal of the public/private IP order in the string interpolation, where the public instance's IP address was being written into a string where the private instance's IP should have gone.  I've updated that as well.