### PR TITLE
Add go module

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,15 @@
+module github.com/gruntwork-io/terratest
+
+require (
+	github.com/aws/aws-sdk-go v1.12.74
+	github.com/boombuler/barcode v1.0.0
+	github.com/davecgh/go-spew v1.1.0
+	github.com/go-ini/ini v1.36.0
+	github.com/google/uuid v0.0.0-20161128191214-064e2069ce9c
+	github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8
+	github.com/pmezard/go-difflib v1.0.0
+	github.com/pquerna/otp v1.0.0
+	github.com/stretchr/testify v1.2.1
+	golang.org/x/crypto v0.0.0-20180426230345-b49d69b5da94
+	golang.org/x/net v0.0.0-20180420171651-5f9ae10d9af5
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,11 @@
+github.com/aws/aws-sdk-go v1.12.74/go.mod h1:ZRmQr0FajVIyZ4ZzBYKG5P3ZqPz9IHG41ZoMu1ADI3k=
+github.com/boombuler/barcode v1.0.0/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/go-ini/ini v1.36.0/go.mod h1:ByCAeIL28uOIIG0E3PJtZPDL8WnHpFKFOtgjp+3Ies8=
+github.com/google/uuid v0.0.0-20161128191214-064e2069ce9c/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/pquerna/otp v1.0.0/go.mod h1:Zad1CMQfSQZI5KLpahDiSUX4tMMREnXw98IvL1nhgMk=
+github.com/stretchr/testify v1.2.1/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+golang.org/x/crypto v0.0.0-20180426230345-b49d69b5da94/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
+golang.org/x/net v0.0.0-20180420171651-5f9ae10d9af5/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=


### PR DESCRIPTION
Hello, 

Thanks for this awesome project!

As `go mod` is the new way of managing dependencies with go, it would be great to also have go module support with terratest.

Currently we are unable to use terratest with go modules, as the dependencies are not pinned correctly. This leads to errors like:

```
../../../../go/pkg/mod/k8s.io/client-go@v10.0.0+incompatible/kubernetes/scheme/register.go:22:2: unknown import path "k8s.io/api/admissionregistration/v1alpha1": cannot find module providing package k8s.io/api/admissionregistration/v1alpha1
``` 


This PR enables go modules support by generating a `go.mod` based on the existing `Gopkg.lock`.
Let me know whether this can get merged, or you need anything else.

Cheers!
