### PR TITLE
Add support for Terraform 12

### DIFF
--- a/modules/terraform/format.go
+++ b/modules/terraform/format.go
@@ -157,6 +157,6 @@ func primitiveToHclString(value interface{}) string {
 	//case int: return strconv.Itoa(v)
 
 	default:
-		return fmt.Sprintf("\"%v\"", v)
+		return fmt.Sprintf("%v", v)
 	}
 }

--- a/modules/terraform/format.go
+++ b/modules/terraform/format.go
@@ -148,9 +148,9 @@ func primitiveToHclString(value interface{}) string {
 	// (https://github.com/hashicorp/terraform/issues/7962), all ints must be wrapped as strings.
 	case bool:
 		if v {
-			return "\"1\""
+			return "1"
 		}
-		return "\"0\""
+		return "0"
 
 	// Note: due to a Terraform bug (https://github.com/hashicorp/terraform/issues/7962), we can't use proper HCL
 	// syntax for ints have to wrap them as strings by falling through to the default case

--- a/modules/terraform/format_test.go
+++ b/modules/terraform/format_test.go
@@ -15,14 +15,14 @@ func TestFormatTerraformVarsAsArgs(t *testing.T) {
 		expected []string
 	}{
 		{map[string]interface{}{}, nil},
-		{map[string]interface{}{"foo": "bar"}, []string{"-var", "foo=\"bar\""}},
-		{map[string]interface{}{"foo": 123}, []string{"-var", "foo=\"123\""}},
-		{map[string]interface{}{"foo": true}, []string{"-var", "foo=\"1\""}},
-		{map[string]interface{}{"foo": []int{1, 2, 3}}, []string{"-var", "foo=[\"1\", \"2\", \"3\"]"}},
-		{map[string]interface{}{"foo": map[string]string{"baz": "blah"}}, []string{"-var", "foo={baz = \"blah\"}"}},
+		{map[string]interface{}{"foo": "bar"}, []string{"-var", "foo=bar"}},
+		{map[string]interface{}{"foo": 123}, []string{"-var", "foo=123"}},
+		{map[string]interface{}{"foo": true}, []string{"-var", "foo=1"}},
+		{map[string]interface{}{"foo": []int{1, 2, 3}}, []string{"-var", "foo=[1, 2, 3]"}},
+		{map[string]interface{}{"foo": map[string]string{"baz": "blah"}}, []string{"-var", "foo={baz = blah}"}},
 		{
 			map[string]interface{}{"str": "bar", "int": -1, "bool": false, "list": []string{"foo", "bar", "baz"}, "map": map[string]int{"foo": 0}},
-			[]string{"-var", "str=\"bar\"", "-var", "int=\"-1\"", "-var", "bool=\"0\"", "-var", "list=[\"foo\", \"bar\", \"baz\"]", "-var", "map={foo = \"0\"}"},
+			[]string{"-var", "str=bar", "-var", "int=-1", "-var", "bool=0", "-var", "list=[foo, bar, baz]", "-var", "map={foo = 0}"},
 		},
 	}
 
@@ -40,12 +40,12 @@ func TestPrimitiveToHclString(t *testing.T) {
 		value    interface{}
 		expected string
 	}{
-		{"", "\"\""},
-		{"foo", "\"foo\""},
-		{"true", "\"true\""},
-		{true, "\"1\""},
-		{3, "\"3\""},
-		{[]int{1, 2, 3}, "\"[1 2 3]\""}, // Anything that isn't a primitive is forced into a string
+		{"", ""},
+		{"foo", "foo"},
+		{"true", "true"},
+		{true, "1"},
+		{3, "3"},
+		{[]int{1, 2, 3}, "[1 2 3]"}, // Anything that isn't a primitive is forced into a string
 	}
 
 	for _, testCase := range testCases {
@@ -62,11 +62,11 @@ func TestMapToHclString(t *testing.T) {
 		expected string
 	}{
 		{map[string]interface{}{}, "{}"},
-		{map[string]interface{}{"key1": "value1"}, "{key1 = \"value1\"}"},
-		{map[string]interface{}{"key1": 123}, "{key1 = \"123\"}"},
-		{map[string]interface{}{"key1": true}, "{key1 = \"1\"}"},
-		{map[string]interface{}{"key1": []int{1, 2, 3}}, "{key1 = [\"1\", \"2\", \"3\"]}"}, // Any value that isn't a primitive is forced into a string
-		{map[string]interface{}{"key1": "value1", "key2": 0, "key3": false}, "{key1 = \"value1\", key2 = \"0\", key3 = \"0\"}"},
+		{map[string]interface{}{"key1": "value1"}, "{key1 = value1}"},
+		{map[string]interface{}{"key1": 123}, "{key1 = 123}"},
+		{map[string]interface{}{"key1": true}, "{key1 = 1}"},
+		{map[string]interface{}{"key1": []int{1, 2, 3}}, "{key1 = [1, 2, 3]}"}, // Any value that isn't a primitive is forced into a string
+		{map[string]interface{}{"key1": "value1", "key2": 0, "key3": false}, "{key1 = value1, key2 = 0, key3 = 0}"},
 	}
 
 	for _, testCase := range testCases {
@@ -116,13 +116,13 @@ func TestSliceToHclString(t *testing.T) {
 		expected string
 	}{
 		{[]interface{}{}, "[]"},
-		{[]interface{}{"foo"}, "[\"foo\"]"},
-		{[]interface{}{123}, "[\"123\"]"},
-		{[]interface{}{true}, "[\"1\"]"},
-		{[]interface{}{[]int{1, 2, 3}}, "[[\"1\", \"2\", \"3\"]]"}, // Any value that isn't a primitive is forced into a string
-		{[]interface{}{"foo", 0, false}, "[\"foo\", \"0\", \"0\"]"},
-		{[]interface{}{map[string]interface{}{"foo": "bar"}}, "[{foo = \"bar\"}]"},
-		{[]interface{}{map[string]interface{}{"foo": "bar"}, map[string]interface{}{"foo": "bar"}}, "[{foo = \"bar\"}, {foo = \"bar\"}]"},
+		{[]interface{}{"foo"}, "[foo]"},
+		{[]interface{}{123}, "[123]"},
+		{[]interface{}{true}, "[1]"},
+		{[]interface{}{[]int{1, 2, 3}}, "[[1, 2, 3]]"}, // Any value that isn't a primitive is forced into a string
+		{[]interface{}{"foo", 0, false}, "[foo, 0, 0]"},
+		{[]interface{}{map[string]interface{}{"foo": "bar"}}, "[{foo = bar}]"},
+		{[]interface{}{map[string]interface{}{"foo": "bar"}, map[string]interface{}{"foo": "bar"}}, "[{foo = bar}, {foo = bar}]"},
 	}
 
 	for _, testCase := range testCases {
@@ -138,14 +138,14 @@ func TestToHclString(t *testing.T) {
 		value    interface{}
 		expected string
 	}{
-		{"", "\"\""},
-		{"foo", "\"foo\""},
-		{123, "\"123\""},
-		{true, "\"1\""},
-		{[]int{1, 2, 3}, "[\"1\", \"2\", \"3\"]"},
-		{[]string{"foo", "bar", "baz"}, "[\"foo\", \"bar\", \"baz\"]"},
-		{map[string]string{"key1": "value1"}, "{key1 = \"value1\"}"},
-		{map[string]int{"key1": 123}, "{key1 = \"123\"}"},
+		{"", ""},
+		{"foo", "foo"},
+		{123, "123"},
+		{true, "1"},
+		{[]int{1, 2, 3}, "[1, 2, 3]"},
+		{[]string{"foo", "bar", "baz"}, "[foo, bar, baz]"},
+		{map[string]string{"key1": "value1"}, "{key1 = value1}"},
+		{map[string]int{"key1": 123}, "{key1 = 123}"},
 	}
 
 	for _, testCase := range testCases {


### PR DESCRIPTION
This PR updates the formatting for variables passed using the `-var` option by removing the surrounding quotes. Text that contain spaces are still passed properly. This change also works with Terraform 11.