### PR TITLE
GetSecret, GetServiceAccount, CreateServiceAccount

### DIFF
--- a/modules/k8s/secret.go
+++ b/modules/k8s/secret.go
@@ -1,0 +1,27 @@
+package k8s
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// GetSecret returns a Kubernetes secret resource in the provided namespace with the given name. The namespace used
+// is the one provided in the KubectlOptions. This will fail the test if there is an error.
+func GetSecret(t *testing.T, options *KubectlOptions, secretName string) *corev1.Secret {
+	secret, err := GetSecretE(t, options, secretName)
+	require.NoError(t, err)
+	return secret
+}
+
+// GetSecret returns a Kubernetes secret resource in the provided namespace with the given name. The namespace used
+// is the one provided in the KubectlOptions.
+func GetSecretE(t *testing.T, options *KubectlOptions, secretName string) (*corev1.Secret, error) {
+	clientset, err := GetKubernetesClientFromOptionsE(t, options)
+	if err != nil {
+		return nil, err
+	}
+	return clientset.CoreV1().Secrets(options.Namespace).Get(secretName, metav1.GetOptions{})
+}

--- a/modules/k8s/secret_test.go
+++ b/modules/k8s/secret_test.go
@@ -1,0 +1,47 @@
+package k8s
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gruntwork-io/terratest/modules/random"
+)
+
+func TestGetSecretEReturnsErrorForNonExistantSecret(t *testing.T) {
+	t.Parallel()
+
+	options := NewKubectlOptions("", "")
+	_, err := GetSecretE(t, options, "master-password")
+	require.Error(t, err)
+}
+
+func TestGetSecretEReturnsCorrectSecretInCorrectNamespace(t *testing.T) {
+	t.Parallel()
+
+	uniqueID := strings.ToLower(random.UniqueId())
+	options := NewKubectlOptions("", "")
+	options.Namespace = uniqueID
+	configData := fmt.Sprintf(EXAMPLE_SECRET_YAML_TEMPLATE, uniqueID, uniqueID)
+	defer KubectlDeleteFromString(t, options, configData)
+	KubectlApplyFromString(t, options, configData)
+
+	secret := GetSecret(t, options, "master-password")
+	require.Equal(t, secret.Name, "master-password")
+	require.Equal(t, secret.Namespace, uniqueID)
+}
+
+const EXAMPLE_SECRET_YAML_TEMPLATE = `---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: %s
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: master-password
+  namespace: %s
+`

--- a/modules/k8s/service_account.go
+++ b/modules/k8s/service_account.go
@@ -1,0 +1,51 @@
+package k8s
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// GetServiceAccount returns a Kubernetes service account resource in the provided namespace with the given name. The
+// namespace used is the one provided in the KubectlOptions. This will fail the test if there is an error.
+func GetServiceAccount(t *testing.T, options *KubectlOptions, serviceAccountName string) *corev1.ServiceAccount {
+	serviceAccount, err := GetServiceAccountE(t, options, serviceAccountName)
+	require.NoError(t, err)
+	return serviceAccount
+}
+
+// GetServiceAccount returns a Kubernetes service account resource in the provided namespace with the given name. The
+// namespace used is the one provided in the KubectlOptions.
+func GetServiceAccountE(t *testing.T, options *KubectlOptions, serviceAccountName string) (*corev1.ServiceAccount, error) {
+	clientset, err := GetKubernetesClientFromOptionsE(t, options)
+	if err != nil {
+		return nil, err
+	}
+	return clientset.CoreV1().ServiceAccounts(options.Namespace).Get(serviceAccountName, metav1.GetOptions{})
+}
+
+// CreateServiceAccount will create a new service account resource in the provided namespace with the given name. The
+// namespace used is the one provided in the KubectlOptions. This will fail the test if there is an error.
+func CreateServiceAccount(t *testing.T, options *KubectlOptions, serviceAccountName string) {
+	require.NoError(t, CreateServiceAccountE(t, options, serviceAccountName))
+}
+
+// CreateServiceAccountE will create a new service account resource in the provided namespace with the given name. The
+// namespace used is the one provided in the KubectlOptions.
+func CreateServiceAccountE(t *testing.T, options *KubectlOptions, serviceAccountName string) error {
+	clientset, err := GetKubernetesClientFromOptionsE(t, options)
+	if err != nil {
+		return err
+	}
+
+	serviceAccount := corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      serviceAccountName,
+			Namespace: options.Namespace,
+		},
+	}
+	_, err = clientset.CoreV1().ServiceAccounts(options.Namespace).Create(&serviceAccount)
+	return err
+}

--- a/modules/k8s/service_account_test.go
+++ b/modules/k8s/service_account_test.go
@@ -1,0 +1,64 @@
+package k8s
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gruntwork-io/terratest/modules/random"
+)
+
+func TestGetServiceAccountEReturnsErrorForNonExistantServiceAccount(t *testing.T) {
+	t.Parallel()
+
+	options := NewKubectlOptions("", "")
+	_, err := GetServiceAccountE(t, options, "terratest")
+	require.Error(t, err)
+}
+
+func TestGetServiceAccountEReturnsCorrectServiceAccountInCorrectNamespace(t *testing.T) {
+	t.Parallel()
+
+	uniqueID := strings.ToLower(random.UniqueId())
+	options := NewKubectlOptions("", "")
+	options.Namespace = uniqueID
+	configData := fmt.Sprintf(EXAMPLE_SERVICEACCOUNT_YAML_TEMPLATE, uniqueID, uniqueID)
+	defer KubectlDeleteFromString(t, options, configData)
+	KubectlApplyFromString(t, options, configData)
+
+	serviceAccount := GetServiceAccount(t, options, "terratest")
+	require.Equal(t, serviceAccount.Name, "terratest")
+	require.Equal(t, serviceAccount.Namespace, uniqueID)
+}
+
+func TestCreateServiceAccountECreatesServiceAccountInNamespaceWithGivenName(t *testing.T) {
+	t.Parallel()
+
+	uniqueID := strings.ToLower(random.UniqueId())
+	options := NewKubectlOptions("", "")
+	options.Namespace = uniqueID
+	defer DeleteNamespace(t, options, options.Namespace)
+	CreateNamespace(t, options, options.Namespace)
+
+	// Note: We don't need to delete this at the end of test, because deleting the namespace automatically deletes
+	// everything created in the namespace.
+	CreateServiceAccount(t, options, "terratest")
+	serviceAccount := GetServiceAccount(t, options, "terratest")
+	require.Equal(t, serviceAccount.Name, "terratest")
+	require.Equal(t, serviceAccount.Namespace, uniqueID)
+}
+
+const EXAMPLE_SERVICEACCOUNT_YAML_TEMPLATE = `---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: %s
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: terratest
+  namespace: %s
+`


### PR DESCRIPTION
This introduces three new functions in the kubernetes module that I needed to test Helm:

- `GetSecret`, `GetSecretE`: Lookup and get the Kubernetes Secret struct in the configured namespace.
- `GetServiceAccount`, `GetServiceAccountE`: Lookup and get the Kubernetes ServiceAccount struct in the configured namespace.
- `CreateServiceAccount`, `CreateServiceAccountE`: Create a ServiceAccount with the provided name in the configured namespace.