### PR TITLE
PrivateHostname of EC2 Instance + CapacityInfo of ASG

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -26,7 +26,7 @@
   version = "v0.6.0"
 
 [[projects]]
-  digest = "1:0702d9e517405bc4eb634e3c7cf909b1da212bb5ce3cb633d1358bd2a7853d82"
+  digest = "1:64d3361d91812fe08e323158379fa8d66d48d9ef6b9a2a6800aef78f95f80ea0"
   name = "github.com/aws/aws-sdk-go"
   packages = [
     "aws",
@@ -65,6 +65,7 @@
     "service/autoscaling",
     "service/cloudwatchlogs",
     "service/ec2",
+    "service/elb",
     "service/iam",
     "service/kms",
     "service/rds",
@@ -776,6 +777,7 @@
     "github.com/aws/aws-sdk-go/service/autoscaling",
     "github.com/aws/aws-sdk-go/service/cloudwatchlogs",
     "github.com/aws/aws-sdk-go/service/ec2",
+    "github.com/aws/aws-sdk-go/service/elb",
     "github.com/aws/aws-sdk-go/service/iam",
     "github.com/aws/aws-sdk-go/service/kms",
     "github.com/aws/aws-sdk-go/service/rds",

--- a/modules/aws/asg.go
+++ b/modules/aws/asg.go
@@ -1,11 +1,56 @@
 package aws
 
 import (
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gruntwork-io/terratest/modules/logger"
+	"github.com/gruntwork-io/terratest/modules/retry"
 )
+
+type AsgCapacityInfo struct {
+	MinCapacity     int64
+	MaxCapacity     int64
+	CurrentCapacity int64
+	DesiredCapacity int64
+}
+
+// GetCapacityInfoForAsg returns the capacity info for the queried asg as a struct, AsgCapacityInfo.
+func GetCapacityInfoForAsg(t *testing.T, asgName string, awsRegion string) AsgCapacityInfo {
+	capacityInfo, err := GetCapacityInfoForAsgE(t, asgName, awsRegion)
+	require.NoError(t, err)
+	return capacityInfo
+}
+
+// GetCapacityInfoForAsgE returns the capacity info for the queried asg as a struct, AsgCapacityInfo.
+func GetCapacityInfoForAsgE(t *testing.T, asgName string, awsRegion string) (AsgCapacityInfo, error) {
+	asgClient, err := NewAsgClientE(t, awsRegion)
+	if err != nil {
+		return AsgCapacityInfo{}, err
+	}
+
+	input := autoscaling.DescribeAutoScalingGroupsInput{AutoScalingGroupNames: []*string{aws.String(asgName)}}
+	output, err := asgClient.DescribeAutoScalingGroups(&input)
+	if err != nil {
+		return AsgCapacityInfo{}, err
+	}
+	groups := output.AutoScalingGroups
+	if len(groups) == 0 {
+		return AsgCapacityInfo{}, NewNotFoundError("ASG", asgName)
+	}
+	capacityInfo := AsgCapacityInfo{
+		MinCapacity:     *groups[0].MinSize,
+		MaxCapacity:     *groups[0].MaxSize,
+		DesiredCapacity: *groups[0].DesiredCapacity,
+		CurrentCapacity: int64(len(groups[0].Instances)),
+	}
+	return capacityInfo, nil
+}
 
 // GetInstanceIdsForAsg gets the IDs of EC2 Instances in the given ASG.
 func GetInstanceIdsForAsg(t *testing.T, asgName string, awsRegion string) []string {
@@ -37,6 +82,47 @@ func GetInstanceIdsForAsgE(t *testing.T, asgName string, awsRegion string) ([]st
 	}
 
 	return instanceIDs, nil
+}
+
+// WaitForCapacity waits for the currently set desired capacity to be reached on the ASG
+func WaitForCapacity(
+	t *testing.T,
+	asgName string,
+	region string,
+	maxRetries int,
+	sleepBetweenRetries time.Duration,
+) {
+	err := WaitForCapacityE(t, asgName, region, maxRetries, sleepBetweenRetries)
+	require.NoError(t, err)
+}
+
+// WaitForCapacityE waits for the currently set desired capacity to be reached on the ASG
+func WaitForCapacityE(
+	t *testing.T,
+	asgName string,
+	region string,
+	maxRetries int,
+	sleepBetweenRetries time.Duration,
+) error {
+	msg, err := retry.DoWithRetryE(
+		t,
+		fmt.Sprintf("Waiting for ASG %s to reach desired capacity.", asgName),
+		maxRetries,
+		sleepBetweenRetries,
+		func() (string, error) {
+			capacityInfo, err := GetCapacityInfoForAsgE(t, asgName, region)
+			if err != nil {
+				return "", err
+			}
+			if capacityInfo.CurrentCapacity != capacityInfo.DesiredCapacity {
+				return "", NewAsgCapacityNotMetError(asgName, capacityInfo.DesiredCapacity, capacityInfo.CurrentCapacity)
+			} else {
+				return fmt.Sprintf("ASG %s is now at desired capacity %d", asgName, capacityInfo.DesiredCapacity), nil
+			}
+		},
+	)
+	logger.Log(t, msg)
+	return err
 }
 
 // NewAsgClient creates an Auto Scaling Group client.

--- a/modules/aws/asg.go
+++ b/modules/aws/asg.go
@@ -41,7 +41,7 @@ func GetCapacityInfoForAsgE(t *testing.T, asgName string, awsRegion string) (Asg
 	}
 	groups := output.AutoScalingGroups
 	if len(groups) == 0 {
-		return AsgCapacityInfo{}, NewNotFoundError("ASG", asgName)
+		return AsgCapacityInfo{}, NewNotFoundError("ASG", asgName, awsRegion)
 	}
 	capacityInfo := AsgCapacityInfo{
 		MinCapacity:     *groups[0].MinSize,

--- a/modules/aws/asg_test.go
+++ b/modules/aws/asg_test.go
@@ -23,12 +23,13 @@ func TestGetCapacityInfoForAsg(t *testing.T) {
 
 	defer deleteAutoScalingGroup(t, asgName, region)
 	createTestAutoScalingGroup(t, asgName, region, 2)
+	WaitForCapacity(t, asgName, region, 40, 15*time.Second)
 
 	capacityInfo := GetCapacityInfoForAsg(t, asgName, region)
-	assert.Equal(t, capacityInfo.DesiredCapacity, 2)
-	assert.Equal(t, capacityInfo.CurrentCapacity, 2)
-	assert.Equal(t, capacityInfo.MinCapacity, 1)
-	assert.Equal(t, capacityInfo.MaxCapacity, 3)
+	assert.Equal(t, capacityInfo.DesiredCapacity, int64(2))
+	assert.Equal(t, capacityInfo.CurrentCapacity, int64(2))
+	assert.Equal(t, capacityInfo.MinCapacity, int64(1))
+	assert.Equal(t, capacityInfo.MaxCapacity, int64(3))
 }
 
 func TestGetInstanceIdsForAsg(t *testing.T) {
@@ -40,6 +41,7 @@ func TestGetInstanceIdsForAsg(t *testing.T) {
 
 	defer deleteAutoScalingGroup(t, asgName, region)
 	createTestAutoScalingGroup(t, asgName, region, 1)
+	WaitForCapacity(t, asgName, region, 40, 15*time.Second)
 
 	instanceIds := GetInstanceIdsForAsg(t, asgName, region)
 	assert.Equal(t, len(instanceIds), 1)

--- a/modules/aws/asg_test.go
+++ b/modules/aws/asg_test.go
@@ -1,0 +1,158 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/autoscaling"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gruntwork-io/terratest/modules/random"
+)
+
+func TestGetCapacityInfoForAsg(t *testing.T) {
+	t.Parallel()
+
+	uniqueID := random.UniqueId()
+	asgName := fmt.Sprintf("%s-%s", t.Name(), uniqueID)
+	region := GetRandomStableRegion(t, []string{}, []string{})
+
+	defer deleteAutoScalingGroup(t, asgName, region)
+	createTestAutoScalingGroup(t, asgName, region, 2)
+
+	capacityInfo := GetCapacityInfoForAsg(t, asgName, region)
+	assert.Equal(t, capacityInfo.DesiredCapacity, 2)
+	assert.Equal(t, capacityInfo.CurrentCapacity, 2)
+	assert.Equal(t, capacityInfo.MinCapacity, 1)
+	assert.Equal(t, capacityInfo.MaxCapacity, 3)
+}
+
+func TestGetInstanceIdsForAsg(t *testing.T) {
+	t.Parallel()
+
+	uniqueID := random.UniqueId()
+	asgName := fmt.Sprintf("%s-%s", t.Name(), uniqueID)
+	region := GetRandomStableRegion(t, []string{}, []string{})
+
+	defer deleteAutoScalingGroup(t, asgName, region)
+	createTestAutoScalingGroup(t, asgName, region, 1)
+
+	instanceIds := GetInstanceIdsForAsg(t, asgName, region)
+	assert.Equal(t, len(instanceIds), 1)
+}
+
+// The following functions were adapted from the tests for cloud-nuke
+
+func createTestAutoScalingGroup(t *testing.T, name string, region string, desiredCount int64) {
+	instance := createTestEC2Instance(t, region, name)
+
+	asgClient := NewAsgClient(t, region)
+	param := &autoscaling.CreateAutoScalingGroupInput{
+		AutoScalingGroupName: &name,
+		InstanceId:           instance.InstanceId,
+		DesiredCapacity:      aws.Int64(desiredCount),
+		MinSize:              aws.Int64(1),
+		MaxSize:              aws.Int64(3),
+	}
+	_, err := asgClient.CreateAutoScalingGroup(param)
+	require.NoError(t, err)
+
+	err = asgClient.WaitUntilGroupExists(&autoscaling.DescribeAutoScalingGroupsInput{
+		AutoScalingGroupNames: []*string{&name},
+	})
+	require.NoError(t, err)
+}
+
+func createTestEC2Instance(t *testing.T, region string, name string) ec2.Instance {
+	ec2Client := NewEc2Client(t, region)
+	imageID := GetAmazonLinuxAmi(t, region)
+	params := &ec2.RunInstancesInput{
+		ImageId:      aws.String(imageID),
+		InstanceType: aws.String("t2.micro"),
+		MinCount:     aws.Int64(1),
+		MaxCount:     aws.Int64(1),
+	}
+	runResult, err := ec2Client.RunInstances(params)
+	require.NoError(t, err)
+
+	require.NotEqual(t, len(runResult.Instances), 0)
+
+	err = ec2Client.WaitUntilInstanceExists(&ec2.DescribeInstancesInput{
+		Filters: []*ec2.Filter{
+			&ec2.Filter{
+				Name:   aws.String("instance-id"),
+				Values: []*string{runResult.Instances[0].InstanceId},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	// Add test tag to the created instance
+	_, err = ec2Client.CreateTags(&ec2.CreateTagsInput{
+		Resources: []*string{runResult.Instances[0].InstanceId},
+		Tags: []*ec2.Tag{
+			{
+				Key:   aws.String("Name"),
+				Value: aws.String(name),
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	// EC2 Instance must be in a running before this function returns
+	err = ec2Client.WaitUntilInstanceRunning(&ec2.DescribeInstancesInput{
+		Filters: []*ec2.Filter{
+			&ec2.Filter{
+				Name:   aws.String("instance-id"),
+				Values: []*string{runResult.Instances[0].InstanceId},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	return *runResult.Instances[0]
+}
+
+func terminateEc2InstancesByName(t *testing.T, region string, names []string) {
+	for _, name := range names {
+		instanceIds := GetEc2InstanceIdsByTag(t, region, "Name", name)
+		for _, instanceId := range instanceIds {
+			TerminateInstance(t, region, instanceId)
+		}
+	}
+}
+
+func deleteAutoScalingGroup(t *testing.T, name string, region string) {
+	// We have to scale ASG down to 0 before we can delete it
+	scaleAsgToZero(t, name, region)
+
+	asgClient := NewAsgClient(t, region)
+	input := &autoscaling.DeleteAutoScalingGroupInput{AutoScalingGroupName: aws.String(name)}
+	_, err := asgClient.DeleteAutoScalingGroup(input)
+	require.NoError(t, err)
+	err = asgClient.WaitUntilGroupNotExists(&autoscaling.DescribeAutoScalingGroupsInput{
+		AutoScalingGroupNames: []*string{aws.String(name)},
+	})
+	require.NoError(t, err)
+}
+
+func scaleAsgToZero(t *testing.T, name string, region string) {
+	asgClient := NewAsgClient(t, region)
+	input := &autoscaling.UpdateAutoScalingGroupInput{
+		AutoScalingGroupName: aws.String(name),
+		DesiredCapacity:      aws.Int64(0),
+		MinSize:              aws.Int64(0),
+		MaxSize:              aws.Int64(0),
+	}
+	_, err := asgClient.UpdateAutoScalingGroup(input)
+	require.NoError(t, err)
+	WaitForCapacity(t, name, region, 40, 15*time.Second)
+
+	// There is an eventual consistency bug where even though the ASG is scaled down, AWS sometimes still views a
+	// scaling activity so we add a 5 second pause here to work around it.
+	time.Sleep(5 * time.Second)
+}

--- a/modules/aws/ec2.go
+++ b/modules/aws/ec2.go
@@ -7,14 +7,13 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/gruntwork-io/terratest/modules/logger"
+	"github.com/stretchr/testify/require"
 )
 
 // GetPrivateIpOfEc2Instance gets the private IP address of the given EC2 Instance in the given region.
 func GetPrivateIpOfEc2Instance(t *testing.T, instanceID string, awsRegion string) string {
 	ip, err := GetPrivateIpOfEc2InstanceE(t, instanceID, awsRegion)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	return ip
 }
 
@@ -37,15 +36,14 @@ func GetPrivateIpOfEc2InstanceE(t *testing.T, instanceID string, awsRegion strin
 // GetPrivateIpsOfEc2Instances gets the private IP address of the given EC2 Instance in the given region. Returns a map of instance ID to IP address.
 func GetPrivateIpsOfEc2Instances(t *testing.T, instanceIDs []string, awsRegion string) map[string]string {
 	ips, err := GetPrivateIpsOfEc2InstancesE(t, instanceIDs, awsRegion)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	return ips
 }
 
 // GetPrivateIpsOfEc2InstancesE gets the private IP address of the given EC2 Instance in the given region. Returns a map of instance ID to IP address.
 func GetPrivateIpsOfEc2InstancesE(t *testing.T, instanceIDs []string, awsRegion string) (map[string]string, error) {
 	ec2Client := NewEc2Client(t, awsRegion)
+	// TODO: implement pagination for cases that extend beyond limit (1000 instances)
 	input := ec2.DescribeInstancesInput{InstanceIds: aws.StringSlice(instanceIDs)}
 	output, err := ec2Client.DescribeInstances(&input)
 	if err != nil {
@@ -66,9 +64,7 @@ func GetPrivateIpsOfEc2InstancesE(t *testing.T, instanceIDs []string, awsRegion 
 // GetPrivateHostnameOfEc2Instance gets the private IP address of the given EC2 Instance in the given region.
 func GetPrivateHostnameOfEc2Instance(t *testing.T, instanceID string, awsRegion string) string {
 	ip, err := GetPrivateHostnameOfEc2InstanceE(t, instanceID, awsRegion)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	return ip
 }
 
@@ -91,9 +87,7 @@ func GetPrivateHostnameOfEc2InstanceE(t *testing.T, instanceID string, awsRegion
 // GetPrivateHostnamesOfEc2Instances gets the private IP address of the given EC2 Instance in the given region. Returns a map of instance ID to IP address.
 func GetPrivateHostnamesOfEc2Instances(t *testing.T, instanceIDs []string, awsRegion string) map[string]string {
 	ips, err := GetPrivateHostnamesOfEc2InstancesE(t, instanceIDs, awsRegion)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	return ips
 }
 
@@ -103,6 +97,7 @@ func GetPrivateHostnamesOfEc2InstancesE(t *testing.T, instanceIDs []string, awsR
 	if err != nil {
 		return nil, err
 	}
+	// TODO: implement pagination for cases that extend beyond limit (1000 instances)
 	input := ec2.DescribeInstancesInput{InstanceIds: aws.StringSlice(instanceIDs)}
 	output, err := ec2Client.DescribeInstances(&input)
 	if err != nil {
@@ -123,9 +118,7 @@ func GetPrivateHostnamesOfEc2InstancesE(t *testing.T, instanceIDs []string, awsR
 // GetPublicIpOfEc2Instance gets the public IP address of the given EC2 Instance in the given region.
 func GetPublicIpOfEc2Instance(t *testing.T, instanceID string, awsRegion string) string {
 	ip, err := GetPublicIpOfEc2InstanceE(t, instanceID, awsRegion)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	return ip
 }
 
@@ -148,15 +141,14 @@ func GetPublicIpOfEc2InstanceE(t *testing.T, instanceID string, awsRegion string
 // GetPublicIpsOfEc2Instances gets the public IP address of the given EC2 Instance in the given region. Returns a map of instance ID to IP address.
 func GetPublicIpsOfEc2Instances(t *testing.T, instanceIDs []string, awsRegion string) map[string]string {
 	ips, err := GetPublicIpsOfEc2InstancesE(t, instanceIDs, awsRegion)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	return ips
 }
 
 // GetPublicIpsOfEc2InstancesE gets the public IP address of the given EC2 Instance in the given region. Returns a map of instance ID to IP address.
 func GetPublicIpsOfEc2InstancesE(t *testing.T, instanceIDs []string, awsRegion string) (map[string]string, error) {
 	ec2Client := NewEc2Client(t, awsRegion)
+	// TODO: implement pagination for cases that extend beyond limit (1000 instances)
 	input := ec2.DescribeInstancesInput{InstanceIds: aws.StringSlice(instanceIDs)}
 	output, err := ec2Client.DescribeInstances(&input)
 	if err != nil {
@@ -177,9 +169,7 @@ func GetPublicIpsOfEc2InstancesE(t *testing.T, instanceIDs []string, awsRegion s
 // GetEc2InstanceIdsByTag returns all the IDs of EC2 instances in the given region with the given tag.
 func GetEc2InstanceIdsByTag(t *testing.T, region string, tagName string, tagValue string) []string {
 	out, err := GetEc2InstanceIdsByTagE(t, region, tagName, tagValue)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	return out
 }
 
@@ -194,6 +184,7 @@ func GetEc2InstanceIdsByTagE(t *testing.T, region string, tagName string, tagVal
 		Name:   aws.String(fmt.Sprintf("tag:%s", tagName)),
 		Values: []*string{aws.String(tagValue)},
 	}
+	// TODO: implement pagination for cases that extend beyond limit (1000 instances)
 	output, err := client.DescribeInstances(&ec2.DescribeInstancesInput{Filters: []*ec2.Filter{tagFilter}})
 	if err != nil {
 		return nil, err
@@ -213,9 +204,7 @@ func GetEc2InstanceIdsByTagE(t *testing.T, region string, tagName string, tagVal
 // GetTagsForEc2Instance returns all the tags for the given EC2 Instance.
 func GetTagsForEc2Instance(t *testing.T, region string, instanceID string) map[string]string {
 	tags, err := GetTagsForEc2InstanceE(t, region, instanceID)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	return tags
 }
 
@@ -255,10 +244,7 @@ func GetTagsForEc2InstanceE(t *testing.T, region string, instanceID string) (map
 
 // DeleteAmi deletes the given AMI in the given region.
 func DeleteAmi(t *testing.T, region string, imageID string) {
-	err := DeleteAmiE(t, region, imageID)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, DeleteAmiE(t, region, imageID))
 }
 
 // DeleteAmiE deletes the given AMI in the given region.
@@ -276,10 +262,7 @@ func DeleteAmiE(t *testing.T, region string, imageID string) error {
 
 // AddTagsToResource adds the tags to the given taggable AWS resource such as EC2, AMI or VPC.
 func AddTagsToResource(t *testing.T, region string, resource string, tags map[string]string) {
-	err := AddTagsToResourceE(t, region, resource, tags)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, AddTagsToResourceE(t, region, resource, tags))
 }
 
 // AddTagsToResourceE adds the tags to the given taggable AWS resource such as EC2, AMI or VPC.
@@ -307,10 +290,7 @@ func AddTagsToResourceE(t *testing.T, region string, resource string, tags map[s
 
 // TerminateInstance terminates the EC2 instance with the given ID in the given region.
 func TerminateInstance(t *testing.T, region string, instanceID string) {
-	err := TerminateInstanceE(t, region, instanceID)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, TerminateInstanceE(t, region, instanceID))
 }
 
 // TerminateInstanceE terminates the EC2 instance with the given ID in the given region.
@@ -334,9 +314,7 @@ func TerminateInstanceE(t *testing.T, region string, instanceID string) error {
 // GetAmiPubliclyAccessible returns whether the AMI is publicly accessible or not
 func GetAmiPubliclyAccessible(t *testing.T, awsRegion string, amiID string) bool {
 	output, err := GetAmiPubliclyAccessibleE(t, awsRegion, amiID)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	return output
 }
 
@@ -357,9 +335,7 @@ func GetAmiPubliclyAccessibleE(t *testing.T, awsRegion string, amiID string) (bo
 // GetAccountsWithLaunchPermissionsForAmi returns list of accounts that the AMI is shared with
 func GetAccountsWithLaunchPermissionsForAmi(t *testing.T, awsRegion string, amiID string) []string {
 	output, err := GetAccountsWithLaunchPermissionsForAmiE(t, awsRegion, amiID)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	return output
 }
 
@@ -396,9 +372,7 @@ func GetLaunchPermissionsForAmiE(t *testing.T, awsRegion string, amiID string) (
 // NewEc2Client creates an EC2 client.
 func NewEc2Client(t *testing.T, region string) *ec2.EC2 {
 	client, err := NewEc2ClientE(t, region)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	return client
 }
 

--- a/modules/aws/errors.go
+++ b/modules/aws/errors.go
@@ -4,18 +4,41 @@ import (
 	"fmt"
 )
 
+// IpForEc2InstanceNotFound is an error that occurs when the IP for an EC2 instance is not found.
+type IpForEc2InstanceNotFound struct {
+	InstanceId string
+	AwsRegion  string
+	Type       string
+}
+
+func (err IpForEc2InstanceNotFound) Error() string {
+	return fmt.Sprintf("Could not find a %s IP address for EC2 Instance %s in %s", err.Type, err.InstanceId, err.AwsRegion)
+}
+
+// HostnameForEc2InstanceNotFound is an error that occurs when the IP for an EC2 instance is not found.
+type HostnameForEc2InstanceNotFound struct {
+	InstanceId string
+	AwsRegion  string
+	Type       string
+}
+
+func (err HostnameForEc2InstanceNotFound) Error() string {
+	return fmt.Sprintf("Could not find a %s hostname for EC2 Instance %s in %s", err.Type, err.InstanceId, err.AwsRegion)
+}
+
 // NotFoundError is returned when an expected object is not found
 type NotFoundError struct {
 	objectType string
 	objectID   string
+	region     string
 }
 
 func (err NotFoundError) Error() string {
-	return fmt.Sprintf("Object of type %s with id %s not found", err.objectType, err.objectID)
+	return fmt.Sprintf("Object of type %s with id %s not found in region %s", err.objectType, err.objectID, err.region)
 }
 
-func NewNotFoundError(objectType string, objectID string) NotFoundError {
-	return NotFoundError{objectType, objectID}
+func NewNotFoundError(objectType string, objectID string, region string) NotFoundError {
+	return NotFoundError{objectType, objectID, region}
 }
 
 // AsgCapacityNotMetError is returned when the ASG capacity is not yet at the desired capacity.

--- a/modules/aws/errors.go
+++ b/modules/aws/errors.go
@@ -1,0 +1,39 @@
+package aws
+
+import (
+	"fmt"
+)
+
+// NotFoundError is returned when an expected object is not found
+type NotFoundError struct {
+	objectType string
+	objectID   string
+}
+
+func (err NotFoundError) Error() string {
+	return fmt.Sprintf("Object of type %s with id %s not found", err.objectType, err.objectID)
+}
+
+func NewNotFoundError(objectType string, objectID string) NotFoundError {
+	return NotFoundError{objectType, objectID}
+}
+
+// AsgCapacityNotMetError is returned when the ASG capacity is not yet at the desired capacity.
+type AsgCapacityNotMetError struct {
+	asgName         string
+	desiredCapacity int64
+	currentCapacity int64
+}
+
+func (err AsgCapacityNotMetError) Error() string {
+	return fmt.Sprintf(
+		"ASG %s not yet at desired capacity %d (current %d)",
+		err.asgName,
+		err.desiredCapacity,
+		err.currentCapacity,
+	)
+}
+
+func NewAsgCapacityNotMetError(asgName string, desiredCapacity int64, currentCapacity int64) AsgCapacityNotMetError {
+	return AsgCapacityNotMetError{asgName, desiredCapacity, currentCapacity}
+}

--- a/test/terraform_ssh_example_test.go
+++ b/test/terraform_ssh_example_test.go
@@ -149,6 +149,18 @@ func testSSHToPublicHost(t *testing.T, terraformOptions *terraform.Options, keyP
 	})
 }
 
+func testSSHToPrivateHostByHostname(t *testing.T, terraformOptions *terraform.Options, keyPair *aws.Ec2Keypair) {
+	// Run `terraform output` to get the value of an output variable
+	publicInstanceIP := terraform.Output(t, terraformOptions, "public_instance_ip")
+
+	// Get hostname of private instance from AWS helper function instead of Terraform output
+	privateInstanceID := terraform.Output(t, terraformOptions, "private_instance_id")
+	deployedAWSRegion := terraformOptions.Vars["aws_region"].(string)
+	privateInstanceHostname := aws.GetPrivateHostnameOfEc2Instance(t, privateInstanceID, deployedAWSRegion)
+
+	sshToPrivateHost(t, publicInstanceIP, privateInstanceHostname, keyPair)
+}
+
 func testSSHToPrivateHost(t *testing.T, terraformOptions *terraform.Options, keyPair *aws.Ec2Keypair) {
 	// Run `terraform output` to get the value of an output variable
 	publicInstanceIP := terraform.Output(t, terraformOptions, "public_instance_ip")
@@ -158,6 +170,10 @@ func testSSHToPrivateHost(t *testing.T, terraformOptions *terraform.Options, key
 	deployedAWSRegion := terraformOptions.Vars["aws_region"].(string)
 	privateInstanceIP := aws.GetPrivateIpOfEc2Instance(t, privateInstanceID, deployedAWSRegion)
 
+	sshToPrivateHost(t, publicInstanceIP, privateInstanceIP, keyPair)
+}
+
+func sshToPrivateHost(t *testing.T, publicInstanceIP string, privateInstanceIP string, keyPair *aws.Ec2Keypair) {
 	// We're going to try to SSH to the private instance using the public instance as a jump host. For both instances,
 	// we are using the Key Pair we created earlier, and the user "ubuntu", as we know the Instances are running an
 	// Ubuntu AMI that has such a user


### PR DESCRIPTION
I had a need for getting the PrivateHostname of the EC2 instances in EKS world, because the kubernetes node names default to the private DNS name of the worker nodes.

I also had a need to get capacity information of ASGs when testing EKS rolling deployments.

Both functions seemed like they belong in terratest, so added them here.