### PR TITLE
RBAC testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,22 +1,131 @@
+defaults: &defaults
+  machine: true
+  environment:
+    GRUNTWORK_INSTALLER_VERSION: v0.0.21
+    MODULE_CI_VERSION: v0.13.3
+    TERRAFORM_VERSION: 0.11.11
+    TERRAGRUNT_VERSION: NONE
+    PACKER_VERSION: 1.3.3
+    GOLANG_VERSION: 1.11
+    K8S_VERSION: v1.10.0  # Same as EKS
+    HELM_VERSION: v2.12.2
+    KUBECONFIG: /home/circleci/.kube/config
+    MINIKUBE_VERSION: v0.28.2  # See https://github.com/kubernetes/minikube/issues/2704
+    MINIKUBE_WANTUPDATENOTIFICATION: "false"
+    MINIKUBE_WANTREPORTERRORPROMPT: "false"
+    MINIKUBE_HOME: /home/circleci
+    CHANGE_MINIKUBE_NONE_USER: "true"
+
+
+# Install and setup minikube
+# https://github.com/kubernetes/minikube#linux-continuous-integration-without-vm-support
+setup_minikube: &setup_minikube
+  name: install helm, kubectl and minikube
+  working_directory: /tmp
+  command: |
+    # install kubectl
+    curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/${K8S_VERSION}/bin/linux/amd64/kubectl
+    chmod +x kubectl
+    sudo mv kubectl /usr/local/bin/
+    mkdir -p ${HOME}/.kube
+    touch ${HOME}/.kube/config
+
+    # install helm
+    curl -Lo helm.tar.gz https://storage.googleapis.com/kubernetes-helm/helm-${HELM_VERSION}-linux-amd64.tar.gz
+    tar -xvf helm.tar.gz
+    chmod +x linux-amd64/helm
+    sudo mv linux-amd64/helm /usr/local/bin/
+
+    # Install minikube
+    curl -Lo minikube https://github.com/kubernetes/minikube/releases/download/${MINIKUBE_VERSION}/minikube-linux-amd64
+    chmod +x minikube
+    sudo mv minikube /usr/local/bin/
+
+    # start minikube and wait for it
+    # Ignore warnings on minikube start command, as it will log a warning due to using deprecated localkube
+    # bootstrapper. However, the localkube bootstrapper is necessary to run on CircleCI which doesn't have
+    # systemd.
+    sudo -E minikube start --vm-driver=none --kubernetes-version=${K8S_VERSION} --bootstrapper=localkube --extra-config=apiserver.Authorization.Mode=RBAC
+    # this for loop waits until kubectl can access the api server that Minikube has created
+    $(
+      for i in {1..150}; do # timeout for 5 minutes
+        kubectl get po &> /dev/null
+        if [ $? -ne 1 ]; then
+          break
+        fi
+        sleep 2
+      done
+      true
+    )
+
+
+install_gruntwork_utils: &install_gruntwork_utils
+  name: install gruntwork utils
+  command: |
+    curl -Ls https://raw.githubusercontent.com/gruntwork-io/gruntwork-installer/master/bootstrap-gruntwork-installer.sh | bash /dev/stdin --version "${GRUNTWORK_INSTALLER_VERSION}"
+    gruntwork-install --module-name "gruntwork-module-circleci-helpers" --repo "https://github.com/gruntwork-io/module-ci" --tag "${MODULE_CI_VERSION}"
+    configure-environment-for-gruntwork-module \
+      --circle-ci-2-machine-executor \
+      --terraform-version ${TERRAFORM_VERSION} \
+      --terragrunt-version ${TERRAGRUNT_VERSION} \
+      --packer-version ${PACKER_VERSION} \
+      --use-go-dep \
+      --go-version ${GOLANG_VERSION} \
+      --go-src-path ./ 
+
+
 version: 2
 jobs:
-  build:
-    # We need to run Docker Compose with volumes, which isn't supported by CircleCI's Docker executor, so we have to use
-    # the machine executor instead.
-    machine: true
-    environment:
-      TERRAFORM_VERSION: 0.11.8
-      TERRAGRUNT_VERSION: NONE
-      GRUNTWORK_INSTALLER_VERSION: v0.0.21
-      K8S_VERSION: v1.10.0  # Same as EKS
-      KUBECONFIG: /home/circleci/.kube/config
-      MINIKUBE_VERSION: v0.28.2  # See https://github.com/kubernetes/minikube/issues/2704
-      MINIKUBE_WANTUPDATENOTIFICATION: "false"
-      MINIKUBE_WANTREPORTERRORPROMPT: "false"
-      MINIKUBE_HOME: /home/circleci
-      CHANGE_MINIKUBE_NONE_USER: "true"
+  setup:
+    <<: *defaults
     steps:
       - checkout
+      - restore_cache:
+          keys:
+          - dep-{{ checksum "Gopkg.lock" }}
+
+      # Install gruntwork utilities
+      - run:
+          <<: *install_gruntwork_utils
+
+      - save_cache:
+          key: dep-{{ checksum "Gopkg.lock" }}
+          paths:
+          - ./vendor
+
+      # Run pre-commit hooks and fail the build if any hook finds required changes.
+      - run: go get golang.org/x/tools/cmd/goimports
+      - run: pip install pre-commit==1.11.2
+      - run: pre-commit install
+      - run: pre-commit run --all-files
+
+      # Build any binaries that need to be built
+      # We always want to build the binaries, because we will use the terratest_log_parser to parse out the test output
+      # during a failure.
+      - run: 
+          command: |
+            cd ~/.go_workspace/src/github.com/gruntwork-io/terratest
+            GO_ENABLED=0 build-go-binaries \
+              --circle-ci-2 \
+              --app-name terratest_log_parser \
+              --src-path ./cmd/terratest_log_parser \
+              --dest-path ./cmd/bin \
+              --ld-flags "-X main.VERSION=$CIRCLE_TAG -extldflags '-static'"
+          when: always
+
+      - persist_to_workspace:
+          root: /home/circleci
+          paths:
+            - project
+              
+  test:
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: /home/circleci
+
+      - run:
+          <<: *install_gruntwork_utils
 
       # The weird way you have to set PATH in Circle 2.0
       - run: echo 'export PATH=$HOME/.local/bin:$HOME/terraform:$HOME/packer:$PATH' >> $BASH_ENV
@@ -25,84 +134,49 @@ jobs:
       - run: echo $GCLOUD_SERVICE_KEY > ${HOME}/gcloud-service-key.json
       - run: echo 'export GOOGLE_APPLICATION_CREDENTIALS=${HOME}/gcloud-service-key.json' >> $BASH_ENV
 
-      # Install Gruntwork and HashiCorp dependencies
-      - restore_cache:
-          keys:
-            - v1-external-dep
-            - v1-dep-{{ checksum "Gopkg.lock" }}
-
-      # Use the Gruntwork Installer to install the gruntwork-module-circleci-helpers
-      - run: curl -Ls https://raw.githubusercontent.com/gruntwork-io/gruntwork-installer/master/bootstrap-gruntwork-installer.sh | bash /dev/stdin --version ${GRUNTWORK_INSTALLER_VERSION}
-      - run: gruntwork-install --module-name "gruntwork-module-circleci-helpers" --repo "https://github.com/gruntwork-io/module-ci" --tag "v0.13.2"
-      - run: configure-environment-for-gruntwork-module --circle-ci-2-machine-executor --go-src-path . --use-go-dep --terraform-version ${TERRAFORM_VERSION} --terragrunt-version ${TERRAGRUNT_VERSION}
-
-      # Install and setup minikube
-      # https://github.com/kubernetes/minikube#linux-continuous-integration-without-vm-support
-      - run:
-          name: install kubectl
-          command: |
-            curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/${K8S_VERSION}/bin/linux/amd64/kubectl
-            chmod +x kubectl
-            sudo mv kubectl /usr/local/bin/
-            mkdir -p ${HOME}/.kube
-            touch ${HOME}/.kube/config
-      - run:
-          name: install minikube
-          command: |
-            curl -Lo minikube https://github.com/kubernetes/minikube/releases/download/${MINIKUBE_VERSION}/minikube-linux-amd64
-            chmod +x minikube
-            sudo mv minikube /usr/local/bin/
-      - run:
-          name: start minikube and wait for it
-          command: |
-            # Ignore warnings on minikube start command, as it will log a warning due to using deprecated localkube
-            # bootstrapper. However, the localkube bootstrapper is necessary to run on CircleCI which doesn't have
-            # systemd.
-            sudo -E minikube start --vm-driver=none --kubernetes-version=${K8S_VERSION} --bootstrapper=localkube --extra-config=apiserver.Authorization.Mode=RBAC
-            # this for loop waits until kubectl can access the api server that Minikube has created
-            $(
-              for i in {1..150}; do # timeout for 5 minutes
-                kubectl get po &> /dev/null
-                if [ $? -ne 1 ]; then
-                  break
-                fi
-                sleep 2
-              done
-              true
-            )
-
-      - save_cache:
-          key: v1-external-dep
-          paths:
-            - $HOME/terraform
-            - $HOME/packer
-      - save_cache:
-          key: v1-dep-{{ checksum "Gopkg.lock" }}
-          paths:
-            - $HOME/.go_workspace/src/github.com/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/test/vendor
-
-      # Run pre-commit hooks and fail the build if any hook finds required changes.
-      - run: go get golang.org/x/tools/cmd/goimports
-      - run: pip install pre-commit==1.11.2
-      - run: pre-commit install
-      - run: pre-commit run --all-files
-
       # Run the tests. Note that we set the "-p 1" flag to tell Go to run tests in each package sequentially. Without
       # this, Go buffers all log output until all packages are done, which with slower running tests can cause CircleCI
       # to kill the build after more than 10 minutes without log output.
+      # NOTE: because this doesn't build with the kubernetes tag, it will not run the kubernetes tests. See
+      # kubernetes_test build steps. 
       - run: mkdir -p /tmp/logs
       - run: run-go-tests --packages "-p 1 ./..." | tee /tmp/logs/test_output.log
 
-      # Build any binaries that need to be built
-      # We always want to build the binaries, because we will use the terratest_log_parser to parse out the test output
-      # during a failure.
-      - run: 
-          command: GO_ENABLED=0 build-go-binaries --circle-ci-2 --app-name terratest_log_parser --src-path ../.go_workspace/src/github.com/gruntwork-io/terratest/cmd/terratest_log_parser --dest-path ./cmd/bin --ld-flags "-X main.VERSION=$CIRCLE_TAG -extldflags '-static'"
+      - run:
+          command: ./cmd/bin/terratest_log_parser_linux_amd64 --testlog /tmp/logs/test_output.log --outputdir /tmp/logs
           when: always
 
-      - persist_to_workspace:
-          root: .
-          paths: cmd/bin
+      # Store test result and log artifacts for browsing purposes
+      - store_artifacts:
+          path: /tmp/logs
+      - store_test_results:
+          path: /tmp/logs
+
+
+  kubernetes_test:
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: /home/circleci
+
+      - run:
+          <<: *install_gruntwork_utils
+
+      # The weird way you have to set PATH in Circle 2.0
+      - run: echo 'export PATH=$HOME/.local/bin:$HOME/terraform:$HOME/packer:$PATH' >> $BASH_ENV
+
+      - run:
+          <<: *setup_minikube
+
+      # Run the Kubernetes tests. These tests are run because the kubernetes build tag is included, and we explicitly
+      # select the kubernetes tests
+      - run:
+          command: |
+            mkdir -p /tmp/logs
+            # Run the unit tests first, then the integration tests. They are separate because the integration tests
+            # require additional filtering.
+            run-go-tests --packages "-tags kubernetes ./modules/k8s" | tee /tmp/logs/test_output.log
+            run-go-tests --packages "-tags kubernetes -run TestKubernetes ./test" | tee -a /tmp/logs/test_output.log
 
       - run:
           command: ./cmd/bin/terratest_log_parser_linux_amd64 --testlog /tmp/logs/test_output.log --outputdir /tmp/logs
@@ -130,14 +204,29 @@ workflows:
   version: 2
   build-and-test:
     jobs:
-      - build:
+      - setup:
+          filters:
+            tags:
+              only: /^v.*/
+
+      - test:
+          requires:
+            - setup
+          filters:
+            tags:
+              only: /^v.*/
+
+      - kubernetes_test:
+          requires:
+            - setup
           filters:
             tags:
               only: /^v.*/
 
       - deploy:
           requires:
-            - build
+            - test
+            - kubernetes_test
           filters:
             tags:
               only: /^v.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -194,7 +194,7 @@ jobs:
     steps:
       - checkout
       - attach_workspace:
-          at: .
+          at: /home/circleci
       - run: curl -Ls https://raw.githubusercontent.com/gruntwork-io/gruntwork-installer/master/bootstrap-gruntwork-installer.sh | bash /dev/stdin --version v0.0.21
       - run: gruntwork-install --module-name "gruntwork-module-circleci-helpers" --repo "https://github.com/gruntwork-io/module-ci" --tag "v0.13.2"
       - run: upload-github-release-assets cmd/bin/*

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,7 @@ jobs:
             # Ignore warnings on minikube start command, as it will log a warning due to using deprecated localkube
             # bootstrapper. However, the localkube bootstrapper is necessary to run on CircleCI which doesn't have
             # systemd.
-            sudo -E minikube start --vm-driver=none --kubernetes-version=${K8S_VERSION} --bootstrapper=localkube
+            sudo -E minikube start --vm-driver=none --kubernetes-version=${K8S_VERSION} --bootstrapper=localkube --extra-config=apiserver.Authorization.Mode=RBAC
             # this for loop waits until kubectl can access the api server that Minikube has created
             $(
               for i in {1..150}; do # timeout for 5 minutes

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -26,7 +26,7 @@
   version = "v0.6.0"
 
 [[projects]]
-  digest = "1:64d3361d91812fe08e323158379fa8d66d48d9ef6b9a2a6800aef78f95f80ea0"
+  digest = "1:0702d9e517405bc4eb634e3c7cf909b1da212bb5ce3cb633d1358bd2a7853d82"
   name = "github.com/aws/aws-sdk-go"
   packages = [
     "aws",
@@ -65,7 +65,6 @@
     "service/autoscaling",
     "service/cloudwatchlogs",
     "service/ec2",
-    "service/elb",
     "service/iam",
     "service/kms",
     "service/rds",
@@ -703,7 +702,7 @@
 
 [[projects]]
   branch = "release-9.0"
-  digest = "1:51fd9ac9f2be10d79f5af101a7a1d758ef283fdb028a0d11198754bd3d4a6020"
+  digest = "1:bac06e69e8c8387d68053aa71f4e96dd8b8afef54135b55f17ff9ccec84fc74e"
   name = "k8s.io/client-go"
   packages = [
     "discovery",
@@ -745,8 +744,10 @@
     "pkg/apis/clientauthentication/v1beta1",
     "pkg/version",
     "plugin/pkg/client/auth/exec",
+    "plugin/pkg/client/auth/gcp",
     "rest",
     "rest/watch",
+    "third_party/forked/golang/template",
     "tools/auth",
     "tools/clientcmd",
     "tools/clientcmd/api",
@@ -760,6 +761,7 @@
     "util/flowcontrol",
     "util/homedir",
     "util/integer",
+    "util/jsonpath",
   ]
   pruneopts = "UT"
   revision = "13596e875accbd333e0b5bd5fd9462185acd9958"
@@ -777,7 +779,6 @@
     "github.com/aws/aws-sdk-go/service/autoscaling",
     "github.com/aws/aws-sdk-go/service/cloudwatchlogs",
     "github.com/aws/aws-sdk-go/service/ec2",
-    "github.com/aws/aws-sdk-go/service/elb",
     "github.com/aws/aws-sdk-go/service/iam",
     "github.com/aws/aws-sdk-go/service/kms",
     "github.com/aws/aws-sdk-go/service/rds",
@@ -813,6 +814,7 @@
     "k8s.io/api/core/v1",
     "k8s.io/apimachinery/pkg/apis/meta/v1",
     "k8s.io/client-go/kubernetes",
+    "k8s.io/client-go/plugin/pkg/client/auth/gcp",
     "k8s.io/client-go/rest",
     "k8s.io/client-go/tools/clientcmd",
     "k8s.io/client-go/tools/clientcmd/api",

--- a/README.md
+++ b/README.md
@@ -129,6 +129,8 @@ such as:
     AWS instance and then uses `remote-exec` to provision it.
 1.  [Basic Kubernetes Example](/examples/kubernetes-basic-example): A minimal Kubernetes resource that deploys an
     addressable nginx instance.
+1.  [Kubernetes RBAC Example](/examples/kubernetes-rbac-example): A Kubernetes resource config that creates a Namespace
+    with a ServiceAccount that has admin permissions within the Namespace, but not outside.
 
 Next, head over to the [test folder](/test) to see how you can use Terratest to test each of these examples:
 
@@ -152,8 +154,13 @@ Next, head over to the [test folder](/test) to see how you can use Terratest to 
     like config files and logs from deployed EC2 Instances. This is especially useful for getting a snapshot of the
     state of a deployment when a test fails.
 1.  [kubernetes_basic_example_test.go](/test/kubernetes_basic_example_test.go): Use Terratest to run `kubectl apply`
-    apply a Kubernetes resource file, verify resources are created using the Kubernetes API, and then run `kubectl
+    to apply a Kubernetes resource file, verify resources are created using the Kubernetes API, and then run `kubectl
     delete` to delete the resources at the end of the test.
+1.  [kubernetes_rbac_example_test.go](/test/kubernetes_rbac_example_test.go): Use Terratest to run `kubectl apply` to
+    apply a Kubernetes resource file, retrieve auth tokens to authenticate as the created ServiceAccount, update the
+    kubeconfig file with the authentication token and add a new context to auth as the ServiceAccount, verify auth as
+    the ServiceAccount by checking what resources you have access to, and finally run `kubectl delete` to delete the
+    resources at the end of the test.
     
 
 Finally, to see some real-world examples of Terratest in action, check out some of our open source infrastructure

--- a/examples/kubernetes-rbac-example/README.md
+++ b/examples/kubernetes-rbac-example/README.md
@@ -1,0 +1,36 @@
+# Kubernetes RBAC Example
+
+This folder contains a Kubernetes resource config file that creates a new Namespace and a ServiceAccount that has admin
+level permissions in the Namespace, but nowhere else. This example is used to demonstrate how you can test RBAC
+permissions using terratest.
+
+See the corresponding terratest code ([kubernetes_rbac_example_test.go](../../test/kubernetes_rbac_example_test.go)) for
+an example of how to test this resource config:
+
+
+## Deploying the Kubernetes resource
+
+1. Setup a Kubernetes cluster. We recommend using a local version:
+    - [minikube](https://github.com/kubernetes/minikube)
+    - [Kubernetes on Docker For Mac](https://docs.docker.com/docker-for-mac/kubernetes/)
+    - [Kubernetes on Docker For Windows](https://docs.docker.com/docker-for-windows/kubernetes/)
+
+1. Install and setup [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) to talk to the deployed
+   Kubernetes cluster.
+1. Run `kubectl apply -f namespace-service-account.yml`
+
+
+## Running automated tests against this Kubernetes deployment
+
+1. Setup a Kubernetes cluster. We recommend using a local version:
+    - [minikube](https://github.com/kubernetes/minikube)
+    - [Kubernetes on Docker For Mac](https://docs.docker.com/docker-for-mac/kubernetes/)
+    - [Kubernetes on Docker For Windows](https://docs.docker.com/docker-for-windows/kubernetes/)
+
+1. Install and setup [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) to talk to the deployed
+   Kubernetes cluster.
+1. Install and setup [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/).
+1. Install [Golang](https://golang.org/) and make sure this code is checked out into your `GOPATH`.
+1. `cd test`
+1. `dep ensure`
+1. `go test -v -run TestKubernetesRBACExample`

--- a/examples/kubernetes-rbac-example/namespace-service-account.yml
+++ b/examples/kubernetes-rbac-example/namespace-service-account.yml
@@ -1,0 +1,35 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: terratest-rbac-example-namespace
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: terratest-rbac-example-service-account
+  namespace: terratest-rbac-example-namespace
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: terratest-rbac-example-role
+  namespace: terratest-rbac-example-namespace
+rules:
+  - apiGroups: ["*"]
+    resources: ["*"]
+    verbs: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: terratest-rbac-example-service-account-binding
+  namespace: terratest-rbac-example-namespace
+subjects:
+  - kind: ServiceAccount
+    name: terratest-rbac-example-service-account
+    namespace: terratest-rbac-example-namespace
+roleRef:
+  kind: Role
+  name: terratest-rbac-example-role
+  apiGroup: rbac.authorization.k8s.io

--- a/modules/k8s/config_test.go
+++ b/modules/k8s/config_test.go
@@ -1,3 +1,9 @@
+// +build kubernetes
+
+// NOTE: we have build tags to differentiate kubernetes tests from non-kubernetes tests. This is done because minikube
+// is heavy and can interfere with docker related tests in terratest. To avoid overloading the system, we run the
+// kubernetes tests separately from the others.
+
 package k8s
 
 import (

--- a/modules/k8s/errors.go
+++ b/modules/k8s/errors.go
@@ -6,6 +6,15 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
+// ServiceAccountTokenNotAvailable is returned when a Kubernetes ServiceAccount does not have a token provisioned yet.
+type ServiceAccountTokenNotAvailable struct {
+	Name string
+}
+
+func (err ServiceAccountTokenNotAvailable) Error() string {
+	return fmt.Sprintf("ServiceAccount %s does not have a token yet.", err.Name)
+}
+
 // PodNotAvailable is returned when a Kubernetes service is not yet available to accept traffic.
 type PodNotAvailable struct {
 	pod *corev1.Pod

--- a/modules/k8s/kubectl_test.go
+++ b/modules/k8s/kubectl_test.go
@@ -1,3 +1,9 @@
+// +build kubernetes
+
+// NOTE: we have build tags to differentiate kubernetes tests from non-kubernetes tests. This is done because minikube
+// is heavy and can interfere with docker related tests in terratest. To avoid overloading the system, we run the
+// kubernetes tests separately from the others.
+
 package k8s
 
 import (

--- a/modules/k8s/namespace_test.go
+++ b/modules/k8s/namespace_test.go
@@ -1,3 +1,9 @@
+// +build kubernetes
+
+// NOTE: we have build tags to differentiate kubernetes tests from non-kubernetes tests. This is done because minikube
+// is heavy and can interfere with docker related tests in terratest. To avoid overloading the system, we run the
+// kubernetes tests separately from the others.
+
 package k8s
 
 import (

--- a/modules/k8s/node_test.go
+++ b/modules/k8s/node_test.go
@@ -1,3 +1,9 @@
+// +build kubernetes
+
+// NOTE: we have build tags to differentiate kubernetes tests from non-kubernetes tests. This is done because minikube
+// is heavy and can interfere with docker related tests in terratest. To avoid overloading the system, we run the
+// kubernetes tests separately from the others.
+
 package k8s
 
 import (

--- a/modules/k8s/pod_test.go
+++ b/modules/k8s/pod_test.go
@@ -1,3 +1,9 @@
+// +build kubernetes
+
+// NOTE: we have build tags to differentiate kubernetes tests from non-kubernetes tests. This is done because minikube
+// is heavy and can interfere with docker related tests in terratest. To avoid overloading the system, we run the
+// kubernetes tests separately from the others.
+
 package k8s
 
 import (

--- a/modules/k8s/secret_test.go
+++ b/modules/k8s/secret_test.go
@@ -1,3 +1,9 @@
+// +build kubernetes
+
+// NOTE: we have build tags to differentiate kubernetes tests from non-kubernetes tests. This is done because minikube
+// is heavy and can interfere with docker related tests in terratest. To avoid overloading the system, we run the
+// kubernetes tests separately from the others.
+
 package k8s
 
 import (

--- a/modules/k8s/self_subject_access_review.go
+++ b/modules/k8s/self_subject_access_review.go
@@ -1,0 +1,39 @@
+package k8s
+
+import (
+	"testing"
+
+	"github.com/gruntwork-io/gruntwork-cli/errors"
+	"github.com/stretchr/testify/require"
+	authv1 "k8s.io/api/authorization/v1"
+
+	"github.com/gruntwork-io/terratest/modules/logger"
+)
+
+// CanIDo returns whether or not the provided action is allowed by the client configured by the provided kubectl option.
+// This will fail if there are any errors accessing the kubernetes API (but not if the action is denied).
+func CanIDo(t *testing.T, options *KubectlOptions, action authv1.ResourceAttributes) bool {
+	allowed, err := CanIDoE(t, options, action)
+	require.NoError(t, err)
+	return allowed
+}
+
+// CanIDoE returns whether or not the provided action is allowed by the client configured by the provided kubectl option.
+// This will an error if there are problems accessing the kubernetes API (but not if the action is simply denied).
+func CanIDoE(t *testing.T, options *KubectlOptions, action authv1.ResourceAttributes) (bool, error) {
+	clientset, err := GetKubernetesClientFromOptionsE(t, options)
+	if err != nil {
+		return false, err
+	}
+	check := authv1.SelfSubjectAccessReview{
+		Spec: authv1.SelfSubjectAccessReviewSpec{ResourceAttributes: &action},
+	}
+	resp, err := clientset.AuthorizationV1().SelfSubjectAccessReviews().Create(&check)
+	if err != nil {
+		return false, errors.WithStackTrace(err)
+	}
+	if !resp.Status.Allowed {
+		logger.Logf(t, "Denied action %s on resource %s with name '%s' for reason %s", action.Verb, action.Resource, action.Name, resp.Status.Reason)
+	}
+	return resp.Status.Allowed, nil
+}

--- a/modules/k8s/self_subject_access_review_test.go
+++ b/modules/k8s/self_subject_access_review_test.go
@@ -1,3 +1,9 @@
+// +build kubernetes
+
+// NOTE: we have build tags to differentiate kubernetes tests from non-kubernetes tests. This is done because minikube
+// is heavy and can interfere with docker related tests in terratest. To avoid overloading the system, we run the
+// kubernetes tests separately from the others.
+
 package k8s
 
 import (

--- a/modules/k8s/self_subject_access_review_test.go
+++ b/modules/k8s/self_subject_access_review_test.go
@@ -1,0 +1,23 @@
+package k8s
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	authv1 "k8s.io/api/authorization/v1"
+)
+
+// NOTE: See service_account_test.go:TestCreateServiceAccountWithAuthTokenCreatesAServiceAccountThatCanBeAuthed for the
+// deny case, as the current authed user is assumed to be a super user and so there is nothing they can't do.
+
+func TestCanIDoReturnsTrueForAllowedAction(t *testing.T) {
+	t.Parallel()
+
+	action := authv1.ResourceAttributes{
+		Namespace: "kube-system",
+		Verb:      "list",
+		Resource:  "pod",
+	}
+	options := NewKubectlOptions("", "")
+	assert.True(t, CanIDo(t, options, action))
+}

--- a/modules/k8s/self_subject_access_review_test.go
+++ b/modules/k8s/self_subject_access_review_test.go
@@ -7,8 +7,8 @@ import (
 	authv1 "k8s.io/api/authorization/v1"
 )
 
-// NOTE: See service_account_test.go:TestCreateServiceAccountWithAuthTokenCreatesAServiceAccountThatCanBeAuthed for the
-// deny case, as the current authed user is assumed to be a super user and so there is nothing they can't do.
+// NOTE: See service_account_test.go:TestGetServiceAccountWithAuthTokenGetsTokenThatCanBeUsedForAuth for the deny case,
+// as the current authed user is assumed to be a super user and so there is nothing they can't do.
 
 func TestCanIDoReturnsTrueForAllowedAction(t *testing.T) {
 	t.Parallel()

--- a/modules/k8s/service_account.go
+++ b/modules/k8s/service_account.go
@@ -1,11 +1,19 @@
 package k8s
 
 import (
+	"fmt"
 	"testing"
+	"time"
 
+	"github.com/gruntwork-io/gruntwork-cli/errors"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/tools/clientcmd/api"
+
+	"github.com/gruntwork-io/terratest/modules/logger"
+	"github.com/gruntwork-io/terratest/modules/retry"
 )
 
 // GetServiceAccount returns a Kubernetes service account resource in the provided namespace with the given name. The
@@ -48,4 +56,88 @@ func CreateServiceAccountE(t *testing.T, options *KubectlOptions, serviceAccount
 	}
 	_, err = clientset.CoreV1().ServiceAccounts(options.Namespace).Create(&serviceAccount)
 	return err
+}
+
+// CreateServiceAccountWithAuthToken will create a new ServiceAccount resource in the configured namespace and generate
+// an auth token that can be used to configure Kubectl to login as that service account. This will fail the test if
+// there is an error.
+func CreateServiceAccountWithAuthToken(t *testing.T, kubectlOptions *KubectlOptions, name string) string {
+	token, err := CreateServiceAccountWithAuthTokenE(t, kubectlOptions, name)
+	require.NoError(t, err)
+	return token
+}
+
+// CreateServiceAccountWithAuthTokenE will create a new ServiceAccount resource in the configured namespace and generate
+// an auth token that can be used to configure Kubectl to login as that service account.
+func CreateServiceAccountWithAuthTokenE(t *testing.T, kubectlOptions *KubectlOptions, name string) (string, error) {
+	// Create a new service account that we will use for auth.
+	if err := CreateServiceAccountE(t, kubectlOptions, name); err != nil {
+		return "", err
+	}
+
+	// Wait for the TokenController to provision a ServiceAccount token
+	msg, err := retry.DoWithRetryE(
+		t,
+		"Waiting for ServiceAccount Token to be provisioned",
+		30,
+		10*time.Second,
+		func() (string, error) {
+			logger.Logf(t, "Checking if service account has secret")
+			serviceAccount := GetServiceAccount(t, kubectlOptions, name)
+			if len(serviceAccount.Secrets) == 0 {
+				msg := "No secrets on the service account yet"
+				logger.Logf(t, msg)
+				return "", fmt.Errorf(msg)
+			}
+			return "Service Account has secret", nil
+		},
+	)
+	if err != nil {
+		return "", err
+	}
+	logger.Logf(t, msg)
+
+	// Then get the service account token
+	serviceAccount, err := GetServiceAccountE(t, kubectlOptions, name)
+	if err != nil {
+		return "", err
+	}
+	if len(serviceAccount.Secrets) != 1 {
+		return "", errors.WithStackTrace(ServiceAccountTokenNotAvailable{name})
+	}
+	secret := GetSecret(t, kubectlOptions, serviceAccount.Secrets[0].Name)
+	return string(secret.Data["token"]), nil
+}
+
+// AddConfigContextForServiceAccountE will add a new config context that binds the ServiceAccount auth token to the
+// Kubernetes cluster of the current config context.
+func AddConfigContextForServiceAccountE(
+	t *testing.T,
+	kubectlOptions *KubectlOptions,
+	contextName string,
+	serviceAccountName string,
+	token string,
+) error {
+	// First load the config context
+	config := LoadConfigFromPath(kubectlOptions.ConfigPath)
+	rawConfig, err := config.RawConfig()
+	if err != nil {
+		return errors.WithStackTrace(err)
+	}
+
+	// Next get the current cluster
+	currentContext := rawConfig.Contexts[rawConfig.CurrentContext]
+	currentCluster := currentContext.Cluster
+
+	// Now insert the auth info for the service account
+	rawConfig.AuthInfos[serviceAccountName] = &api.AuthInfo{Token: token}
+
+	// We now have enough info to add the new context
+	UpsertConfigContext(&rawConfig, contextName, currentCluster, serviceAccountName)
+
+	// Finally, overwrite the config
+	if err := clientcmd.ModifyConfig(config.ConfigAccess(), rawConfig, false); err != nil {
+		return errors.WithStackTrace(err)
+	}
+	return nil
 }

--- a/modules/k8s/service_account_test.go
+++ b/modules/k8s/service_account_test.go
@@ -1,3 +1,9 @@
+// +build kubernetes
+
+// NOTE: we have build tags to differentiate kubernetes tests from non-kubernetes tests. This is done because minikube
+// is heavy and can interfere with docker related tests in terratest. To avoid overloading the system, we run the
+// kubernetes tests separately from the others.
+
 package k8s
 
 import (

--- a/modules/k8s/service_account_test.go
+++ b/modules/k8s/service_account_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/gruntwork-io/terratest/modules/random"
 )
 
-func TestCreateServiceAccountWithAuthTokenCreatesAServiceAccountThatCanBeAuthed(t *testing.T) {
+func TestGetServiceAccountWithAuthTokenGetsTokenThatCanBeUsedForAuth(t *testing.T) {
 	t.Parallel()
 
 	// make a copy of kubeconfig to namespace it
@@ -26,7 +26,8 @@ func TestCreateServiceAccountWithAuthTokenCreatesAServiceAccountThatCanBeAuthed(
 
 	// Create service account
 	serviceAccountName := strings.ToLower(random.UniqueId())
-	token := CreateServiceAccountWithAuthToken(t, options, serviceAccountName)
+	CreateServiceAccount(t, options, serviceAccountName)
+	token := GetServiceAccountAuthToken(t, options, serviceAccountName)
 	require.NoError(t, AddConfigContextForServiceAccountE(t, options, serviceAccountName, serviceAccountName, token))
 
 	// Now validate auth as service account. This is a bit tricky because we don't have an API endpoint in k8s that

--- a/modules/k8s/service_account_test.go
+++ b/modules/k8s/service_account_test.go
@@ -6,9 +6,40 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	authv1 "k8s.io/api/authorization/v1"
 
 	"github.com/gruntwork-io/terratest/modules/random"
 )
+
+func TestCreateServiceAccountWithAuthTokenCreatesAServiceAccountThatCanBeAuthed(t *testing.T) {
+	t.Parallel()
+
+	// make a copy of kubeconfig to namespace it
+	tmpConfigPath := CopyHomeKubeConfigToTemp(t)
+	options := NewKubectlOptions("", tmpConfigPath)
+
+	// Create a new namespace to work in
+	namespaceName := strings.ToLower(random.UniqueId())
+	CreateNamespace(t, options, namespaceName)
+	defer DeleteNamespace(t, options, namespaceName)
+	options.Namespace = namespaceName
+
+	// Create service account
+	serviceAccountName := strings.ToLower(random.UniqueId())
+	token := CreateServiceAccountWithAuthToken(t, options, serviceAccountName)
+	require.NoError(t, AddConfigContextForServiceAccountE(t, options, serviceAccountName, serviceAccountName, token))
+
+	// Now validate auth as service account. This is a bit tricky because we don't have an API endpoint in k8s that
+	// tells you who you are, so we will rely on the self subject access review and see if we have access to the
+	// kube-system namespace.
+	serviceAccountOptions := NewKubectlOptions(serviceAccountName, tmpConfigPath)
+	action := authv1.ResourceAttributes{
+		Namespace: "kube-system",
+		Verb:      "list",
+		Resource:  "pod",
+	}
+	require.False(t, CanIDo(t, serviceAccountOptions, action))
+}
 
 func TestGetServiceAccountEReturnsErrorForNonExistantServiceAccount(t *testing.T) {
 	t.Parallel()

--- a/modules/k8s/service_test.go
+++ b/modules/k8s/service_test.go
@@ -1,3 +1,9 @@
+// +build kubernetes
+
+// NOTE: we have build tags to differentiate kubernetes tests from non-kubernetes tests. This is done because minikube
+// is heavy and can interfere with docker related tests in terratest. To avoid overloading the system, we run the
+// kubernetes tests separately from the others.
+
 package k8s
 
 import (

--- a/modules/logger/parser/integration_test.go
+++ b/modules/logger/parser/integration_test.go
@@ -23,7 +23,7 @@ func DirectoryEqual(t *testing.T, dirA string, dirB string) bool {
 	// recursively
 	cmd := shell.Command{
 		Command: "diff",
-		Args:    []string{"-arq", dirAAbs, dirBAbs},
+		Args:    []string{"-ar", dirAAbs, dirBAbs},
 	}
 	err = shell.RunCommandE(t, cmd)
 	exitCode, err := shell.GetExitCodeForRunCommandError(err)

--- a/test/kubernetes_basic_example_service_check_test.go
+++ b/test/kubernetes_basic_example_service_check_test.go
@@ -1,3 +1,9 @@
+// +build kubernetes
+
+// NOTE: we have build tags to differentiate kubernetes tests from non-kubernetes tests. This is done because minikube
+// is heavy and can interfere with docker related tests in terratest. To avoid overloading the system, we run the
+// kubernetes tests separately from the others.
+
 package test
 
 import (

--- a/test/kubernetes_basic_example_test.go
+++ b/test/kubernetes_basic_example_test.go
@@ -1,3 +1,9 @@
+// +build kubernetes
+
+// NOTE: we have build tags to differentiate kubernetes tests from non-kubernetes tests. This is done because minikube
+// is heavy and can interfere with docker related tests in terratest. To avoid overloading the system, we run the
+// kubernetes tests separately from the others.
+
 package test
 
 import (

--- a/test/kubernetes_rbac_example_test.go
+++ b/test/kubernetes_rbac_example_test.go
@@ -1,3 +1,9 @@
+// +build kubernetes
+
+// NOTE: we have build tags to differentiate kubernetes tests from non-kubernetes tests. This is done because minikube
+// is heavy and can interfere with docker related tests in terratest. To avoid overloading the system, we run the
+// kubernetes tests separately from the others.
+
 package test
 
 import (

--- a/test/kubernetes_rbac_example_test.go
+++ b/test/kubernetes_rbac_example_test.go
@@ -1,0 +1,70 @@
+package test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	authv1 "k8s.io/api/authorization/v1"
+
+	"github.com/gruntwork-io/terratest/modules/k8s"
+)
+
+// An example of how to test the Kubernetes resource config in examples/kubernetes-rbac-example using Terratest,
+// including whether or not the permissions are set correctly.
+func TestKubernetesRBACExample(t *testing.T) {
+	t.Parallel()
+
+	// These are pulled from the kubernetes resource config
+	const serviceAccountName = "terratest-rbac-example-service-account"
+	const namespaceName = "terratest-rbac-example-namespace"
+
+	// Path to the Kubernetes resource config we will test
+	kubeResourcePath, err := filepath.Abs("../examples/kubernetes-rbac-example/namespace-service-account.yml")
+	require.NoError(t, err)
+
+	// Setup the kubectl config and context. Here we choose to create a new one because we will be manipulating the
+	// entries to be able to add a new authentication option.
+	tmpConfigPath := k8s.CopyHomeKubeConfigToTemp(t)
+	defer os.Remove(tmpConfigPath)
+	options := k8s.NewKubectlOptions("", tmpConfigPath)
+
+	// At the end of the test, run `kubectl delete -f RESOURCE_CONFIG` to clean up any resources that were created.
+	defer k8s.KubectlDelete(t, options, kubeResourcePath)
+
+	// This will run `kubectl apply -f RESOURCE_CONFIG` and fail the test if there are any errors
+	k8s.KubectlApply(t, options, kubeResourcePath)
+
+	// Retrieve authentication token for the newly created ServiceAccount
+	// Make sure to configure to access the right namespace
+	options.Namespace = namespaceName
+	token := k8s.GetServiceAccountAuthToken(t, options, serviceAccountName)
+
+	// Now update the configuration to add a new context that can be used to make requests as that service account
+	require.NoError(t, k8s.AddConfigContextForServiceAccountE(
+		t,
+		options,
+		serviceAccountName, // for this test we will name the context after the ServiceAccount
+		serviceAccountName,
+		token,
+	))
+	serviceAccountKubectlOptions := k8s.NewKubectlOptions(serviceAccountName, tmpConfigPath)
+
+	// At this point all requests made with serviceAccountKubectlOptions will be auth'd as that ServiceAccount. So let's
+	// verify that! We will check:
+	// - we can't access the kube-system namespace
+	// - we can access the namespace the service account is in
+	namespaceListPodAction := authv1.ResourceAttributes{
+		Namespace: namespaceName,
+		Verb:      "list",
+		Resource:  "pod",
+	}
+	require.True(t, k8s.CanIDo(t, serviceAccountKubectlOptions, namespaceListPodAction))
+	adminListPodAction := authv1.ResourceAttributes{
+		Namespace: "kube-system",
+		Verb:      "list",
+		Resource:  "pod",
+	}
+	require.False(t, k8s.CanIDo(t, serviceAccountKubectlOptions, adminListPodAction))
+}

--- a/test/kubernetes_rbac_example_test.go
+++ b/test/kubernetes_rbac_example_test.go
@@ -54,6 +54,12 @@ func TestKubernetesRBACExample(t *testing.T) {
 	// At this point all requests made with serviceAccountKubectlOptions will be auth'd as that ServiceAccount. So let's
 	// verify that! We will check:
 	// - we can't access the kube-system namespace
+	adminListPodAction := authv1.ResourceAttributes{
+		Namespace: "kube-system",
+		Verb:      "list",
+		Resource:  "pod",
+	}
+	require.False(t, k8s.CanIDo(t, serviceAccountKubectlOptions, adminListPodAction))
 	// - we can access the namespace the service account is in
 	namespaceListPodAction := authv1.ResourceAttributes{
 		Namespace: namespaceName,
@@ -61,10 +67,4 @@ func TestKubernetesRBACExample(t *testing.T) {
 		Resource:  "pod",
 	}
 	require.True(t, k8s.CanIDo(t, serviceAccountKubectlOptions, namespaceListPodAction))
-	adminListPodAction := authv1.ResourceAttributes{
-		Namespace: "kube-system",
-		Verb:      "list",
-		Resource:  "pod",
-	}
-	require.False(t, k8s.CanIDo(t, serviceAccountKubectlOptions, adminListPodAction))
 }


### PR DESCRIPTION
This adds functions that help with testing Kubernetes RBAC roles:

- Ability to auth as a `ServiceAccount`
- Ability to check what actions the user can perform
- A top level example demonstrating how one would test an RBAC role

TODO:
- [x] Investigate test instability. I have a suspicion that all the kubernetes actions against minikube are overloading the system. The docker test is also failing now.