### PR TITLE
Update google cloud dependency

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,7 +2,7 @@
 
 
 [[projects]]
-  digest = "1:ad676a8a8a37b6e10e71a52e014ded88ce0027463c66a50011bf844843a89736"
+  digest = "1:f28b5363f59b4c568f37ebaecf1d739d0dc5818f57b07f9bda776367ffe046fb"
   name = "cloud.google.com/go"
   packages = [
     "compute/metadata",
@@ -14,8 +14,8 @@
     "storage",
   ]
   pruneopts = "UT"
-  revision = "64a2037ec6be8a4b0c1d1f706ed35b428b989239"
-  version = "v0.26.0"
+  revision = "28a4bc8c44b3acbcc482cff0cdf7de29a4688b61"
+  version = "v0.35.1"
 
 [[projects]]
   digest = "1:dc27d9777febe9e63ab33a2cd15e31ce8d9463932d2472cc7097dc662dedb5ab"
@@ -26,7 +26,7 @@
   version = "v0.6.0"
 
 [[projects]]
-  digest = "1:64d3361d91812fe08e323158379fa8d66d48d9ef6b9a2a6800aef78f95f80ea0"
+  digest = "1:0702d9e517405bc4eb634e3c7cf909b1da212bb5ce3cb633d1358bd2a7853d82"
   name = "github.com/aws/aws-sdk-go"
   packages = [
     "aws",
@@ -65,7 +65,6 @@
     "service/autoscaling",
     "service/cloudwatchlogs",
     "service/ec2",
-    "service/elb",
     "service/iam",
     "service/kms",
     "service/rds",
@@ -191,12 +190,12 @@
   version = "0.2"
 
 [[projects]]
-  digest = "1:e145e9710a10bc114a6d3e2738aadf8de146adaa031854ffdf7bbfe15da85e63"
+  digest = "1:856bd1e35f6da8ce5671a5df09d0e89bf01e9b74b3dabb6d097d39b3813801e1"
   name = "github.com/googleapis/gax-go"
-  packages = ["."]
+  packages = ["v2"]
   pruneopts = "UT"
-  revision = "317e0006254c44a0ac427cc52a0e083ff0b9622f"
-  version = "v2.0.0"
+  revision = "c8a15bac9b9fe955bd9f900272f9a306465d28cf"
+  version = "v2.0.3"
 
 [[projects]]
   digest = "1:65c4414eeb350c47b8de71110150d0ea8a281835b1f386eacaa3ad7325929c21"
@@ -703,7 +702,7 @@
 
 [[projects]]
   branch = "release-9.0"
-  digest = "1:51fd9ac9f2be10d79f5af101a7a1d758ef283fdb028a0d11198754bd3d4a6020"
+  digest = "1:bac06e69e8c8387d68053aa71f4e96dd8b8afef54135b55f17ff9ccec84fc74e"
   name = "k8s.io/client-go"
   packages = [
     "discovery",
@@ -745,8 +744,10 @@
     "pkg/apis/clientauthentication/v1beta1",
     "pkg/version",
     "plugin/pkg/client/auth/exec",
+    "plugin/pkg/client/auth/gcp",
     "rest",
     "rest/watch",
+    "third_party/forked/golang/template",
     "tools/auth",
     "tools/clientcmd",
     "tools/clientcmd/api",
@@ -760,6 +761,7 @@
     "util/flowcontrol",
     "util/homedir",
     "util/integer",
+    "util/jsonpath",
   ]
   pruneopts = "UT"
   revision = "13596e875accbd333e0b5bd5fd9462185acd9958"
@@ -777,7 +779,6 @@
     "github.com/aws/aws-sdk-go/service/autoscaling",
     "github.com/aws/aws-sdk-go/service/cloudwatchlogs",
     "github.com/aws/aws-sdk-go/service/ec2",
-    "github.com/aws/aws-sdk-go/service/elb",
     "github.com/aws/aws-sdk-go/service/iam",
     "github.com/aws/aws-sdk-go/service/kms",
     "github.com/aws/aws-sdk-go/service/rds",
@@ -813,6 +814,7 @@
     "k8s.io/api/core/v1",
     "k8s.io/apimachinery/pkg/apis/meta/v1",
     "k8s.io/client-go/kubernetes",
+    "k8s.io/client-go/plugin/pkg/client/auth/gcp",
     "k8s.io/client-go/rest",
     "k8s.io/client-go/tools/clientcmd",
     "k8s.io/client-go/tools/clientcmd/api",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -55,7 +55,7 @@
 
 [[constraint]]
   name = "cloud.google.com/go"
-  version = "0.26.0"
+  version = "0.35.1"
 
 [[constraint]]
   name = "golang.org/x/oauth2"


### PR DESCRIPTION
Update cloud.google.com/go to the latest version. Avoids a grpc bug when
terratest is imported into tests sometimes.

see: https://github.com/gruntwork-io/cloud-nuke/pull/45#issuecomment-456846470