### PR TITLE
Fix test failure in TestTerraformBasicExample

### DIFF
--- a/examples/terraform-basic-example/main.tf
+++ b/examples/terraform-basic-example/main.tf
@@ -10,6 +10,7 @@ data "template_file" "example" {
 data "template_file" "example2" {
   template = "${var.example2}"
 }
+
 resource "local_file" "example" {
   content  = "${data.template_file.example.rendered} + ${data.template_file.example2.rendered}"
   filename = "example.txt"

--- a/test/terraform_basic_example_test.go
+++ b/test/terraform_basic_example_test.go
@@ -10,49 +10,22 @@ import (
 // An example of how to test the simple Terraform module in examples/terraform-basic-example using Terratest.
 func TestTerraformBasicExample(t *testing.T) {
 	t.Parallel()
-	terraformDir := "../examples/terraform-basic-example"
 
-	expectedText := "foo"
+	expectedText := "test"
 
 	terraformOptions := &terraform.Options{
 		// The path to where our Terraform code is located
-		TerraformDir: terraformDir,
+		TerraformDir: "../examples/terraform-basic-example",
 
 		// Variables to pass to our Terraform code using -var options
 		Vars: map[string]interface{}{
 			"example": expectedText,
 		},
 
-		NoColor: true,
-	}
-
-	// At the end of the test, run `terraform destroy` to clean up any resources that were created
-	defer terraform.Destroy(t, terraformOptions)
-
-	// This will run `terraform init` and `terraform apply` and fail the test if there are any errors
-	terraform.InitAndApply(t, terraformOptions)
-
-	// Run `terraform output` to get the value of an output variable
-	actualText := terraform.Output(t, terraformOptions, "example")
-
-	// Verify we're getting back the variable we expect
-	assert.Equal(t, expectedText, actualText)
-}
-
-// An example of using -var-file argument in a test
-func TestTerraformVarFilesExample(t *testing.T) {
-	t.Parallel()
-	terraformDir := "../examples/terraform-basic-example"
-
-	expectedText := "test"
-
-	terraformOptions := &terraform.Options{
-		// The path to where our Terraform code is located
-		TerraformDir: terraformDir,
-
-		// Use the var files
+		// Variables to pass to our Terraform code using -var-file options
 		VarFiles: []string{"varfile.tfvars"},
 
+		// Disable colors in Terraform commands so its easier to parse stdout/stderr
 		NoColor: true,
 	}
 
@@ -62,9 +35,11 @@ func TestTerraformVarFilesExample(t *testing.T) {
 	// This will run `terraform init` and `terraform apply` and fail the test if there are any errors
 	terraform.InitAndApply(t, terraformOptions)
 
-	// Test for the variable which comes from the var file
-	actualText := terraform.Output(t, terraformOptions, "example2")
+	// Run `terraform output` to get the values of output variables
+	actualTextExample := terraform.Output(t, terraformOptions, "example")
+	actualTextExample2 := terraform.Output(t, terraformOptions, "example2")
 
-	// Verify we're getting the expected value from the file
-	assert.Equal(t, expectedText, actualText)
+	// Verify we're getting back the outputs we expect
+	assert.Equal(t, expectedText, actualTextExample)
+	assert.Equal(t, expectedText, actualTextExample2)
 }


### PR DESCRIPTION
This is a follow-up to #201.

We're running two tests at the same time in the same folder, which is causing issues. This consolidates the two tests down to one.