### PR TITLE
Fix curl based terratest_log_parser installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ to install version 0.13.13 of `terratest_log_parser`:
 ```bash
 # This example assumes a linux 64bit machine
 # Use curl to download the binary
-curl -Lo terratest_log_parser https://github.com/gruntwork-io/terratest/releases/download/v0.13.13/terratest_log_parser_linux_amd64
+curl --location --silent --fail --show-error -o terratest_log_parser https://github.com/gruntwork-io/terratest/releases/download/v0.13.13/terratest_log_parser_linux_amd64
 # Make the downloaded binary executable
 chmod +x terratest_log_parser
 # Finally, we place the downloaded binary to a place in the PATH

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ to install version 0.13.13 of `terratest_log_parser`:
 ```bash
 # This example assumes a linux 64bit machine
 # Use curl to download the binary
-curl -o terratest_log_parser https://github.com/gruntwork-io/terratest/releases/download/v0.13.13/terratest_log_parser_linux_amd64
+curl -Lo terratest_log_parser https://github.com/gruntwork-io/terratest/releases/download/v0.13.13/terratest_log_parser_linux_amd64
 # Make the downloaded binary executable
 chmod +x terratest_log_parser
 # Finally, we place the downloaded binary to a place in the PATH


### PR DESCRIPTION
`curl` does not follow redirects by default, so we need to pass the option `-L`. Addresses https://github.com/gruntwork-io/terratest/issues/220