### PR TITLE
modules/terraform: Implement GetResourceCount function

### DIFF
--- a/modules/terraform/count.go
+++ b/modules/terraform/count.go
@@ -1,0 +1,87 @@
+package terraform
+
+import (
+	"errors"
+	"regexp"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// ResourceCount represents counts of resources affected by terraform apply/plan/destroy command.
+type ResourceCount struct {
+	Add     int
+	Change  int
+	Destroy int
+}
+
+// Regular expressions for terraform commands stdout pattern matching.
+const (
+	applyRegexp             = `Apply complete! Resources: (\d+) added, (\d+) changed, (\d+) destroyed\.`
+	destroyRegexp           = `Destroy complete! Resources: (\d+) destroyed\.`
+	planWithChangesRegexp   = `(\033\[1m)?Plan:(\033\[0m)? (\d+) to add, (\d+) to change, (\d+) to destroy\.`
+	planWithNoChangesRegexp = `No changes\. Infrastructure is up-to-date\.`
+)
+
+const getResourceCountErrMessage = "Can't parse Terraform output"
+
+// GetResourceCount parses stdout/stderr of apply/plan/destroy commands and returns number of affected resources.
+// This will fail the test if given stdout/stderr isn't a valid output of apply/plan/destroy.
+func GetResourceCount(t *testing.T, cmdout string) *ResourceCount {
+	cnt, err := GetResourceCountE(t, cmdout)
+	require.NoError(t, err)
+	return cnt
+}
+
+// GetResourceCountE parses stdout/stderr of apply/plan/destroy commands and returns number of affected resources.
+func GetResourceCountE(t *testing.T, cmdout string) (*ResourceCount, error) {
+	cnt := ResourceCount{}
+
+	terraformCommandPatterns := []struct {
+		regexpStr       string
+		addPosition     int
+		changePosition  int
+		destroyPosition int
+	}{
+		{applyRegexp, 1, 2, 3},
+		{destroyRegexp, -1, -1, 1},
+		{planWithChangesRegexp, 3, 4, 5},
+		{planWithNoChangesRegexp, -1, -1, -1},
+	}
+
+	for _, tc := range terraformCommandPatterns {
+		pattern, err := regexp.Compile(tc.regexpStr)
+		if err != nil {
+			return nil, err
+		}
+
+		matches := pattern.FindStringSubmatch(cmdout)
+		if matches != nil {
+			if tc.addPosition != -1 {
+				cnt.Add, err = strconv.Atoi(matches[tc.addPosition])
+				if err != nil {
+					return nil, err
+				}
+			}
+
+			if tc.changePosition != -1 {
+				cnt.Change, err = strconv.Atoi(matches[tc.changePosition])
+				if err != nil {
+					return nil, err
+				}
+			}
+
+			if tc.destroyPosition != -1 {
+				cnt.Destroy, err = strconv.Atoi(matches[tc.destroyPosition])
+				if err != nil {
+					return nil, err
+				}
+			}
+
+			return &cnt, nil
+		}
+	}
+
+	return nil, errors.New(getResourceCountErrMessage)
+}

--- a/modules/terraform/count_test.go
+++ b/modules/terraform/count_test.go
@@ -1,0 +1,90 @@
+package terraform
+
+import (
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/files"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetResourceCount(t *testing.T) {
+	t.Parallel()
+	testFolder, err := files.CopyTerraformFolderToTemp("../../test/fixtures/terraform-basic-configuration", t.Name())
+	require.NoError(t, err)
+
+	terraformOptions := &Options{
+		TerraformDir: testFolder,
+		Vars: map[string]interface{}{
+			"cnt": 1,
+		},
+	}
+
+	cnt := GetResourceCount(t, InitAndPlan(t, terraformOptions))
+	assert.Equal(t, 1, cnt.Add)
+	assert.Equal(t, 0, cnt.Change)
+	assert.Equal(t, 0, cnt.Destroy)
+}
+
+func TestGetResourceCountEColor(t *testing.T) {
+	t.Parallel()
+	runTestGetResourceCountE(t, false)
+}
+
+func TestGetResourceCountENoColor(t *testing.T) {
+	t.Parallel()
+	runTestGetResourceCountE(t, true)
+}
+
+func runTestGetResourceCountE(t *testing.T, noColor bool) {
+	testCases := []struct {
+		Name                                         string
+		tfFuncToRun                                  func(t *testing.T, options *Options) string
+		cntValue                                     int
+		expectedAdd, expectedChange, expectedDestroy int
+	}{
+		{"PlanZero", InitAndPlan, 0, 0, 0, 0},
+		{"ApplyZero", InitAndApply, 0, 0, 0, 0},
+		{"PlanAddResouce", InitAndPlan, 2, 2, 0, 0},
+		{"ApplyAddResouce", InitAndApply, 2, 2, 0, 0},
+		{"PlanNoOp", InitAndApply, 2, 0, 0, 0},
+		{"ApplyNoOp", InitAndApply, 2, 0, 0, 0},
+		{"PlanDestroyResource", InitAndPlan, 1, 0, 0, 1},
+		{"ApplyDestroyResource", InitAndApply, 1, 0, 0, 1},
+		{"Destroy", Destroy, 1, 0, 0, 1},
+		{"DestroyNoOp", Destroy, 1, 0, 0, 0},
+	}
+
+	testFolder, err := files.CopyTerraformFolderToTemp("../../test/fixtures/terraform-basic-configuration", t.Name())
+	require.NoError(t, err)
+
+	terraformOptions := &Options{
+		TerraformDir: testFolder,
+		Vars: map[string]interface{}{
+			"cnt": 0,
+		},
+		NoColor: noColor,
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Name,
+			func(t *testing.T) {
+				terraformOptions.Vars["cnt"] = tc.cntValue
+				cnt, err := GetResourceCountE(t, tc.tfFuncToRun(t, terraformOptions))
+				assert.NoError(t, err)
+				assert.Equal(t, tc.expectedAdd, cnt.Add)
+				assert.Equal(t, tc.expectedChange, cnt.Change)
+				assert.Equal(t, tc.expectedDestroy, cnt.Destroy)
+			})
+	}
+
+	t.Run("InvalidInput",
+		func(t *testing.T) {
+			terraformOptions.Vars["cnt"] = "abc"
+			cmdout, _ := PlanE(t, terraformOptions)
+			cnt, err := GetResourceCountE(t, cmdout)
+			assert.EqualError(t, err, getResourceCountErrMessage)
+			assert.Nil(t, cnt)
+		})
+
+}


### PR DESCRIPTION
Addresses issue #236 

- Added `GetResourceCount`, `GetResourceCountE` functions which get counts for Added/Changed/Destroyed resources parsing stdout of `terraform (apply|plan|destroy)` command
 - No breaking changes