### PR TITLE
Expose FindNodePortE and allow filtering nodes

### DIFF
--- a/modules/k8s/node.go
+++ b/modules/k8s/node.go
@@ -23,6 +23,12 @@ func GetNodes(t *testing.T, options *KubectlOptions) []corev1.Node {
 
 // GetNodesE queries Kubernetes for information about the worker nodes registered to the cluster.
 func GetNodesE(t *testing.T, options *KubectlOptions) ([]corev1.Node, error) {
+	return GetNodesByFilterE(t, options, metav1.ListOptions{})
+}
+
+// GetNodesByFilterE queries Kubernetes for information about the worker nodes registered to the cluster, filtering the
+// list of nodes using the provided ListOptions.
+func GetNodesByFilterE(t *testing.T, options *KubectlOptions, filter metav1.ListOptions) ([]corev1.Node, error) {
 	logger.Logf(t, "Getting list of nodes from Kubernetes")
 
 	clientset, err := GetKubernetesClientFromOptionsE(t, options)
@@ -30,7 +36,7 @@ func GetNodesE(t *testing.T, options *KubectlOptions) ([]corev1.Node, error) {
 		return nil, err
 	}
 
-	nodes, err := clientset.CoreV1().Nodes().List(metav1.ListOptions{})
+	nodes, err := clientset.CoreV1().Nodes().List(filter)
 	if err != nil {
 		return nil, err
 	}

--- a/modules/k8s/service.go
+++ b/modules/k8s/service.go
@@ -131,7 +131,7 @@ func findEndpointForNodePortService(
 	service *corev1.Service,
 	servicePort int32,
 ) (string, error) {
-	nodePort, err := findNodePortE(service, int32(servicePort))
+	nodePort, err := FindNodePortE(service, int32(servicePort))
 	if err != nil {
 		return "", err
 	}
@@ -147,7 +147,7 @@ func findEndpointForNodePortService(
 }
 
 // Given the desired servicePort, return the allocated nodeport
-func findNodePortE(service *corev1.Service, servicePort int32) (int32, error) {
+func FindNodePortE(service *corev1.Service, servicePort int32) (int32, error) {
 	for _, port := range service.Spec.Ports {
 		if port.Port == servicePort {
 			return port.NodePort, nil

--- a/modules/k8s/service.go
+++ b/modules/k8s/service.go
@@ -139,7 +139,7 @@ func findEndpointForNodePortService(
 	if err != nil {
 		return "", err
 	}
-	nodeHostname, err := findNodeHostnameE(t, node)
+	nodeHostname, err := FindNodeHostnameE(t, node)
 	if err != nil {
 		return "", err
 	}
@@ -170,7 +170,7 @@ func pickRandomNodeE(t *testing.T, options *KubectlOptions) (corev1.Node, error)
 }
 
 // Given a node, return the ip address, preferring the external IP
-func findNodeHostnameE(t *testing.T, node corev1.Node) (string, error) {
+func FindNodeHostnameE(t *testing.T, node corev1.Node) (string, error) {
 	nodeIDUri, err := url.Parse(node.Spec.ProviderID)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
This improves support for testing multi nodegroup kubernetes clusters. Specifically, right now `GetServiceEndpoint` will pick a random node from the full list of nodes. This is problematic for multi nodegroup clusters because some nodes might have restricted network settings, and thus are not intended to be accessed.

On the otherhand, it isn't clear to me what the right interface for `GetServiceEndpoint` would be to support restricting the node selection. Since this is a pretty specific use case, rather than supporting it in the generic `GetServiceEndpoint` function, I decided to expose the building blocks to support a user to implement this. This entails:

- Exposing `findNodePortE` as a public function so that users can easily find the associated node port for a service even outside the module.
- Exposing `findNodeHostnameE` as a public function
- Exposing `GetNodesByFilterE`, which can be used to filter nodes