### PR TITLE
k8s ingress functions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,67 +12,6 @@ defaults: &defaults
     K8S_VERSION: v1.10.0  # Same as EKS
     HELM_VERSION: v2.12.2
     KUBECONFIG: /home/circleci/.kube/config
-    MINIKUBE_VERSION: v0.28.2  # See https://github.com/kubernetes/minikube/issues/2704
-    MINIKUBE_WANTUPDATENOTIFICATION: "false"
-    MINIKUBE_WANTREPORTERRORPROMPT: "false"
-    MINIKUBE_HOME: /home/circleci
-    CHANGE_MINIKUBE_NONE_USER: "true"
-
-
-# Install and setup minikube
-# https://github.com/kubernetes/minikube#linux-continuous-integration-without-vm-support
-setup_minikube: &setup_minikube
-  name: install helm, kubectl and minikube
-  working_directory: /tmp
-  command: |
-    # Install yq so we can modify the configmap
-    sudo add-apt-repository ppa:rmescandon/yq
-    sudo apt-get update
-    sudo apt install -y yq
-
-    # install kubectl
-    curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/${K8S_VERSION}/bin/linux/amd64/kubectl
-    chmod +x kubectl
-    sudo mv kubectl /usr/local/bin/
-    mkdir -p ${HOME}/.kube
-    touch ${HOME}/.kube/config
-
-    # Install minikube
-    curl -Lo minikube https://github.com/kubernetes/minikube/releases/download/${MINIKUBE_VERSION}/minikube-linux-amd64
-    chmod +x minikube
-    sudo mv minikube /usr/local/bin/
-
-    # start minikube and wait for it
-    # Ignore warnings on minikube start command, as it will log a warning due to using deprecated localkube
-    # bootstrapper. However, the localkube bootstrapper is necessary to run on CircleCI which doesn't have
-    # systemd.
-    sudo -E minikube start \
-      --vm-driver=none \
-      --kubernetes-version=${K8S_VERSION} \
-      --bootstrapper=localkube \
-      --extra-config=apiserver.Authorization.Mode=RBAC \
-      --cpus 2 --memory 4096
-
-    # this for loop waits until kubectl can access the api server that Minikube has created
-    $(
-      for i in {1..150}; do # timeout for 5 minutes
-        kubectl get po &> /dev/null
-        if [ $? -ne 1 ]; then
-          break
-        fi
-        sleep 2
-      done
-      true
-    )
-
-    # Make sure to grant the default service account cluster admin rights so helm and ingress controller works
-    kubectl create clusterrolebinding default-service-account-cluster-admin-binding --clusterrole cluster-admin --serviceaccount kube-system:default
-
-    # Update the configmap to disable SSL since we won't have certs
-    kubectl get configmap -n kube-system nginx-load-balancer-conf -o yaml | yq write - data.ssl-redirect "\"false\"" | kubectl replace -f -
-
-    # Finally we wait for the rollout
-    kubectl rollout status -n kube-system deployment/nginx-ingress-controller --watch
 
 
 install_helm: &install_helm
@@ -93,6 +32,7 @@ install_gruntwork_utils: &install_gruntwork_utils
   command: |
     curl -Ls https://raw.githubusercontent.com/gruntwork-io/gruntwork-installer/master/bootstrap-gruntwork-installer.sh | bash /dev/stdin --version "${GRUNTWORK_INSTALLER_VERSION}"
     gruntwork-install --module-name "gruntwork-module-circleci-helpers" --repo "https://github.com/gruntwork-io/module-ci" --tag "${MODULE_CI_VERSION}"
+    gruntwork-install --module-name "kubernetes-circleci-helpers" --repo "https://github.com/gruntwork-io/module-ci" --branch yori-add-k8s
     configure-environment-for-gruntwork-module \
       --circle-ci-2-machine-executor \
       --terraform-version ${TERRAFORM_VERSION} \
@@ -195,7 +135,7 @@ jobs:
       - run: echo 'export PATH=$HOME/.local/bin:$HOME/terraform:$HOME/packer:$PATH' >> $BASH_ENV
 
       - run:
-          <<: *setup_minikube
+          command: setup-minikube
 
       # Run the Kubernetes tests. These tests are run because the kubernetes build tag is included, and we explicitly
       # select the kubernetes tests
@@ -231,7 +171,7 @@ jobs:
       - run: echo 'export PATH=$HOME/.local/bin:$HOME/terraform:$HOME/packer:$PATH' >> $BASH_ENV
 
       - run:
-          <<: *setup_minikube
+          command: setup-minikube
 
       - run:
           <<: *install_helm

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,7 @@
 defaults: &defaults
-  machine: true
+  machine:
+    enabled: true
+    image: "ubuntu-1604:201903-01"
   environment:
     GRUNTWORK_INSTALLER_VERSION: v0.0.21
     MODULE_CI_VERSION: v0.13.3
@@ -23,6 +25,11 @@ setup_minikube: &setup_minikube
   name: install helm, kubectl and minikube
   working_directory: /tmp
   command: |
+    # Install yq so we can modify the configmap
+    sudo add-apt-repository ppa:rmescandon/yq
+    sudo apt-get update
+    sudo apt install -y yq
+
     # install kubectl
     curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/${K8S_VERSION}/bin/linux/amd64/kubectl
     chmod +x kubectl
@@ -39,7 +46,13 @@ setup_minikube: &setup_minikube
     # Ignore warnings on minikube start command, as it will log a warning due to using deprecated localkube
     # bootstrapper. However, the localkube bootstrapper is necessary to run on CircleCI which doesn't have
     # systemd.
-    sudo -E minikube start --vm-driver=none --kubernetes-version=${K8S_VERSION} --bootstrapper=localkube --extra-config=apiserver.Authorization.Mode=RBAC
+    sudo -E minikube start \
+      --vm-driver=none \
+      --kubernetes-version=${K8S_VERSION} \
+      --bootstrapper=localkube \
+      --extra-config=apiserver.Authorization.Mode=RBAC \
+      --cpus 2 --memory 4096
+
     # this for loop waits until kubectl can access the api server that Minikube has created
     $(
       for i in {1..150}; do # timeout for 5 minutes
@@ -52,6 +65,15 @@ setup_minikube: &setup_minikube
       true
     )
 
+    # Make sure to grant the default service account cluster admin rights so helm and ingress controller works
+    kubectl create clusterrolebinding default-service-account-cluster-admin-binding --clusterrole cluster-admin --serviceaccount kube-system:default
+
+    # Update the configmap to disable SSL since we won't have certs
+    kubectl get configmap -n kube-system nginx-load-balancer-conf -o yaml | yq write - data.ssl-redirect "\"false\"" | kubectl replace -f -
+
+    # Finally we wait for the rollout
+    kubectl rollout status -n kube-system deployment/nginx-ingress-controller --watch
+
 
 install_helm: &install_helm
   name: install helm
@@ -61,9 +83,6 @@ install_helm: &install_helm
     tar -xvf helm.tar.gz
     chmod +x linux-amd64/helm
     sudo mv linux-amd64/helm /usr/local/bin/
-
-    # Grant the default service account cluster admin rights so helm works
-    kubectl create clusterrolebinding default-service-account-cluster-admin-binding --clusterrole cluster-admin --serviceaccount kube-system:default
 
     # Deploy Tiller
     helm init --wait

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ defaults: &defaults
     image: "ubuntu-1604:201903-01"
   environment:
     GRUNTWORK_INSTALLER_VERSION: v0.0.21
-    MODULE_CI_VERSION: v0.13.3
+    MODULE_CI_VERSION: v0.13.4
     TERRAFORM_VERSION: 0.11.11
     TERRAGRUNT_VERSION: NONE
     PACKER_VERSION: 1.3.3

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -861,6 +861,7 @@
     "k8s.io/api/apps/v1",
     "k8s.io/api/authorization/v1",
     "k8s.io/api/core/v1",
+    "k8s.io/api/extensions/v1beta1",
     "k8s.io/api/rbac/v1",
     "k8s.io/apimachinery/pkg/apis/meta/v1",
     "k8s.io/client-go/kubernetes",

--- a/modules/k8s/errors.go
+++ b/modules/k8s/errors.go
@@ -4,8 +4,18 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
+	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+// IngressNotAvailable is returned when a Kubernetes service is not yet available to accept traffic.
+type IngressNotAvailable struct {
+	ingress *extensionsv1beta1.Ingress
+}
+
+func (err IngressNotAvailable) Error() string {
+	return fmt.Sprintf("Ingress %s is not available", err.ingress.Name)
+}
 
 // UnknownKubeResourceType is returned if the given resource type does not match the list of known resource types.
 type UnknownKubeResourceType struct {

--- a/modules/k8s/ingress.go
+++ b/modules/k8s/ingress.go
@@ -3,6 +3,7 @@ package k8s
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
@@ -36,15 +37,15 @@ func ListIngressesE(t *testing.T, options *KubectlOptions, filters metav1.ListOp
 
 // GetIngress returns a Kubernetes Ingress resource in the provided namespace with the given name. This will fail the
 // test if there is an error.
-func GetIngress(t *testing.T, options *k8s.KubectlOptions, ingressName string) *extensionsv1beta1.Ingress {
+func GetIngress(t *testing.T, options *KubectlOptions, ingressName string) *extensionsv1beta1.Ingress {
 	ingress, err := GetIngressE(t, options, ingressName)
 	require.NoError(t, err)
 	return ingress
 }
 
 // GetIngressE returns a Kubernetes Ingress resource in the provided namespace with the given name.
-func GetIngressE(t *testing.T, options *k8s.KubectlOptions, ingressName string) (*extensionsv1beta1.Ingress, error) {
-	clientset, err := k8s.GetKubernetesClientFromOptionsE(t, options)
+func GetIngressE(t *testing.T, options *KubectlOptions, ingressName string) (*extensionsv1beta1.Ingress, error) {
+	clientset, err := GetKubernetesClientFromOptionsE(t, options)
 	if err != nil {
 		return nil, err
 	}

--- a/modules/k8s/ingress.go
+++ b/modules/k8s/ingress.go
@@ -1,0 +1,81 @@
+package k8s
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/gruntwork-io/terratest/modules/logger"
+	"github.com/gruntwork-io/terratest/modules/retry"
+)
+
+// ListIngresses will look for Ingress resources in the given namespace that match the given filters and return them.
+// This will fail the test if there is an error.
+func ListIngresses(t *testing.T, options *KubectlOptions, filters metav1.ListOptions) []extensionsv1beta1.Ingress {
+	ingresses, err := ListIngressesE(t, options, filters)
+	require.NoError(t, err)
+	return ingresses
+}
+
+// ListIngressesE will look for Ingress resources in the given namespace that match the given filters and return them.
+func ListIngressesE(t *testing.T, options *KubectlOptions, filters metav1.ListOptions) ([]extensionsv1beta1.Ingress, error) {
+	clientset, err := GetKubernetesClientFromOptionsE(t, options)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := clientset.ExtensionsV1beta1().Ingresses(options.Namespace).List(filters)
+	if err != nil {
+		return nil, err
+	}
+	return resp.Items, nil
+
+}
+
+// GetIngress returns a Kubernetes Ingress resource in the provided namespace with the given name. This will fail the
+// test if there is an error.
+func GetIngress(t *testing.T, options *k8s.KubectlOptions, ingressName string) *extensionsv1beta1.Ingress {
+	ingress, err := GetIngressE(t, options, ingressName)
+	require.NoError(t, err)
+	return ingress
+}
+
+// GetIngressE returns a Kubernetes Ingress resource in the provided namespace with the given name.
+func GetIngressE(t *testing.T, options *k8s.KubectlOptions, ingressName string) (*extensionsv1beta1.Ingress, error) {
+	clientset, err := k8s.GetKubernetesClientFromOptionsE(t, options)
+	if err != nil {
+		return nil, err
+	}
+	return clientset.ExtensionsV1beta1().Ingresses(options.Namespace).Get(ingressName, metav1.GetOptions{})
+}
+
+// IsIngressAvailable returns true if the Ingress endpoint is provisioned and available.
+func IsIngressAvailable(ingress *extensionsv1beta1.Ingress) bool {
+	// Ingress is ready if it has at least one endpoint
+	endpoints := ingress.Status.LoadBalancer.Ingress
+	return len(endpoints) > 0
+}
+
+// WaitUntilIngressAvailable waits until the Ingress resource has an endpoint provisioned for it.
+func WaitUntilIngressAvailable(t *testing.T, options *KubectlOptions, ingressName string, retries int, sleepBetweenRetries time.Duration) {
+	statusMsg := fmt.Sprintf("Wait for ingress %s to be provisioned.", ingressName)
+	message := retry.DoWithRetry(
+		t,
+		statusMsg,
+		retries,
+		sleepBetweenRetries,
+		func() (string, error) {
+			ingress, err := GetIngressE(t, options, ingressName)
+			if err != nil {
+				return "", err
+			}
+			if !IsIngressAvailable(ingress) {
+				return "", IngressNotAvailable{ingress: ingress}
+			}
+			return "Ingress is now available", nil
+		},
+	)
+	logger.Logf(t, message)
+}

--- a/modules/k8s/ingress_test.go
+++ b/modules/k8s/ingress_test.go
@@ -73,7 +73,7 @@ func TestWaitUntilIngressAvailableReturnsSuccessfully(t *testing.T) {
 	KubectlApplyFromString(t, options, configData)
 	defer KubectlDeleteFromString(t, options, configData)
 
-	WaitUntilIngressAvailable(t, options, ExampleIngressName, 10, 1*time.Second)
+	WaitUntilIngressAvailable(t, options, ExampleIngressName, 60, 5*time.Second)
 }
 
 const EXAMPLE_INGRESS_DEPLOYMENT_YAML_TEMPLATE = `---

--- a/modules/k8s/ingress_test.go
+++ b/modules/k8s/ingress_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	http_helper "github.com/gruntwork-io/terratest/modules/http-helper"
 	"github.com/gruntwork-io/terratest/modules/random"
 )
 
@@ -125,8 +124,10 @@ metadata:
   namespace: %s
 spec:
   rules:
-  - path: /app
-    backend:
-	  serviceName: nginx-service
-	  servicePort: 80
+  - http:
+      paths:
+      - path: /app
+        backend:
+          serviceName: nginx-service
+          servicePort: 80
 `

--- a/modules/k8s/ingress_test.go
+++ b/modules/k8s/ingress_test.go
@@ -1,0 +1,132 @@
+// +build kubernetes
+
+// NOTE: we have build tags to differentiate kubernetes tests from non-kubernetes tests. This is done because minikube
+// is heavy and can interfere with docker related tests in terratest. Specifically, many of the tests start to fail with
+// `connection refused` errors from `minikube`. To avoid overloading the system, we run the kubernetes tests and helm
+// tests separately from the others. This may not be necessary if you have a sufficiently powerful machine.  We
+// recommend at least 4 cores and 16GB of RAM if you want to run all the tests together.
+
+package k8s
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	http_helper "github.com/gruntwork-io/terratest/modules/http-helper"
+	"github.com/gruntwork-io/terratest/modules/random"
+)
+
+const ExampleIngressName = "nginx-service-ingress"
+
+func TestGetIngressEReturnsErrorForNonExistantIngress(t *testing.T) {
+	t.Parallel()
+
+	options := NewKubectlOptions("", "")
+	_, err := GetIngressE(t, options, "i-dont-exist")
+	require.Error(t, err)
+}
+
+func TestGetIngressEReturnsCorrectIngressInCorrectNamespace(t *testing.T) {
+	t.Parallel()
+
+	uniqueID := strings.ToLower(random.UniqueId())
+	options := NewKubectlOptions("", "")
+	options.Namespace = uniqueID
+	configData := fmt.Sprintf(EXAMPLE_INGRESS_DEPLOYMENT_YAML_TEMPLATE, uniqueID, uniqueID, uniqueID, uniqueID)
+	KubectlApplyFromString(t, options, configData)
+	defer KubectlDeleteFromString(t, options, configData)
+
+	service := GetIngress(t, options, "nginx-service-ingress")
+	require.Equal(t, service.Name, "nginx-service-ingress")
+	require.Equal(t, service.Namespace, uniqueID)
+}
+
+func TestListIngressesReturnsCorrectIngressInCorrectNamespace(t *testing.T) {
+	t.Parallel()
+
+	uniqueID := strings.ToLower(random.UniqueId())
+	options := NewKubectlOptions("", "")
+	options.Namespace = uniqueID
+	configData := fmt.Sprintf(EXAMPLE_INGRESS_DEPLOYMENT_YAML_TEMPLATE, uniqueID, uniqueID, uniqueID, uniqueID)
+	KubectlApplyFromString(t, options, configData)
+	defer KubectlDeleteFromString(t, options, configData)
+
+	ingresses := ListIngresses(t, options, metav1.ListOptions{})
+	require.Equal(t, len(ingresses), 1)
+
+	ingress := ingresses[0]
+	require.Equal(t, ingress.Name, ExampleIngressName)
+	require.Equal(t, ingress.Namespace, uniqueID)
+}
+
+func TestWaitUntilIngressAvailableReturnsSuccessfully(t *testing.T) {
+	t.Parallel()
+
+	uniqueID := strings.ToLower(random.UniqueId())
+	options := NewKubectlOptions("", "")
+	options.Namespace = uniqueID
+	configData := fmt.Sprintf(EXAMPLE_INGRESS_DEPLOYMENT_YAML_TEMPLATE, uniqueID, uniqueID, uniqueID, uniqueID)
+	KubectlApplyFromString(t, options, configData)
+	defer KubectlDeleteFromString(t, options, configData)
+
+	WaitUntilIngressAvailable(t, options, ExampleIngressName, 10, 1*time.Second)
+}
+
+const EXAMPLE_INGRESS_DEPLOYMENT_YAML_TEMPLATE = `---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: %s
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+  namespace: %s
+spec:
+  selector:
+    matchLabels:
+      app: nginx
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.15.7
+        ports:
+        - containerPort: 80
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: nginx-service
+  namespace: %s
+spec:
+  selector:
+    app: nginx
+  ports:
+  - protocol: TCP
+    targetPort: 80
+    port: 80
+  type: NodePort
+---
+kind: Ingress
+apiVersion: extensions/v1beta1
+metadata:
+  name: nginx-service-ingress
+  namespace: %s
+spec:
+  rules:
+  - path: /app
+    backend:
+	  serviceName: nginx-service
+	  servicePort: 80
+`


### PR DESCRIPTION
__NOTE: This is blocked on a feature being implemented in `module-ci` to share a common script for setting up minikube__

This implements the following functions in the `k8s` module for helping with testing Ingress resources:
- `ListIngresses` and `ListIngressesE` for listing all the Ingress resources available in the cluster.
- `GetIngress` and `GetIngressE` for getting a single Ingress resource by name from the cluster.
- `IsIngressAvailable` which tells you if an Ingress is available to accept requests.
- `WaitUntilIngressAvailable` which will wait until the given ingress resource (by name) is available to accept requests (with timeout).