### PR TITLE
reorder of terraform arguments var and varFiles to reflect common usage

### DIFF
--- a/modules/terraform/format.go
+++ b/modules/terraform/format.go
@@ -11,8 +11,8 @@ import (
 func FormatArgs(options *Options, args ...string) []string {
 	var terraformArgs []string
 	terraformArgs = append(terraformArgs, args...)
-	terraformArgs = append(terraformArgs, FormatTerraformVarsAsArgs(options.Vars)...)
 	terraformArgs = append(terraformArgs, FormatTerraformArgs("-var-file", options.VarFiles)...)
+	terraformArgs = append(terraformArgs, FormatTerraformVarsAsArgs(options.Vars)...)
 	terraformArgs = append(terraformArgs, FormatTerraformArgs("-target", options.Targets)...)
 	return terraformArgs
 }


### PR DESCRIPTION
Switching the order of Vars and VarFiles in terraformArgs to reflect a more common scenario. 

It's likely that a user would like to override one or two variables from a var-file using single variables, currently the behaviour is the opposite way round. 

link to terraform [variable precedence](https://www.terraform.io/docs/configuration/variables.html#variable-definition-precedence) documentation.