### PR TITLE
[WIP] Add Support for Authenticating against GKE clusters

### DIFF
--- a/modules/k8s/node.go
+++ b/modules/k8s/node.go
@@ -9,6 +9,9 @@ import (
 	"github.com/gruntwork-io/terratest/modules/retry"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	// The following line loads the gcp plugin which is required to authenticate against GKE clusters.
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 )
 
 // GetNodes queries Kubernetes for information about the worker nodes registered to the cluster. If anything goes wrong,

--- a/modules/k8s/node.go
+++ b/modules/k8s/node.go
@@ -11,6 +11,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	// The following line loads the gcp plugin which is required to authenticate against GKE clusters.
+	// See: https://github.com/kubernetes/client-go/issues/242
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 )
 


### PR DESCRIPTION
This PR allows the Kubernetes module to authenticate correctly against GKE clusters by loading the GCP plugin.

Inspired by: https://github.com/kubernetes/client-go/blob/53c7adfd0294caa142d961e1f780f74081d5b15f/examples/out-of-cluster-client-configuration/main.go#L31

Reference: https://github.com/kubernetes/client-go/issues/242

### TODO
 - [x] Currently the tests are failing