### PR TITLE
Functions for interacting with pods

### DIFF
--- a/modules/k8s/errors.go
+++ b/modules/k8s/errors.go
@@ -6,6 +6,19 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
+// PodNotAvailable is returned when a Kubernetes service is not yet available to accept traffic.
+type PodNotAvailable struct {
+	pod *corev1.Pod
+}
+
+func (err PodNotAvailable) Error() string {
+	return fmt.Sprintf("Pod %s is not available", err.pod.Name)
+}
+
+func NewPodNotAvailableError(pod *corev1.Pod) PodNotAvailable {
+	return PodNotAvailable{pod}
+}
+
 // ServiceNotAvailable is returned when a Kubernetes service is not yet available to accept traffic.
 type ServiceNotAvailable struct {
 	service *corev1.Service

--- a/modules/k8s/pod.go
+++ b/modules/k8s/pod.go
@@ -1,0 +1,58 @@
+package k8s
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/gruntwork-io/terratest/modules/logger"
+	"github.com/gruntwork-io/terratest/modules/retry"
+)
+
+// GetPod returns a Kubernetes pod resource in the provided namespace with the given name. This will
+// fail the test if there is an error.
+func GetPod(t *testing.T, options *KubectlOptions, podName string) *corev1.Pod {
+	pod, err := GetPodE(t, options, podName)
+	require.NoError(t, err)
+	return pod
+}
+
+// GetPodE returns a Kubernetes pod resource in the provided namespace with the given name.
+func GetPodE(t *testing.T, options *KubectlOptions, podName string) (*corev1.Pod, error) {
+	clientset, err := GetKubernetesClientFromOptionsE(t, options)
+	if err != nil {
+		return nil, err
+	}
+	return clientset.CoreV1().Pods(options.Namespace).Get(podName, metav1.GetOptions{})
+}
+
+// WaitUntilPodAvailable waits until the pod is running.
+func WaitUntilPodAvailable(t *testing.T, options *KubectlOptions, podName string, retries int, sleepBetweenRetries time.Duration) {
+	statusMsg := fmt.Sprintf("Wait for pod %s to be provisioned.", podName)
+	message := retry.DoWithRetry(
+		t,
+		statusMsg,
+		retries,
+		sleepBetweenRetries,
+		func() (string, error) {
+			pod, err := GetPodE(t, options, podName)
+			if err != nil {
+				return "", err
+			}
+			if !IsPodAvailable(pod) {
+				return "", NewPodNotAvailableError(pod)
+			}
+			return "Pod is now available", nil
+		},
+	)
+	logger.Logf(t, message)
+}
+
+// IsPodAvailable returns true if the pod is running.
+func IsPodAvailable(pod *corev1.Pod) bool {
+	return pod.Status.Phase == corev1.PodRunning
+}

--- a/modules/k8s/pod_test.go
+++ b/modules/k8s/pod_test.go
@@ -1,0 +1,67 @@
+package k8s
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gruntwork-io/terratest/modules/random"
+)
+
+func TestGetPodEReturnsErrorForNonExistantPod(t *testing.T) {
+	t.Parallel()
+
+	options := NewKubectlOptions("", "")
+	_, err := GetPodE(t, options, "nginx-pod")
+	require.Error(t, err)
+}
+
+func TestGetPodEReturnsCorrectPodInCorrectNamespace(t *testing.T) {
+	t.Parallel()
+
+	uniqueID := strings.ToLower(random.UniqueId())
+	options := NewKubectlOptions("", "")
+	options.Namespace = uniqueID
+	configData := fmt.Sprintf(EXAMPLE_POD_YAML_TEMPLATE, uniqueID, uniqueID)
+	defer KubectlDeleteFromString(t, options, configData)
+	KubectlApplyFromString(t, options, configData)
+
+	pod := GetPod(t, options, "nginx-pod")
+	require.Equal(t, pod.Name, "nginx-pod")
+	require.Equal(t, pod.Namespace, uniqueID)
+}
+
+func TestWaitUntilPodAvailableReturnsSuccessfully(t *testing.T) {
+	t.Parallel()
+
+	uniqueID := strings.ToLower(random.UniqueId())
+	options := NewKubectlOptions("", "")
+	options.Namespace = uniqueID
+	configData := fmt.Sprintf(EXAMPLE_POD_YAML_TEMPLATE, uniqueID, uniqueID)
+	defer KubectlDeleteFromString(t, options, configData)
+	KubectlApplyFromString(t, options, configData)
+
+	WaitUntilPodAvailable(t, options, "nginx-pod", 10, 1*time.Second)
+}
+
+const EXAMPLE_POD_YAML_TEMPLATE = `---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: %s
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx-pod
+  namespace: %s
+spec:
+  containers:
+  - name: nginx
+    image: nginx:1.15.7
+    ports:
+    - containerPort: 80
+`

--- a/modules/k8s/pod_test.go
+++ b/modules/k8s/pod_test.go
@@ -44,7 +44,7 @@ func TestWaitUntilPodAvailableReturnsSuccessfully(t *testing.T) {
 	defer KubectlDeleteFromString(t, options, configData)
 	KubectlApplyFromString(t, options, configData)
 
-	WaitUntilPodAvailable(t, options, "nginx-pod", 10, 1*time.Second)
+	WaitUntilPodAvailable(t, options, "nginx-pod", 60, 1*time.Second)
 }
 
 const EXAMPLE_POD_YAML_TEMPLATE = `---


### PR DESCRIPTION
### Modules affected

* `k8s`

### Description

New functions added:

* `GetPod` and `GetPodE`: Look up a pod by name and return it.
* `WaitUntilPodAvailable` and `WaitUntilPodAvailableE`: Wait for the pod to be running on the cluster.