### PR TITLE
Add support for retries to Packer. Use regex to match errors.

### DIFF
--- a/modules/gcp/compute.go
+++ b/modules/gcp/compute.go
@@ -3,12 +3,13 @@ package gcp
 import (
 	"context"
 	"fmt"
-	"github.com/gruntwork-io/terratest/modules/retry"
 	"net/http"
 	"path"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/gruntwork-io/terratest/modules/retry"
 
 	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/random"
@@ -593,7 +594,7 @@ func NewComputeServiceE(t *testing.T) (*compute.Service, error) {
 	timeBetweenRetries := 10 * time.Second
 
 	var client *http.Client
-	
+
 	_, retryErr := retry.DoWithRetryE(t, description, maxRetries, timeBetweenRetries, func() (string, error) {
 		var clientErr error
 		client, clientErr = google.DefaultClient(ctx, compute.CloudPlatformScope)

--- a/modules/gcp/compute.go
+++ b/modules/gcp/compute.go
@@ -3,6 +3,7 @@ package gcp
 import (
 	"context"
 	"fmt"
+	"github.com/gruntwork-io/terratest/modules/retry"
 	"net/http"
 	"path"
 	"strings"
@@ -586,24 +587,21 @@ func NewComputeServiceE(t *testing.T) (*compute.Service, error) {
 	// Retrieve the Google OAuth token using a retry loop as it can sometimes return an error.
 	// e.g: oauth2: cannot fetch token: Post https://oauth2.googleapis.com/token: net/http: TLS handshake timeout
 	// This is loosely based on https://github.com/kubernetes/kubernetes/blob/7e8de5422cb5ad76dd0c147cf4336220d282e34b/pkg/cloudprovider/providers/gce/gce.go#L831.
-	var client *http.Client
-	var err error
+
+	description := "Attempting to request a Google OAuth2 token"
 	maxRetries := 6
 	timeBetweenRetries := 10 * time.Second
-	// We directly implement the retry logic here instead of using the `retry` module so that we aren't relying on
-	// modifying variables in an inner function.
-	for i := 0; i < maxRetries; i++ {
-		logger.Logf(t, "Attempting to request a Google OAuth2 token (%d/%d)...", i+1, maxRetries)
-		client, err = google.DefaultClient(ctx, compute.CloudPlatformScope)
-		if err == nil {
-			logger.Log(t, "Got Google OAuth2 token, continuing.")
-			break
-		}
-		logger.Logf(t, "Failed to get Google OAuth2 token. Sleeping for %s seconds...", timeBetweenRetries.String())
-		time.Sleep(timeBetweenRetries)
-	}
-	if err != nil {
-		return nil, err
+
+	var client *http.Client
+	
+	_, retryErr := retry.DoWithRetryE(t, description, maxRetries, timeBetweenRetries, func() (string, error) {
+		var clientErr error
+		client, clientErr = google.DefaultClient(ctx, compute.CloudPlatformScope)
+		return "", clientErr
+	})
+
+	if retryErr != nil {
+		return nil, retryErr
 	}
 
 	service, err := compute.New(client)

--- a/modules/packer/packer.go
+++ b/modules/packer/packer.go
@@ -18,14 +18,14 @@ import (
 
 // Options are the options for Packer.
 type Options struct {
-	Template           string                    // The path to the Packer template
-	Vars               map[string]string         // The custom vars to pass when running the build command
-	VarFiles           []string                  // Var file paths to pass Packer using -var-file option
-	Only               string                    // If specified, only run the build of this name
-	Env                map[string]string         // Custom environment variables to set when running Packer
-	RetryableErrors    map[*regexp.Regexp]string // If packer build fails with one of these (transient) errors, retry. The keys are a regexp to match against the error and the message is what to display to a user if that error is matched.
-	MaxRetries         int                       // Maximum number of times to retry errors matching RetryableErrors
-	TimeBetweenRetries time.Duration             // The amount of time to wait between retries
+	Template           string            // The path to the Packer template
+	Vars               map[string]string // The custom vars to pass when running the build command
+	VarFiles           []string          // Var file paths to pass Packer using -var-file option
+	Only               string            // If specified, only run the build of this name
+	Env                map[string]string // Custom environment variables to set when running Packer
+	RetryableErrors    map[string]string // If packer build fails with one of these (transient) errors, retry. The keys are a regexp to match against the error and the message is what to display to a user if that error is matched.
+	MaxRetries         int               // Maximum number of times to retry errors matching RetryableErrors
+	TimeBetweenRetries time.Duration     // The amount of time to wait between retries
 }
 
 // BuildArtifacts can take a map of identifierName <-> Options and then parallelize

--- a/modules/packer/packer.go
+++ b/modules/packer/packer.go
@@ -4,11 +4,12 @@ package packer
 import (
 	"errors"
 	"fmt"
-	"github.com/gruntwork-io/terratest/modules/retry"
 	"regexp"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/gruntwork-io/terratest/modules/retry"
 
 	"github.com/gruntwork-io/terratest/modules/customerrors"
 	"github.com/gruntwork-io/terratest/modules/logger"

--- a/modules/packer/packer.go
+++ b/modules/packer/packer.go
@@ -4,9 +4,11 @@ package packer
 import (
 	"errors"
 	"fmt"
+	"github.com/gruntwork-io/terratest/modules/retry"
 	"regexp"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/gruntwork-io/terratest/modules/customerrors"
 	"github.com/gruntwork-io/terratest/modules/logger"
@@ -15,11 +17,14 @@ import (
 
 // Options are the options for Packer.
 type Options struct {
-	Template string            // The path to the Packer template
-	Vars     map[string]string // The custom vars to pass when running the build command
-	VarFiles []string          // Var file paths to pass Packer using -var-file option
-	Only     string            // If specified, only run the build of this name
-	Env      map[string]string // Custom environment variables to set when running Packer
+	Template           string                    // The path to the Packer template
+	Vars               map[string]string         // The custom vars to pass when running the build command
+	VarFiles           []string                  // Var file paths to pass Packer using -var-file option
+	Only               string                    // If specified, only run the build of this name
+	Env                map[string]string         // Custom environment variables to set when running Packer
+	RetryableErrors    map[*regexp.Regexp]string // If packer build fails with one of these (transient) errors, retry. The keys are a regexp to match against the error and the message is what to display to a user if that error is matched.
+	MaxRetries         int                       // Maximum number of times to retry errors matching RetryableErrors
+	TimeBetweenRetries time.Duration             // The amount of time to wait between retries
 }
 
 // BuildArtifacts can take a map of identifierName <-> Options and then parallelize
@@ -89,7 +94,11 @@ func BuildArtifactE(t *testing.T, options *Options) (string, error) {
 		Env:     options.Env,
 	}
 
-	output, err := shell.RunCommandAndGetOutputE(t, cmd)
+	description := fmt.Sprintf("%s %v", cmd.Command, cmd.Args)
+	output, err := retry.DoWithRetryableErrorsE(t, description, options.RetryableErrors, options.MaxRetries, options.TimeBetweenRetries, func() (string, error) {
+		return shell.RunCommandAndGetOutputE(t, cmd)
+	})
+
 	if err != nil {
 		return "", err
 	}

--- a/modules/retry/retry.go
+++ b/modules/retry/retry.go
@@ -3,10 +3,11 @@ package retry
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/require"
 	"regexp"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/gruntwork-io/terratest/modules/logger"
 	"golang.org/x/net/context"

--- a/modules/retry/retry.go
+++ b/modules/retry/retry.go
@@ -3,6 +3,8 @@ package retry
 
 import (
 	"fmt"
+	"github.com/stretchr/testify/require"
+	"regexp"
 	"testing"
 	"time"
 
@@ -83,6 +85,40 @@ func DoWithRetryE(t *testing.T, actionDescription string, maxRetries int, sleepB
 	}
 
 	return output, MaxRetriesExceeded{Description: actionDescription, MaxRetries: maxRetries}
+}
+
+// DoWithRetryableErrors runs the specified action. If it returns a value, return that value. If it returns an error,
+// check if error message or the string output from the action (which is often stdout/stderr from running some command)
+// matches any of the regular expressions in the specified retryableErrors map. If there is a match, sleep for
+// sleepBetweenRetries, and retry the specified action, up to a maximum of maxRetries retries. If there is no match,
+// return that error immediately, wrapped in a FatalError. If maxRetries is exceeded, return a MaxRetriesExceeded error.
+func DoWithRetryableErrors(t *testing.T, actionDescription string, retryableErrors map[*regexp.Regexp]string, maxRetries int, sleepBetweenRetries time.Duration, action func() (string, error)) string {
+	out, err := DoWithRetryableErrorsE(t, actionDescription, retryableErrors, maxRetries, sleepBetweenRetries, action)
+	require.NoError(t, err)
+	return out
+}
+
+// DoWithRetryableErrorsE runs the specified action. If it returns a value, return that value. If it returns an error,
+// check if error message or the string output from the action (which is often stdout/stderr from running some command)
+// matches any of the regular expressions in the specified retryableErrors map. If there is a match, sleep for
+// sleepBetweenRetries, and retry the specified action, up to a maximum of maxRetries retries. If there is no match,
+// return that error immediately, wrapped in a FatalError. If maxRetries is exceeded, return a MaxRetriesExceeded error.
+func DoWithRetryableErrorsE(t *testing.T, actionDescription string, retryableErrors map[*regexp.Regexp]string, maxRetries int, sleepBetweenRetries time.Duration, action func() (string, error)) (string, error) {
+	return DoWithRetryE(t, actionDescription, maxRetries, sleepBetweenRetries, func() (string, error) {
+		output, err := action()
+		if err == nil {
+			return output, nil
+		}
+
+		for errorRegexp, errorMessage := range retryableErrors {
+			if errorRegexp.MatchString(output) || errorRegexp.MatchString(err.Error()) {
+				logger.Logf(t, "'%s' failed with the error '%s' but this error was expected and warrants a retry. Further details: %s\n", actionDescription, err.Error(), errorMessage)
+				return output, err
+			}
+		}
+
+		return output, FatalError{Underlying: err}
+	})
 }
 
 // Done can be stopped.

--- a/modules/retry/retry_test.go
+++ b/modules/retry/retry_test.go
@@ -2,10 +2,11 @@ package retry
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/require"
 	"regexp"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/modules/retry/retry_test.go
+++ b/modules/retry/retry_test.go
@@ -2,6 +2,8 @@ package retry
 
 import (
 	"fmt"
+	"github.com/stretchr/testify/require"
+	"regexp"
 	"testing"
 	"time"
 
@@ -129,4 +131,148 @@ func TestDoInBackgroundUntilStopped(t *testing.T) {
 
 	time.Sleep(sleepBetweenRetries * 3)
 	assert.Equal(t, 3, counter)
+}
+
+func TestDoWithRetryableErrors(t *testing.T) {
+	t.Parallel()
+
+	expectedOutput := "this is the expected output"
+	expectedError := fmt.Errorf("expected error")
+	unexpectedError := fmt.Errorf("some other error")
+
+	actionAlwaysReturnsExpected := func() (string, error) { return expectedOutput, nil }
+	actionAlwaysReturnsExpectedError := func() (string, error) { return expectedOutput, expectedError }
+	actionAlwaysReturnsUnexpectedError := func() (string, error) { return expectedOutput, unexpectedError }
+
+	createActionThatReturnsExpectedAfterFiveRetriesOfExpectedErrors := func() func() (string, error) {
+		count := 0
+		return func() (string, error) {
+			count++
+			if count > 5 {
+				return expectedOutput, nil
+			}
+			return expectedOutput, expectedError
+		}
+	}
+
+	createActionThatReturnsExpectedAfterFiveRetriesOfUnexpectedErrors := func() func() (string, error) {
+		count := 0
+		return func() (string, error) {
+			count++
+			if count > 5 {
+				return expectedOutput, nil
+			}
+			return expectedOutput, unexpectedError
+		}
+	}
+
+	createActionThatReturnsErrorCounterAfterFiveRetriesOfExpectedErrors := func() func() (string, error) {
+		count := 0
+		return func() (string, error) {
+			count++
+			if count > 5 {
+				return expectedOutput, ErrorCounter(count)
+			}
+			return expectedOutput, expectedError
+		}
+	}
+
+	matchAllRegexp, err := regexp.Compile(".*")
+	require.NoError(t, err)
+
+	matchExpectedErrorExactRegexp, err := regexp.Compile(expectedError.Error())
+	require.NoError(t, err)
+
+	matchExpectedErrorRegexp, err := regexp.Compile("^expected.*$")
+	require.NoError(t, err)
+
+	matchNothingRegexp1, err := regexp.Compile("this won't match any of our errors")
+	require.NoError(t, err)
+
+	matchNothingRegexp2, err := regexp.Compile("this also won't match any of our errors")
+	require.NoError(t, err)
+
+	matchStdoutExactlyRegexp, err := regexp.Compile(expectedOutput)
+	require.NoError(t, err)
+
+	matchStdoutRegexp, err := regexp.Compile("this.*output")
+	require.NoError(t, err)
+
+	noRetryableErrors := map[*regexp.Regexp]string{}
+	retryOnAllErrors := map[*regexp.Regexp]string{
+		matchAllRegexp: "match all errors",
+	}
+	retryOnExpectedErrorExactMatch := map[*regexp.Regexp]string{
+		matchExpectedErrorExactRegexp: "match expected error exactly",
+	}
+	retryOnExpectedErrorRegexpMatch := map[*regexp.Regexp]string{
+		matchExpectedErrorRegexp: "match expected error using a regex",
+	}
+	retryOnExpectedErrorRegexpMatchWithOthers := map[*regexp.Regexp]string{
+		matchNothingRegexp1:      "unrelated regex that shouldn't match anything",
+		matchExpectedErrorRegexp: "match expected error using a regex",
+		matchNothingRegexp2:      "another unrelated regex that shouldn't match anything",
+	}
+	retryOnErrorsThatWontMatch := map[*regexp.Regexp]string{
+		matchNothingRegexp1: "unrelated regex that shouldn't match anything",
+		matchNothingRegexp2: "another unrelated regex that shouldn't match anything",
+	}
+	retryOnExpectedStdoutExactMatch := map[*regexp.Regexp]string{
+		matchStdoutExactlyRegexp: "match expected stdout exactly",
+	}
+	retryOnExpectedStdoutRegex := map[*regexp.Regexp]string{
+		matchStdoutRegexp: "match expected stdout using a regex",
+	}
+
+	testCases := []struct {
+		description     string
+		retryableErrors map[*regexp.Regexp]string
+		maxRetries      int
+		expectedError   error
+		action          func() (string, error)
+	}{
+		{"Return value on first try", noRetryableErrors, 10, nil, actionAlwaysReturnsExpected},
+		{"Return expected error, but no retryable errors requested", noRetryableErrors, 10, FatalError{Underlying: expectedError}, actionAlwaysReturnsExpectedError},
+		{"Return expected error, but retryable errors do not match", retryOnErrorsThatWontMatch, 10, FatalError{Underlying: expectedError}, actionAlwaysReturnsExpectedError},
+		{"Return expected error on all retries, use match all regex", retryOnAllErrors, 10, MaxRetriesExceeded{Description: "Return expected error on all retries, use match all regex", MaxRetries: 10}, actionAlwaysReturnsExpectedError},
+		{"Return expected error on all retries, use match exactly regex", retryOnExpectedErrorExactMatch, 3, MaxRetriesExceeded{Description: "Return expected error on all retries, use match exactly regex", MaxRetries: 3}, actionAlwaysReturnsExpectedError},
+		{"Return expected error on all retries, use regex", retryOnExpectedErrorRegexpMatch, 1, MaxRetriesExceeded{Description: "Return expected error on all retries, use regex", MaxRetries: 1}, actionAlwaysReturnsExpectedError},
+		{"Return expected error on all retries, use regex amidst others", retryOnExpectedErrorRegexpMatchWithOthers, 1, MaxRetriesExceeded{Description: "Return expected error on all retries, use regex amidst others", MaxRetries: 1}, actionAlwaysReturnsExpectedError},
+		{"Return unexpected error on all retries, but match stdout exactly", retryOnExpectedStdoutExactMatch, 10, MaxRetriesExceeded{Description: "Return unexpected error on all retries, but match stdout exactly", MaxRetries: 10}, actionAlwaysReturnsUnexpectedError},
+		{"Return unexpected error on all retries, but match stdout with regex", retryOnExpectedStdoutRegex, 3, MaxRetriesExceeded{Description: "Return unexpected error on all retries, but match stdout with regex", MaxRetries: 3}, actionAlwaysReturnsUnexpectedError},
+		{"Return value after 5 retries with expected error, match all", retryOnAllErrors, 10, nil, createActionThatReturnsExpectedAfterFiveRetriesOfExpectedErrors()},
+		{"Return value after 5 retries with expected error, match exactly", retryOnExpectedErrorExactMatch, 10, nil, createActionThatReturnsExpectedAfterFiveRetriesOfExpectedErrors()},
+		{"Return value after 5 retries with expected error, match regex", retryOnExpectedErrorRegexpMatch, 10, nil, createActionThatReturnsExpectedAfterFiveRetriesOfExpectedErrors()},
+		{"Return value after 5 retries with expected error, match multiple regex", retryOnExpectedErrorRegexpMatchWithOthers, 10, nil, createActionThatReturnsExpectedAfterFiveRetriesOfExpectedErrors()},
+		{"Return value after 5 retries with expected error, match stdout exactly", retryOnExpectedStdoutExactMatch, 10, nil, createActionThatReturnsExpectedAfterFiveRetriesOfUnexpectedErrors()},
+		{"Return value after 5 retries with expected error, match stdout with regex", retryOnExpectedStdoutRegex, 10, nil, createActionThatReturnsExpectedAfterFiveRetriesOfUnexpectedErrors()},
+		{"Return value after 5 retries with expected error, match exactly, but only do 4 retries", retryOnExpectedErrorExactMatch, 4, MaxRetriesExceeded{Description: "Return value after 5 retries with expected error, match exactly, but only do 4 retries", MaxRetries: 4}, createActionThatReturnsExpectedAfterFiveRetriesOfExpectedErrors()},
+		{"Return unexpected error after 5 retries with expected error, match exactly", retryOnExpectedErrorExactMatch, 10, FatalError{Underlying: ErrorCounter(6)}, createActionThatReturnsErrorCounterAfterFiveRetriesOfExpectedErrors()},
+		{"Return unexpected error after 5 retries with expected error, match regex", retryOnExpectedErrorRegexpMatch, 10, FatalError{Underlying: ErrorCounter(6)}, createActionThatReturnsErrorCounterAfterFiveRetriesOfExpectedErrors()},
+		{"Return unexpected error after 5 retries with expected error, match multiple regex", retryOnExpectedErrorRegexpMatchWithOthers, 10, FatalError{Underlying: ErrorCounter(6)}, createActionThatReturnsErrorCounterAfterFiveRetriesOfExpectedErrors()},
+		{"Return unexpected error after 5 retries with expected error, match all", retryOnAllErrors, 10, MaxRetriesExceeded{Description: "Return unexpected error after 5 retries with expected error, match all", MaxRetries: 10}, createActionThatReturnsErrorCounterAfterFiveRetriesOfExpectedErrors()},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase // capture range variable for each test case
+
+		t.Run(testCase.description, func(t *testing.T) {
+			t.Parallel()
+
+			actualOutput, err := DoWithRetryableErrorsE(t, testCase.description, testCase.retryableErrors, testCase.maxRetries, 1*time.Millisecond, testCase.action)
+			assert.Equal(t, expectedOutput, actualOutput)
+			if testCase.expectedError != nil {
+				assert.Equal(t, testCase.expectedError, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, expectedOutput, actualOutput)
+			}
+		})
+	}
+}
+
+type ErrorCounter int
+
+func (count ErrorCounter) Error() string {
+	return fmt.Sprintf("%d", int(count))
 }

--- a/modules/retry/retry_test.go
+++ b/modules/retry/retry_test.go
@@ -2,11 +2,8 @@ package retry
 
 import (
 	"fmt"
-	"regexp"
 	"testing"
 	"time"
-
-	"github.com/stretchr/testify/require"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -178,56 +175,43 @@ func TestDoWithRetryableErrors(t *testing.T) {
 		}
 	}
 
-	matchAllRegexp, err := regexp.Compile(".*")
-	require.NoError(t, err)
+	matchAllRegexp := ".*"
+	matchExpectedErrorExactRegexp := expectedError.Error()
+	matchExpectedErrorRegexp := "^expected.*$"
+	matchNothingRegexp1 := "this won't match any of our errors"
+	matchNothingRegexp2 := "this also won't match any of our errors"
+	matchStdoutExactlyRegexp := expectedOutput
+	matchStdoutRegexp := "this.*output"
 
-	matchExpectedErrorExactRegexp, err := regexp.Compile(expectedError.Error())
-	require.NoError(t, err)
-
-	matchExpectedErrorRegexp, err := regexp.Compile("^expected.*$")
-	require.NoError(t, err)
-
-	matchNothingRegexp1, err := regexp.Compile("this won't match any of our errors")
-	require.NoError(t, err)
-
-	matchNothingRegexp2, err := regexp.Compile("this also won't match any of our errors")
-	require.NoError(t, err)
-
-	matchStdoutExactlyRegexp, err := regexp.Compile(expectedOutput)
-	require.NoError(t, err)
-
-	matchStdoutRegexp, err := regexp.Compile("this.*output")
-	require.NoError(t, err)
-
-	noRetryableErrors := map[*regexp.Regexp]string{}
-	retryOnAllErrors := map[*regexp.Regexp]string{
+	noRetryableErrors := map[string]string{}
+	retryOnAllErrors := map[string]string{
 		matchAllRegexp: "match all errors",
 	}
-	retryOnExpectedErrorExactMatch := map[*regexp.Regexp]string{
+	retryOnExpectedErrorExactMatch := map[string]string{
 		matchExpectedErrorExactRegexp: "match expected error exactly",
 	}
-	retryOnExpectedErrorRegexpMatch := map[*regexp.Regexp]string{
+	retryOnExpectedErrorRegexpMatch := map[string]string{
 		matchExpectedErrorRegexp: "match expected error using a regex",
 	}
-	retryOnExpectedErrorRegexpMatchWithOthers := map[*regexp.Regexp]string{
+	retryOnExpectedErrorRegexpMatchWithOthers := map[string]string{
 		matchNothingRegexp1:      "unrelated regex that shouldn't match anything",
 		matchExpectedErrorRegexp: "match expected error using a regex",
 		matchNothingRegexp2:      "another unrelated regex that shouldn't match anything",
 	}
-	retryOnErrorsThatWontMatch := map[*regexp.Regexp]string{
+	retryOnErrorsThatWontMatch := map[string]string{
 		matchNothingRegexp1: "unrelated regex that shouldn't match anything",
 		matchNothingRegexp2: "another unrelated regex that shouldn't match anything",
 	}
-	retryOnExpectedStdoutExactMatch := map[*regexp.Regexp]string{
+	retryOnExpectedStdoutExactMatch := map[string]string{
 		matchStdoutExactlyRegexp: "match expected stdout exactly",
 	}
-	retryOnExpectedStdoutRegex := map[*regexp.Regexp]string{
+	retryOnExpectedStdoutRegex := map[string]string{
 		matchStdoutRegexp: "match expected stdout using a regex",
 	}
 
 	testCases := []struct {
 		description     string
-		retryableErrors map[*regexp.Regexp]string
+		retryableErrors map[string]string
 		maxRetries      int
 		expectedError   error
 		action          func() (string, error)

--- a/modules/terraform/apply_test.go
+++ b/modules/terraform/apply_test.go
@@ -1,6 +1,7 @@
 package terraform
 
 import (
+	"regexp"
 	"testing"
 
 	"github.com/gruntwork-io/terratest/modules/files"
@@ -48,11 +49,14 @@ func TestApplyWithErrorWithRetry(t *testing.T) {
 	testFolder, err := files.CopyTerraformFolderToTemp("../../test/fixtures/terraform-with-error", t.Name())
 	require.NoError(t, err)
 
+	firstRunError, err := regexp.Compile("This is the first run, exiting with an error")
+	require.NoError(t, err)
+
 	options := &Options{
 		TerraformDir: testFolder,
 		MaxRetries:   1,
-		RetryableTerraformErrors: map[string]string{
-			"This is the first run, exiting with an error": "Intentional failure in test fixture",
+		RetryableTerraformErrors: map[*regexp.Regexp]string{
+			firstRunError: "Intentional failure in test fixture",
 		},
 	}
 
@@ -82,12 +86,15 @@ func TestTgApplyAllError(t *testing.T) {
 	testFolder, err := files.CopyTerragruntFolderToTemp("../../test/fixtures/terragrunt/terragrunt-with-error", t.Name())
 	require.NoError(t, err)
 
+	firstRunError, err := regexp.Compile("This is the first run, exiting with an error")
+	require.NoError(t, err)
+
 	options := &Options{
 		TerraformDir:    testFolder,
 		TerraformBinary: "terragrunt",
 		MaxRetries:      1,
-		RetryableTerraformErrors: map[string]string{
-			"This is the first run, exiting with an error": "Intentional failure in test fixture",
+		RetryableTerraformErrors: map[*regexp.Regexp]string{
+			firstRunError: "Intentional failure in test fixture",
 		},
 	}
 

--- a/modules/terraform/apply_test.go
+++ b/modules/terraform/apply_test.go
@@ -1,7 +1,6 @@
 package terraform
 
 import (
-	"regexp"
 	"testing"
 
 	"github.com/gruntwork-io/terratest/modules/files"
@@ -49,14 +48,11 @@ func TestApplyWithErrorWithRetry(t *testing.T) {
 	testFolder, err := files.CopyTerraformFolderToTemp("../../test/fixtures/terraform-with-error", t.Name())
 	require.NoError(t, err)
 
-	firstRunError, err := regexp.Compile("This is the first run, exiting with an error")
-	require.NoError(t, err)
-
 	options := &Options{
 		TerraformDir: testFolder,
 		MaxRetries:   1,
-		RetryableTerraformErrors: map[*regexp.Regexp]string{
-			firstRunError: "Intentional failure in test fixture",
+		RetryableTerraformErrors: map[string]string{
+			"This is the first run, exiting with an error": "Intentional failure in test fixture",
 		},
 	}
 
@@ -86,15 +82,12 @@ func TestTgApplyAllError(t *testing.T) {
 	testFolder, err := files.CopyTerragruntFolderToTemp("../../test/fixtures/terragrunt/terragrunt-with-error", t.Name())
 	require.NoError(t, err)
 
-	firstRunError, err := regexp.Compile("This is the first run, exiting with an error")
-	require.NoError(t, err)
-
 	options := &Options{
 		TerraformDir:    testFolder,
 		TerraformBinary: "terragrunt",
 		MaxRetries:      1,
-		RetryableTerraformErrors: map[*regexp.Regexp]string{
-			firstRunError: "Intentional failure in test fixture",
+		RetryableTerraformErrors: map[string]string{
+			"This is the first run, exiting with an error": "Intentional failure in test fixture",
 		},
 	}
 

--- a/modules/terraform/options.go
+++ b/modules/terraform/options.go
@@ -1,7 +1,6 @@
 package terraform
 
 import (
-	"regexp"
 	"time"
 
 	"github.com/gruntwork-io/terratest/modules/ssh"
@@ -9,18 +8,18 @@ import (
 
 // Options for running Terraform commands
 type Options struct {
-	TerraformBinary          string                    // Name of the binary that will be used
-	TerraformDir             string                    // The path to the folder where the Terraform code is defined.
-	Vars                     map[string]interface{}    // The vars to pass to Terraform commands using the -var option.
-	VarFiles                 []string                  // The var file paths to pass to Terraform commands using -var-file option.
-	Targets                  []string                  // The target resources to pass to the terraform command with -target
-	EnvVars                  map[string]string         // Environment variables to set when running Terraform
-	BackendConfig            map[string]interface{}    // The vars to pass to the terraform init command for extra configuration for the backend
-	RetryableTerraformErrors map[*regexp.Regexp]string // If Terraform apply fails with one of these (transient) errors, retry. The keys are a regexp to match against the error and the message is what to display to a user if that error is matched.
-	MaxRetries               int                       // Maximum number of times to retry errors matching RetryableTerraformErrors
-	TimeBetweenRetries       time.Duration             // The amount of time to wait between retries
-	Upgrade                  bool                      // Whether the -upgrade flag of the terraform init command should be set to true or not
-	NoColor                  bool                      // Whether the -no-color flag will be set for any Terraform command or not
-	SshAgent                 *ssh.SshAgent             // Overrides local SSH agent with the given in-process agent
-	NoStderr                 bool                      // Disable stderr redirection
+	TerraformBinary          string                 // Name of the binary that will be used
+	TerraformDir             string                 // The path to the folder where the Terraform code is defined.
+	Vars                     map[string]interface{} // The vars to pass to Terraform commands using the -var option.
+	VarFiles                 []string               // The var file paths to pass to Terraform commands using -var-file option.
+	Targets                  []string               // The target resources to pass to the terraform command with -target
+	EnvVars                  map[string]string      // Environment variables to set when running Terraform
+	BackendConfig            map[string]interface{} // The vars to pass to the terraform init command for extra configuration for the backend
+	RetryableTerraformErrors map[string]string      // If Terraform apply fails with one of these (transient) errors, retry. The keys are a regexp to match against the error and the message is what to display to a user if that error is matched.
+	MaxRetries               int                    // Maximum number of times to retry errors matching RetryableTerraformErrors
+	TimeBetweenRetries       time.Duration          // The amount of time to wait between retries
+	Upgrade                  bool                   // Whether the -upgrade flag of the terraform init command should be set to true or not
+	NoColor                  bool                   // Whether the -no-color flag will be set for any Terraform command or not
+	SshAgent                 *ssh.SshAgent          // Overrides local SSH agent with the given in-process agent
+	NoStderr                 bool                   // Disable stderr redirection
 }

--- a/modules/terraform/options.go
+++ b/modules/terraform/options.go
@@ -1,6 +1,7 @@
 package terraform
 
 import (
+	"regexp"
 	"time"
 
 	"github.com/gruntwork-io/terratest/modules/ssh"
@@ -8,18 +9,18 @@ import (
 
 // Options for running Terraform commands
 type Options struct {
-	TerraformBinary          string                 // Name of the binary that will be used
-	TerraformDir             string                 // The path to the folder where the Terraform code is defined.
-	Vars                     map[string]interface{} // The vars to pass to Terraform commands using the -var option.
-	VarFiles                 []string               // The var file paths to pass to Terraform commands using -var-file option.
-	Targets                  []string               // The target resources to pass to the terraform command with -target
-	EnvVars                  map[string]string      // Environment variables to set when running Terraform
-	BackendConfig            map[string]interface{} // The vars to pass to the terraform init command for extra configuration for the backend
-	RetryableTerraformErrors map[string]string      // If Terraform apply fails with one of these (transient) errors, retry. The keys are text to look for in the error and the message is what to display to a user if that error is found.
-	MaxRetries               int                    // Maximum number of times to retry errors matching RetryableTerraformErrors
-	TimeBetweenRetries       time.Duration          // The amount of time to wait between retries
-	Upgrade                  bool                   // Whether the -upgrade flag of the terraform init command should be set to true or not
-	NoColor                  bool                   // Whether the -no-color flag will be set for any Terraform command or not
-	SshAgent                 *ssh.SshAgent          // Overrides local SSH agent with the given in-process agent
-	NoStderr                 bool                   // Disable stderr redirection
+	TerraformBinary          string                    // Name of the binary that will be used
+	TerraformDir             string                    // The path to the folder where the Terraform code is defined.
+	Vars                     map[string]interface{}    // The vars to pass to Terraform commands using the -var option.
+	VarFiles                 []string                  // The var file paths to pass to Terraform commands using -var-file option.
+	Targets                  []string                  // The target resources to pass to the terraform command with -target
+	EnvVars                  map[string]string         // Environment variables to set when running Terraform
+	BackendConfig            map[string]interface{}    // The vars to pass to the terraform init command for extra configuration for the backend
+	RetryableTerraformErrors map[*regexp.Regexp]string // If Terraform apply fails with one of these (transient) errors, retry. The keys are a regexp to match against the error and the message is what to display to a user if that error is matched.
+	MaxRetries               int                       // Maximum number of times to retry errors matching RetryableTerraformErrors
+	TimeBetweenRetries       time.Duration             // The amount of time to wait between retries
+	Upgrade                  bool                      // Whether the -upgrade flag of the terraform init command should be set to true or not
+	NoColor                  bool                      // Whether the -no-color flag will be set for any Terraform command or not
+	SshAgent                 *ssh.SshAgent             // Overrides local SSH agent with the given in-process agent
+	NoStderr                 bool                      // Disable stderr redirection
 }

--- a/test/packer_basic_example_test.go
+++ b/test/packer_basic_example_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"regexp"
 	"testing"
 	"time"
 
@@ -20,8 +19,8 @@ import (
 // Occasionally, a Packer build may fail due to intermittent issues (e.g., brief network outage or EC2 issue). We try
 // to make our tests resilient to that by specifying those known common errors here and telling our builds to retry if
 // they hit those errors.
-var DefaultRetryablePackerErrors = map[*regexp.Regexp]string{
-	regexp.MustCompile("Script disconnected unexpectedly"): "Occasionally, Packer seems to lose connectivity to AWS, perhaps due to a brief network outage",
+var DefaultRetryablePackerErrors = map[string]string{
+	"Script disconnected unexpectedly": "Occasionally, Packer seems to lose connectivity to AWS, perhaps due to a brief network outage",
 }
 var DefaultTimeBetweenPackerRetries = 15 * time.Second
 

--- a/test/packer_basic_example_test.go
+++ b/test/packer_basic_example_test.go
@@ -4,7 +4,9 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"regexp"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
@@ -14,6 +16,16 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// Occasionally, a Packer build may fail due to intermittent issues (e.g., brief network outage or EC2 issue). We try
+// to make our tests resilient to that by specifying those known common errors here and telling our builds to retry if
+// they hit those errors.
+var DefaultRetryablePackerErrors = map[*regexp.Regexp]string{
+	regexp.MustCompile("Script disconnected unexpectedly"): "Occasionally, Packer seems to lose connectivity to AWS, perhaps due to a brief network outage",
+}
+var DefaultTimeBetweenPackerRetries = 15 * time.Second
+
+const DefaultMaxPackerRetries = 3
 
 // An example of how to test the Packer template in examples/packer-basic-example using Terratest.
 func TestPackerBasicExample(t *testing.T) {
@@ -33,6 +45,11 @@ func TestPackerBasicExample(t *testing.T) {
 
 		// Only build the AWS AMI
 		Only: "amazon-ebs",
+
+		// Configure retries for intermittent errors
+		RetryableErrors:    DefaultRetryablePackerErrors,
+		TimeBetweenRetries: DefaultTimeBetweenPackerRetries,
+		MaxRetries:         DefaultMaxPackerRetries,
 	}
 
 	// Make sure the Packer build completes successfully
@@ -88,6 +105,11 @@ func TestPackerBasicExampleWithVarFile(t *testing.T) {
 
 		// Only build the AWS AMI
 		Only: "amazon-ebs",
+
+		// Configure retries for intermittent errors
+		RetryableErrors:    DefaultRetryablePackerErrors,
+		TimeBetweenRetries: DefaultTimeBetweenPackerRetries,
+		MaxRetries:         DefaultMaxPackerRetries,
 	}
 
 	// Make sure the Packer build completes successfully
@@ -134,6 +156,11 @@ func TestPackerMultipleConcurrentAmis(t *testing.T) {
 
 			// Only build the AWS AMI
 			Only: "amazon-ebs",
+
+			// Configure retries for intermittent errors
+			RetryableErrors:    DefaultRetryablePackerErrors,
+			TimeBetweenRetries: DefaultTimeBetweenPackerRetries,
+			MaxRetries:         DefaultMaxPackerRetries,
 		}
 
 		identifierToOptions[random.UniqueId()] = packerOptions

--- a/test/packer_docker_example_test.go
+++ b/test/packer_docker_example_test.go
@@ -31,7 +31,7 @@ func TestPackerDockerExampleLocal(t *testing.T) {
 	}
 
 	// Build the Docker image using Packer
-	packer.BuildAmi(t, packerOptions)
+	packer.BuildArtifact(t, packerOptions)
 
 	serverPort := 8080
 	expectedServerText := fmt.Sprintf("Hello, %s!", random.UniqueId())

--- a/test/packer_docker_example_test.go
+++ b/test/packer_docker_example_test.go
@@ -23,6 +23,11 @@ func TestPackerDockerExampleLocal(t *testing.T) {
 
 		// Only build the Docker image for local testing
 		Only: "ubuntu-docker",
+
+		// Configure retries for intermittent errors
+		RetryableErrors:    DefaultRetryablePackerErrors,
+		TimeBetweenRetries: DefaultTimeBetweenPackerRetries,
+		MaxRetries:         DefaultMaxPackerRetries,
 	}
 
 	// Build the Docker image using Packer

--- a/test/packer_gcp_basic_example_test.go
+++ b/test/packer_gcp_basic_example_test.go
@@ -30,6 +30,11 @@ func TestPackerGCPBasicExample(t *testing.T) {
 
 		// Only build the Google Compute Image
 		Only: "googlecompute",
+
+		// Configure retries for intermittent errors
+		RetryableErrors:    DefaultRetryablePackerErrors,
+		TimeBetweenRetries: DefaultTimeBetweenPackerRetries,
+		MaxRetries:         DefaultMaxPackerRetries,
 	}
 
 	// Make sure the Packer build completes successfully

--- a/test/packer_oci_example_test.go
+++ b/test/packer_oci_example_test.go
@@ -39,6 +39,11 @@ func TestPackerOciExample(t *testing.T) {
 
 		// Only build an OCI image
 		Only: "oracle-oci",
+
+		// Configure retries for intermittent errors
+		RetryableErrors:    DefaultRetryablePackerErrors,
+		TimeBetweenRetries: DefaultTimeBetweenPackerRetries,
+		MaxRetries:         DefaultMaxPackerRetries,
 	}
 
 	// Make sure the Packer build completes successfully

--- a/test/terraform_packer_example_test.go
+++ b/test/terraform_packer_example_test.go
@@ -76,6 +76,11 @@ func buildAMI(t *testing.T, awsRegion string, workingDir string) {
 		Vars: map[string]string{
 			"aws_region": awsRegion,
 		},
+
+		// Configure retries for intermittent errors
+		RetryableErrors:    DefaultRetryablePackerErrors,
+		TimeBetweenRetries: DefaultTimeBetweenPackerRetries,
+		MaxRetries:         DefaultMaxPackerRetries,
 	}
 
 	// Save the Packer Options so future test stages can use them


### PR DESCRIPTION
This PR does the following:

1. Add a `DoWithRetryableErrors` method that takes in a map of retryable errors and an action to execute, and if the action returns an error, retries it if the error or the action's stdout/stderr matches one of the retryable errors.

1. Update the Packer code to use this method so we can have flaky Packer builds retry on known errors.

1. Update Terraform to use this code. The Terraform code already supported retries; the main (backwards incompatible!) change here is that you can now match error messages using a regular expression instead of plain string.