### PR TITLE
Fix output commands to only read from stdout

### DIFF
--- a/modules/shell/command.go
+++ b/modules/shell/command.go
@@ -61,6 +61,7 @@ func RunCommandAndGetOutputE(t *testing.T, command Command) (string, error) {
 
 // RunCommandAndGetStdOut runs a shell command and returns solely its stdout (but not stderr) as a string. The stdout
 // and stderr of that command will also be printed to the stdout and stderr of this Go program to make debugging easier.
+// If there are any errors, fail the test.
 func RunCommandAndGetStdOut(t *testing.T, command Command) string {
 	output, err := RunCommandAndGetStdOutE(t, command)
 	require.NoError(t, err)

--- a/modules/shell/command.go
+++ b/modules/shell/command.go
@@ -78,7 +78,8 @@ func RunCommandAndGetStdOutE(t *testing.T, command Command) (string, error) {
 	return output, err
 }
 
-// RunCommandAndGetOutputE runs a shell command and returns its stdout and stderr as a string. The stdout and stderr of that command will also
+// runCommandAndStoreOutputE runs a shell command and stores each line from stdout and stderr in the given
+// storedStdout and storedStderr variables, respectively. The stdout and stderr of that command will also
 // be printed to the stdout and stderr of this Go program to make debugging easier.
 func runCommandAndStoreOutputE(t *testing.T, command Command, storedStdout *[]string, storedStderr *[]string) error {
 	logger.Logf(t, "Running command %s with args %s", command.Command, command.Args)

--- a/modules/shell/command.go
+++ b/modules/shell/command.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"errors"
 	"fmt"
-	"github.com/stretchr/testify/require"
 	"io"
 	"os"
 	"os/exec"
@@ -12,6 +11,8 @@ import (
 	"sync"
 	"syscall"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/gruntwork-io/terratest/modules/logger"
 )
@@ -101,7 +102,6 @@ func runCommandAndStoreOutputE(t *testing.T, command Command, storedStdout *[]st
 	if err != nil {
 		return err
 	}
-
 
 	if err := readStdoutAndStderr(t, stdout, stderr, storedStdout, storedStderr); err != nil {
 		return err

--- a/modules/shell/command.go
+++ b/modules/shell/command.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"errors"
 	"fmt"
+	"github.com/stretchr/testify/require"
 	"io"
 	"os"
 	"os/exec"
@@ -50,6 +51,35 @@ func RunCommandAndGetOutput(t *testing.T, command Command) string {
 // RunCommandAndGetOutputE runs a shell command and returns its stdout and stderr as a string. The stdout and stderr of that command will also
 // be printed to the stdout and stderr of this Go program to make debugging easier.
 func RunCommandAndGetOutputE(t *testing.T, command Command) (string, error) {
+	allOutput := []string{}
+	err := runCommandAndStoreOutputE(t, command, &allOutput, &allOutput)
+
+	output := strings.Join(allOutput, "\n")
+	return output, err
+}
+
+// RunCommandAndGetStdOut runs a shell command and returns solely its stdout (but not stderr) as a string. The stdout
+// and stderr of that command will also be printed to the stdout and stderr of this Go program to make debugging easier.
+func RunCommandAndGetStdOut(t *testing.T, command Command) string {
+	output, err := RunCommandAndGetStdOutE(t, command)
+	require.NoError(t, err)
+	return output
+}
+
+// RunCommandAndGetStdOutE runs a shell command and returns solely its stdout (but not stderr) as a string. The stdout
+// and stderr of that command will also be printed to the stdout and stderr of this Go program to make debugging easier.
+func RunCommandAndGetStdOutE(t *testing.T, command Command) (string, error) {
+	stdout := []string{}
+	stderr := []string{}
+	err := runCommandAndStoreOutputE(t, command, &stdout, &stderr)
+
+	output := strings.Join(stdout, "\n")
+	return output, err
+}
+
+// RunCommandAndGetOutputE runs a shell command and returns its stdout and stderr as a string. The stdout and stderr of that command will also
+// be printed to the stdout and stderr of this Go program to make debugging easier.
+func runCommandAndStoreOutputE(t *testing.T, command Command, storedStdout *[]string, storedStderr *[]string) error {
 	logger.Logf(t, "Running command %s with args %s", command.Command, command.Args)
 
 	cmd := exec.Command(command.Command, command.Args...)
@@ -59,54 +89,53 @@ func RunCommandAndGetOutputE(t *testing.T, command Command) (string, error) {
 
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
-		return "", err
+		return err
 	}
 
 	stderr, err := cmd.StderrPipe()
 	if err != nil {
-		return "", err
+		return err
 	}
 
 	err = cmd.Start()
 	if err != nil {
-		return "", err
+		return err
 	}
 
-	output, err := readStdoutAndStderr(t, stdout, stderr)
-	if err != nil {
-		return output, err
+
+	if err := readStdoutAndStderr(t, stdout, stderr, storedStdout, storedStderr); err != nil {
+		return err
 	}
 
 	if err := cmd.Wait(); err != nil {
-		return output, err
+		return err
 	}
 
-	return output, nil
+	return nil
 }
 
-// This function captures stdout and stderr while still printing it to the stdout and stderr of this Go program
-func readStdoutAndStderr(t *testing.T, stdout io.ReadCloser, stderr io.ReadCloser) (string, error) {
-	allOutput := []string{}
-
+// This function captures stdout and stderr into the given variables while still printing it to the stdout and stderr
+// of this Go program
+func readStdoutAndStderr(t *testing.T, stdout io.ReadCloser, stderr io.ReadCloser, storedStdout *[]string, storedStderr *[]string) error {
 	stdoutScanner := bufio.NewScanner(stdout)
 	stderrScanner := bufio.NewScanner(stderr)
 
 	wg := &sync.WaitGroup{}
 	mutex := &sync.Mutex{}
 	wg.Add(2)
-	go readData(t, stdoutScanner, wg, mutex, &allOutput)
-	go readData(t, stderrScanner, wg, mutex, &allOutput)
+	go readData(t, stdoutScanner, wg, mutex, storedStdout)
+	go readData(t, stderrScanner, wg, mutex, storedStderr)
 	wg.Wait()
 
 	if err := stdoutScanner.Err(); err != nil {
-		return "", err
+		return err
 	}
 
 	if err := stderrScanner.Err(); err != nil {
-		return "", err
+		return err
 	}
 
-	return strings.Join(allOutput, "\n"), nil
+	return nil
 }
 
 func readData(t *testing.T, scanner *bufio.Scanner, wg *sync.WaitGroup, mutex *sync.Mutex, allOutput *[]string) {

--- a/modules/terraform/apply_test.go
+++ b/modules/terraform/apply_test.go
@@ -1,10 +1,9 @@
 package terraform
 
 import (
-	"fmt"
-	"github.com/magiconair/properties/assert"
-	"reflect"
 	"testing"
+
+	"github.com/magiconair/properties/assert"
 
 	"github.com/gruntwork-io/terratest/modules/files"
 	"github.com/stretchr/testify/require"

--- a/modules/terraform/apply_test.go
+++ b/modules/terraform/apply_test.go
@@ -1,6 +1,9 @@
 package terraform
 
 import (
+	"fmt"
+	"github.com/magiconair/properties/assert"
+	"reflect"
 	"testing"
 
 	"github.com/gruntwork-io/terratest/modules/files"
@@ -94,4 +97,27 @@ func TestTgApplyAllError(t *testing.T) {
 	out := TgApplyAll(t, options)
 
 	require.Contains(t, out, "This is the first run, exiting with an error")
+}
+
+func TestTgApplyOutput(t *testing.T) {
+	t.Parallel()
+
+	options := &Options{
+		TerraformDir:    "../../test/fixtures/terragrunt/terragrunt-output",
+		TerraformBinary: "terragrunt",
+	}
+
+	Apply(t, options)
+
+	strOutput := OutputRequired(t, options, "str")
+	assert.Equal(t, strOutput, "str")
+
+	listOutput := OutputList(t, options, "list")
+	assert.Equal(t, listOutput, []string{"a", "b", "c"})
+
+	mapOutput := OutputMap(t, options, "map")
+	assert.Equal(t, mapOutput, map[string]string{"foo": "bar"})
+
+	allOutputs := OutputForKeys(t, options, []string{"str", "list", "map"})
+	assert.Equal(t, allOutputs, map[string]interface{}{"str": "str", "list": []interface{}{"a", "b", "c"}, "map": map[string]interface{}{"foo": "bar"}})
 }

--- a/modules/terraform/cmd.go
+++ b/modules/terraform/cmd.go
@@ -61,8 +61,8 @@ func RunTerraformCommandE(t *testing.T, additionalOptions *Options, additionalAr
 	})
 }
 
-// RunTerraformCommandE runs terraform with the given arguments and options and returns solely its stdout (but not
-// stderr).
+// RunTerraformCommandAndGetStdoutE runs terraform with the given arguments and options and returns solely its stdout
+// (but not stderr).
 func RunTerraformCommandAndGetStdoutE(t *testing.T, additionalOptions *Options, additionalArgs ...string) (string, error) {
 	options, args := GetCommonOptions(additionalOptions, additionalArgs...)
 

--- a/modules/terraform/cmd.go
+++ b/modules/terraform/cmd.go
@@ -61,6 +61,24 @@ func RunTerraformCommandE(t *testing.T, additionalOptions *Options, additionalAr
 	})
 }
 
+// RunTerraformCommandE runs terraform with the given arguments and options and returns solely its stdout (but not
+// stderr).
+func RunTerraformCommandAndGetStdoutE(t *testing.T, additionalOptions *Options, additionalArgs ...string) (string, error) {
+	options, args := GetCommonOptions(additionalOptions, additionalArgs...)
+
+	cmd := shell.Command{
+		Command:    options.TerraformBinary,
+		Args:       args,
+		WorkingDir: options.TerraformDir,
+		Env:        options.EnvVars,
+	}
+
+	description := fmt.Sprintf("%s %v", options.TerraformBinary, args)
+	return retry.DoWithRetryableErrorsE(t, description, options.RetryableTerraformErrors, options.MaxRetries, options.TimeBetweenRetries, func() (string, error) {
+		return shell.RunCommandAndGetStdOutE(t, cmd)
+	})
+}
+
 // GetExitCodeForTerraformCommand runs terraform with the given arguments and options and returns exit code
 func GetExitCodeForTerraformCommand(t *testing.T, additionalOptions *Options, args ...string) int {
 	exitCode, err := GetExitCodeForTerraformCommandE(t, additionalOptions, args...)

--- a/modules/terraform/output.go
+++ b/modules/terraform/output.go
@@ -19,7 +19,7 @@ func Output(t *testing.T, options *Options, key string) string {
 
 // OutputE calls terraform output for the given variable and return its value.
 func OutputE(t *testing.T, options *Options, key string) (string, error) {
-	output, err := RunTerraformCommandE(t, options, "output", "-no-color", key)
+	output, err := RunTerraformCommandAndGetStdoutE(t, options, "output", "-no-color", key)
 
 	if err != nil {
 		return "", err
@@ -60,7 +60,7 @@ func OutputList(t *testing.T, options *Options, key string) []string {
 // OutputListE calls terraform output for the given variable and returns its value as a list.
 // If the output value is not a list type, then it returns an error.
 func OutputListE(t *testing.T, options *Options, key string) ([]string, error) {
-	out, err := RunTerraformCommandE(t, options, "output", "-no-color", "-json", key)
+	out, err := RunTerraformCommandAndGetStdoutE(t, options, "output", "-no-color", "-json", key)
 	if err != nil {
 		return nil, err
 	}
@@ -121,7 +121,7 @@ func OutputMap(t *testing.T, options *Options, key string) map[string]string {
 // OutputMapE calls terraform output for the given variable and returns its value as a map.
 // If the output value is not a map type, then it returns an error.
 func OutputMapE(t *testing.T, options *Options, key string) (map[string]string, error) {
-	out, err := RunTerraformCommandE(t, options, "output", "-no-color", "-json", key)
+	out, err := RunTerraformCommandAndGetStdoutE(t, options, "output", "-no-color", "-json", key)
 	if err != nil {
 		return nil, err
 	}
@@ -164,7 +164,7 @@ func OutputForKeys(t *testing.T, options *Options, keys []string) map[string]int
 // OutputForKeysE calls terraform output for the given key list and returns values as a map.
 // The returned values are of type interface{} and need to be type casted as necessary. Refer to output_test.go
 func OutputForKeysE(t *testing.T, options *Options, keys []string) (map[string]interface{}, error) {
-	out, err := RunTerraformCommandE(t, options, "output", "-no-color", "-json")
+	out, err := RunTerraformCommandAndGetStdoutE(t, options, "output", "-no-color", "-json")
 	if err != nil {
 		return nil, err
 	}

--- a/test/fixtures/terragrunt/terragrunt-output/main.tf
+++ b/test/fixtures/terragrunt/terragrunt-output/main.tf
@@ -1,0 +1,11 @@
+output "str" {
+  value = "str"
+}
+
+output "list" {
+  value = ["a", "b", "c"]
+}
+
+output "map" {
+  value = { foo = "bar" }
+}

--- a/test/fixtures/terragrunt/terragrunt-output/terraform.tfvars
+++ b/test/fixtures/terragrunt/terragrunt-output/terraform.tfvars
@@ -1,0 +1,3 @@
+terragrunt = {
+  # Intentionally empty
+}


### PR DESCRIPTION
The `Output` commands in Terratest were running `terraform output` and then parsing the results from both `stdout` and `stderr`. This works with Terraform, as its `output` commands solely right to `stdout`, though it's a risky way to do it and may well break in the future; more to the point, it's broken with `terragrunt output` commands. Added failing test case and then fixed the code to make the test case pass.