### PR TITLE
Use a retry loop to obtain the GCP OAuth2 token

### DIFF
--- a/modules/gcp/compute.go
+++ b/modules/gcp/compute.go
@@ -591,7 +591,7 @@ func NewComputeServiceE(t *testing.T) (*compute.Service, error) {
 	maxRetries := 6
 	timeBetweenRetries := 10 * time.Second
 	for i := 0; i < maxRetries; i++ {
-		logger.Log(t, "Attempting to request a Google OAuth2 token...")
+		logger.Logf(t, "Attempting to request a Google OAuth2 token (%d/%d)...", i+1, maxRetries)
 		client, err = google.DefaultClient(ctx, compute.CloudPlatformScope)
 		if err == nil {
 			logger.Log(t, "Got Google OAuth2 token, continuing.")

--- a/modules/gcp/compute.go
+++ b/modules/gcp/compute.go
@@ -590,6 +590,8 @@ func NewComputeServiceE(t *testing.T) (*compute.Service, error) {
 	var err error
 	maxRetries := 6
 	timeBetweenRetries := 10 * time.Second
+	// We directly implement the retry logic here instead of using the `retry` module so that we aren't relying on
+	// modifying variables in an inner function.
 	for i := 0; i < maxRetries; i++ {
 		logger.Logf(t, "Attempting to request a Google OAuth2 token (%d/%d)...", i+1, maxRetries)
 		client, err = google.DefaultClient(ctx, compute.CloudPlatformScope)

--- a/modules/gcp/compute.go
+++ b/modules/gcp/compute.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/random"
-	"github.com/robmorgan/terratest/modules/retry"
+	"github.com/gruntwork-io/terratest/modules/retry"
 	"golang.org/x/oauth2/google"
 	"google.golang.org/api/compute/v1"
 )


### PR DESCRIPTION
This PR is designed to improve the resiliency of the GCP methods for obtaining an OAuth2 token. In the past, we would often get errors such as:

```
region.go:77: Get https://www.googleapis.com/compute/v1/projects/terratest-214610/zones?alt=json&prettyPrint=false: oauth2: cannot fetch token: Post https://oauth2.googleapis.com/token: net/http: TLS handshake timeout
```
You can refer to the [Terratest log output](https://1429-53174289-gh.circle-artifacts.com/0/tmp/logs/TestPackerGCPBasicExample.log) from a recent build for more information. This patch is inspired by https://github.com/kubernetes/kubernetes/pull/56394.