### PR TITLE
Add Get helpers for 'cluster_role' and 'role' resource

### DIFF
--- a/modules/k8s/cluster_role.go
+++ b/modules/k8s/cluster_role.go
@@ -1,0 +1,23 @@
+package k8s
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// GetClusterRole returns a Kubernetes role resource with the given name. This will fail the test if there is an error.
+func GetClusterRole(t *testing.T, options *KubectlOptions, roleName string) *rbacv1.ClusterRole {
+	role, err := GetClusterRoleE(t, options, roleName)
+	require.NoError(t, err)
+	return role
+}
+
+// GetRole returns a Kubernetes role resource with the given name.
+func GetClusterRoleE(t *testing.T, options *KubectlOptions, roleName string) (*rbacv1.ClusterRole, error) {
+	clientset, err := GetKubernetesClientFromOptionsE(t, options)
+	require.NoError(t, err)
+	return clientset.RbacV1().ClusterRoles().Get(roleName, metav1.GetOptions{})
+}

--- a/modules/k8s/cluster_role.go
+++ b/modules/k8s/cluster_role.go
@@ -18,6 +18,8 @@ func GetClusterRole(t *testing.T, options *KubectlOptions, roleName string) *rba
 // GetClusterRoleE returns a Kubernetes ClusterRole resource with the given name.
 func GetClusterRoleE(t *testing.T, options *KubectlOptions, roleName string) (*rbacv1.ClusterRole, error) {
 	clientset, err := GetKubernetesClientFromOptionsE(t, options)
-	require.NoError(t, err)
+	if err != nil {
+		return nil, err
+	}
 	return clientset.RbacV1().ClusterRoles().Get(roleName, metav1.GetOptions{})
 }

--- a/modules/k8s/cluster_role.go
+++ b/modules/k8s/cluster_role.go
@@ -15,7 +15,7 @@ func GetClusterRole(t *testing.T, options *KubectlOptions, roleName string) *rba
 	return role
 }
 
-// GetRole returns a Kubernetes role resource with the given name.
+// GetClusterRoleE returns a Kubernetes ClusterRole resource with the given name.
 func GetClusterRoleE(t *testing.T, options *KubectlOptions, roleName string) (*rbacv1.ClusterRole, error) {
 	clientset, err := GetKubernetesClientFromOptionsE(t, options)
 	require.NoError(t, err)

--- a/modules/k8s/cluster_role_test.go
+++ b/modules/k8s/cluster_role_test.go
@@ -1,5 +1,11 @@
 // +build kubeall kubernetes
 
+// NOTE: we have build tags to differentiate kubernetes tests from non-kubernetes tests. This is done because minikube
+// is heavy and can interfere with docker related tests in terratest. Specifically, many of the tests start to fail with
+// `connection refused` errors from `minikube`. To avoid overloading the system, we run the kubernetes tests and helm
+// tests separately from the others. This may not be necessary if you have a sufficiently powerful machine.  We
+// recommend at least 4 cores and 16GB of RAM if you want to run all the tests together.
+
 package k8s
 
 import (

--- a/modules/k8s/cluster_role_test.go
+++ b/modules/k8s/cluster_role_test.go
@@ -1,0 +1,42 @@
+// +build kubeall kubernetes
+
+package k8s
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetClusterRoleEReturnsErrorForNonExistantClusterRole(t *testing.T) {
+	t.Parallel()
+
+	options := NewKubectlOptions("", "")
+	_, err := GetClusterRoleE(t, options, "non-existing-role")
+	require.Error(t, err)
+}
+
+func TestGetClusterRoleEReturnsCorrectClusterRoleInCorrectNamespace(t *testing.T) {
+	t.Parallel()
+
+	options := NewKubectlOptions("", "")
+	defer KubectlDeleteFromString(t, options, EXAMPLE_CLUSTER_ROLE_YAML_TEMPLATE)
+	KubectlApplyFromString(t, options, EXAMPLE_CLUSTER_ROLE_YAML_TEMPLATE)
+
+	role := GetClusterRole(t, options, "terratest-cluster-role")
+	require.Equal(t, role.Name, "terratest-cluster-role")
+}
+
+const EXAMPLE_CLUSTER_ROLE_YAML_TEMPLATE = `---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: 'terratest-cluster-role'
+rules:
+- apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - '*'
+`

--- a/modules/k8s/role.go
+++ b/modules/k8s/role.go
@@ -1,0 +1,25 @@
+package k8s
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// GetRole returns a Kubernetes role resource in the provided namespace with the given name. The namespace used
+// is the one provided in the KubectlOptions. This will fail the test if there is an error.
+func GetRole(t *testing.T, options *KubectlOptions, roleName string) *rbacv1.Role {
+	role, err := GetRoleE(t, options, roleName)
+	require.NoError(t, err)
+	return role
+}
+
+// GetRole returns a Kubernetes role resource in the provided namespace with the given name. The namespace used
+// is the one provided in the KubectlOptions.
+func GetRoleE(t *testing.T, options *KubectlOptions, roleName string) (*rbacv1.Role, error) {
+	clientset, err := GetKubernetesClientFromOptionsE(t, options)
+	require.NoError(t, err)
+	return clientset.RbacV1().Roles(options.Namespace).Get(roleName, metav1.GetOptions{})
+}

--- a/modules/k8s/role.go
+++ b/modules/k8s/role.go
@@ -20,6 +20,8 @@ func GetRole(t *testing.T, options *KubectlOptions, roleName string) *rbacv1.Rol
 // is the one provided in the KubectlOptions.
 func GetRoleE(t *testing.T, options *KubectlOptions, roleName string) (*rbacv1.Role, error) {
 	clientset, err := GetKubernetesClientFromOptionsE(t, options)
-	require.NoError(t, err)
+	if err != nil {
+		return nil, err
+	}
 	return clientset.RbacV1().Roles(options.Namespace).Get(roleName, metav1.GetOptions{})
 }

--- a/modules/k8s/role_test.go
+++ b/modules/k8s/role_test.go
@@ -1,5 +1,11 @@
 // +build kubeall kubernetes
 
+// NOTE: we have build tags to differentiate kubernetes tests from non-kubernetes tests. This is done because minikube
+// is heavy and can interfere with docker related tests in terratest. Specifically, many of the tests start to fail with
+// `connection refused` errors from `minikube`. To avoid overloading the system, we run the kubernetes tests and helm
+// tests separately from the others. This may not be necessary if you have a sufficiently powerful machine.  We
+// recommend at least 4 cores and 16GB of RAM if you want to run all the tests together.
+
 package k8s
 
 import (

--- a/modules/k8s/role_test.go
+++ b/modules/k8s/role_test.go
@@ -1,0 +1,56 @@
+// +build kubeall kubernetes
+
+package k8s
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gruntwork-io/terratest/modules/random"
+)
+
+func TestGetRoleEReturnsErrorForNonExistantRole(t *testing.T) {
+	t.Parallel()
+
+	options := NewKubectlOptions("", "")
+	_, err := GetRoleE(t, options, "non-existing-role")
+	require.Error(t, err)
+}
+
+func TestGetRoleEReturnsCorrectRoleInCorrectNamespace(t *testing.T) {
+	t.Parallel()
+
+	uniqueID := strings.ToLower(random.UniqueId())
+	options := NewKubectlOptions("", "")
+	options.Namespace = uniqueID
+	configData := fmt.Sprintf(EXAMPLE_ROLE_YAML_TEMPLATE, uniqueID, uniqueID)
+	defer KubectlDeleteFromString(t, options, configData)
+	KubectlApplyFromString(t, options, configData)
+
+	role := GetRole(t, options, "terratest-role")
+	require.Equal(t, role.Name, "terratest-role")
+	require.Equal(t, role.Namespace, uniqueID)
+}
+
+const EXAMPLE_ROLE_YAML_TEMPLATE = `---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: '%s'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: 'terratest-role'
+  namespace: '%s'
+rules:
+- apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - '*'
+`


### PR DESCRIPTION
This PR adds getters for kubernetes [role](https://www.terraform.io/docs/providers/kubernetes/r/role.html) and [cluster_role](https://www.terraform.io/docs/providers/kubernetes/r/role.html) resources.

Test results:

```
$ go test -tags='kubernetes kubeall' -run 'TestGet(Cluster)?Role.*'

TestGetClusterRoleEReturnsErrorForNonExistantClusterRole 2019-03-01T14:57:49+01:00 client.go:30: Configuring kubectl using config file /home/kirecek/.kube/config with context 
TestGetRoleEReturnsCorrectRoleInCorrectNamespace 2019-03-01T14:57:49+01:00 command.go:53: Running command kubectl with args [--namespace gfjufh apply -f /tmp/TestGetRoleEReturnsCorrectRoleInCorrectNamespace118283240]
TestGetRoleEReturnsErrorForNonExistantRole 2019-03-01T14:57:49+01:00 client.go:30: Configuring kubectl using config file /home/kirecek/.kube/config with context 
TestGetClusterRoleEReturnsCorrectClusterRoleInCorrectNamespace 2019-03-01T14:57:49+01:00 command.go:53: Running command kubectl with args [apply -f /tmp/TestGetClusterRoleEReturnsCorrectClusterRoleInCorrectNamespace662649895]
TestGetClusterRoleEReturnsCorrectClusterRoleInCorrectNamespace 2019-03-01T14:57:50+01:00 command.go:121: clusterrole.rbac.authorization.k8s.io "terratest-cluster-role" created
TestGetClusterRoleEReturnsCorrectClusterRoleInCorrectNamespace 2019-03-01T14:57:50+01:00 client.go:30: Configuring kubectl using config file /home/kirecek/.kube/config with context 
TestGetClusterRoleEReturnsCorrectClusterRoleInCorrectNamespace 2019-03-01T14:57:50+01:00 command.go:53: Running command kubectl with args [delete -f /tmp/TestGetClusterRoleEReturnsCorrectClusterRoleInCorrectNamespace858159962]
TestGetRoleEReturnsCorrectRoleInCorrectNamespace 2019-03-01T14:57:50+01:00 command.go:121: namespace "gfjufh" created
TestGetRoleEReturnsCorrectRoleInCorrectNamespace 2019-03-01T14:57:50+01:00 command.go:121: role.rbac.authorization.k8s.io "terratest-role" created
TestGetRoleEReturnsCorrectRoleInCorrectNamespace 2019-03-01T14:57:50+01:00 client.go:30: Configuring kubectl using config file /home/kirecek/.kube/config with context 
TestGetRoleEReturnsCorrectRoleInCorrectNamespace 2019-03-01T14:57:50+01:00 command.go:53: Running command kubectl with args [--namespace gfjufh delete -f /tmp/TestGetRoleEReturnsCorrectRoleInCorrectNamespace285447921]
TestGetClusterRoleEReturnsCorrectClusterRoleInCorrectNamespace 2019-03-01T14:57:50+01:00 command.go:121: clusterrole.rbac.authorization.k8s.io "terratest-cluster-role" deleted
TestGetRoleEReturnsCorrectRoleInCorrectNamespace 2019-03-01T14:57:50+01:00 command.go:121: namespace "gfjufh" deleted
TestGetRoleEReturnsCorrectRoleInCorrectNamespace 2019-03-01T14:57:50+01:00 command.go:121: role.rbac.authorization.k8s.io "terratest-role" deleted
PASS
ok      _/home/kirecek/codehub/src/github.com/kirecek/terratest/modules/k8s     0.277s
```