### PR TITLE
Add support for GCP's OS Login API

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -26,7 +26,7 @@
   version = "v0.6.0"
 
 [[projects]]
-  digest = "1:0702d9e517405bc4eb634e3c7cf909b1da212bb5ce3cb633d1358bd2a7853d82"
+  digest = "1:881f40b2f21b424275136d8e134cfc393d7897e52df3fd49d898dc11b1e9fed8"
   name = "github.com/aws/aws-sdk-go"
   packages = [
     "aws",
@@ -65,6 +65,7 @@
     "service/autoscaling",
     "service/cloudwatchlogs",
     "service/ec2",
+    "service/ecs",
     "service/iam",
     "service/kms",
     "service/rds",
@@ -543,7 +544,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:a124d2ef8b444eee0f0bf419136052570947651dd738cf220b1cd1cea669ddc6"
+  digest = "1:57065bc4b99a833ed207371240f61c214ccbaedaa1ed6398484d3e32d2a0396f"
   name = "google.golang.org/api"
   packages = [
     "compute/v1",
@@ -554,6 +555,7 @@
     "internal",
     "iterator",
     "option",
+    "oslogin/v1",
     "storage/v1",
     "transport/http",
   ]
@@ -820,6 +822,7 @@
     "github.com/aws/aws-sdk-go/service/autoscaling",
     "github.com/aws/aws-sdk-go/service/cloudwatchlogs",
     "github.com/aws/aws-sdk-go/service/ec2",
+    "github.com/aws/aws-sdk-go/service/ecs",
     "github.com/aws/aws-sdk-go/service/iam",
     "github.com/aws/aws-sdk-go/service/kms",
     "github.com/aws/aws-sdk-go/service/rds",
@@ -854,9 +857,11 @@
     "golang.org/x/oauth2/google",
     "google.golang.org/api/compute/v1",
     "google.golang.org/api/iterator",
+    "google.golang.org/api/oslogin/v1",
     "k8s.io/api/apps/v1",
     "k8s.io/api/authorization/v1",
     "k8s.io/api/core/v1",
+    "k8s.io/api/rbac/v1",
     "k8s.io/apimachinery/pkg/apis/meta/v1",
     "k8s.io/client-go/kubernetes",
     "k8s.io/client-go/plugin/pkg/client/auth/gcp",

--- a/modules/gcp/oslogin.go
+++ b/modules/gcp/oslogin.go
@@ -3,6 +3,7 @@ package gcp
 import (
 	"context"
 	"fmt"
+	"github.com/stretchr/testify/require"
 	"testing"
 
 	"github.com/gruntwork-io/terratest/modules/logger"
@@ -11,14 +12,17 @@ import (
 	"google.golang.org/api/oslogin/v1"
 )
 
-// Add an OS Login SSH Key
+// ImportSSHKey will import an SSH key to GCP under the provided user identity.
+// The `user` parameter should be the email address of the user.
+// The `key` parameter should be the public key of the SSH key being uploaded.
+// This will fail the test if there is an error.
 func ImportSSHKey(t *testing.T, user, key string) {
-	err := ImportSSHKeyE(t, user, key)
-	if err != nil {
-		t.Fatalf("Could not add SSH Key to user %s: %s", user, err)
-	}
+	require.NoErrorf(t, ImportSSHKeyE(t, user, key), "Could not add SSH Key to user %")
 }
 
+// ImportSSHKeyE will import an SSH key to GCP under the provided user identity.
+// The `user` parameter should be the email address of the user.
+// The `key` parameter should be the public key of the SSH key being uploaded.
 func ImportSSHKeyE(t *testing.T, user, key string) error {
 	logger.Logf(t, "Importing SSH key for user %s", user)
 
@@ -42,8 +46,10 @@ func ImportSSHKeyE(t *testing.T, user, key string) error {
 	return nil
 }
 
-// Retrieve the login profile; OS Login + ephemeral gcloud keys + identities for
-// the user.
+// GetLoginProfile will retrieve the login profile for a user's Google identity. The login profile is a combination of OS Login + gcloud SSH keys and POSIX
+// accounts the user will appear as. Generally, this will only be the OS Login key + account, but `gcloud compute ssh` could create temporary keys and profiles.
+// The `user` parameter should be the email address of the user.
+// This will fail the test if there is an error.
 func GetLoginProfile(t *testing.T, user string) *oslogin.LoginProfile {
 	profile, err := GetLoginProfileE(t, user)
 	if err != nil {
@@ -53,6 +59,9 @@ func GetLoginProfile(t *testing.T, user string) *oslogin.LoginProfile {
 	return profile
 }
 
+// GetLoginProfileE will retrieve the login profile for a user's Google identity. The login profile is a combination of OS Login + gcloud SSH keys and POSIX
+// accounts the user will appear as. Generally, this will only be the OS Login key + account, but `gcloud compute ssh` could create temporary keys and profiles.
+// The `user` parameter should be the email address of the user.
 func GetLoginProfileE(t *testing.T, user string) (*oslogin.LoginProfile, error) {
 	logger.Logf(t, "Getting login profile for user %s", user)
 

--- a/modules/gcp/oslogin.go
+++ b/modules/gcp/oslogin.go
@@ -3,10 +3,10 @@ package gcp
 import (
 	"context"
 	"fmt"
-	"github.com/stretchr/testify/require"
 	"testing"
 
 	"github.com/gruntwork-io/terratest/modules/logger"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/oauth2/google"
 	"google.golang.org/api/compute/v1"
 	"google.golang.org/api/oslogin/v1"
@@ -17,7 +17,7 @@ import (
 // The `key` parameter should be the public key of the SSH key being uploaded.
 // This will fail the test if there is an error.
 func ImportSSHKey(t *testing.T, user, key string) {
-	require.NoErrorf(t, ImportSSHKeyE(t, user, key), "Could not add SSH Key to user %")
+	require.NoErrorf(t, ImportSSHKeyE(t, user, key), "Could not add SSH Key to user %s", user)
 }
 
 // ImportSSHKeyE will import an SSH key to GCP under the provided user identity.
@@ -52,9 +52,7 @@ func ImportSSHKeyE(t *testing.T, user, key string) error {
 // This will fail the test if there is an error.
 func GetLoginProfile(t *testing.T, user string) *oslogin.LoginProfile {
 	profile, err := GetLoginProfileE(t, user)
-	if err != nil {
-		t.Fatalf("Could not get login profile for user %s: %s", user, err)
-	}
+	require.NoErrorf(t, err, "Could not get login profile for user %s", user)
 
 	return profile
 }

--- a/modules/gcp/oslogin.go
+++ b/modules/gcp/oslogin.go
@@ -1,0 +1,90 @@
+package gcp
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/logger"
+	"golang.org/x/oauth2/google"
+	"google.golang.org/api/compute/v1"
+	"google.golang.org/api/oslogin/v1"
+)
+
+// Add an OS Login SSH Key
+func ImportSSHKey(t *testing.T, user, key string) {
+	err := ImportSSHKeyE(t, user, key)
+	if err != nil {
+		t.Fatalf("Could not add SSH Key to user %s: %s", user, err)
+	}
+}
+
+func ImportSSHKeyE(t *testing.T, user, key string) error {
+	logger.Logf(t, "Importing SSH key for user %s", user)
+
+	ctx := context.Background()
+	service, err := NewOSLoginServiceE(t)
+	if err != nil {
+		return err
+	}
+
+	parent := fmt.Sprintf("users/%s", user)
+
+	sshPublicKey := &oslogin.SshPublicKey{
+		Key: key,
+	}
+
+	_, err = service.Users.ImportSshPublicKey(parent, sshPublicKey).Context(ctx).Do()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Retrieve the login profile; OS Login + ephemeral gcloud keys + identities for
+// the user.
+func GetLoginProfile(t *testing.T, user string) *oslogin.LoginProfile {
+	profile, err := GetLoginProfileE(t, user)
+	if err != nil {
+		t.Fatalf("Could not get login profile for user %s: %s", user, err)
+	}
+
+	return profile
+}
+
+func GetLoginProfileE(t *testing.T, user string) (*oslogin.LoginProfile, error) {
+	logger.Logf(t, "Getting login profile for user %s", user)
+
+	ctx := context.Background()
+	service, err := NewOSLoginServiceE(t)
+	if err != nil {
+		return nil, err
+	}
+
+	name := fmt.Sprintf("users/%s", user)
+
+	profile, err := service.Users.GetLoginProfile(name).Context(ctx).Do()
+	if err != nil {
+		return nil, err
+	}
+
+	return profile, nil
+}
+
+// NewOSLoginServiceE creates a new OS Login service, which is used to make OS Login API calls.
+func NewOSLoginServiceE(t *testing.T) (*oslogin.Service, error) {
+	ctx := context.Background()
+
+	client, err := google.DefaultClient(ctx, compute.CloudPlatformScope)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to get default client: %v", err)
+	}
+
+	service, err := oslogin.New(client)
+	if err != nil {
+		return nil, err
+	}
+
+	return service, nil
+}

--- a/modules/gcp/oslogin_test.go
+++ b/modules/gcp/oslogin_test.go
@@ -1,0 +1,48 @@
+package gcp
+
+import (
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/ssh"
+)
+
+func TestImportSSHKeyOSLogin(t *testing.T) {
+	t.Parallel()
+
+	keyPair := ssh.GenerateRSAKeyPair(t, 2048)
+	key := keyPair.PublicKey
+
+	user := GetGoogleIdentityTerratestEnvVar(t)
+
+	ImportSSHKey(t, user, key)
+}
+
+func TestGetLoginProfile(t *testing.T) {
+	t.Parallel()
+
+	user := GetGoogleIdentityTerratestEnvVar(t)
+	GetLoginProfile(t, user)
+}
+
+func TestSetOSLoginKey(t *testing.T) {
+	t.Parallel()
+
+	keyPair := ssh.GenerateRSAKeyPair(t, 2048)
+	key := keyPair.PublicKey
+
+	user := GetGoogleIdentityTerratestEnvVar(t)
+
+	ImportSSHKey(t, user, key)
+	loginProfile := GetLoginProfile(t, user)
+
+	found := false
+	for _, v := range loginProfile.SshPublicKeys {
+		if key == v.Key {
+			found = true
+		}
+	}
+
+	if found != true {
+		t.Fatalf("Did not find key in login profile for user %s", user)
+	}
+}

--- a/modules/gcp/oslogin_test.go
+++ b/modules/gcp/oslogin_test.go
@@ -12,7 +12,7 @@ func TestImportSSHKeyOSLogin(t *testing.T) {
 	keyPair := ssh.GenerateRSAKeyPair(t, 2048)
 	key := keyPair.PublicKey
 
-	user := GetGoogleIdentityTerratestEnvVar(t)
+	user := GetGoogleIdentityEmailEnvVar(t)
 
 	ImportSSHKey(t, user, key)
 }
@@ -20,7 +20,7 @@ func TestImportSSHKeyOSLogin(t *testing.T) {
 func TestGetLoginProfile(t *testing.T) {
 	t.Parallel()
 
-	user := GetGoogleIdentityTerratestEnvVar(t)
+	user := GetGoogleIdentityEmailEnvVar(t)
 	GetLoginProfile(t, user)
 }
 
@@ -30,7 +30,7 @@ func TestSetOSLoginKey(t *testing.T) {
 	keyPair := ssh.GenerateRSAKeyPair(t, 2048)
 	key := keyPair.PublicKey
 
-	user := GetGoogleIdentityTerratestEnvVar(t)
+	user := GetGoogleIdentityEmailEnvVar(t)
 
 	ImportSSHKey(t, user, key)
 	loginProfile := GetLoginProfile(t, user)

--- a/modules/gcp/provider.go
+++ b/modules/gcp/provider.go
@@ -27,8 +27,8 @@ var regionEnvVars = []string{
 	"CLOUDSDK_COMPUTE_REGION",
 }
 
-var googleIdentityEnvVars = []string{
-	"GOOGLE_IDENTITY_TERRATEST",
+var googleIdentityEmailEnvVars = []string{
+	"GOOGLE_IDENTITY_EMAIL",
 }
 
 // GetGoogleCredentialsFromEnvVar returns the Credentials for use with testing.
@@ -46,7 +46,7 @@ func GetGoogleRegionFromEnvVar(t *testing.T) string {
 	return environment.GetFirstNonEmptyEnvVarOrFatal(t, regionEnvVars)
 }
 
-// GetGoogleIdentityTerratestEnvVar returns a Google identity (user) for use with testing.
-func GetGoogleIdentityTerratestEnvVar(t *testing.T) string {
-	return environment.GetFirstNonEmptyEnvVarOrFatal(t, googleIdentityEnvVars)
+// GetGoogleIdentityEmailEnvVar returns a Google identity (user) for use with testing.
+func GetGoogleIdentityEmailEnvVar(t *testing.T) string {
+	return environment.GetFirstNonEmptyEnvVarOrFatal(t, googleIdentityEmailEnvVars)
 }

--- a/modules/gcp/provider.go
+++ b/modules/gcp/provider.go
@@ -27,6 +27,10 @@ var regionEnvVars = []string{
 	"CLOUDSDK_COMPUTE_REGION",
 }
 
+var googleIdentityEnvVars = []string{
+	"GOOGLE_IDENTITY_TERRATEST",
+}
+
 // GetGoogleCredentialsFromEnvVar returns the Credentials for use with testing.
 func GetGoogleCredentialsFromEnvVar(t *testing.T) string {
 	return environment.GetFirstNonEmptyEnvVarOrEmptyString(t, credsEnvVars)
@@ -40,4 +44,9 @@ func GetGoogleProjectIDFromEnvVar(t *testing.T) string {
 // GetGoogleRegionFromEnvVar returns the Region for use with testing.
 func GetGoogleRegionFromEnvVar(t *testing.T) string {
 	return environment.GetFirstNonEmptyEnvVarOrFatal(t, regionEnvVars)
+}
+
+// GetGoogleIdentityTerratestEnvVar returns a Google identity (user) for use with testing.
+func GetGoogleIdentityTerratestEnvVar(t *testing.T) string {
+	return environment.GetFirstNonEmptyEnvVarOrFatal(t, googleIdentityEnvVars)
 }


### PR DESCRIPTION
This allows users to configure a single SSH key for access to Google Compute Engine VM instances using their Google identity (eg: Gmail, GSuite account).