### PR TITLE
PR for Issue #208 - Returning multiple outputs

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -811,6 +811,7 @@
     "k8s.io/api/core/v1",
     "k8s.io/apimachinery/pkg/apis/meta/v1",
     "k8s.io/client-go/kubernetes",
+    "k8s.io/client-go/rest",
     "k8s.io/client-go/tools/clientcmd",
     "k8s.io/client-go/tools/clientcmd/api",
   ]

--- a/modules/terraform/output.go
+++ b/modules/terraform/output.go
@@ -128,8 +128,64 @@ func OutputMapE(t *testing.T, options *Options, key string) (map[string]string, 
 	for k, v := range valueMap {
 		resultMap[k] = fmt.Sprintf("%v", v)
 	}
-
 	return resultMap, nil
+}
+
+// OutputsForKeysE calls terraform output for the given variable list and returns values as a map.
+// If keys not found in the output, fails the test
+func OutputForKeys(t *testing.T, options *Options, keys []string) map[string]interface{} {
+	out, err := OutputsForKeysE(t, options, keys)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return out
+}
+
+// OutputsForKeysE calls terraform output for the given variable list and returns values as a map.
+// The returned values are of type interface{} and need to be type casted as necessary. Refer to output_test.go
+func OutputsForKeysE(t *testing.T, options *Options, keys []string) (map[string]interface{}, error) {
+	out, err := RunTerraformCommandE(t, options, "output", "-no-color", "-json")
+	if err != nil {
+		return nil, err
+	}
+
+	outputMap := map[string]map[string]interface{}{}
+	if err := json.Unmarshal([]byte(out), &outputMap); err != nil {
+		return nil, err
+	}
+
+	if keys == nil {
+		outputKeys := make([]string, 0, len(outputMap))
+		for k := range outputMap {
+			outputKeys = append(outputKeys, k)
+		}
+		keys = outputKeys
+	}
+
+	resultMap := make(map[string]interface{})
+	for _, key := range keys {
+		value, containsValue := outputMap[key]["value"]
+		if !containsValue {
+			return nil, fmt.Errorf("output doesn't contain a value for the key %q", key)
+		}
+		resultMap[key] = value
+	}
+	return resultMap, nil
+}
+
+// OutputsForKeysE calls terraform output for the given variable list and returns values as a map.
+// If there is error fetching the output, fails the test
+func OutputAll(t *testing.T, options *Options) map[string]interface{} {
+	out, err := OutputAllE(t, options)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return out
+}
+
+// OutputListE calls terraform output and returns all the outputs as a map
+func OutputAllE(t *testing.T, options *Options) (map[string]interface{}, error) {
+	return OutputsForKeysE(t, options, nil)
 }
 
 // EmptyOutput is an error that occurs when an output is empty.

--- a/modules/terraform/output.go
+++ b/modules/terraform/output.go
@@ -131,19 +131,19 @@ func OutputMapE(t *testing.T, options *Options, key string) (map[string]string, 
 	return resultMap, nil
 }
 
-// OutputsForKeysE calls terraform output for the given variable list and returns values as a map.
+// OutputForKeysE calls terraform output for the given key list and returns values as a map.
 // If keys not found in the output, fails the test
 func OutputForKeys(t *testing.T, options *Options, keys []string) map[string]interface{} {
-	out, err := OutputsForKeysE(t, options, keys)
+	out, err := OutputForKeysE(t, options, keys)
 	if err != nil {
 		t.Fatal(err)
 	}
 	return out
 }
 
-// OutputsForKeysE calls terraform output for the given variable list and returns values as a map.
+// OutputForKeysE calls terraform output for the given key list and returns values as a map.
 // The returned values are of type interface{} and need to be type casted as necessary. Refer to output_test.go
-func OutputsForKeysE(t *testing.T, options *Options, keys []string) (map[string]interface{}, error) {
+func OutputForKeysE(t *testing.T, options *Options, keys []string) (map[string]interface{}, error) {
 	out, err := RunTerraformCommandE(t, options, "output", "-no-color", "-json")
 	if err != nil {
 		return nil, err
@@ -173,7 +173,7 @@ func OutputsForKeysE(t *testing.T, options *Options, keys []string) (map[string]
 	return resultMap, nil
 }
 
-// OutputsForKeysE calls terraform output for the given variable list and returns values as a map.
+// OutputAll calls terraform output returns all values as a map.
 // If there is error fetching the output, fails the test
 func OutputAll(t *testing.T, options *Options) map[string]interface{} {
 	out, err := OutputAllE(t, options)
@@ -185,7 +185,7 @@ func OutputAll(t *testing.T, options *Options) map[string]interface{} {
 
 // OutputListE calls terraform output and returns all the outputs as a map
 func OutputAllE(t *testing.T, options *Options) (map[string]interface{}, error) {
-	return OutputsForKeysE(t, options, nil)
+	return OutputForKeysE(t, options, nil)
 }
 
 // EmptyOutput is an error that occurs when an output is empty.

--- a/modules/terraform/output_test.go
+++ b/modules/terraform/output_test.go
@@ -96,3 +96,101 @@ func TestOutputNotMapError(t *testing.T) {
 
 	assert.Error(t, err)
 }
+
+func TestOutputsForKeys(t *testing.T) {
+	t.Parallel()
+
+	testFolder, err := files.CopyTerraformFolderToTemp("../../test/fixtures/terraform-output-all", t.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	options := &Options{
+		TerraformDir: testFolder,
+	}
+
+	keys := []string{"our_star", "stars", "magnitudes"}
+
+	InitAndApply(t, options)
+	out := OutputForKeys(t, options, keys)
+
+	expectedLen := 3
+	assert.Len(t, out, expectedLen, "Output should contain %d items", expectedLen)
+
+	expectedString := "Sun"
+	str, ok := out["our_star"].(string)
+	assert.True(t, ok, "data type wrong")
+	assert.Equal(t, expectedString, str, "String %q should String %q", expectedString, str)
+
+	expectedListLen := 3
+	outputInterfaceList, ok := out["stars"].([]interface{})
+	expectedListItem := "Sirius"
+	assert.Len(t, outputInterfaceList, expectedListLen, "output map should contain %d items", expectedListLen)
+	assert.Equal(t, expectedListItem, outputInterfaceList[0].(string), "Item %q should item %q", expectedListItem, outputInterfaceList[0].(string))
+
+	outputInterfaceMap, ok := out["magnitudes"].(map[string]interface{})
+	expectedMapLen := 3
+	expectedMapItem := -1.46
+	assert.Len(t, outputInterfaceMap, expectedMapLen, "output map should contain %d items", expectedMapLen)
+	assert.Equal(t, expectedMapItem, outputInterfaceMap["Sirius"].(float64), "Item %q should item %q", expectedMapItem, outputInterfaceMap["Sirius"].(float64))
+
+	outputNotPresentMap, ok := out["constellations"].(map[string]interface{})
+	assert.False(t, ok)
+	assert.Nil(t, outputNotPresentMap)
+}
+
+func TestOutputsAll(t *testing.T) {
+	t.Parallel()
+
+	testFolder, err := files.CopyTerraformFolderToTemp("../../test/fixtures/terraform-output-all", t.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	options := &Options{
+		TerraformDir: testFolder,
+	}
+
+	InitAndApply(t, options)
+	out := OutputAll(t, options)
+
+	expectedLen := 4
+	assert.Len(t, out, expectedLen, "Output should contain %d items", expectedLen)
+
+	expectedString := "Sun"
+	str, ok := out["our_star"].(string)
+	assert.True(t, ok, "data type wrong")
+	assert.Equal(t, expectedString, str, "Map %q should match %q", expectedString, str)
+
+	expectedListLen := 3
+	outputInterfaceList, ok := out["stars"].([]interface{})
+	expectedListItem := "Betelgeuse"
+	assert.Len(t, outputInterfaceList, expectedListLen, "output list should contain %d items", expectedListLen)
+	assert.Equal(t, expectedListItem, outputInterfaceList[2].(string), "List item %q should list item %q", expectedListItem, outputInterfaceList[0].(string))
+
+	expectedMapLen := 4
+	outputInterfaceMap, ok := out["constellations"].(map[string]interface{})
+	expectedMapItem := "Aldebaran"
+	assert.Len(t, outputInterfaceMap, expectedMapLen, "output map should contain 4 items")
+	assert.Equal(t, expectedMapItem, outputInterfaceMap["Taurus"].(string), "Map %q should match %q", expectedMapItem, outputInterfaceMap["Taurus"].(string))
+}
+
+func TestOutputsForKeysError(t *testing.T) {
+	t.Parallel()
+
+	testFolder, err := files.CopyTerraformFolderToTemp("../../test/fixtures/terraform-output-map", t.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	options := &Options{
+		TerraformDir: testFolder,
+	}
+
+	InitAndApply(t, options)
+
+	_, err = OutputsForKeysE(t, options, []string{"random_key"})
+
+	assert.Error(t, err)
+}
+

--- a/modules/terraform/output_test.go
+++ b/modules/terraform/output_test.go
@@ -117,23 +117,29 @@ func TestOutputsForKeys(t *testing.T) {
 	expectedLen := 3
 	assert.Len(t, out, expectedLen, "Output should contain %d items", expectedLen)
 
+	//String value
 	expectedString := "Sun"
 	str, ok := out["our_star"].(string)
 	assert.True(t, ok, "data type wrong")
-	assert.Equal(t, expectedString, str, "String %q should String %q", expectedString, str)
+	assert.Equal(t, expectedString, str, "String %q should match %q", expectedString, str)
 
+	//List value
 	expectedListLen := 3
 	outputInterfaceList, ok := out["stars"].([]interface{})
 	expectedListItem := "Sirius"
-	assert.Len(t, outputInterfaceList, expectedListLen, "output map should contain %d items", expectedListLen)
-	assert.Equal(t, expectedListItem, outputInterfaceList[0].(string), "Item %q should item %q", expectedListItem, outputInterfaceList[0].(string))
+	assert.Len(t, outputInterfaceList, expectedListLen, "Output list should contain %d items", expectedListLen)
+	assert.Equal(t, expectedListItem, outputInterfaceList[0].(string), "List Item %q should match %q",
+		expectedListItem, outputInterfaceList[0].(string))
 
+	//Map value
 	outputInterfaceMap, ok := out["magnitudes"].(map[string]interface{})
 	expectedMapLen := 3
 	expectedMapItem := -1.46
-	assert.Len(t, outputInterfaceMap, expectedMapLen, "output map should contain %d items", expectedMapLen)
-	assert.Equal(t, expectedMapItem, outputInterfaceMap["Sirius"].(float64), "Item %q should item %q", expectedMapItem, outputInterfaceMap["Sirius"].(float64))
+	assert.Len(t, outputInterfaceMap, expectedMapLen, "Output map should contain %d items", expectedMapLen)
+	assert.Equal(t, expectedMapItem, outputInterfaceMap["Sirius"].(float64), "Map Item %q should match %q",
+		expectedMapItem, outputInterfaceMap["Sirius"].(float64))
 
+	//Key not in the parameter list
 	outputNotPresentMap, ok := out["constellations"].(map[string]interface{})
 	assert.False(t, ok)
 	assert.Nil(t, outputNotPresentMap)
@@ -157,22 +163,27 @@ func TestOutputsAll(t *testing.T) {
 	expectedLen := 4
 	assert.Len(t, out, expectedLen, "Output should contain %d items", expectedLen)
 
+	//String Value
 	expectedString := "Sun"
 	str, ok := out["our_star"].(string)
 	assert.True(t, ok, "data type wrong")
-	assert.Equal(t, expectedString, str, "Map %q should match %q", expectedString, str)
+	assert.Equal(t, expectedString, str, "String %q should match %q", expectedString, str)
 
+	//List Value
 	expectedListLen := 3
 	outputInterfaceList, ok := out["stars"].([]interface{})
 	expectedListItem := "Betelgeuse"
-	assert.Len(t, outputInterfaceList, expectedListLen, "output list should contain %d items", expectedListLen)
-	assert.Equal(t, expectedListItem, outputInterfaceList[2].(string), "List item %q should list item %q", expectedListItem, outputInterfaceList[0].(string))
+	assert.Len(t, outputInterfaceList, expectedListLen, "Output list should contain %d items", expectedListLen)
+	assert.Equal(t, expectedListItem, outputInterfaceList[2].(string), "List item %q should match %q",
+		expectedListItem, outputInterfaceList[0].(string))
 
+	//Map Value
 	expectedMapLen := 4
 	outputInterfaceMap, ok := out["constellations"].(map[string]interface{})
 	expectedMapItem := "Aldebaran"
-	assert.Len(t, outputInterfaceMap, expectedMapLen, "output map should contain 4 items")
-	assert.Equal(t, expectedMapItem, outputInterfaceMap["Taurus"].(string), "Map %q should match %q", expectedMapItem, outputInterfaceMap["Taurus"].(string))
+	assert.Len(t, outputInterfaceMap, expectedMapLen, "Output map should contain 4 items")
+	assert.Equal(t, expectedMapItem, outputInterfaceMap["Taurus"].(string), "Map item %q should match %q",
+		expectedMapItem, outputInterfaceMap["Taurus"].(string))
 }
 
 func TestOutputsForKeysError(t *testing.T) {
@@ -189,8 +200,7 @@ func TestOutputsForKeysError(t *testing.T) {
 
 	InitAndApply(t, options)
 
-	_, err = OutputsForKeysE(t, options, []string{"random_key"})
+	_, err = OutputForKeysE(t, options, []string{"random_key"})
 
 	assert.Error(t, err)
 }
-

--- a/test/fixtures/terraform-output-all/output.tf
+++ b/test/fixtures/terraform-output-all/output.tf
@@ -1,0 +1,28 @@
+output "stars" {
+  value = [
+    "Sirius",
+    "Rigel",
+    "Betelgeuse",
+  ]
+}
+
+output "our_star" {
+  value = "Sun"
+}
+
+output "constellations" {
+  value = {
+    Gemini = "Pollux",
+    Scorpio = "Antares",
+    Taurus = "Aldebaran",
+    Virgo = "Spica",
+  }
+}
+
+output "magnitudes" {
+  value = {
+    Sirius = -1.46,
+    Canopus = -0.72,
+    Antares = 0.96,
+  }
+}


### PR DESCRIPTION
PR to address issue #208 
Added 2 functions : 
- Function to return all output as map[string]interface{}
- Function to return outputs for requested keys as map[string]interface{}

Tests updated as well.