### PR TITLE
Fix k8s dep

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -24,6 +24,17 @@
 #   go-tests = true
 #   unused-packages = true
 
+# These dependencies are not directly required by terratest, but are defined here to directly hook them up so that they
+# are version locked when it is pulled in by projects depending on terratest.
+# This is necessary because kubernetes apimachinery and client-go do not support dep natively, and so overrides are
+# necessary to make it work.
+# See for more info:
+# - https://github.com/kubernetes/client-go/blob/kubernetes-1.11.3/INSTALL.md#dep-not-supported-yet
+# - https://golang.github.io/dep/docs/FAQ.html#how-do-i-constrain-a-transitive-dependency-s-version
+require = [
+    "github.com/json-iterator/go",
+]
+
 
 [[constraint]]
   name = "github.com/aws/aws-sdk-go"
@@ -80,3 +91,7 @@
 [[constraint]]
   branch = "release-9.0"
   name = "k8s.io/client-go"
+
+[[constraint]]
+  name = "github.com/json-iterator/go"
+  version = "v1.1.5"


### PR DESCRIPTION
Because Kubernetes doesn't support dep, the dependencies of apimachinery and client-go for Kubernetes are free floating. This caused some issues when bootstrapping a new project on terratest, where one of the dependencies had a breaking change that was pulled in.

This fixes the current breaking change, and also introduces a pattern for fixing it. Specifically:

- Transitive dependencies should be locked using `constraint` and not `override` (if you use `override`, it isn't pulled in for projects depending on terratest).
- To make `dep` work, each transitive dependency locked using `constraint` need to be forced into a direct dependency by adding it into the `required` list.