### PR TITLE
Add checksums to release files

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -243,6 +243,7 @@ jobs:
           at: /home/circleci
       - run: curl -Ls https://raw.githubusercontent.com/gruntwork-io/gruntwork-installer/master/bootstrap-gruntwork-installer.sh | bash /dev/stdin --version v0.0.21
       - run: gruntwork-install --module-name "gruntwork-module-circleci-helpers" --repo "https://github.com/gruntwork-io/module-ci" --tag "v0.13.2"
+      - run: cd bin && sha256sum * > SHA256SUMS
       - run: upload-github-release-assets cmd/bin/*
 
 


### PR DESCRIPTION
This is to address an unopened issue similar to:
https://github.com/gruntwork-io/terragrunt/issues/610

The checksums of all binaries within `bin/` will be saved within
`SHA256SUMS`. The integrity of binaries can now be verified with this
command: `sha256sum --check --ignore-missing SHA256SUMS`.

In the future, Gruntwork should consider using a PGP key to
cryptographically sign this checksums file and to distribute the
signature along with the rest of the release files. Doing so will likely
require using private CI/CD infrastructure instead of CircleCI so that
Gruntwork may have full control over their private signing key.