### PR TITLE
Improve documentation for test_structure.CopyTerraformFolderToTemp

### DIFF
--- a/modules/test-structure/test_structure.go
+++ b/modules/test-structure/test_structure.go
@@ -58,9 +58,6 @@ func SkipStageEnvVarSet() bool {
 //       // Copy the terraform folder to a temp folder
 //       tempTestFolder := test_structure.CopyTerraformFolderToTemp(t, rootFolder, terraformFolderRelativeToRoot)
 //
-//       // Log temp folder so we can see it
-//       logger.Logf(t, "Temp test folder: %s", tempTestFolder)
-//
 //       // Make sure to use the temp test folder in the terraform options
 //       terraformOptions := &terraform.Options{
 //       		TerraformDir: tempTestFolder,
@@ -80,7 +77,12 @@ func CopyTerraformFolderToTemp(t *testing.T, rootFolder string, terraformModuleF
 		t.Fatal(err)
 	}
 
-	return filepath.Join(tmpRootFolder, terraformModuleFolder)
+	tmpTestFolder := filepath.Join(tmpRootFolder, terraformModuleFolder)
+
+	// Log temp folder so we can see it
+	logger.Logf(t, "Copied terraform folder %s to %s", filepath.Join(rootFolder, terraformModuleFolder), tmpTestFolder)
+
+	return tmpTestFolder
 }
 
 func cleanName(originalName string) string {


### PR DESCRIPTION
Context is https://github.com/gruntwork-io/terratest/issues/219.

I know we have examples of usage of this, but it is dug deep in the test stages example and it isn't immediately obvious how to extract it out, so I decided to embed an example in the docs.

Also, I couldn't come up with a use case where we don't want to log the new temp folder, so added in the log in the function.