### PR TITLE
Helm integration test framework

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,7 @@ setup_minikube: &setup_minikube
     )
 
     # Install helm
-    helm init --wait
+    # helm init --wait
 
 
 install_gruntwork_utils: &install_gruntwork_utils

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,12 +30,6 @@ setup_minikube: &setup_minikube
     mkdir -p ${HOME}/.kube
     touch ${HOME}/.kube/config
 
-    # install helm
-    curl -Lo helm.tar.gz https://storage.googleapis.com/kubernetes-helm/helm-${HELM_VERSION}-linux-amd64.tar.gz
-    tar -xvf helm.tar.gz
-    chmod +x linux-amd64/helm
-    sudo mv linux-amd64/helm /usr/local/bin/
-
     # Install minikube
     curl -Lo minikube https://github.com/kubernetes/minikube/releases/download/${MINIKUBE_VERSION}/minikube-linux-amd64
     chmod +x minikube
@@ -57,6 +51,22 @@ setup_minikube: &setup_minikube
       done
       true
     )
+
+
+install_helm: &install_helm
+  name: install helm
+  command: |
+    # install helm
+    curl -Lo helm.tar.gz https://storage.googleapis.com/kubernetes-helm/helm-${HELM_VERSION}-linux-amd64.tar.gz
+    tar -xvf helm.tar.gz
+    chmod +x linux-amd64/helm
+    sudo mv linux-amd64/helm /usr/local/bin/
+
+    # Grant the default service account cluster admin rights so helm works
+    kubectl create clusterrolebinding default-service-account-cluster-admin-binding --clusterrole cluster-admin --serviceaccount kube-system:default
+
+    # Deploy Tiller
+    helm init --wait
 
 
 install_gruntwork_utils: &install_gruntwork_utils
@@ -204,7 +214,8 @@ jobs:
       - run:
           <<: *setup_minikube
 
-      - run: helm init --wait
+      - run:
+          <<: *install_helm
 
       # Run the Helm tests. These tests are run because the helm build tag is included, and we explicitly
       # select the helm tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,9 +58,6 @@ setup_minikube: &setup_minikube
       true
     )
 
-    # Install helm
-    # helm init --wait
-
 
 install_gruntwork_utils: &install_gruntwork_utils
   name: install gruntwork utils
@@ -176,10 +173,42 @@ jobs:
       - run:
           command: |
             mkdir -p /tmp/logs
-            # Run the unit tests first, then the integration tests. They are separate because the integration tests
-            # require additional filtering.
-            run-go-tests --packages "-tags kubernetes ./modules/k8s" | tee /tmp/logs/test_output.log
-            run-go-tests --packages "-tags kubernetes -run \"(TestKubernetes)|(TestHelm)\" ./test" | tee -a /tmp/logs/test_output.log
+            run-go-tests --packages "-tags kubernetes ./test ./modules/k8s" | tee /tmp/logs/test_output.log
+
+      - run:
+          command: ./cmd/bin/terratest_log_parser_linux_amd64 --testlog /tmp/logs/test_output.log --outputdir /tmp/logs
+          when: always
+
+      # Store test result and log artifacts for browsing purposes
+      - store_artifacts:
+          path: /tmp/logs
+      - store_test_results:
+          path: /tmp/logs
+
+
+  helm_test:
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: /home/circleci
+
+      - run:
+          <<: *install_gruntwork_utils
+
+      # The weird way you have to set PATH in Circle 2.0
+      - run: echo 'export PATH=$HOME/.local/bin:$HOME/terraform:$HOME/packer:$PATH' >> $BASH_ENV
+
+      - run:
+          <<: *setup_minikube
+
+      - run: helm init --wait
+
+      # Run the Helm tests. These tests are run because the helm build tag is included, and we explicitly
+      # select the helm tests
+      - run:
+          command: |
+            mkdir -p /tmp/logs
+            run-go-tests --packages "-tags helm -run ./test" | tee -a /tmp/logs/test_output.log
 
       - run:
           command: ./cmd/bin/terratest_log_parser_linux_amd64 --testlog /tmp/logs/test_output.log --outputdir /tmp/logs
@@ -226,10 +255,18 @@ workflows:
             tags:
               only: /^v.*/
 
+      - helm_test:
+          requires:
+            - setup
+          filters:
+            tags:
+              only: /^v.*/
+
       - deploy:
           requires:
             - test
             - kubernetes_test
+            - helm_test
           filters:
             tags:
               only: /^v.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -173,7 +173,10 @@ jobs:
       - run:
           command: |
             mkdir -p /tmp/logs
-            run-go-tests --packages "-tags kubernetes ./test ./modules/k8s" | tee /tmp/logs/test_output.log
+            # Run the unit tests first, then the integration tests. They are separate because the integration tests
+            # require additional filtering.
+            run-go-tests --packages "-tags kubernetes ./modules/k8s" | tee /tmp/logs/test_output.log
+            run-go-tests --packages "-tags kubernetes -run TestKubernetes ./test" | tee -a /tmp/logs/test_output.log
 
       - run:
           command: ./cmd/bin/terratest_log_parser_linux_amd64 --testlog /tmp/logs/test_output.log --outputdir /tmp/logs
@@ -208,7 +211,7 @@ jobs:
       - run:
           command: |
             mkdir -p /tmp/logs
-            run-go-tests --packages "-tags helm -run ./test" | tee -a /tmp/logs/test_output.log
+            run-go-tests --packages "-tags helm -run TestHelm ./test" | tee -a /tmp/logs/test_output.log
 
       - run:
           command: ./cmd/bin/terratest_log_parser_linux_amd64 --testlog /tmp/logs/test_output.log --outputdir /tmp/logs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,6 +58,9 @@ setup_minikube: &setup_minikube
       true
     )
 
+    # Install helm
+    helm init --wait
+
 
 install_gruntwork_utils: &install_gruntwork_utils
   name: install gruntwork utils

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -100,6 +100,17 @@
   version = "v1.1.1"
 
 [[projects]]
+  branch = "master"
+  digest = "1:ecdc8e0fe3bc7d549af1c9c36acf3820523b707d6c071b6d0c3860882c6f7b42"
+  name = "github.com/docker/spdystream"
+  packages = [
+    ".",
+    "spdy",
+  ]
+  pruneopts = "UT"
+  revision = "6480d4af844c189cf5dd913db24ddd339d3a4f85"
+
+[[projects]]
   digest = "1:2cd7915ab26ede7d95b8749e6b1f933f1c6d5398030684e6505940a10f31cfda"
   name = "github.com/ghodss/yaml"
   packages = ["."]
@@ -243,6 +254,14 @@
   version = "v0.3.6"
 
 [[projects]]
+  digest = "1:870d441fe217b8e689d7949fef6e43efbc787e50f200cb1e70dbca9204a1d6be"
+  name = "github.com/inconshreveable/mousetrap"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "76626ae9c91c4f2a10f34cad8ce83ea42c93bb75"
+  version = "v1.0"
+
+[[projects]]
   digest = "1:e22af8c7518e1eab6f2eab2b7d7558927f816262586cd6ed9f349c97a6c285c4"
   name = "github.com/jmespath/go-jmespath"
   packages = ["."]
@@ -374,6 +393,14 @@
   pruneopts = "UT"
   revision = "ad15b42461921f1fb3529b058c6786c6a45d5162"
   version = "v1.1.1"
+
+[[projects]]
+  digest = "1:645cabccbb4fa8aab25a956cbcbdf6a6845ca736b2c64e197ca7cbb9d210b939"
+  name = "github.com/spf13/cobra"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "ef82de70bb3f60c65fb8eebacbb2d122ef517385"
+  version = "v0.0.3"
 
 [[projects]]
   digest = "1:c1b1102241e7f645bc8e0c22ae352e8f0dc6484b6cb4d132fa9f24174e0119e2"
@@ -659,7 +686,7 @@
 
 [[projects]]
   branch = "release-1.12"
-  digest = "1:20e81d00ebab40306e54d2fae81fd150af032d5181f6baf5528215d6f9fdaba0"
+  digest = "1:7cf08237862cf2fbdc62a89bba895062034786438684129a35ebd0c3341aec8d"
   name = "k8s.io/apimachinery"
   packages = [
     "pkg/api/errors",
@@ -685,6 +712,8 @@
     "pkg/util/clock",
     "pkg/util/errors",
     "pkg/util/framer",
+    "pkg/util/httpstream",
+    "pkg/util/httpstream/spdy",
     "pkg/util/intstr",
     "pkg/util/json",
     "pkg/util/naming",
@@ -696,6 +725,7 @@
     "pkg/util/yaml",
     "pkg/version",
     "pkg/watch",
+    "third_party/forked/golang/netutil",
     "third_party/forked/golang/reflect",
   ]
   pruneopts = "UT"
@@ -703,7 +733,7 @@
 
 [[projects]]
   branch = "release-9.0"
-  digest = "1:bac06e69e8c8387d68053aa71f4e96dd8b8afef54135b55f17ff9ccec84fc74e"
+  digest = "1:f071d003720e1c8a4b24f10cd753ec1194d30733e3eb7f65b4a253141ceebd27"
   name = "k8s.io/client-go"
   packages = [
     "discovery",
@@ -755,8 +785,10 @@
     "tools/clientcmd/api/latest",
     "tools/clientcmd/api/v1",
     "tools/metrics",
+    "tools/portforward",
     "tools/reference",
     "transport",
+    "transport/spdy",
     "util/cert",
     "util/connrotation",
     "util/flowcontrol",
@@ -766,6 +798,14 @@
   ]
   pruneopts = "UT"
   revision = "13596e875accbd333e0b5bd5fd9462185acd9958"
+
+[[projects]]
+  digest = "1:51314886250b22f73377febaadd972084684122e2e1d3004f388dff60754ba05"
+  name = "k8s.io/kubernetes"
+  packages = ["pkg/kubectl/generate"]
+  pruneopts = "UT"
+  revision = "721bfa751924da8d1680787490c54b9179b1fed0"
+  version = "v1.13.3"
 
 [solve-meta]
   analyzer-name = "dep"
@@ -823,6 +863,9 @@
     "k8s.io/client-go/rest",
     "k8s.io/client-go/tools/clientcmd",
     "k8s.io/client-go/tools/clientcmd/api",
+    "k8s.io/client-go/tools/portforward",
+    "k8s.io/client-go/transport/spdy",
+    "k8s.io/kubernetes/pkg/kubectl/generate",
   ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/examples/helm-basic-example/README.md
+++ b/examples/helm-basic-example/README.md
@@ -31,5 +31,7 @@ See the corresponding terratest code for an example of how to test this chart:
 
 **NOTE**: we have build tags to differentiate kubernetes tests from non-kubernetes tests, and further differentiate helm
 tests. This is done because minikube is heavy and can interfere with docker related tests in terratest. Similarly, helm
-can overload the minikube system and thus interfere with the other kubernetes tests. To avoid overloading the system, we
-run the kubernetes tests and helm tests separately from the others.
+can overload the minikube system and thus interfere with the other kubernetes tests. Specifically, many of the tests
+start to fail with `connection refused` errors from `minikube`. To avoid overloading the system, we run the kubernetes
+tests and helm tests separately from the others. This may not be necessary if you have a sufficiently powerful machine.
+We recommend at least 4 cores and 16GB of RAM if you want to run all the tests together.

--- a/examples/helm-basic-example/README.md
+++ b/examples/helm-basic-example/README.md
@@ -11,13 +11,14 @@ There are two kinds of tests you can perform on a helm chart:
   works as expected. If you consider the templates to be syntactic tests, these are semantic tests that validate the
   behavior of the deployed resources.
 
-The helm chart deploys a single replica Deployment resource given the container image spec. This chart requires the
-`containerImageRepo` and `containerImageTag` input values.
+The helm chart deploys a single replica `Deployment` resource given the container image spec and a `Service` that
+exposes it. This chart requires the `containerImageRepo` and `containerImageTag` input values.
 
 See the corresponding terratest code for an example of how to test this chart:
 
 - [helm_basic_example_template_test.go](/test/helm_basic_example_template_test.go): the template tests for this chart.
-<!-- TODO: Append the example with integration tests and deployment instructions once terratest has deploy test functions -->
+- [helm_basic_example_integration_test.go](/test/helm_basic_example_integration_test.go): the integration test for this
+  chart. This test will deploy the Helm Chart and verify the `Service` endpoint.
 
 ## Running automated tests against this Helm Chart
 
@@ -25,7 +26,8 @@ See the corresponding terratest code for an example of how to test this chart:
 1. Install [Golang](https://golang.org/) and make sure this code is checked out into your `GOPATH`.
 1. `cd test`
 1. `dep ensure`
-1. `go test -v -tags kubernetes -run TestHelmBasicExampleTemplate`
+1. `go test -v -tags kubernetes -run TestHelmBasicExampleTemplate` for the template test
+1. `go test -v -tags kubernetes -run TestHelmBasicExampleDeployment` for the integration test
 
 **NOTE:** we have build tags to differentiate kubernetes tests from non-kubernetes tests. This is done because minikube
 is heavy and can interfere with docker related tests in terratest. To avoid overloading the system, we run the

--- a/examples/helm-basic-example/README.md
+++ b/examples/helm-basic-example/README.md
@@ -26,9 +26,10 @@ See the corresponding terratest code for an example of how to test this chart:
 1. Install [Golang](https://golang.org/) and make sure this code is checked out into your `GOPATH`.
 1. `cd test`
 1. `dep ensure`
-1. `go test -v -tags kubernetes -run TestHelmBasicExampleTemplate` for the template test
-1. `go test -v -tags kubernetes -run TestHelmBasicExampleDeployment` for the integration test
+1. `go test -v -tags helm -run TestHelmBasicExampleTemplate` for the template test
+1. `go test -v -tags helm -run TestHelmBasicExampleDeployment` for the integration test
 
-**NOTE:** we have build tags to differentiate kubernetes tests from non-kubernetes tests. This is done because minikube
-is heavy and can interfere with docker related tests in terratest. To avoid overloading the system, we run the
-kubernetes tests separately from the others.
+**NOTE**: we have build tags to differentiate kubernetes tests from non-kubernetes tests, and further differentiate helm
+tests. This is done because minikube is heavy and can interfere with docker related tests in terratest. Similarly, helm
+can overload the minikube system and thus interfere with the other kubernetes tests. To avoid overloading the system, we
+run the kubernetes tests and helm tests separately from the others.

--- a/examples/helm-basic-example/templates/deployment.yaml
+++ b/examples/helm-basic-example/templates/deployment.yaml
@@ -26,3 +26,5 @@ spec:
           {{- $repo := required "containerImageRepo is required" .Values.containerImageRepo }}
           {{- $tag := required "containerImageTag is required" .Values.containerImageTag }}
           image: "{{ $repo }}:{{ $tag }}"
+          ports:
+          - containerPort: 80

--- a/examples/helm-basic-example/templates/service.yaml
+++ b/examples/helm-basic-example/templates/service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "helm-basic-example.fullname" . }}
+  labels:
+    # These labels are required by helm. You can read more about required labels in the chart best pracices guide:
+    # https://docs.helm.sh/chart_best_practices/#standard-labels
+    helm.sh/chart: {{ include "helm-basic-example.chart" . }}
+    app.kubernetes.io/name: {{ include "helm-basic-example.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  selector:
+    app.kubernetes.io/name: {{ include "helm-basic-example.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  type: NodePort
+  ports:
+  - protocol: TCP
+    targetPort: 80
+    port: 80

--- a/modules/helm/cmd.go
+++ b/modules/helm/cmd.go
@@ -7,10 +7,9 @@ import (
 	"github.com/gruntwork-io/terratest/modules/shell"
 )
 
-// GetCommonArgs extracts common helm options. In this case, these are:
+// getCommonArgs extracts common helm options. In this case, these are:
 // - kubeconfig path
 // - kubeconfig context
-// - namespace
 // - helm home path
 func getCommonArgs(options *Options, args ...string) []string {
 	if options.KubectlOptions != nil && options.KubectlOptions.ContextName != "" {
@@ -19,34 +18,34 @@ func getCommonArgs(options *Options, args ...string) []string {
 	if options.KubectlOptions != nil && options.KubectlOptions.ConfigPath != "" {
 		args = append(args, "--kubeconfig", options.KubectlOptions.ConfigPath)
 	}
-	if options.KubectlOptions != nil && options.KubectlOptions.Namespace != "" {
-		args = append(args, "--namespace", options.KubectlOptions.Namespace)
-	}
 	if options.HomePath != "" {
 		args = append(args, "--home", options.HomePath)
 	}
 	return args
 }
 
-// RunHelmCommandAndGetOutputE runs helm with the given arguments and options and returns stdout/stderr.
-func RunHelmCommandAndGetOutputE(t *testing.T, options *Options, cmd string, additionalArgs ...string) (string, error) {
-	args := []string{cmd}
-	args = getCommonArgs(options, args...)
-
+// getValuesArgsE computes the args to pass in for setting values
+func getValuesArgsE(t *testing.T, options *Options, args ...string) ([]string, error) {
 	args = append(args, formatSetValuesAsArgs(options.SetValues)...)
 
 	valuesFilesArgs, err := formatValuesFilesAsArgsE(t, options.ValuesFiles)
 	if err != nil {
-		return "", errors.WithStackTrace(err)
+		return args, errors.WithStackTrace(err)
 	}
 	args = append(args, valuesFilesArgs...)
 
 	setFilesArgs, err := formatSetFilesAsArgsE(t, options.SetFiles)
 	if err != nil {
-		return "", errors.WithStackTrace(err)
+		return args, errors.WithStackTrace(err)
 	}
 	args = append(args, setFilesArgs...)
+	return args, nil
+}
 
+// RunHelmCommandAndGetOutputE runs helm with the given arguments and options and returns stdout/stderr.
+func RunHelmCommandAndGetOutputE(t *testing.T, options *Options, cmd string, additionalArgs ...string) (string, error) {
+	args := []string{cmd}
+	args = getCommonArgs(options, args...)
 	args = append(args, additionalArgs...)
 
 	helmCmd := shell.Command{

--- a/modules/helm/delete.go
+++ b/modules/helm/delete.go
@@ -6,10 +6,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// Delete will delete the provided release from Tiller. If you set purge to true, Tiller will delete the release object
+// as well so that the release name can be reused. This will fail the test if there is an error.
 func Delete(t *testing.T, options *Options, releaseName string, purge bool) {
 	require.NoError(t, DeleteE(t, options, releaseName, purge))
 }
 
+// DeleteE will delete the provided release from Tiller. If you set purge to true, Tiller will delete the release object
+// as well so that the release name can be reused.
 func DeleteE(t *testing.T, options *Options, releaseName string, purge bool) error {
 	args := []string{}
 	if purge {

--- a/modules/helm/delete.go
+++ b/modules/helm/delete.go
@@ -1,0 +1,21 @@
+package helm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Delete(t *testing.T, options *Options, releaseName string, purge bool) {
+	require.NoError(t, DeleteE(t, options, releaseName, purge))
+}
+
+func DeleteE(t *testing.T, options *Options, releaseName string, purge bool) error {
+	args := []string{}
+	if purge {
+		args = append(args, "--purge")
+	}
+	args = append(args, releaseName)
+	_, err := RunHelmCommandAndGetOutputE(t, options, "delete", args...)
+	return err
+}

--- a/modules/helm/errors.go
+++ b/modules/helm/errors.go
@@ -31,3 +31,12 @@ type TemplateFileNotFoundError struct {
 func (err TemplateFileNotFoundError) Error() string {
 	return fmt.Sprintf("Could not resolve template file %s relative to chart path %s", err.Path, err.ChartDir)
 }
+
+// ChartNotFoundError is returned when a provided chart dir is not found
+type ChartNotFoundError struct {
+	Path string
+}
+
+func (err ChartNotFoundError) Error() string {
+	return fmt.Sprintf("Could not chart path %s", err.Path)
+}

--- a/modules/helm/install.go
+++ b/modules/helm/install.go
@@ -1,0 +1,39 @@
+package helm
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/gruntwork-io/gruntwork-cli/errors"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gruntwork-io/terratest/modules/files"
+)
+
+func Install(t *testing.T, options *Options, chartDir string, releaseName string) {
+	require.NoError(t, InstallE(t, options, chartDir, releaseName))
+}
+
+func InstallE(t *testing.T, options *Options, chartDir string, releaseName string) error {
+	// First, verify the charts dir exists
+	absChartDir, err := filepath.Abs(chartDir)
+	if err != nil {
+		return errors.WithStackTrace(err)
+	}
+	if !files.FileExists(chartDir) {
+		return errors.WithStackTrace(ChartNotFoundError{chartDir})
+	}
+
+	// Now call out to helm install to install the charts with the provided options
+	args := []string{}
+	if options.KubectlOptions != nil && options.KubectlOptions.Namespace != "" {
+		args = append(args, "--namespace", options.KubectlOptions.Namespace)
+	}
+	args, err = getValuesArgsE(t, options, args...)
+	if err != nil {
+		return err
+	}
+	args = append(args, "-n", releaseName, absChartDir)
+	_, err = RunHelmCommandAndGetOutputE(t, options, "install", args...)
+	return err
+}

--- a/modules/helm/install.go
+++ b/modules/helm/install.go
@@ -10,10 +10,13 @@ import (
 	"github.com/gruntwork-io/terratest/modules/files"
 )
 
+// Install will install the selected helm chart with the provided options under the given release name. This will fail
+// the test if there is an error.
 func Install(t *testing.T, options *Options, chartDir string, releaseName string) {
 	require.NoError(t, InstallE(t, options, chartDir, releaseName))
 }
 
+// InstallE will install the selected helm chart with the provided options under the given release name.
 func InstallE(t *testing.T, options *Options, chartDir string, releaseName string) error {
 	// First, verify the charts dir exists
 	absChartDir, err := filepath.Abs(chartDir)

--- a/modules/helm/template.go
+++ b/modules/helm/template.go
@@ -29,10 +29,17 @@ func RenderTemplateE(t *testing.T, options *Options, chartDir string, templateFi
 	if err != nil {
 		return "", errors.WithStackTrace(err)
 	}
+	if !files.FileExists(chartDir) {
+		return "", errors.WithStackTrace(ChartNotFoundError{chartDir})
+	}
 
 	// Now construct the args
 	// We first construct the template args
 	args := []string{}
+	args, err = getValuesArgsE(t, options, args...)
+	if err != nil {
+		return "", err
+	}
 	for _, templateFile := range templateFiles {
 		// validate this is a valid template file
 		absTemplateFile := filepath.Join(absChartDir, templateFile)

--- a/modules/k8s/client.go
+++ b/modules/k8s/client.go
@@ -23,15 +23,10 @@ func GetKubernetesClientE(t *testing.T) (*kubernetes.Clientset, error) {
 func GetKubernetesClientFromOptionsE(t *testing.T, options *KubectlOptions) (*kubernetes.Clientset, error) {
 	var err error
 
-	// We have to give an actual configpath for LoadApiClientConfigE to work
-	kubeConfigPath := options.ConfigPath
-	if kubeConfigPath == "" {
-		kubeConfigPath, err = GetKubeConfigPathE(t)
-		if err != nil {
-			return nil, err
-		}
+	kubeConfigPath, err := options.GetConfigPath(t)
+	if err != nil {
+		return nil, err
 	}
-
 	logger.Logf(t, "Configuring kubectl using config file %s with context %s", kubeConfigPath, options.ContextName)
 	// Load API config (instead of more low level ClientConfig)
 	config, err := LoadApiClientConfigE(kubeConfigPath, options.ContextName)

--- a/modules/k8s/config_test.go
+++ b/modules/k8s/config_test.go
@@ -1,4 +1,4 @@
-// +build kubernetes
+// +build kubeall kubernetes
 
 // NOTE: we have build tags to differentiate kubernetes tests from non-kubernetes tests. This is done because minikube
 // is heavy and can interfere with docker related tests in terratest. To avoid overloading the system, we run the

--- a/modules/k8s/config_test.go
+++ b/modules/k8s/config_test.go
@@ -1,8 +1,10 @@
 // +build kubeall kubernetes
 
 // NOTE: we have build tags to differentiate kubernetes tests from non-kubernetes tests. This is done because minikube
-// is heavy and can interfere with docker related tests in terratest. To avoid overloading the system, we run the
-// kubernetes tests separately from the others.
+// is heavy and can interfere with docker related tests in terratest. Specifically, many of the tests start to fail with
+// `connection refused` errors from `minikube`. To avoid overloading the system, we run the kubernetes tests and helm
+// tests separately from the others. This may not be necessary if you have a sufficiently powerful machine.  We
+// recommend at least 4 cores and 16GB of RAM if you want to run all the tests together.
 
 package k8s
 

--- a/modules/k8s/errors.go
+++ b/modules/k8s/errors.go
@@ -4,7 +4,19 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+// DesiredNumberOfPodsNotCreated is returned when the number of pods matching a filter condition does not match the
+// desired number of Pods.
+type DesiredNumberOfPodsNotCreated struct {
+	Filter       metav1.ListOptions
+	DesiredCount int
+}
+
+func (err DesiredNumberOfPodsNotCreated) Error() string {
+	return fmt.Sprintf("Desired number of pods (%d) matching filter %v not yet created", err.DesiredCount, err.Filter)
+}
 
 // ServiceAccountTokenNotAvailable is returned when a Kubernetes ServiceAccount does not have a token provisioned yet.
 type ServiceAccountTokenNotAvailable struct {

--- a/modules/k8s/errors.go
+++ b/modules/k8s/errors.go
@@ -7,6 +7,15 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// UnknownKubeResourceType is returned if the given resource type does not match the list of known resource types.
+type UnknownKubeResourceType struct {
+	ResourceType KubeResourceType
+}
+
+func (err UnknownKubeResourceType) Error() string {
+	return fmt.Sprintf("ResourceType ID %d is unknown", err.ResourceType)
+}
+
 // DesiredNumberOfPodsNotCreated is returned when the number of pods matching a filter condition does not match the
 // desired number of Pods.
 type DesiredNumberOfPodsNotCreated struct {

--- a/modules/k8s/kubectl_options.go
+++ b/modules/k8s/kubectl_options.go
@@ -1,5 +1,7 @@
 package k8s
 
+import "testing"
+
 // Represents common options necessary to specify for all Kubectl calls
 type KubectlOptions struct {
 	ContextName string
@@ -13,4 +15,17 @@ func NewKubectlOptions(contextName string, configPath string) *KubectlOptions {
 		ContextName: contextName,
 		ConfigPath:  configPath,
 	}
+}
+
+// GetConfigPath will return a sensible default if the config path is not set on the options.
+func (kubectlOptions *KubectlOptions) GetConfigPath(t *testing.T) (string, error) {
+	var err error
+	kubeConfigPath := kubectlOptions.ConfigPath
+	if kubeConfigPath == "" {
+		kubeConfigPath, err = GetKubeConfigPathE(t)
+		if err != nil {
+			return "", err
+		}
+	}
+	return kubeConfigPath, nil
 }

--- a/modules/k8s/kubectl_options.go
+++ b/modules/k8s/kubectl_options.go
@@ -19,7 +19,10 @@ func NewKubectlOptions(contextName string, configPath string) *KubectlOptions {
 
 // GetConfigPath will return a sensible default if the config path is not set on the options.
 func (kubectlOptions *KubectlOptions) GetConfigPath(t *testing.T) (string, error) {
+	// We predeclare `err` here so that we can update `kubeConfigPath` in the if block below. Otherwise, go complains
+	// saying `err` is undefined.
 	var err error
+
 	kubeConfigPath := kubectlOptions.ConfigPath
 	if kubeConfigPath == "" {
 		kubeConfigPath, err = GetKubeConfigPathE(t)

--- a/modules/k8s/kubectl_test.go
+++ b/modules/k8s/kubectl_test.go
@@ -1,4 +1,4 @@
-// +build kubernetes
+// +build kubeall kubernetes
 
 // NOTE: we have build tags to differentiate kubernetes tests from non-kubernetes tests. This is done because minikube
 // is heavy and can interfere with docker related tests in terratest. To avoid overloading the system, we run the

--- a/modules/k8s/kubectl_test.go
+++ b/modules/k8s/kubectl_test.go
@@ -1,8 +1,10 @@
 // +build kubeall kubernetes
 
 // NOTE: we have build tags to differentiate kubernetes tests from non-kubernetes tests. This is done because minikube
-// is heavy and can interfere with docker related tests in terratest. To avoid overloading the system, we run the
-// kubernetes tests separately from the others.
+// is heavy and can interfere with docker related tests in terratest. Specifically, many of the tests start to fail with
+// `connection refused` errors from `minikube`. To avoid overloading the system, we run the kubernetes tests and helm
+// tests separately from the others. This may not be necessary if you have a sufficiently powerful machine.  We
+// recommend at least 4 cores and 16GB of RAM if you want to run all the tests together.
 
 package k8s
 

--- a/modules/k8s/namespace_test.go
+++ b/modules/k8s/namespace_test.go
@@ -1,4 +1,4 @@
-// +build kubernetes
+// +build kubeall kubernetes
 
 // NOTE: we have build tags to differentiate kubernetes tests from non-kubernetes tests. This is done because minikube
 // is heavy and can interfere with docker related tests in terratest. To avoid overloading the system, we run the

--- a/modules/k8s/namespace_test.go
+++ b/modules/k8s/namespace_test.go
@@ -1,8 +1,10 @@
 // +build kubeall kubernetes
 
 // NOTE: we have build tags to differentiate kubernetes tests from non-kubernetes tests. This is done because minikube
-// is heavy and can interfere with docker related tests in terratest. To avoid overloading the system, we run the
-// kubernetes tests separately from the others.
+// is heavy and can interfere with docker related tests in terratest. Specifically, many of the tests start to fail with
+// `connection refused` errors from `minikube`. To avoid overloading the system, we run the kubernetes tests and helm
+// tests separately from the others. This may not be necessary if you have a sufficiently powerful machine.  We
+// recommend at least 4 cores and 16GB of RAM if you want to run all the tests together.
 
 package k8s
 

--- a/modules/k8s/node_test.go
+++ b/modules/k8s/node_test.go
@@ -1,4 +1,4 @@
-// +build kubernetes
+// +build kubeall kubernetes
 
 // NOTE: we have build tags to differentiate kubernetes tests from non-kubernetes tests. This is done because minikube
 // is heavy and can interfere with docker related tests in terratest. To avoid overloading the system, we run the

--- a/modules/k8s/node_test.go
+++ b/modules/k8s/node_test.go
@@ -1,8 +1,10 @@
 // +build kubeall kubernetes
 
 // NOTE: we have build tags to differentiate kubernetes tests from non-kubernetes tests. This is done because minikube
-// is heavy and can interfere with docker related tests in terratest. To avoid overloading the system, we run the
-// kubernetes tests separately from the others.
+// is heavy and can interfere with docker related tests in terratest. Specifically, many of the tests start to fail with
+// `connection refused` errors from `minikube`. To avoid overloading the system, we run the kubernetes tests and helm
+// tests separately from the others. This may not be necessary if you have a sufficiently powerful machine.  We
+// recommend at least 4 cores and 16GB of RAM if you want to run all the tests together.
 
 package k8s
 

--- a/modules/k8s/pod.go
+++ b/modules/k8s/pod.go
@@ -80,8 +80,8 @@ func WaitUntilNumPodsCreatedE(
 	message, err := retry.DoWithRetryE(
 		t,
 		statusMsg,
-		60,
-		1*time.Second,
+		retries,
+		sleepBetweenRetries,
 		func() (string, error) {
 			pods, err := ListPodsE(t, options, filters)
 			if err != nil {

--- a/modules/k8s/pod.go
+++ b/modules/k8s/pod.go
@@ -52,9 +52,9 @@ func GetPodE(t *testing.T, options *KubectlOptions, podName string) (*corev1.Pod
 	return clientset.CoreV1().Pods(options.Namespace).Get(podName, metav1.GetOptions{})
 }
 
-// WaitUntilNumPods waits until the desired number of pods are created that match the provided filter. This will retry
-// the check for the specified amount of times, sleeping for the provided duration between each try. This will fail the
-// test if the retry times out.
+// WaitUntilNumPodsCreated waits until the desired number of pods are created that match the provided filter. This will
+// retry the check for the specified amount of times, sleeping for the provided duration between each try. This will
+// fail the test if the retry times out.
 func WaitUntilNumPodsCreated(
 	t *testing.T,
 	options *KubectlOptions,

--- a/modules/k8s/pod_test.go
+++ b/modules/k8s/pod_test.go
@@ -1,4 +1,4 @@
-// +build kubernetes
+// +build kubeall kubernetes
 
 // NOTE: we have build tags to differentiate kubernetes tests from non-kubernetes tests. This is done because minikube
 // is heavy and can interfere with docker related tests in terratest. To avoid overloading the system, we run the

--- a/modules/k8s/pod_test.go
+++ b/modules/k8s/pod_test.go
@@ -1,8 +1,10 @@
 // +build kubeall kubernetes
 
 // NOTE: we have build tags to differentiate kubernetes tests from non-kubernetes tests. This is done because minikube
-// is heavy and can interfere with docker related tests in terratest. To avoid overloading the system, we run the
-// kubernetes tests separately from the others.
+// is heavy and can interfere with docker related tests in terratest. Specifically, many of the tests start to fail with
+// `connection refused` errors from `minikube`. To avoid overloading the system, we run the kubernetes tests and helm
+// tests separately from the others. This may not be necessary if you have a sufficiently powerful machine.  We
+// recommend at least 4 cores and 16GB of RAM if you want to run all the tests together.
 
 package k8s
 

--- a/modules/k8s/secret_test.go
+++ b/modules/k8s/secret_test.go
@@ -1,4 +1,4 @@
-// +build kubernetes
+// +build kubeall kubernetes
 
 // NOTE: we have build tags to differentiate kubernetes tests from non-kubernetes tests. This is done because minikube
 // is heavy and can interfere with docker related tests in terratest. To avoid overloading the system, we run the

--- a/modules/k8s/secret_test.go
+++ b/modules/k8s/secret_test.go
@@ -1,8 +1,10 @@
 // +build kubeall kubernetes
 
 // NOTE: we have build tags to differentiate kubernetes tests from non-kubernetes tests. This is done because minikube
-// is heavy and can interfere with docker related tests in terratest. To avoid overloading the system, we run the
-// kubernetes tests separately from the others.
+// is heavy and can interfere with docker related tests in terratest. Specifically, many of the tests start to fail with
+// `connection refused` errors from `minikube`. To avoid overloading the system, we run the kubernetes tests and helm
+// tests separately from the others. This may not be necessary if you have a sufficiently powerful machine.  We
+// recommend at least 4 cores and 16GB of RAM if you want to run all the tests together.
 
 package k8s
 

--- a/modules/k8s/self_subject_access_review_test.go
+++ b/modules/k8s/self_subject_access_review_test.go
@@ -1,4 +1,4 @@
-// +build kubernetes
+// +build kubeall kubernetes
 
 // NOTE: we have build tags to differentiate kubernetes tests from non-kubernetes tests. This is done because minikube
 // is heavy and can interfere with docker related tests in terratest. To avoid overloading the system, we run the

--- a/modules/k8s/self_subject_access_review_test.go
+++ b/modules/k8s/self_subject_access_review_test.go
@@ -1,8 +1,10 @@
 // +build kubeall kubernetes
 
 // NOTE: we have build tags to differentiate kubernetes tests from non-kubernetes tests. This is done because minikube
-// is heavy and can interfere with docker related tests in terratest. To avoid overloading the system, we run the
-// kubernetes tests separately from the others.
+// is heavy and can interfere with docker related tests in terratest. Specifically, many of the tests start to fail with
+// `connection refused` errors from `minikube`. To avoid overloading the system, we run the kubernetes tests and helm
+// tests separately from the others. This may not be necessary if you have a sufficiently powerful machine.  We
+// recommend at least 4 cores and 16GB of RAM if you want to run all the tests together.
 
 package k8s
 

--- a/modules/k8s/service.go
+++ b/modules/k8s/service.go
@@ -17,6 +17,27 @@ import (
 	"github.com/gruntwork-io/terratest/modules/retry"
 )
 
+// ListServices will look for services in the given namespace that match the given filters and return them. This will
+// fail the test if there is an error.
+func ListServices(t *testing.T, options *KubectlOptions, filters metav1.ListOptions) []corev1.Service {
+	service, err := ListServicesE(t, options, filters)
+	require.NoError(t, err)
+	return service
+}
+
+// ListServicesE will look for services in the given namespace that match the given filters and return them.
+func ListServicesE(t *testing.T, options *KubectlOptions, filters metav1.ListOptions) ([]corev1.Service, error) {
+	clientset, err := GetKubernetesClientFromOptionsE(t, options)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := clientset.CoreV1().Services(options.Namespace).List(filters)
+	if err != nil {
+		return nil, err
+	}
+	return resp.Items, nil
+}
+
 // GetService returns a Kubernetes service resource in the provided namespace with the given name. This will
 // fail the test if there is an error.
 func GetService(t *testing.T, options *KubectlOptions, serviceName string) *corev1.Service {

--- a/modules/k8s/service_account_test.go
+++ b/modules/k8s/service_account_test.go
@@ -1,4 +1,4 @@
-// +build kubernetes
+// +build kubeall kubernetes
 
 // NOTE: we have build tags to differentiate kubernetes tests from non-kubernetes tests. This is done because minikube
 // is heavy and can interfere with docker related tests in terratest. To avoid overloading the system, we run the

--- a/modules/k8s/service_account_test.go
+++ b/modules/k8s/service_account_test.go
@@ -1,8 +1,10 @@
 // +build kubeall kubernetes
 
 // NOTE: we have build tags to differentiate kubernetes tests from non-kubernetes tests. This is done because minikube
-// is heavy and can interfere with docker related tests in terratest. To avoid overloading the system, we run the
-// kubernetes tests separately from the others.
+// is heavy and can interfere with docker related tests in terratest. Specifically, many of the tests start to fail with
+// `connection refused` errors from `minikube`. To avoid overloading the system, we run the kubernetes tests and helm
+// tests separately from the others. This may not be necessary if you have a sufficiently powerful machine.  We
+// recommend at least 4 cores and 16GB of RAM if you want to run all the tests together.
 
 package k8s
 

--- a/modules/k8s/service_test.go
+++ b/modules/k8s/service_test.go
@@ -1,8 +1,10 @@
 // +build kubernetes
 
 // NOTE: we have build tags to differentiate kubernetes tests from non-kubernetes tests. This is done because minikube
-// is heavy and can interfere with docker related tests in terratest. To avoid overloading the system, we run the
-// kubernetes tests separately from the others.
+// is heavy and can interfere with docker related tests in terratest. Specifically, many of the tests start to fail with
+// `connection refused` errors from `minikube`. To avoid overloading the system, we run the kubernetes tests and helm
+// tests separately from the others. This may not be necessary if you have a sufficiently powerful machine.  We
+// recommend at least 4 cores and 16GB of RAM if you want to run all the tests together.
 
 package k8s
 

--- a/modules/k8s/service_test.go
+++ b/modules/k8s/service_test.go
@@ -1,4 +1,4 @@
-// +build kubernetes foo
+// +build kubernetes
 
 // NOTE: we have build tags to differentiate kubernetes tests from non-kubernetes tests. This is done because minikube
 // is heavy and can interfere with docker related tests in terratest. To avoid overloading the system, we run the

--- a/modules/k8s/tunnel.go
+++ b/modules/k8s/tunnel.go
@@ -1,0 +1,225 @@
+package k8s
+
+// The following code is a fork of the Helm client. The main differences are:
+// - Support testing context for better logging
+// - Support resources other than pods
+// See: https://github.com/helm/helm/blob/master/pkg/kube/tunnel.go
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/portforward"
+	"k8s.io/client-go/transport/spdy"
+	"k8s.io/kubernetes/pkg/kubectl/generate"
+
+	"github.com/gruntwork-io/terratest/modules/logger"
+)
+
+// KubeResourceType is an enum representing known resource types that can support port forwarding
+type KubeResourceType int
+
+const (
+	Pod KubeResourceType = iota
+	Service
+)
+
+func (resourceType KubeResourceType) String() string {
+	switch resourceType {
+	case Pod:
+		return "pod"
+	case Service:
+		return "svc"
+	default:
+		// This should not happen
+		return ""
+	}
+}
+
+// Tunnel is the main struct that configures and manages port forwading tunnels to Kubernetes resources.
+type Tunnel struct {
+	KubectlOptions *KubectlOptions
+	LocalPort      int
+	RemotePort     int
+	ResourceType   KubeResourceType
+	ResourceName   string
+	Out            io.Writer
+	StopChan       chan struct{}
+	ReadyChan      chan struct{}
+}
+
+// NewTunnel will create a new Tunnel struct.
+func NewTunnel(kubectlOptions *KubectlOptions, resourceType KubeResourceType, resourceName string, local int, remote int) *Tunnel {
+	return &Tunnel{
+		KubectlOptions: kubectlOptions,
+		LocalPort:      local,
+		RemotePort:     remote,
+		ResourceType:   resourceType,
+		ResourceName:   resourceName,
+		Out:            ioutil.Discard,
+		StopChan:       make(chan struct{}, 1),
+		ReadyChan:      make(chan struct{}, 1),
+	}
+}
+
+// Close disconnects a tunnel connection by closing the StopChan, thereby stopping the goroutine.
+func (tunnel *Tunnel) Close() {
+	close(tunnel.StopChan)
+}
+
+// getAttachablePodForResource will find a pod that can be port forwarded to given the provided resource type and return
+// the name.
+func (tunnel *Tunnel) getAttachablePodForResourceE(t *testing.T) (string, error) {
+	switch tunnel.ResourceType {
+	case Pod:
+		return tunnel.ResourceName, nil
+	case Service:
+		return tunnel.getAttachablePodForServiceE(t)
+	default:
+		return "", UnknownKubeResourceType{tunnel.ResourceType}
+	}
+}
+
+// getAttachablePodForServiceE will find an active pod associated with the Service and return the pod name.
+func (tunnel *Tunnel) getAttachablePodForServiceE(t *testing.T) (string, error) {
+	service, err := GetServiceE(t, tunnel.KubectlOptions, tunnel.ResourceName)
+	if err != nil {
+		return "", err
+	}
+	selectorLabelsOfPods := generate.MakeLabels(service.Spec.Selector)
+	servicePods, err := ListPodsE(t, tunnel.KubectlOptions, metav1.ListOptions{LabelSelector: selectorLabelsOfPods})
+	if err != nil {
+		return "", err
+	}
+	for _, pod := range servicePods {
+		if IsPodAvailable(&pod) {
+			return pod.Name, nil
+		}
+	}
+	return "", ServiceNotAvailable{service}
+}
+
+// ForwardPort opens a tunnel to a kubernetes resource, as specified by the provided tunnel struct. This will fail the
+// test if there is an error attempting to open the port.
+func (tunnel *Tunnel) ForwardPort(t *testing.T) {
+	require.NoError(t, tunnel.ForwardPortE(t))
+}
+
+// ForwardPortE opens a tunnel to a kubernetes resource, as specified by the provided tunnel struct.
+func (tunnel *Tunnel) ForwardPortE(t *testing.T) error {
+	logger.Logf(
+		t,
+		"Creating a port forwarding tunnel for resource %s/%s routing local port %d to remote port %d",
+		tunnel.ResourceType.String(),
+		tunnel.ResourceName,
+		tunnel.LocalPort,
+		tunnel.RemotePort,
+	)
+
+	// Prepare a kubernetes client for the client-go library
+	clientset, err := GetKubernetesClientFromOptionsE(t, tunnel.KubectlOptions)
+	if err != nil {
+		logger.Logf(t, "Error creating a new Kubernetes client: %s", err)
+		return err
+	}
+	kubeConfigPath, err := tunnel.KubectlOptions.GetConfigPath(t)
+	if err != nil {
+		logger.Logf(t, "Error getting kube config path: %s", err)
+		return err
+	}
+	config, err := LoadApiClientConfigE(kubeConfigPath, tunnel.KubectlOptions.ContextName)
+	if err != nil {
+		logger.Logf(t, "Error loading Kubernetes config: %s", err)
+		return err
+	}
+
+	// Find the pod to port forward to
+	podName, err := tunnel.getAttachablePodForResourceE(t)
+	if err != nil {
+		logger.Logf(t, "Error finding available pod: %s", err)
+		return err
+	}
+	logger.Logf(t, "Selected pod %s to open port forward to", podName)
+
+	// Build a url to the portforward endpoint
+	// example: http://localhost:8080/api/v1/namespaces/helm/pods/tiller-deploy-9itlq/portforward
+	postEndpoint := clientset.CoreV1().RESTClient().Post()
+	namespace := tunnel.KubectlOptions.Namespace
+	portForwardCreateURL := postEndpoint.
+		Resource("pods").
+		Namespace(namespace).
+		Name(podName).
+		SubResource("portforward").
+		URL()
+
+	logger.Logf(t, "Using URL %s to create portforward", portForwardCreateURL)
+
+	// Construct the spdy client required by the client-go portforward library
+	transport, upgrader, err := spdy.RoundTripperFor(config)
+	if err != nil {
+		logger.Logf(t, "Error creating http client: %s", err)
+		return err
+	}
+	dialer := spdy.NewDialer(upgrader, &http.Client{Transport: transport}, "POST", portForwardCreateURL)
+
+	// Construct a new PortForwarder struct that manages the instructed port forward tunnel
+	ports := []string{fmt.Sprintf("%d:%d", tunnel.LocalPort, tunnel.RemotePort)}
+	portforwarder, err := portforward.New(dialer, ports, tunnel.StopChan, tunnel.ReadyChan, tunnel.Out, tunnel.Out)
+	if err != nil {
+		logger.Logf(t, "Error creating port forwarding tunnel: %s", err)
+		return err
+	}
+
+	// Open the tunnel in a goroutine so that it is available in the background. Report errors to the main goroutine via
+	// a new channel.
+	errChan := make(chan error)
+	go func() {
+		errChan <- portforwarder.ForwardPorts()
+	}()
+
+	// Wait for an error or the tunnel to be ready
+	select {
+	case err = <-errChan:
+		logger.Logf(t, "Error starting port forwarding tunnel: %s", err)
+		return err
+	case <-portforwarder.Ready:
+		logger.Logf(t, "Successfully created port forwarding tunnel")
+		return nil
+	}
+}
+
+// GetAvailablePort retrieves an available port on the host machine. This delegates the port selection to the golang net
+// library by starting a server and then checking the port that the server is using. This will fail the test if it could
+// not find an avilable port.
+func GetAvailablePort(t *testing.T) int {
+	port, err := GetAvailablePortE(t)
+	require.NoError(t, err)
+	return port
+}
+
+// GetAvailablePortE retrieves an available port on the host machine. This delegates the port selection to the golang net
+// library by starting a server and then checking the port that the server is using.
+func GetAvailablePortE(t *testing.T) (int, error) {
+	l, err := net.Listen("tcp", ":0")
+	if err != nil {
+		return 0, err
+	}
+	defer l.Close()
+
+	_, p, err := net.SplitHostPort(l.Addr().String())
+	if err != nil {
+		return 0, err
+	}
+	port, err := strconv.Atoi(p)
+	if err != nil {
+		return 0, err
+	}
+	return port, err
+}

--- a/modules/k8s/tunnel.go
+++ b/modules/k8s/tunnel.go
@@ -27,15 +27,15 @@ import (
 type KubeResourceType int
 
 const (
-	Pod KubeResourceType = iota
-	Service
+	ResourceTypePod KubeResourceType = iota
+	ResourceTypeService
 )
 
 func (resourceType KubeResourceType) String() string {
 	switch resourceType {
-	case Pod:
+	case ResourceTypePod:
 		return "pod"
-	case Service:
+	case ResourceTypeService:
 		return "svc"
 	default:
 		// This should not happen
@@ -78,9 +78,9 @@ func (tunnel *Tunnel) Close() {
 // the name.
 func (tunnel *Tunnel) getAttachablePodForResourceE(t *testing.T) (string, error) {
 	switch tunnel.ResourceType {
-	case Pod:
+	case ResourceTypePod:
 		return tunnel.ResourceName, nil
-	case Service:
+	case ResourceTypeService:
 		return tunnel.getAttachablePodForServiceE(t)
 	default:
 		return "", UnknownKubeResourceType{tunnel.ResourceType}

--- a/modules/k8s/tunnel_test.go
+++ b/modules/k8s/tunnel_test.go
@@ -1,4 +1,4 @@
-// +build kubernetes
+// +build kubeall kubernetes
 
 // NOTE: we have build tags to differentiate kubernetes tests from non-kubernetes tests. This is done because minikube
 // is heavy and can interfere with docker related tests in terratest. To avoid overloading the system, we run the

--- a/modules/k8s/tunnel_test.go
+++ b/modules/k8s/tunnel_test.go
@@ -38,12 +38,10 @@ func TestTunnelOpensAPortForwardTunnelToPod(t *testing.T) {
 	// Try to access the nginx service on the local port, retrying until we get a good response for up to 5 minutes
 	http_helper.HttpGetWithRetryWithCustomValidation(
 		t,
-		fmt.Sprintf("http://localhost:%d", localPort),
+		fmt.Sprintf("http://%s", tunnel.Endpoint()),
 		60,
 		5*time.Second,
-		func(statusCode int, body string) bool {
-			return statusCode == 200
-		},
+		verifyNginxWelcomePage,
 	)
 }
 
@@ -68,13 +66,18 @@ func TestTunnelOpensAPortForwardTunnelToService(t *testing.T) {
 	// Try to access the nginx service on the local port, retrying until we get a good response for up to 5 minutes
 	http_helper.HttpGetWithRetryWithCustomValidation(
 		t,
-		fmt.Sprintf("http://localhost:%d", localPort),
+		fmt.Sprintf("http://%s", tunnel.Endpoint()),
 		60,
 		5*time.Second,
-		func(statusCode int, body string) bool {
-			return statusCode == 200
-		},
+		verifyNginxWelcomePage,
 	)
+}
+
+func verifyNginxWelcomePage(statusCode int, body string) bool {
+	if statusCode != 200 {
+		return false
+	}
+	return strings.Contains(body, "Welcome to nginx")
 }
 
 const EXAMPLE_POD_WITH_SERVICE_YAML_TEMPLATE = `---

--- a/modules/k8s/tunnel_test.go
+++ b/modules/k8s/tunnel_test.go
@@ -1,0 +1,114 @@
+// +build kubernetes
+
+// NOTE: we have build tags to differentiate kubernetes tests from non-kubernetes tests. This is done because minikube
+// is heavy and can interfere with docker related tests in terratest. To avoid overloading the system, we run the
+// kubernetes tests separately from the others.
+
+package k8s
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	http_helper "github.com/gruntwork-io/terratest/modules/http-helper"
+	"github.com/gruntwork-io/terratest/modules/random"
+)
+
+func TestTunnelOpensAPortForwardTunnelToPod(t *testing.T) {
+	t.Parallel()
+
+	uniqueID := strings.ToLower(random.UniqueId())
+	options := NewKubectlOptions("", "")
+	options.Namespace = uniqueID
+	configData := fmt.Sprintf(EXAMPLE_POD_YAML_TEMPLATE, uniqueID, uniqueID)
+	defer KubectlDeleteFromString(t, options, configData)
+	KubectlApplyFromString(t, options, configData)
+	WaitUntilPodAvailable(t, options, "nginx-pod", 60, 1*time.Second)
+
+	// Open a tunnel to pod from any available port locally
+	localPort := GetAvailablePort(t)
+	tunnel := NewTunnel(options, Pod, "nginx-pod", localPort, 80)
+	defer tunnel.Close()
+	tunnel.ForwardPort(t)
+
+	// Try to access the nginx service on the local port, retrying until we get a good response for up to 5 minutes
+	http_helper.HttpGetWithRetryWithCustomValidation(
+		t,
+		fmt.Sprintf("http://localhost:%d", localPort),
+		60,
+		5*time.Second,
+		func(statusCode int, body string) bool {
+			return statusCode == 200
+		},
+	)
+}
+
+func TestTunnelOpensAPortForwardTunnelToService(t *testing.T) {
+	t.Parallel()
+
+	uniqueID := strings.ToLower(random.UniqueId())
+	options := NewKubectlOptions("", "")
+	options.Namespace = uniqueID
+	configData := fmt.Sprintf(EXAMPLE_POD_WITH_SERVICE_YAML_TEMPLATE, uniqueID, uniqueID, uniqueID)
+	defer KubectlDeleteFromString(t, options, configData)
+	KubectlApplyFromString(t, options, configData)
+	WaitUntilPodAvailable(t, options, "nginx-pod", 60, 1*time.Second)
+	WaitUntilServiceAvailable(t, options, "nginx-service", 60, 1*time.Second)
+
+	// Open a tunnel from any available port locally
+	localPort := GetAvailablePort(t)
+	tunnel := NewTunnel(options, Service, "nginx-service", localPort, 80)
+	defer tunnel.Close()
+	tunnel.ForwardPort(t)
+
+	// Try to access the nginx service on the local port, retrying until we get a good response for up to 5 minutes
+	http_helper.HttpGetWithRetryWithCustomValidation(
+		t,
+		fmt.Sprintf("http://localhost:%d", localPort),
+		60,
+		5*time.Second,
+		func(statusCode int, body string) bool {
+			return statusCode == 200
+		},
+	)
+}
+
+const EXAMPLE_POD_WITH_SERVICE_YAML_TEMPLATE = `---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: %s
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx-pod
+  namespace: %s
+  labels:
+    app: nginx
+spec:
+  containers:
+  - name: nginx
+    image: nginx:1.15.7
+    ports:
+    - containerPort: 80
+    readinessProbe:
+      httpGet:
+        path: /
+        port: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx-service
+  namespace: %s
+spec:
+  selector:
+    app: nginx
+  ports:
+  - protocol: TCP
+    targetPort: 80
+    port: 80
+`

--- a/modules/k8s/tunnel_test.go
+++ b/modules/k8s/tunnel_test.go
@@ -1,8 +1,10 @@
 // +build kubeall kubernetes
 
 // NOTE: we have build tags to differentiate kubernetes tests from non-kubernetes tests. This is done because minikube
-// is heavy and can interfere with docker related tests in terratest. To avoid overloading the system, we run the
-// kubernetes tests separately from the others.
+// is heavy and can interfere with docker related tests in terratest. Specifically, many of the tests start to fail with
+// `connection refused` errors from `minikube`. To avoid overloading the system, we run the kubernetes tests and helm
+// tests separately from the others. This may not be necessary if you have a sufficiently powerful machine.  We
+// recommend at least 4 cores and 16GB of RAM if you want to run all the tests together.
 
 package k8s
 

--- a/modules/k8s/tunnel_test.go
+++ b/modules/k8s/tunnel_test.go
@@ -30,8 +30,7 @@ func TestTunnelOpensAPortForwardTunnelToPod(t *testing.T) {
 	WaitUntilPodAvailable(t, options, "nginx-pod", 60, 1*time.Second)
 
 	// Open a tunnel to pod from any available port locally
-	localPort := GetAvailablePort(t)
-	tunnel := NewTunnel(options, ResourceTypePod, "nginx-pod", localPort, 80)
+	tunnel := NewTunnel(options, ResourceTypePod, "nginx-pod", 0, 80)
 	defer tunnel.Close()
 	tunnel.ForwardPort(t)
 
@@ -58,8 +57,7 @@ func TestTunnelOpensAPortForwardTunnelToService(t *testing.T) {
 	WaitUntilServiceAvailable(t, options, "nginx-service", 60, 1*time.Second)
 
 	// Open a tunnel from any available port locally
-	localPort := GetAvailablePort(t)
-	tunnel := NewTunnel(options, ResourceTypeService, "nginx-service", localPort, 80)
+	tunnel := NewTunnel(options, ResourceTypeService, "nginx-service", 0, 80)
 	defer tunnel.Close()
 	tunnel.ForwardPort(t)
 

--- a/modules/k8s/tunnel_test.go
+++ b/modules/k8s/tunnel_test.go
@@ -29,7 +29,7 @@ func TestTunnelOpensAPortForwardTunnelToPod(t *testing.T) {
 
 	// Open a tunnel to pod from any available port locally
 	localPort := GetAvailablePort(t)
-	tunnel := NewTunnel(options, Pod, "nginx-pod", localPort, 80)
+	tunnel := NewTunnel(options, ResourceTypePod, "nginx-pod", localPort, 80)
 	defer tunnel.Close()
 	tunnel.ForwardPort(t)
 
@@ -59,7 +59,7 @@ func TestTunnelOpensAPortForwardTunnelToService(t *testing.T) {
 
 	// Open a tunnel from any available port locally
 	localPort := GetAvailablePort(t)
-	tunnel := NewTunnel(options, Service, "nginx-service", localPort, 80)
+	tunnel := NewTunnel(options, ResourceTypeService, "nginx-service", localPort, 80)
 	defer tunnel.Close()
 	tunnel.ForwardPort(t)
 

--- a/test/helm_basic_example_integration_test.go
+++ b/test/helm_basic_example_integration_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/gruntwork-io/terratest/modules/helm"
-	"github.com/gruntwork-io/terratest/modules/http-helper"
+	http_helper "github.com/gruntwork-io/terratest/modules/http-helper"
 	"github.com/gruntwork-io/terratest/modules/k8s"
 	"github.com/gruntwork-io/terratest/modules/random"
 )

--- a/test/helm_basic_example_integration_test.go
+++ b/test/helm_basic_example_integration_test.go
@@ -38,7 +38,7 @@ func TestHelmBasicExampleDeployment(t *testing.T) {
 	// To ensure we can reuse the resource config on the same cluster to test different scenarios, we setup a unique
 	// namespace for the resources for this test.
 	// Note that namespaces must be lowercase.
-	namespaceName := strings.ToLower(random.UniqueId())
+	namespaceName := fmt.Sprintf("helm-basic-example-%s", strings.ToLower(random.UniqueId()))
 	k8s.CreateNamespace(t, kubectlOptions, namespaceName)
 	// Make sure we set the namespace on the options
 	kubectlOptions.Namespace = namespaceName
@@ -60,7 +60,7 @@ func TestHelmBasicExampleDeployment(t *testing.T) {
 	// By doing so, we can schedule the delete call here so that at the end of the test, we run
 	// `helm delete RELEASE_NAME` to clean up any resources that were created.
 	releaseName := fmt.Sprintf(
-		"%s-nginx-service",
+		"nginx-service-%s",
 		strings.ToLower(random.UniqueId()),
 	)
 	defer helm.Delete(t, options, releaseName, true)

--- a/test/helm_basic_example_integration_test.go
+++ b/test/helm_basic_example_integration_test.go
@@ -1,0 +1,96 @@
+// +build kubernetes
+
+// NOTE: we have build tags to differentiate kubernetes tests from non-kubernetes tests. This is done because minikube
+// is heavy and can interfere with docker related tests in terratest. To avoid overloading the system, we run the
+// kubernetes tests separately from the others.
+
+package test
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gruntwork-io/terratest/modules/helm"
+	"github.com/gruntwork-io/terratest/modules/http-helper"
+	"github.com/gruntwork-io/terratest/modules/k8s"
+	"github.com/gruntwork-io/terratest/modules/random"
+)
+
+// This file contains examples of how to use terratest to test helm charts by deploying the chart and verifying the
+// deployment by hitting the service endpoint.
+func TestHelmBasicExampleDeployment(t *testing.T) {
+	t.Parallel()
+
+	// Path to the helm chart we will test
+	helmChartPath, err := filepath.Abs("../examples/helm-basic-example")
+	require.NoError(t, err)
+
+	// Setup the kubectl config and context. Here we choose to use the defaults, which is:
+	// - HOME/.kube/config for the kubectl config file
+	// - Current context of the kubectl config file
+	kubectlOptions := k8s.NewKubectlOptions("", "")
+
+	// To ensure we can reuse the resource config on the same cluster to test different scenarios, we setup a unique
+	// namespace for the resources for this test.
+	// Note that namespaces must be lowercase.
+	namespaceName := strings.ToLower(random.UniqueId())
+	k8s.CreateNamespace(t, kubectlOptions, namespaceName)
+	// Make sure we set the namespace on the options
+	kubectlOptions.Namespace = namespaceName
+	// ... and make sure to delete the namespace at the end of the test
+	defer k8s.DeleteNamespace(t, kubectlOptions, namespaceName)
+
+	// Setup the args. For this test, we will set the following input values:
+	// - containerImageRepo=nginx
+	// - containerImageTag=1.15.8
+	options := &helm.Options{
+		KubectlOptions: kubectlOptions,
+		SetValues: map[string]string{
+			"containerImageRepo": "nginx",
+			"containerImageTag":  "1.15.8",
+		},
+	}
+
+	// We generate a unique release name so that we can refer to after deployment.
+	// By doing so, we can schedule the delete call here so that at the end of the test, we run
+	// `helm delete RELEASE_NAME` to clean up any resources that were created.
+	releaseName := fmt.Sprintf(
+		"%s-nginx-service",
+		strings.ToLower(random.UniqueId()),
+	)
+	defer helm.Delete(t, options, releaseName, true)
+
+	// Deploy the chart using `helm install`. Note that we use the version without `E`, since we want to assert the
+	// install succeeds without any errors.
+	helm.Install(t, options, helmChartPath, releaseName)
+
+	// Now let's verify the deployment. We will get the service endpoint and try to access it.
+
+	// First we need to get the service name. We will use domain knowledge of the chart here, where the name is
+	// RELEASE_NAME-CHART_NAME
+	serviceName := fmt.Sprintf("%s-helm-basic-example", releaseName)
+
+	// Next we wait until the service is available. This will wait up to 10 seconds for the service to become available,
+	// to ensure that we can access it.
+	k8s.WaitUntilServiceAvailable(t, kubectlOptions, serviceName, 10, 1*time.Second)
+
+	// Now we verify that the service will successfully boot and start serving requests
+	service := k8s.GetService(t, kubectlOptions, serviceName)
+	endpoint := k8s.GetServiceEndpoint(t, service, 80)
+	// Test the endpoint for up to 5 minutes. This will only fail if we timeout waiting for the service to return a 200
+	// response.
+	http_helper.HttpGetWithRetryWithCustomValidation(
+		t,
+		fmt.Sprintf("http://%s", endpoint),
+		30,
+		10*time.Second,
+		func(statusCode int, body string) bool {
+			return statusCode == 200
+		},
+	)
+}

--- a/test/helm_basic_example_integration_test.go
+++ b/test/helm_basic_example_integration_test.go
@@ -1,8 +1,9 @@
-// +build kubernetes
+// +build kubeall helm
 
-// NOTE: we have build tags to differentiate kubernetes tests from non-kubernetes tests. This is done because minikube
-// is heavy and can interfere with docker related tests in terratest. To avoid overloading the system, we run the
-// kubernetes tests separately from the others.
+// NOTE: we have build tags to differentiate kubernetes tests from non-kubernetes tests, and further differentiate helm
+// tests. This is done because minikube is heavy and can interfere with docker related tests in terratest. Similarly,
+// helm can overload the minikube system and thus interfere with the other kubernetes tests. To avoid overloading the
+// system, we run the kubernetes tests and helm tests separately from the others.
 
 package test
 

--- a/test/helm_basic_example_template_test.go
+++ b/test/helm_basic_example_template_test.go
@@ -1,9 +1,11 @@
 // +build kubeall helm
 
-// NOTE: we have build tags to differentiate kubernetes tests from non-kubernetes tests, and further differentiate helm
-// tests. This is done because minikube is heavy and can interfere with docker related tests in terratest. Similarly,
-// helm can overload the minikube system and thus interfere with the other kubernetes tests. To avoid overloading the
-// system, we run the kubernetes tests and helm tests separately from the others.
+// **NOTE**: we have build tags to differentiate kubernetes tests from non-kubernetes tests, and further differentiate helm
+// tests. This is done because minikube is heavy and can interfere with docker related tests in terratest. Similarly, helm
+// can overload the minikube system and thus interfere with the other kubernetes tests. Specifically, many of the tests
+// start to fail with `connection refused` errors from `minikube`. To avoid overloading the system, we run the kubernetes
+// tests and helm tests separately from the others. This may not be necessary if you have a sufficiently powerful machine.
+// We recommend at least 4 cores and 16GB of RAM if you want to run all the tests together.
 
 package test
 

--- a/test/helm_basic_example_template_test.go
+++ b/test/helm_basic_example_template_test.go
@@ -1,8 +1,9 @@
-// +build kubernetes
+// +build kubeall helm
 
-// NOTE: we have build tags to differentiate kubernetes tests from non-kubernetes tests. This is done because minikube
-// is heavy and can interfere with docker related tests in terratest. To avoid overloading the system, we run the
-// kubernetes tests separately from the others.
+// NOTE: we have build tags to differentiate kubernetes tests from non-kubernetes tests, and further differentiate helm
+// tests. This is done because minikube is heavy and can interfere with docker related tests in terratest. Similarly,
+// helm can overload the minikube system and thus interfere with the other kubernetes tests. To avoid overloading the
+// system, we run the kubernetes tests and helm tests separately from the others.
 
 package test
 

--- a/test/kubernetes_basic_example_service_check_test.go
+++ b/test/kubernetes_basic_example_service_check_test.go
@@ -1,4 +1,4 @@
-// +build kubernetes
+// +build kubeall kubernetes
 
 // NOTE: we have build tags to differentiate kubernetes tests from non-kubernetes tests. This is done because minikube
 // is heavy and can interfere with docker related tests in terratest. To avoid overloading the system, we run the

--- a/test/kubernetes_basic_example_service_check_test.go
+++ b/test/kubernetes_basic_example_service_check_test.go
@@ -1,8 +1,10 @@
 // +build kubeall kubernetes
 
 // NOTE: we have build tags to differentiate kubernetes tests from non-kubernetes tests. This is done because minikube
-// is heavy and can interfere with docker related tests in terratest. To avoid overloading the system, we run the
-// kubernetes tests separately from the others.
+// is heavy and can interfere with docker related tests in terratest. Specifically, many of the tests start to fail with
+// `connection refused` errors from `minikube`. To avoid overloading the system, we run the kubernetes tests and helm
+// tests separately from the others. This may not be necessary if you have a sufficiently powerful machine.  We
+// recommend at least 4 cores and 16GB of RAM if you want to run all the tests together.
 
 package test
 

--- a/test/kubernetes_basic_example_test.go
+++ b/test/kubernetes_basic_example_test.go
@@ -1,4 +1,4 @@
-// +build kubernetes
+// +build kubeall kubernetes
 
 // NOTE: we have build tags to differentiate kubernetes tests from non-kubernetes tests. This is done because minikube
 // is heavy and can interfere with docker related tests in terratest. To avoid overloading the system, we run the

--- a/test/kubernetes_basic_example_test.go
+++ b/test/kubernetes_basic_example_test.go
@@ -1,8 +1,10 @@
 // +build kubeall kubernetes
 
 // NOTE: we have build tags to differentiate kubernetes tests from non-kubernetes tests. This is done because minikube
-// is heavy and can interfere with docker related tests in terratest. To avoid overloading the system, we run the
-// kubernetes tests separately from the others.
+// is heavy and can interfere with docker related tests in terratest. Specifically, many of the tests start to fail with
+// `connection refused` errors from `minikube`. To avoid overloading the system, we run the kubernetes tests and helm
+// tests separately from the others. This may not be necessary if you have a sufficiently powerful machine.  We
+// recommend at least 4 cores and 16GB of RAM if you want to run all the tests together.
 
 package test
 

--- a/test/kubernetes_basic_example_test.go
+++ b/test/kubernetes_basic_example_test.go
@@ -7,6 +7,7 @@
 package test
 
 import (
+	"fmt"
 	"path/filepath"
 	"strings"
 	"testing"

--- a/test/kubernetes_basic_example_test.go
+++ b/test/kubernetes_basic_example_test.go
@@ -33,7 +33,7 @@ func TestKubernetesBasicExample(t *testing.T) {
 	// To ensure we can reuse the resource config on the same cluster to test different scenarios, we setup a unique
 	// namespace for the resources for this test.
 	// Note that namespaces must be lowercase.
-	namespaceName := strings.ToLower(random.UniqueId())
+	namespaceName := fmt.Sprintf("kubernetes-basic-example-%s", strings.ToLower(random.UniqueId()))
 	k8s.CreateNamespace(t, options, namespaceName)
 	// Make sure we set the namespace on the options
 	options.Namespace = namespaceName

--- a/test/kubernetes_rbac_example_test.go
+++ b/test/kubernetes_rbac_example_test.go
@@ -1,4 +1,4 @@
-// +build kubernetes
+// +build kubeall kubernetes
 
 // NOTE: we have build tags to differentiate kubernetes tests from non-kubernetes tests. This is done because minikube
 // is heavy and can interfere with docker related tests in terratest. To avoid overloading the system, we run the

--- a/test/kubernetes_rbac_example_test.go
+++ b/test/kubernetes_rbac_example_test.go
@@ -1,8 +1,10 @@
 // +build kubeall kubernetes
 
 // NOTE: we have build tags to differentiate kubernetes tests from non-kubernetes tests. This is done because minikube
-// is heavy and can interfere with docker related tests in terratest. To avoid overloading the system, we run the
-// kubernetes tests separately from the others.
+// is heavy and can interfere with docker related tests in terratest. Specifically, many of the tests start to fail with
+// `connection refused` errors from `minikube`. To avoid overloading the system, we run the kubernetes tests and helm
+// tests separately from the others. This may not be necessary if you have a sufficiently powerful machine.  We
+// recommend at least 4 cores and 16GB of RAM if you want to run all the tests together.
 
 package test
 


### PR DESCRIPTION
This introduces helm integration tests by providing `helm.Install` and `helm.Delete` functions. Additionally, this extends the `k8s` module with additional functions that map better to helm. Specifically, when you install a chart, it is not obvious what name is chosen for the chart. However, you are always guaranteed to have a bunch of labels defined on the resources, so it is more common to query Kubernetes resources using the labels than directly by name with helm.

Here is the list of new functions introduced:
- `helm.Install`: Install a helm chart onto a Kubernetes cluster
- `helm.Delete`: Delete a deployed release from Tiller
- `k8s.ListPods`: List pods in a given namespace
- `k8s.ListServices`: List services in a given namespace
- `k8s.WaitUntilNumPodsCreated`: Waits until the number of pods matching the given filters reaches the desired count.
- `k8s.Tunnel`: A struct that can be used to create and manage port forward tunnel to a Pod.

Finally, I had to further separate out the helm tests because Tiller overloaded minikube when running with the kubernetes tests.