### PR TITLE
Delete SSH Public Keys imported during tests

### DIFF
--- a/modules/gcp/oslogin_test.go
+++ b/modules/gcp/oslogin_test.go
@@ -15,6 +15,7 @@ func TestImportSSHKeyOSLogin(t *testing.T) {
 	user := GetGoogleIdentityEmailEnvVar(t)
 
 	ImportSSHKey(t, user, key)
+	DeleteSSHKey(t, user, key)
 }
 
 func TestGetLoginProfile(t *testing.T) {
@@ -33,6 +34,7 @@ func TestSetOSLoginKey(t *testing.T) {
 	user := GetGoogleIdentityEmailEnvVar(t)
 
 	ImportSSHKey(t, user, key)
+	defer DeleteSSHKey(t, user, key)
 	loginProfile := GetLoginProfile(t, user)
 
 	found := false

--- a/modules/gcp/oslogin_test.go
+++ b/modules/gcp/oslogin_test.go
@@ -14,8 +14,8 @@ func TestImportSSHKeyOSLogin(t *testing.T) {
 
 	user := GetGoogleIdentityEmailEnvVar(t)
 
+	defer DeleteSSHKey(t, user, key)
 	ImportSSHKey(t, user, key)
-	DeleteSSHKey(t, user, key)
 }
 
 func TestGetLoginProfile(t *testing.T) {
@@ -33,8 +33,8 @@ func TestSetOSLoginKey(t *testing.T) {
 
 	user := GetGoogleIdentityEmailEnvVar(t)
 
-	ImportSSHKey(t, user, key)
 	defer DeleteSSHKey(t, user, key)
+	ImportSSHKey(t, user, key)
 	loginProfile := GetLoginProfile(t, user)
 
 	found := false


### PR DESCRIPTION
This PR adds two methods `DeleteSSHKey` and `DeleteSSHKeyE` for deleting SSH public keys that can be imported to a user identity. It seems GCP limits the maximum number of SSH keys to 70 per user and our tests were attaching a random key during each execution.