### PR TITLE
modules/terraform:  Rename existing InitAndPlan* functions to InitAndPlanWithExitCode*, add InitAndPlan* and Plan* functions with consistent signatures

### DIFF
--- a/modules/terraform/plan.go
+++ b/modules/terraform/plan.go
@@ -7,15 +7,50 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// InitAndPlan runs terraform init and plan with the given options and return stdout/stderr from the apply command.
-func InitAndPlan(t *testing.T, options *Options) int {
-	exitCode, err := InitAndPlanE(t, options)
+// InitAndPlan runs terraform init and plan with the given options and returns stdout/stderr from the plan command.
+// This will fail the test if there is an error in the command.
+func InitAndPlan(t *testing.T, options *Options) string {
+	out, err := InitAndPlanE(t, options)
+	require.NoError(t, err)
+	return out
+}
+
+// InitAndPlanE runs terraform init and plan with the given options and returns stdout/stderr from the plan command.
+func InitAndPlanE(t *testing.T, options *Options) (string, error) {
+	if _, err := InitE(t, options); err != nil {
+		return "", err
+	}
+
+	if _, err := GetE(t, options); err != nil {
+		return "", err
+	}
+
+	return PlanE(t, options)
+}
+
+// Plan runs terraform plan with the given options and returns stdout/stderr.
+// This will fail the test if there is an error in the command.
+func Plan(t *testing.T, options *Options) string {
+	out, err := PlanE(t, options)
+	require.NoError(t, err)
+	return out
+}
+
+// PlanE runs terraform plan with the given options and returns stdout/stderr.
+func PlanE(t *testing.T, options *Options) (string, error) {
+	return RunTerraformCommandE(t, options, FormatArgs(options, "plan", "-input=false", "-lock=false")...)
+}
+
+// InitAndPlanWithExitCode runs terraform init and plan with the given options and returns exitcode for the plan command.
+// This will fail the test if there is an error in the command.
+func InitAndPlanWithExitCode(t *testing.T, options *Options) int {
+	exitCode, err := InitAndPlanWithExitCodeE(t, options)
 	require.NoError(t, err)
 	return exitCode
 }
 
-// InitAndPlanE runs terraform init and plan with the given options and return stdout/stderr from the apply command.
-func InitAndPlanE(t *testing.T, options *Options) (int, error) {
+// InitAndPlanWithExitCodeE runs terraform init and plan with the given options and returns exitcode for the plan command.
+func InitAndPlanWithExitCodeE(t *testing.T, options *Options) (int, error) {
 	if _, err := InitE(t, options); err != nil {
 		return DefaultErrorExitCode, err
 	}
@@ -23,7 +58,8 @@ func InitAndPlanE(t *testing.T, options *Options) (int, error) {
 	return PlanExitCodeE(t, options)
 }
 
-// PlanExitCode runs terraform apply with the given options and returns the detailed exitcode.
+// PlanExitCode runs terraform plan with the given options and returns the detailed exitcode.
+// This will fail the test if there is an error in the command.
 func PlanExitCode(t *testing.T, options *Options) int {
 	exitCode, err := PlanExitCodeE(t, options)
 	require.NoError(t, err)
@@ -36,6 +72,7 @@ func PlanExitCodeE(t *testing.T, options *Options) (int, error) {
 }
 
 // TgPlanAllExitCode runs terragrunt plan-all with the given options and returns the detailed exitcode.
+// This will fail the test if there is an error in the command.
 func TgPlanAllExitCode(t *testing.T, options *Options) int {
 	exitCode, err := TgPlanAllExitCodeE(t, options)
 	require.NoError(t, err)

--- a/test/fixtures/terraform-basic-configuration/main.tf
+++ b/test/fixtures/terraform-basic-configuration/main.tf
@@ -1,0 +1,5 @@
+variable cnt {}
+
+resource "null_resource" test {
+  count = "${var.cnt}"
+}


### PR DESCRIPTION
Addresses issue #319 
-  **[Breaking Change]** `InitAndPlan`, `InitAndPlanE` now return `stdout/stderr` from `terraform plan` command , not its return value
- **[Breaking Change]** Old `InitAndPlan`, `InitAndPlanE` functions which returned OS exitcode from `terraform plan` command are renamed to `InitAndPlanWithExitCode`, `InitAndPlanWithExitCode`
- Added `Plan`, `PlanE` functions
- 3 above changes are required for `*Plan*` functions to have consistent API with the rest of Terraform-related functions
- Removed dependency on `aws` in `TestPlanWithExitCodeWithChanges` (test execution is sped up) 
