### PR TITLE
Cleanup GCP disk images

### DIFF
--- a/examples/packer-basic-example/build.json
+++ b/examples/packer-basic-example/build.json
@@ -35,7 +35,7 @@
     "image_name": "terratest-packer-example-{{isotime | clean_image_name}}",
     "image_family": "terratest",
     "project_id": "{{user `gcp_project_id`}}",
-    "source_image_family": "ubuntu-1604-lts",
+    "source_image_family": "ubuntu-1804-lts",
     "zone": "{{user `gcp_zone`}}",
     "ssh_username": "ubuntu"
   }, {

--- a/modules/gcp/compute_test.go
+++ b/modules/gcp/compute_test.go
@@ -162,14 +162,14 @@ func createComputeInstance(t *testing.T, projectID string, zone string, name str
 
 	// Per GCP docs (https://cloud.google.com/compute/docs/reference/rest/v1/instances/setMachineType), the MachineType
 	// is actually specified as a partial URL
-	machineTypeUrl := fmt.Sprintf("zones/%s/machineTypes/%s", zone, machineType)
-	sourceImageUrl := fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s/global/images/%s", sourceImageFamilyProjectName, sourceImageFamilyName)
+	machineTypeURL := fmt.Sprintf("zones/%s/machineTypes/%s", zone, machineType)
+	sourceImageURL := fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s/global/images/%s", sourceImageFamilyProjectName, sourceImageFamilyName)
 
 	// Based on the properties listed as required at https://cloud.google.com/compute/docs/reference/rest/v1/instances/insert
 	// plus a somewhat painful cycle of add-next-property-try-fix-error-message-repeat.
 	instanceConfig := &compute.Instance{
 		Name:        name,
-		MachineType: machineTypeUrl,
+		MachineType: machineTypeURL,
 		NetworkInterfaces: []*compute.NetworkInterface{
 			&compute.NetworkInterface{
 				AccessConfigs: []*compute.AccessConfig{
@@ -179,9 +179,10 @@ func createComputeInstance(t *testing.T, projectID string, zone string, name str
 		},
 		Disks: []*compute.AttachedDisk{
 			&compute.AttachedDisk{
-				Boot: true,
+				AutoDelete: true,
+				Boot:       true,
 				InitializeParams: &compute.AttachedDiskInitializeParams{
-					SourceImage: sourceImageUrl,
+					SourceImage: sourceImageURL,
 				},
 			},
 		},
@@ -200,7 +201,7 @@ func createComputeInstance(t *testing.T, projectID string, zone string, name str
 	}
 }
 
-// Helper function that destroys the given Compute Instance
+// Helper function that destroys the given Compute Instance and all of its attached disks.
 func deleteComputeInstance(t *testing.T, projectID string, zone string, name string) {
 	t.Logf("Deleting Compute Instance %s\n", name)
 


### PR DESCRIPTION
This PR fixes the issue where the tests would leave GCP disk images lying around after destroying compute instances. Eventually, this would chew up all of the free space across our entire GCP account. This PR also bumps the Packer template to target Ubuntu 18.04 for GCP.

<img width="596" alt="Screenshot 2019-05-15 17 36 35" src="https://user-images.githubusercontent.com/178939/57841712-5afb5d00-77cb-11e9-95ec-3afd2e7c04f0.png">
