### PR TITLE
Add VarFiles flag to packer Options

### DIFF
--- a/modules/packer/packer.go
+++ b/modules/packer/packer.go
@@ -17,6 +17,7 @@ import (
 type Options struct {
 	Template string            // The path to the Packer template
 	Vars     map[string]string // The custom vars to pass when running the build command
+	VarFiles []string          // Var file paths to pass Packer using -var-file option
 	Only     string            // If specified, only run the build of this name
 	Env      map[string]string // Custom environment variables to set when running Packer
 }
@@ -138,6 +139,10 @@ func formatPackerArgs(options *Options) []string {
 
 	for key, value := range options.Vars {
 		args = append(args, "-var", fmt.Sprintf("%s=%s", key, value))
+	}
+
+	for _, file_path := range options.VarFiles {
+		args = append(args, "-var-file", file_path)
 	}
 
 	if options.Only != "" {

--- a/modules/packer/packer_test.go
+++ b/modules/packer/packer_test.go
@@ -2,6 +2,7 @@ package packer
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 )
 
@@ -115,5 +116,53 @@ func TestExtractArtifactINoIdPresent(t *testing.T) {
 
 	if err == nil {
 		t.Error("Expected to get an error when extracting an Artifact ID from text with no Artifact ID in it, but got nil")
+	}
+}
+
+func TestFormatPackerArgs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		option   *Options
+		expected string
+	}{
+		{
+			option: &Options{
+				Template: "packer.json",
+			},
+			expected: "build -machine-readable packer.json",
+		},
+		{
+			option: &Options{
+				Template: "packer.json",
+				Vars: map[string]string{
+					"foo": "bar",
+				},
+				Only: "onlythis",
+			},
+			expected: "build -machine-readable -var foo=bar -only=onlythis packer.json",
+		},
+		{
+			option: &Options{
+				Template: "packer.json",
+				Vars: map[string]string{
+					"foo": "bar",
+				},
+				VarFiles: []string{
+					"foofile.json",
+				},
+			},
+			expected: "build -machine-readable -var foo=bar -var-file foofile.json packer.json",
+		},
+	}
+
+	for _, test := range tests {
+		args := formatPackerArgs(test.option)
+		if strings.Join(args, " ") != test.expected {
+			t.Errorf("Did not get expected formatted packer args. Expected: %s. Actual: %s",
+				test.expected,
+				args,
+			)
+		}
 	}
 }

--- a/modules/packer/packer_test.go
+++ b/modules/packer/packer_test.go
@@ -160,8 +160,6 @@ func TestFormatPackerArgs(t *testing.T) {
 
 	for _, test := range tests {
 		args := formatPackerArgs(test.option)
-		if strings.Join(args, " ") != test.expected {
-			assert.Equal(t, strings.Join(args, " "), test.expected)
-		}
+		assert.Equal(t, strings.Join(args, " "), test.expected)
 	}
 }

--- a/modules/packer/packer_test.go
+++ b/modules/packer/packer_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestExtractAmiIdFromOneLine(t *testing.T) {
@@ -159,10 +161,7 @@ func TestFormatPackerArgs(t *testing.T) {
 	for _, test := range tests {
 		args := formatPackerArgs(test.option)
 		if strings.Join(args, " ") != test.expected {
-			t.Errorf("Did not get expected formatted packer args. Expected: %s. Actual: %s",
-				test.expected,
-				args,
-			)
+			assert.Equal(t, strings.Join(args, " "), test.expected)
 		}
 	}
 }

--- a/test/packer_basic_example_test.go
+++ b/test/packer_basic_example_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gruntwork-io/terratest/modules/packer"
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // An example of how to test the Packer template in examples/packer-basic-example using Terratest.
@@ -66,7 +67,7 @@ func TestPackerBasicExampleWithVarFile(t *testing.T) {
 
 	// Create temporary packer variable file to store aws region
 	varFile, err := ioutil.TempFile("", "*.json")
-	assert.NoError(t, err, "Did not expect temp file creation to cause error")
+	require.NoError(t, err, "Did not expect temp file creation to cause error")
 
 	// Be sure to clean up temp file
 	defer os.Remove(varFile.Name())
@@ -74,7 +75,7 @@ func TestPackerBasicExampleWithVarFile(t *testing.T) {
 	// Write random generated aws region to temporary json file
 	varFileContent := []byte(fmt.Sprintf("{ \"aws_region\": \"%s\" }", awsRegion))
 	_, err = varFile.Write(varFileContent)
-	assert.NoError(t, err, "Did not expect writing to temp file %s to cause error", varFile.Name())
+	require.NoError(t, err, "Did not expect writing to temp file %s to cause error", varFile.Name())
 
 	packerOptions := &packer.Options{
 		// The path to where the Packer template is located


### PR DESCRIPTION
Hello! This resolves the issue #285 that adds support for the `var-file` option for packer options. In lieu of modifying the [basic packer test](https://github.com/gruntwork-io/terratest/blob/master/test/packer_basic_example_test.go), I added an additional unit test to validate the output of the [formatPackerArgs](https://github.com/gruntwork-io/terratest/blob/master/modules/packer/packer.go#L136) function. However, if that does not suffice, I can update [test/packer_basic_example_test.go](https://github.com/gruntwork-io/terratest/blob/master/test/packer_basic_example_test.go) accordingly! 