### PR TITLE
 Fix #242: Support installation of remote charts 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -222,6 +222,9 @@ jobs:
       - run:
           command: |
             mkdir -p /tmp/logs
+            # Run the unit tests first, then the integration tests. They are separate because the integration tests
+            # require additional filtering.
+            run-go-tests --packages "-tags helm ./modules/helm" | tee /tmp/logs/test_output.log
             run-go-tests --packages "-tags helm -run TestHelm ./test" | tee -a /tmp/logs/test_output.log
 
       - run:

--- a/modules/helm/install.go
+++ b/modules/helm/install.go
@@ -12,22 +12,25 @@ import (
 
 // Install will install the selected helm chart with the provided options under the given release name. This will fail
 // the test if there is an error.
-func Install(t *testing.T, options *Options, chartDir string, releaseName string) {
-	require.NoError(t, InstallE(t, options, chartDir, releaseName))
+func Install(t *testing.T, options *Options, chart string, releaseName string) {
+	require.NoError(t, InstallE(t, options, chart, releaseName))
 }
 
 // InstallE will install the selected helm chart with the provided options under the given release name.
-func InstallE(t *testing.T, options *Options, chartDir string, releaseName string) error {
-	// First, verify the charts dir exists
-	absChartDir, err := filepath.Abs(chartDir)
-	if err != nil {
-		return errors.WithStackTrace(err)
-	}
-	if !files.FileExists(chartDir) {
-		return errors.WithStackTrace(ChartNotFoundError{chartDir})
+func InstallE(t *testing.T, options *Options, chart string, releaseName string) error {
+	// If the chart refers to a path, convert to absolute path. Otherwise, pass straight through as it may be a remote
+	// chart.
+	if files.FileExists(chart) {
+		absChartDir, err := filepath.Abs(chart)
+		if err != nil {
+			return errors.WithStackTrace(err)
+		}
+		chart = absChartDir
 	}
 
 	// Now call out to helm install to install the charts with the provided options
+	// Declare err here so that we can update args later
+	var err error
 	args := []string{}
 	if options.KubectlOptions != nil && options.KubectlOptions.Namespace != "" {
 		args = append(args, "--namespace", options.KubectlOptions.Namespace)
@@ -36,7 +39,7 @@ func InstallE(t *testing.T, options *Options, chartDir string, releaseName strin
 	if err != nil {
 		return err
 	}
-	args = append(args, "-n", releaseName, absChartDir)
+	args = append(args, "-n", releaseName, chart)
 	_, err = RunHelmCommandAndGetOutputE(t, options, "install", args...)
 	return err
 }

--- a/modules/helm/install_test.go
+++ b/modules/helm/install_test.go
@@ -1,0 +1,70 @@
+// +build kubeall helm
+
+// NOTE: we have build tags to differentiate kubernetes tests from non-kubernetes tests, and further differentiate helm
+// tests. This is done because minikube is heavy and can interfere with docker related tests in terratest. Similarly,
+// helm can overload the minikube system and thus interfere with the other kubernetes tests. To avoid overloading the
+// system, we run the kubernetes tests and helm tests separately from the others.
+
+package helm
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	http_helper "github.com/gruntwork-io/terratest/modules/http-helper"
+	"github.com/gruntwork-io/terratest/modules/k8s"
+	"github.com/gruntwork-io/terratest/modules/random"
+)
+
+// Test that we can install a remote chart (e.g stable/kubernetes-dashboard)
+func TestRemoteChartInstall(t *testing.T) {
+	t.Parallel()
+
+	helmChart := "stable/kubernetes-dashboard"
+
+	// Use default kubectl options to create a new namespace for this test, and then update the namespace for kubectl
+	kubectlOptions := k8s.NewKubectlOptions("", "")
+	namespaceName := fmt.Sprintf(
+		"%s-%s",
+		strings.ToLower(t.Name()),
+		strings.ToLower(random.UniqueId()),
+	)
+	defer k8s.DeleteNamespace(t, kubectlOptions, namespaceName)
+	k8s.CreateNamespace(t, kubectlOptions, namespaceName)
+	kubectlOptions.Namespace = namespaceName
+
+	// Override service type to node port
+	options := &Options{
+		KubectlOptions: kubectlOptions,
+		SetValues: map[string]string{
+			"service.type": "NodePort",
+		},
+	}
+
+	// Generate a unique release name so we can defer the delete before installing
+	releaseName := fmt.Sprintf(
+		"kube-dashboard-%s",
+		strings.ToLower(random.UniqueId()),
+	)
+	defer Delete(t, options, releaseName, true)
+	Install(t, options, helmChart, releaseName)
+
+	// Service name is RELEASE_NAME-CHART_NAME
+	serviceName := fmt.Sprintf("%s-kubernetes-dashboard", releaseName)
+
+	// Verify service is accessible. Wait for it to become available and then hit the endpoint.
+	k8s.WaitUntilServiceAvailable(t, kubectlOptions, serviceName, 10, 1*time.Second)
+	service := k8s.GetService(t, kubectlOptions, serviceName)
+	endpoint := k8s.GetServiceEndpoint(t, service, 443)
+	http_helper.HttpGetWithRetryWithCustomValidation(
+		t,
+		fmt.Sprintf("http://%s", endpoint),
+		30,
+		10*time.Second,
+		func(statusCode int, body string) bool {
+			return statusCode == 200
+		},
+	)
+}


### PR DESCRIPTION
This fixes https://github.com/gruntwork-io/terratest/issues/242 by relaxing the constraint that the passing chart must exist on the file system to run `helm.Install`.