### PR TITLE
Lock down k8s.io/api so that it doesn't break over time

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -649,10 +649,10 @@
   version = "v2.2.1"
 
 [[projects]]
-  branch = "master"
-  digest = "1:bf61730197acc225b5153ba3eb3d7b87c01da71f98896d9855309f37be7743ca"
+  digest = "1:aa8baec3af7896083e40bdd77a8bb00c74a0ab9f29672b970ec6001b4daf3105"
   name = "k8s.io/api"
   packages = [
+    ".",
     "admissionregistration/v1alpha1",
     "admissionregistration/v1beta1",
     "apps/v1",
@@ -843,6 +843,7 @@
     "github.com/gruntwork-io/gruntwork-cli/errors",
     "github.com/gruntwork-io/gruntwork-cli/files",
     "github.com/gruntwork-io/gruntwork-cli/logging",
+    "github.com/json-iterator/go",
     "github.com/jstemmer/go-junit-report/formatter",
     "github.com/jstemmer/go-junit-report/parser",
     "github.com/magiconair/properties/assert",
@@ -862,6 +863,7 @@
     "google.golang.org/api/compute/v1",
     "google.golang.org/api/iterator",
     "google.golang.org/api/oslogin/v1",
+    "k8s.io/api",
     "k8s.io/api/apps/v1",
     "k8s.io/api/authorization/v1",
     "k8s.io/api/core/v1",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -31,8 +31,9 @@
 # See for more info:
 # - https://github.com/kubernetes/client-go/blob/kubernetes-1.11.3/INSTALL.md#dep-not-supported-yet
 # - https://golang.github.io/dep/docs/FAQ.html#how-do-i-constrain-a-transitive-dependency-s-version
-require = [
+required = [
     "github.com/json-iterator/go",
+    "k8s.io/api",
 ]
 
 
@@ -95,3 +96,7 @@ require = [
 [[constraint]]
   name = "github.com/json-iterator/go"
   version = "v1.1.5"
+
+[[override]]
+  name = "k8s.io/api"
+  revision = "a33c8200050fc0751848276811abf3fc029b3133"


### PR DESCRIPTION
As I was upgrading to the latest terratest on a few of our modules, I ran into an issue with `dep` where it was pulling in the latest version of `k8s.io/api` that has some backwards incompatible changes which broke `k8s.io/client-go`.

We fix this by defining `k8s.io/api` as a transitive dependency and lock it down to a specific version: the last known revision locked down in `terratest` that is known to work.