### PR TITLE
Change EC2 to RDS and point to correct example

### DIFF
--- a/test/terraform_aws_rds_example_test.go
+++ b/test/terraform_aws_rds_example_test.go
@@ -11,13 +11,13 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// An example of how to test the Terraform module in examples/terraform-aws-example using Terratest.
+// An example of how to test the Terraform module in examples/terraform-aws-rds-example using Terratest.
 func TestTerraformAwsRdsExample(t *testing.T) {
 	t.Parallel()
 
-	// Give this EC2 Instance a unique ID for a name tag so we can distinguish it from any other EC2 Instance running
+	// Give this RDS Instance a unique ID for a name tag so we can distinguish it from any other RDS Instance running
 	// in your AWS account
-	expectedName := fmt.Sprintf("terratest-aws-example-%s", strings.ToLower(random.UniqueId()))
+	expectedName := fmt.Sprintf("terratest-aws-rds-example-%s", strings.ToLower(random.UniqueId()))
 	expectedPort := int64(3306)
 	expectedDatabaseName := "terratest"
 	username := "username"


### PR DESCRIPTION
The rds example looks like it has a few copy/paste artifacts. Cleaning those up to ensure consistency. I'm unable to actually get this test running as it continually times out at 10 mins.