### PR TITLE
Fix spelling mistake in README about Debugging

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,7 +357,7 @@ To use the utility, you simply give it the log output from a `go test` run and a
 
 ```bash
 go test -timeout 30m | tee test_output.log
-terratest_log_parser -testlog test_ouptut.log -outputdir test_output
+terratest_log_parser -testlog test_output.log -outputdir test_output
 ```
 
 This will:


### PR DESCRIPTION
In command example for `Debugging interleaved test output` the log file's name was misspelled in the second command invocation. As written the command would fail.

This does not change any tool code or tests. Purely a documentation improvement.