### PR TITLE
Bump ubuntu test image to 18.04

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ defaults: &defaults
     image: "ubuntu-1604:201903-01"
   environment:
     GRUNTWORK_INSTALLER_VERSION: v0.0.21
-    MODULE_CI_VERSION: v0.13.12
+    MODULE_CI_VERSION: v0.14.1
     TERRAFORM_VERSION: 0.11.11
     TERRAGRUNT_VERSION: v0.18.3
     PACKER_VERSION: 1.3.3

--- a/test-docker-images/README.md
+++ b/test-docker-images/README.md
@@ -26,7 +26,7 @@ that Packer templates that build Docker images can reference them directly as in
   },{
     "name": "ubuntu-docker",
     "type": "docker",
-    "image": "gruntwork/ubuntu-test:16.04",
+    "image": "gruntwork/ubuntu-test:18.04",
     "commit": "true"
   }],
   "provisioners": [

--- a/test-docker-images/gruntwork-ubuntu-test/Dockerfile
+++ b/test-docker-images/gruntwork-ubuntu-test/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 # Reduce Docker image size per https://blog.replicated.com/refactoring-a-dockerfile-for-image-size/
 # - dnsutils: Install handy DNS checking tools like dig
@@ -8,11 +8,14 @@ RUN DEBIAN_FRONTEND=noninteractive \
     apt-get update && \
     apt-get upgrade -y && \
     apt-get install --no-install-recommends -y \
+        gpg-agent \
+        apt-transport-https \
         ca-certificates \
         curl \
         dnsutils \
         jq \
         libcrypt-hcesha-perl \
+        python \
         python-pip \
         rsyslog \
         software-properties-common \
@@ -22,15 +25,17 @@ RUN DEBIAN_FRONTEND=noninteractive \
         rm -rf /var/lib/apt/lists/*
 
 # Install the AWS CLI per https://docs.aws.amazon.com/cli/latest/userguide/installing.html. The last line upgrades pip
-# to the latest version.
+# to the latest version. Note that we need to remove python-pip before we can use the updated pip, as pip does not
+# automatically remove the ubuntu managed pip. We also need to refresh the cached pip path in the current bash session so
+# that it picks up the new pip.
 RUN pip install --upgrade setuptools && \
     pip install --upgrade pip && \
+    apt-get remove -y python-pip python-pip-whl && \
+    hash pip && \
     pip install awscli --upgrade
 
 # Install the latest version of Docker, Consumer Edition
 RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - && \
-    apt-get update && \
-    apt-get -y install apt-transport-https && \
     add-apt-repository \
        "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
        $(lsb_release -cs) \

--- a/test-docker-images/gruntwork-ubuntu-test/README.md
+++ b/test-docker-images/gruntwork-ubuntu-test/README.md
@@ -1,14 +1,14 @@
 # Gruntwork Ubuntu-Test Docker Image
 
-The purpose of this Docker image is to provide a pre-built Ubuntu 16.04 Docker image that has most of the libraries
-we would expect to be installed on the Ubuntu 16.04 AMI that would run in AWS. For example, we'd expect `curl` in AWS,
-but it doesn't exist by default in Docker `ubuntu:16.04`.
+The purpose of this Docker image is to provide a pre-built Ubuntu 18.04 Docker image that has most of the libraries
+we would expect to be installed on the Ubuntu 18.04 AMI that would run in AWS. For example, we'd expect `curl` in AWS,
+but it doesn't exist by default in Docker `ubuntu:18.04`.
 
 ### Building and Pushing a New Docker Image to Docker Hub
 
 This Docker image should publicly accessible via Docker Hub at https://hub.docker.com/r/gruntwork/ubuntu-test/. To build and
 upload it:
 
-1. `docker build -t gruntwork/ubuntu-test:16.04 .`
-1. `docker push gruntwork/ubuntu-test:16.04`
+1. `docker build -t gruntwork/ubuntu-test:18.04 .`
+1. `docker push gruntwork/ubuntu-test:18.04`
 


### PR DESCRIPTION
This bumps the `ubuntu-test` docker image to 18.04. I already built and pushed the new image under the tag `18.04`: https://cloud.docker.com/u/gruntwork/repository/docker/gruntwork/ubuntu-test