### PR TITLE
Standardize modules/k8s functions to take in KubectlOptions

### DIFF
--- a/modules/k8s/client.go
+++ b/modules/k8s/client.go
@@ -5,6 +5,10 @@ import (
 
 	"k8s.io/client-go/kubernetes"
 
+	// The following line loads the gcp plugin which is required to authenticate against GKE clusters.
+	// See: https://github.com/kubernetes/client-go/issues/242
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+
 	"github.com/gruntwork-io/terratest/modules/logger"
 )
 

--- a/modules/k8s/node_test.go
+++ b/modules/k8s/node_test.go
@@ -23,7 +23,8 @@ func TestGetNodes(t *testing.T) {
 	t.Parallel()
 
 	// Assumes local kubernetes (minikube or docker-for-desktop kube), where there is only one node
-	nodes := GetNodes(t)
+	options := NewKubectlOptions("", "")
+	nodes := GetNodes(t, options)
 	require.Equal(t, len(nodes), 1)
 
 	node := nodes[0]
@@ -38,7 +39,8 @@ func TestGetReadyNodes(t *testing.T) {
 	t.Parallel()
 
 	// Assumes local kubernetes (minikube or docker-for-desktop kube), where there is only one node
-	nodes := GetReadyNodes(t)
+	options := NewKubectlOptions("", "")
+	nodes := GetReadyNodes(t, options)
 	require.Equal(t, len(nodes), 1)
 
 	node := nodes[0]
@@ -52,15 +54,17 @@ func TestGetReadyNodes(t *testing.T) {
 func TestWaitUntilAllNodesReady(t *testing.T) {
 	t.Parallel()
 
-	WaitUntilAllNodesReady(t, 12, 5*time.Second)
+	options := NewKubectlOptions("", "")
 
-	nodes := GetNodes(t)
+	WaitUntilAllNodesReady(t, options, 12, 5*time.Second)
+
+	nodes := GetNodes(t, options)
 	nodeNames := map[string]bool{}
 	for _, node := range nodes {
 		nodeNames[node.Name] = true
 	}
 
-	readyNodes := GetReadyNodes(t)
+	readyNodes := GetReadyNodes(t, options)
 	readyNodeNames := map[string]bool{}
 	for _, node := range readyNodes {
 		readyNodeNames[node.Name] = true

--- a/modules/k8s/service_test.go
+++ b/modules/k8s/service_test.go
@@ -86,7 +86,7 @@ func TestGetServiceEndpointEReturnsAccessibleEndpointForNodePort(t *testing.T) {
 	defer KubectlDeleteFromString(t, options, configData)
 
 	service := GetService(t, options, "nginx-service")
-	endpoint := GetServiceEndpoint(t, service, 80)
+	endpoint := GetServiceEndpoint(t, options, service, 80)
 	// Test up to 5 minutes
 	http_helper.HttpGetWithRetryWithCustomValidation(
 		t,

--- a/test/helm_basic_example_integration_test.go
+++ b/test/helm_basic_example_integration_test.go
@@ -82,7 +82,7 @@ func TestHelmBasicExampleDeployment(t *testing.T) {
 
 	// Now we verify that the service will successfully boot and start serving requests
 	service := k8s.GetService(t, kubectlOptions, serviceName)
-	endpoint := k8s.GetServiceEndpoint(t, service, 80)
+	endpoint := k8s.GetServiceEndpoint(t, kubectlOptions, service, 80)
 	// Test the endpoint for up to 5 minutes. This will only fail if we timeout waiting for the service to return a 200
 	// response.
 	http_helper.HttpGetWithRetryWithCustomValidation(

--- a/test/kubernetes_basic_example_service_check_test.go
+++ b/test/kubernetes_basic_example_service_check_test.go
@@ -56,7 +56,7 @@ func TestKubernetesBasicExampleServiceCheck(t *testing.T) {
 
 	// Now we verify that the service will successfully boot and start serving requests
 	service := k8s.GetService(t, options, "nginx-service")
-	endpoint := k8s.GetServiceEndpoint(t, service, 80)
+	endpoint := k8s.GetServiceEndpoint(t, options, service, 80)
 	// Test the endpoint for up to 5 minutes. This will only fail if we timeout waiting for the service to return a 200
 	// response.
 	http_helper.HttpGetWithRetryWithCustomValidation(


### PR DESCRIPTION
__NOTE: This is a backwards incompatible change__

This standardizes all the functions in `modules/k8s` to explicitly take in a `KubectlOptions` as opposed to assuming the default so that you can control which cluster actions perform. This is necessary to support test parallelism, so that you can either select a specific context for the action OR create a temp kubeconfig file and use that.

Additional features:
- The GKE auth plugin import is moved to the `client.go` file.