### PR TITLE
Fix T12 regression

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -26,7 +26,7 @@
   version = "v0.6.0"
 
 [[projects]]
-  digest = "1:881f40b2f21b424275136d8e134cfc393d7897e52df3fd49d898dc11b1e9fed8"
+  digest = "1:2d250c122b8bac482f51d6a2fbed9252f0d7bdc53f5a324db00061cc5d7254d8"
   name = "github.com/aws/aws-sdk-go"
   packages = [
     "aws",
@@ -74,6 +74,7 @@
     "service/s3/s3manager",
     "service/sns",
     "service/sqs",
+    "service/ssm",
     "service/sts",
   ]
   pruneopts = "UT"
@@ -830,6 +831,7 @@
     "github.com/aws/aws-sdk-go/service/s3/s3manager",
     "github.com/aws/aws-sdk-go/service/sns",
     "github.com/aws/aws-sdk-go/service/sqs",
+    "github.com/aws/aws-sdk-go/service/ssm",
     "github.com/aws/aws-sdk-go/service/sts",
     "github.com/ghodss/yaml",
     "github.com/go-sql-driver/mysql",

--- a/examples/terraform-basic-example/outputs.tf
+++ b/examples/terraform-basic-example/outputs.tf
@@ -5,3 +5,11 @@ output "example" {
 output "example2" {
   value = "${data.template_file.example2.rendered}"
 }
+
+output "example_list" {
+  value = "${var.example_list}"
+}
+
+output "example_map" {
+  value = "${var.example_map}"
+}

--- a/examples/terraform-basic-example/variables.tf
+++ b/examples/terraform-basic-example/variables.tf
@@ -11,7 +11,6 @@
 # You must provide a value for each of these parameters.
 # ---------------------------------------------------------------------------------------------------------------------
 
-
 # ---------------------------------------------------------------------------------------------------------------------
 # OPTIONAL PARAMETERS
 # These parameters have reasonable defaults.
@@ -25,4 +24,16 @@ variable "example" {
 variable "example2" {
   description = "Example variable 2"
   default     = ""
+}
+
+variable "example_list" {
+  description = "An example variable that is a list."
+  type        = "list"
+  default     = []
+}
+
+variable "example_map" {
+  description = "An example variable that is a map."
+  type        = "map"
+  default     = {}
 }

--- a/modules/terraform/format.go
+++ b/modules/terraform/format.go
@@ -57,7 +57,7 @@ func formatTerraformArgs(vars map[string]interface{}, prefix string) []string {
 // arbitrary Go types to an HCL string. Therefore, this method is a simple implementation that correctly handles
 // ints, booleans, lists, and maps. Everything else is forced into a string using Sprintf. Hopefully, this approach is
 // good enough for the type of variables we deal with in Terratest.
-func toHclString(value interface{}, isChild bool) string {
+func toHclString(value interface{}, isNested bool) string {
 	// Ideally, we'd use a type switch here to identify slices and maps, but we can't do that, because Go doesn't
 	// support generics, and the type switch only matches concrete types. So we could match []interface{}, but if
 	// a user passes in []string{}, that would NOT match (the same logic applies to maps). Therefore, we have to
@@ -68,7 +68,7 @@ func toHclString(value interface{}, isChild bool) string {
 	} else if m, isMap := tryToConvertToGenericMap(value); isMap {
 		return mapToHclString(m)
 	} else {
-		return primitiveToHclString(value, isChild)
+		return primitiveToHclString(value, isNested)
 	}
 }
 
@@ -140,7 +140,7 @@ func mapToHclString(m map[string]interface{}) string {
 
 // Convert a primitive, such as a bool, int, or string, to an HCL string. If this isn't a primitive, force its value
 // using Sprintf. See ToHclString for details.
-func primitiveToHclString(value interface{}, isChild bool) string {
+func primitiveToHclString(value interface{}, isNested bool) string {
 	switch v := value.(type) {
 
 	case bool:
@@ -150,8 +150,8 @@ func primitiveToHclString(value interface{}, isChild bool) string {
 		return "0"
 
 	case string:
-		// If string is a child of a larger data structure (e.g. list of string, map of string), ensure value is quoted
-		if isChild {
+		// If string is nested in a larger data structure (e.g. list of string, map of string), ensure value is quoted
+		if isNested {
 			return fmt.Sprintf("\"%v\"", v)
 		}
 

--- a/modules/terraform/format.go
+++ b/modules/terraform/format.go
@@ -44,7 +44,7 @@ func formatTerraformArgs(vars map[string]interface{}, prefix string) []string {
 	var args []string
 
 	for key, value := range vars {
-		hclString := toHclString(value)
+		hclString := toHclString(value, false)
 		argValue := fmt.Sprintf("%s=%s", key, hclString)
 		args = append(args, prefix, argValue)
 	}
@@ -57,7 +57,7 @@ func formatTerraformArgs(vars map[string]interface{}, prefix string) []string {
 // arbitrary Go types to an HCL string. Therefore, this method is a simple implementation that correctly handles
 // ints, booleans, lists, and maps. Everything else is forced into a string using Sprintf. Hopefully, this approach is
 // good enough for the type of variables we deal with in Terratest.
-func toHclString(value interface{}) string {
+func toHclString(value interface{}, isChild bool) string {
 	// Ideally, we'd use a type switch here to identify slices and maps, but we can't do that, because Go doesn't
 	// support generics, and the type switch only matches concrete types. So we could match []interface{}, but if
 	// a user passes in []string{}, that would NOT match (the same logic applies to maps). Therefore, we have to
@@ -68,7 +68,7 @@ func toHclString(value interface{}) string {
 	} else if m, isMap := tryToConvertToGenericMap(value); isMap {
 		return mapToHclString(m)
 	} else {
-		return primitiveToHclString(value)
+		return primitiveToHclString(value, isChild)
 	}
 }
 
@@ -119,7 +119,7 @@ func sliceToHclString(slice []interface{}) string {
 	hclValues := []string{}
 
 	for _, value := range slice {
-		hclValue := toHclString(value)
+		hclValue := toHclString(value, true)
 		hclValues = append(hclValues, hclValue)
 	}
 
@@ -131,7 +131,7 @@ func mapToHclString(m map[string]interface{}) string {
 	keyValuePairs := []string{}
 
 	for key, value := range m {
-		keyValuePair := fmt.Sprintf("%s = %s", key, toHclString(value))
+		keyValuePair := fmt.Sprintf("%s = %s", key, toHclString(value, true))
 		keyValuePairs = append(keyValuePairs, keyValuePair)
 	}
 
@@ -140,21 +140,22 @@ func mapToHclString(m map[string]interface{}) string {
 
 // Convert a primitive, such as a bool, int, or string, to an HCL string. If this isn't a primitive, force its value
 // using Sprintf. See ToHclString for details.
-func primitiveToHclString(value interface{}) string {
+func primitiveToHclString(value interface{}, isChild bool) string {
 	switch v := value.(type) {
 
-	// Terraform treats a boolean true as a 1 and a boolean false as a 0. It's best to convert to these ints when
-	// passing booleans as -var parameters. Moreover, due to a Terraform bug
-	// (https://github.com/hashicorp/terraform/issues/7962), all ints must be wrapped as strings.
 	case bool:
 		if v {
 			return "1"
 		}
 		return "0"
 
-	// Note: due to a Terraform bug (https://github.com/hashicorp/terraform/issues/7962), we can't use proper HCL
-	// syntax for ints have to wrap them as strings by falling through to the default case
-	//case int: return strconv.Itoa(v)
+	case string:
+		// If string is a child of a larger data structure (e.g. list of string, map of string), ensure value is quoted
+		if isChild {
+			return fmt.Sprintf("\"%v\"", v)
+		}
+
+		return fmt.Sprintf("%v", v)
 
 	default:
 		return fmt.Sprintf("%v", v)

--- a/modules/terraform/format_test.go
+++ b/modules/terraform/format_test.go
@@ -19,10 +19,10 @@ func TestFormatTerraformVarsAsArgs(t *testing.T) {
 		{map[string]interface{}{"foo": 123}, []string{"-var", "foo=123"}},
 		{map[string]interface{}{"foo": true}, []string{"-var", "foo=1"}},
 		{map[string]interface{}{"foo": []int{1, 2, 3}}, []string{"-var", "foo=[1, 2, 3]"}},
-		{map[string]interface{}{"foo": map[string]string{"baz": "blah"}}, []string{"-var", "foo={baz = blah}"}},
+		{map[string]interface{}{"foo": map[string]string{"baz": "blah"}}, []string{"-var", "foo={baz = \"blah\"}"}},
 		{
 			map[string]interface{}{"str": "bar", "int": -1, "bool": false, "list": []string{"foo", "bar", "baz"}, "map": map[string]int{"foo": 0}},
-			[]string{"-var", "str=bar", "-var", "int=-1", "-var", "bool=0", "-var", "list=[foo, bar, baz]", "-var", "map={foo = 0}"},
+			[]string{"-var", "str=bar", "-var", "int=-1", "-var", "bool=0", "-var", "list=[\"foo\", \"bar\", \"baz\"]", "-var", "map={foo = 0}"},
 		},
 	}
 
@@ -49,7 +49,7 @@ func TestPrimitiveToHclString(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		actual := primitiveToHclString(testCase.value)
+		actual := primitiveToHclString(testCase.value, false)
 		assert.Equal(t, testCase.expected, actual, "Value: %v", testCase.value)
 	}
 }
@@ -62,11 +62,11 @@ func TestMapToHclString(t *testing.T) {
 		expected string
 	}{
 		{map[string]interface{}{}, "{}"},
-		{map[string]interface{}{"key1": "value1"}, "{key1 = value1}"},
+		{map[string]interface{}{"key1": "value1"}, "{key1 = \"value1\"}"},
 		{map[string]interface{}{"key1": 123}, "{key1 = 123}"},
 		{map[string]interface{}{"key1": true}, "{key1 = 1}"},
 		{map[string]interface{}{"key1": []int{1, 2, 3}}, "{key1 = [1, 2, 3]}"}, // Any value that isn't a primitive is forced into a string
-		{map[string]interface{}{"key1": "value1", "key2": 0, "key3": false}, "{key1 = value1, key2 = 0, key3 = 0}"},
+		{map[string]interface{}{"key1": "value1", "key2": 0, "key3": false}, "{key1 = \"value1\", key2 = 0, key3 = 0}"},
 	}
 
 	for _, testCase := range testCases {
@@ -116,13 +116,13 @@ func TestSliceToHclString(t *testing.T) {
 		expected string
 	}{
 		{[]interface{}{}, "[]"},
-		{[]interface{}{"foo"}, "[foo]"},
+		{[]interface{}{"foo"}, "[\"foo\"]"},
 		{[]interface{}{123}, "[123]"},
 		{[]interface{}{true}, "[1]"},
 		{[]interface{}{[]int{1, 2, 3}}, "[[1, 2, 3]]"}, // Any value that isn't a primitive is forced into a string
-		{[]interface{}{"foo", 0, false}, "[foo, 0, 0]"},
-		{[]interface{}{map[string]interface{}{"foo": "bar"}}, "[{foo = bar}]"},
-		{[]interface{}{map[string]interface{}{"foo": "bar"}, map[string]interface{}{"foo": "bar"}}, "[{foo = bar}, {foo = bar}]"},
+		{[]interface{}{"foo", 0, false}, "[\"foo\", 0, 0]"},
+		{[]interface{}{map[string]interface{}{"foo": "bar"}}, "[{foo = \"bar\"}]"},
+		{[]interface{}{map[string]interface{}{"foo": "bar"}, map[string]interface{}{"foo": "bar"}}, "[{foo = \"bar\"}, {foo = \"bar\"}]"},
 	}
 
 	for _, testCase := range testCases {
@@ -143,13 +143,13 @@ func TestToHclString(t *testing.T) {
 		{123, "123"},
 		{true, "1"},
 		{[]int{1, 2, 3}, "[1, 2, 3]"},
-		{[]string{"foo", "bar", "baz"}, "[foo, bar, baz]"},
-		{map[string]string{"key1": "value1"}, "{key1 = value1}"},
+		{[]string{"foo", "bar", "baz"}, "[\"foo\", \"bar\", \"baz\"]"},
+		{map[string]string{"key1": "value1"}, "{key1 = \"value1\"}"},
 		{map[string]int{"key1": 123}, "{key1 = 123}"},
 	}
 
 	for _, testCase := range testCases {
-		actual := toHclString(testCase.value)
+		actual := toHclString(testCase.value, false)
 		assert.Equal(t, testCase.expected, actual, "Value: %v", testCase.value)
 	}
 }

--- a/test/terraform_basic_example_regression_test.go
+++ b/test/terraform_basic_example_regression_test.go
@@ -1,0 +1,179 @@
+package test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gruntwork-io/terratest/modules/random"
+	"github.com/gruntwork-io/terratest/modules/terraform"
+	test_structure "github.com/gruntwork-io/terratest/modules/test-structure"
+)
+
+// The tests in this folder are not example usage of Terratest. Instead, this is a regression test to ensure the
+// formatting rules work with an actual Terraform call when using more complex structures.
+
+func TestTerraformFormatNestedOneLevelList(t *testing.T) {
+	t.Parallel()
+
+	testList := [][]string{
+		[]string{random.UniqueId()},
+	}
+
+	options := GetTerraformOptionsForFormatTests(t)
+	options.Vars["example_list"] = testList
+
+	defer terraform.Destroy(t, options)
+	terraform.InitAndApply(t, options)
+	outputMap := OutputJsonMap(t, options, "example_list")
+	actualExampleList := outputMap["value"]
+	AssertEqualJson(t, actualExampleList, testList)
+}
+
+func TestTerraformFormatNestedTwoLevelList(t *testing.T) {
+	t.Parallel()
+
+	testList := [][][]string{
+		[][]string{[]string{random.UniqueId()}},
+	}
+
+	options := GetTerraformOptionsForFormatTests(t)
+	options.Vars["example_list"] = testList
+
+	defer terraform.Destroy(t, options)
+	terraform.InitAndApply(t, options)
+	outputMap := OutputJsonMap(t, options, "example_list")
+	actualExampleList := outputMap["value"]
+	AssertEqualJson(t, actualExampleList, testList)
+}
+
+func TestTerraformFormatNestedMultipleItems(t *testing.T) {
+	t.Parallel()
+
+	testList := [][]string{
+		[]string{random.UniqueId(), random.UniqueId()},
+		[]string{random.UniqueId(), random.UniqueId(), random.UniqueId()},
+	}
+
+	options := GetTerraformOptionsForFormatTests(t)
+	options.Vars["example_list"] = testList
+
+	defer terraform.Destroy(t, options)
+	outputMap := OutputJsonMap(t, options, "example_list")
+	actualExampleList := outputMap["value"]
+	AssertEqualJson(t, actualExampleList, testList)
+}
+
+func TestTerraformFormatNestedOneLevelMap(t *testing.T) {
+	t.Parallel()
+
+	testMap := map[string]map[string]string{
+		"test": map[string]string{
+			"foo": random.UniqueId(),
+		},
+	}
+
+	options := GetTerraformOptionsForFormatTests(t)
+	options.Vars["example_map"] = testMap
+
+	defer terraform.Destroy(t, options)
+	outputMap := OutputJsonMap(t, options, "example_map")
+	actualExampleMap := outputMap["value"]
+	AssertEqualJson(t, actualExampleMap, testMap)
+}
+
+func TestTerraformFormatNestedTwoLevelMap(t *testing.T) {
+	t.Parallel()
+
+	testMap := map[string]map[string]map[string]string{
+		"test": map[string]map[string]string{
+			"foo": map[string]string{
+				"bar": random.UniqueId(),
+			},
+		},
+	}
+
+	options := GetTerraformOptionsForFormatTests(t)
+	options.Vars["example_map"] = testMap
+
+	defer terraform.Destroy(t, options)
+	terraform.InitAndApply(t, options)
+	outputMap := OutputJsonMap(t, options, "example_map")
+	actualExampleMap := outputMap["value"]
+	AssertEqualJson(t, actualExampleMap, testMap)
+}
+
+func TestTerraformFormatNestedMultipleItemsMap(t *testing.T) {
+	t.Parallel()
+
+	testMap := map[string]map[string]string{
+		"test": map[string]string{
+			"foo": random.UniqueId(),
+			"bar": random.UniqueId(),
+		},
+		"other": map[string]string{
+			"baz": random.UniqueId(),
+			"boo": random.UniqueId(),
+		},
+	}
+
+	options := GetTerraformOptionsForFormatTests(t)
+	options.Vars["example_map"] = testMap
+
+	defer terraform.Destroy(t, options)
+	terraform.InitAndApply(t, options)
+	outputMap := OutputJsonMap(t, options, "example_map")
+	actualExampleMap := outputMap["value"]
+	AssertEqualJson(t, actualExampleMap, testMap)
+}
+
+func TestTerraformFormatNestedListMap(t *testing.T) {
+	t.Parallel()
+
+	testMap := map[string][]string{
+		"test": []string{random.UniqueId(), random.UniqueId()},
+	}
+
+	options := GetTerraformOptionsForFormatTests(t)
+	options.Vars["example_map"] = testMap
+
+	defer terraform.Destroy(t, options)
+	terraform.InitAndApply(t, options)
+	outputMap := OutputJsonMap(t, options, "example_map")
+	actualExampleMap := outputMap["value"]
+	AssertEqualJson(t, actualExampleMap, testMap)
+}
+
+func GetTerraformOptionsForFormatTests(t *testing.T) *terraform.Options {
+	exampleFolder := test_structure.CopyTerraformFolderToTemp(t, "../", "examples/terraform-basic-example")
+
+	terraformOptions := &terraform.Options{
+		TerraformDir: exampleFolder,
+		Vars:         map[string]interface{}{},
+		NoColor:      true,
+	}
+	return terraformOptions
+}
+
+// To avoid conversion errors with nested data structures, we work directly off the json output when comparing the data.
+// This is because both OutputList and OutputMap assume the data is single level deep.
+func OutputJsonMap(t *testing.T, options *terraform.Options, key string) map[string]interface{} {
+	out, err := terraform.RunTerraformCommandE(t, options, "output", "-no-color", "-json", key)
+	require.NoError(t, err)
+
+	outputMap := map[string]interface{}{}
+	require.NoError(t, json.Unmarshal([]byte(out), &outputMap))
+	return outputMap
+}
+
+// The value of the output nested in the outputMap returned by OutputJsonMap uses the interface{} type for nested
+// structures. This can't be compared to actual types like [][]string{}, so we instead compare the json versions.
+func AssertEqualJson(t *testing.T, actual interface{}, expected interface{}) {
+	actualJson, err := json.Marshal(actual)
+	require.NoError(t, err)
+	expectedJson, err := json.Marshal(expected)
+	require.NoError(t, err)
+	assert.Equal(t, actualJson, expectedJson)
+}

--- a/test/terraform_basic_example_regression_test.go
+++ b/test/terraform_basic_example_regression_test.go
@@ -61,6 +61,7 @@ func TestTerraformFormatNestedMultipleItems(t *testing.T) {
 	options.Vars["example_list"] = testList
 
 	defer terraform.Destroy(t, options)
+	terraform.InitAndApply(t, options)
 	outputMap := OutputJsonMap(t, options, "example_list")
 	actualExampleList := outputMap["value"]
 	AssertEqualJson(t, actualExampleList, testList)
@@ -79,6 +80,7 @@ func TestTerraformFormatNestedOneLevelMap(t *testing.T) {
 	options.Vars["example_map"] = testMap
 
 	defer terraform.Destroy(t, options)
+	terraform.InitAndApply(t, options)
 	outputMap := OutputJsonMap(t, options, "example_map")
 	actualExampleMap := outputMap["value"]
 	AssertEqualJson(t, actualExampleMap, testMap)

--- a/test/terraform_basic_example_test.go
+++ b/test/terraform_basic_example_test.go
@@ -12,6 +12,8 @@ func TestTerraformBasicExample(t *testing.T) {
 	t.Parallel()
 
 	expectedText := "test"
+	expectedList := []string{expectedText}
+	expectedMap := map[string]string{"expected": expectedText}
 
 	terraformOptions := &terraform.Options{
 		// The path to where our Terraform code is located
@@ -20,6 +22,10 @@ func TestTerraformBasicExample(t *testing.T) {
 		// Variables to pass to our Terraform code using -var options
 		Vars: map[string]interface{}{
 			"example": expectedText,
+
+			// We also can see how lists and maps translate between terratest and terraform.
+			"example_list": expectedList,
+			"example_map":  expectedMap,
 		},
 
 		// Variables to pass to our Terraform code using -var-file options
@@ -38,8 +44,12 @@ func TestTerraformBasicExample(t *testing.T) {
 	// Run `terraform output` to get the values of output variables
 	actualTextExample := terraform.Output(t, terraformOptions, "example")
 	actualTextExample2 := terraform.Output(t, terraformOptions, "example2")
+	actualExampleList := terraform.OutputList(t, terraformOptions, "example_list")
+	actualExampleMap := terraform.OutputMap(t, terraformOptions, "example_map")
 
 	// Verify we're getting back the outputs we expect
 	assert.Equal(t, expectedText, actualTextExample)
 	assert.Equal(t, expectedText, actualTextExample2)
+	assert.Equal(t, expectedList, actualExampleList)
+	assert.Equal(t, expectedMap, actualExampleMap)
 }


### PR DESCRIPTION
This PR addresses the issues introduced by #284. It works by introducing a new `isChild` argument to the `primitiveToHclString` function and creates a special case for the `string` type. If a string is a value in a map or an item in a list then it'll be quoted, otherwise, it remains unquoted. Behaviour for booleans and integers stay the same

E.g.

**Before**
-var name=Instance1
-var subnet_names=[terratest_eth0, terratest_eth1]
-var subnet_cidr_blocks={terratest_eth0 = 10.1.1.0/24, terratest_eth1 = 10.1.2.0/24}
-var private_ips_count_list=[1, 0]

**After**
-var name=Instance1
-var subnet_names=["terratest_eth0", "terratest_eth1"]
-var subnet_cidr_blocks={terratest_eth0 = "10.1.1.0/24", terratest_eth1 = "10.1.2.0/24"}
-var private_ips_count_list=[1, 0]

Fixes #293 

cc @s012sameer @sumitmaggo can you try importing this branch and confirm that this change fixes your issue before I go ahead to merge it
