### PR TITLE
Fixes to PR #282

### DIFF
--- a/modules/helm/install_test.go
+++ b/modules/helm/install_test.go
@@ -8,6 +8,7 @@
 package helm
 
 import (
+	"crypto/tls"
 	"fmt"
 	"strings"
 	"testing"
@@ -70,9 +71,14 @@ func TestRemoteChartInstall(t *testing.T) {
 	k8s.WaitUntilServiceAvailable(t, kubectlOptions, serviceName, 10, 1*time.Second)
 	service := k8s.GetService(t, kubectlOptions, serviceName)
 	endpoint := k8s.GetServiceEndpoint(t, kubectlOptions, service, 8080)
+
+	// Setup a TLS configuration to submit with the helper, a blank struct is acceptable
+	tlsConfig := tls.Config{}
+
 	http_helper.HttpGetWithRetryWithCustomValidation(
 		t,
 		fmt.Sprintf("http://%s", endpoint),
+		&tlsConfig,
 		30,
 		10*time.Second,
 		func(statusCode int, body string) bool {

--- a/modules/helm/upgrade_test.go
+++ b/modules/helm/upgrade_test.go
@@ -8,6 +8,7 @@
 package helm
 
 import (
+	"crypto/tls"
 	"fmt"
 	"strings"
 	"testing"
@@ -93,9 +94,14 @@ func TestRemoteChartInstallAndUpgrade(t *testing.T) {
 	k8s.WaitUntilServiceAvailable(t, kubectlOptions, serviceName, 10, 1*time.Second)
 	service := k8s.GetService(t, kubectlOptions, serviceName)
 	endpoint := k8s.GetServiceEndpoint(t, kubectlOptions, service, 8080)
+
+	// Setup a TLS configuration to submit with the helper, a blank struct is acceptable
+	tlsConfig := tls.Config{}
+
 	http_helper.HttpGetWithRetryWithCustomValidation(
 		t,
 		fmt.Sprintf("http://%s", endpoint),
+		&tlsConfig,
 		30,
 		10*time.Second,
 		func(statusCode int, body string) bool {

--- a/modules/http-helper/continuous.go
+++ b/modules/http-helper/continuous.go
@@ -1,6 +1,7 @@
 package http_helper
 
 import (
+	"crypto/tls"
 	"sync"
 	"testing"
 	"time"
@@ -35,8 +36,8 @@ func ContinuouslyCheckUrl(
 				logger.Logf(t, "Got signal to stop downtime checks for URL %s.\n", url)
 				return
 			case <-time.After(sleepBetweenChecks):
-				statusCode, body, err := HttpGetE(t, url)
-				// Nonblocking send, defaulting to logging a warning if there is no channel reader
+				statusCode, body, err := HttpGetE(t, url, &tls.Config{})
+				// Non-blocking send, defaulting to logging a warning if there is no channel reader
 				select {
 				case responses <- GetResponse{StatusCode: statusCode, Body: body}:
 					// do nothing since all we want to do is send the response

--- a/modules/http-helper/dummy_server_test.go
+++ b/modules/http-helper/dummy_server_test.go
@@ -1,6 +1,7 @@
 package http_helper
 
 import (
+	"crypto/tls"
 	"fmt"
 	"io"
 	"testing"
@@ -20,7 +21,7 @@ func TestRunDummyServer(t *testing.T) {
 	defer shutDownServer(t, listener)
 
 	url := fmt.Sprintf("http://localhost:%d", port)
-	HttpGetWithValidation(t, url, 200, text)
+	HttpGetWithValidation(t, url, &tls.Config{}, 200, text)
 }
 
 func TestContinuouslyCheck(t *testing.T) {

--- a/modules/http-helper/errors.go
+++ b/modules/http-helper/errors.go
@@ -1,0 +1,14 @@
+package http_helper
+
+import "fmt"
+
+// ValidationFunctionFailed is an error that occurs if a validation function fails.
+type ValidationFunctionFailed struct {
+	Url    string
+	Status int
+	Body   string
+}
+
+func (err ValidationFunctionFailed) Error() string {
+	return fmt.Sprintf("Validation failed for URL %s. Response status: %d. Response body:\n%s", err.Url, err.Status, err.Body)
+}

--- a/modules/http-helper/http_helper.go
+++ b/modules/http-helper/http_helper.go
@@ -16,8 +16,8 @@ import (
 
 // HttpGet performs an HTTP GET, with an optional pointer to a custom TLS configuration, on the given URL and
 // return the HTTP status code and body. If there's any error, fail the test.
-func HttpGet(t *testing.T, url string, TLSConfig *tls.Config) (int, string) {
-	statusCode, body, err := HttpGetE(t, url, TLSConfig)
+func HttpGet(t *testing.T, url string, tlsConfig *tls.Config) (int, string) {
+	statusCode, body, err := HttpGetE(t, url, tlsConfig)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -26,14 +26,19 @@ func HttpGet(t *testing.T, url string, TLSConfig *tls.Config) (int, string) {
 
 // HttpGetE performs an HTTP GET, with an optional pointer to a custom TLS configuration, on the given URL and
 // return the HTTP status code, body, and any error.
-func HttpGetE(t *testing.T, url string, TLSConfig *tls.Config) (int, string, error) {
+func HttpGetE(t *testing.T, url string, tlsConfig *tls.Config) (int, string, error) {
 	logger.Logf(t, "Making an HTTP GET call to URL %s", url)
 
-	http.DefaultTransport.(*http.Transport).TLSClientConfig = TLSConfig
+	// Set HTTP client transport config
+	tr := &http.Transport{
+		TLSClientConfig: tlsConfig,
+	}
 
 	client := http.Client{
 		// By default, Go does not impose a timeout, so an HTTP connection attempt can hang for a LONG time.
 		Timeout: 10 * time.Second,
+		// Include the previously created transport config
+		Transport: tr,
 	}
 
 	resp, err := client.Get(url)
@@ -53,8 +58,8 @@ func HttpGetE(t *testing.T, url string, TLSConfig *tls.Config) (int, string, err
 
 // HttpGetWithValidation performs an HTTP GET on the given URL and verify that you get back the expected status code and body. If either
 // doesn't match, fail the test.
-func HttpGetWithValidation(t *testing.T, url string, TLSConfig *tls.Config, expectedStatusCode int, expectedBody string) {
-	err := HttpGetWithValidationE(t, url, TLSConfig, expectedStatusCode, expectedBody)
+func HttpGetWithValidation(t *testing.T, url string, tlsConfig *tls.Config, expectedStatusCode int, expectedBody string) {
+	err := HttpGetWithValidationE(t, url, tlsConfig, expectedStatusCode, expectedBody)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -62,23 +67,23 @@ func HttpGetWithValidation(t *testing.T, url string, TLSConfig *tls.Config, expe
 
 // HttpGetWithValidationE performs an HTTP GET on the given URL and verify that you get back the expected status code and body. If either
 // doesn't match, return an error.
-func HttpGetWithValidationE(t *testing.T, url string, TLSConfig *tls.Config, expectedStatusCode int, expectedBody string) error {
-	return HttpGetWithCustomValidationE(t, url, TLSConfig, func(statusCode int, body string) bool {
+func HttpGetWithValidationE(t *testing.T, url string, tlsConfig *tls.Config, expectedStatusCode int, expectedBody string) error {
+	return HttpGetWithCustomValidationE(t, url, tlsConfig, func(statusCode int, body string) bool {
 		return statusCode == expectedStatusCode && body == expectedBody
 	})
 }
 
 // HttpGetWithCustomValidation performs an HTTP GET on the given URL and validate the returned status code and body using the given function.
-func HttpGetWithCustomValidation(t *testing.T, url string, TLSConfig *tls.Config, validateResponse func(int, string) bool) {
-	err := HttpGetWithCustomValidationE(t, url, TLSConfig, validateResponse)
+func HttpGetWithCustomValidation(t *testing.T, url string, tlsConfig *tls.Config, validateResponse func(int, string) bool) {
+	err := HttpGetWithCustomValidationE(t, url, tlsConfig, validateResponse)
 	if err != nil {
 		t.Fatal(err)
 	}
 }
 
 // HttpGetWithCustomValidationE performs an HTTP GET on the given URL and validate the returned status code and body using the given function.
-func HttpGetWithCustomValidationE(t *testing.T, url string, TLSConfig *tls.Config, validateResponse func(int, string) bool) error {
-	statusCode, body, err := HttpGetE(t, url, TLSConfig)
+func HttpGetWithCustomValidationE(t *testing.T, url string, tlsConfig *tls.Config, validateResponse func(int, string) bool) error {
+	statusCode, body, err := HttpGetE(t, url, tlsConfig)
 
 	if err != nil {
 		return err
@@ -93,8 +98,8 @@ func HttpGetWithCustomValidationE(t *testing.T, url string, TLSConfig *tls.Confi
 
 // HttpGetWithRetry repeatedly performs an HTTP GET on the given URL until the given status code and body are returned or until max
 // retries has been exceeded.
-func HttpGetWithRetry(t *testing.T, url string, TLSConfig *tls.Config, expectedStatus int, expectedBody string, retries int, sleepBetweenRetries time.Duration) {
-	err := HttpGetWithRetryE(t, url, TLSConfig, expectedStatus, expectedBody, retries, sleepBetweenRetries)
+func HttpGetWithRetry(t *testing.T, url string, tlsConfig *tls.Config, expectedStatus int, expectedBody string, retries int, sleepBetweenRetries time.Duration) {
+	err := HttpGetWithRetryE(t, url, tlsConfig, expectedStatus, expectedBody, retries, sleepBetweenRetries)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -102,9 +107,9 @@ func HttpGetWithRetry(t *testing.T, url string, TLSConfig *tls.Config, expectedS
 
 // HttpGetWithRetryE repeatedly performs an HTTP GET on the given URL until the given status code and body are returned or until max
 // retries has been exceeded.
-func HttpGetWithRetryE(t *testing.T, url string, TLSConfig *tls.Config, expectedStatus int, expectedBody string, retries int, sleepBetweenRetries time.Duration) error {
+func HttpGetWithRetryE(t *testing.T, url string, tlsConfig *tls.Config, expectedStatus int, expectedBody string, retries int, sleepBetweenRetries time.Duration) error {
 	_, err := retry.DoWithRetryE(t, fmt.Sprintf("HTTP GET to URL %s", url), retries, sleepBetweenRetries, func() (string, error) {
-		return "", HttpGetWithValidationE(t, url, TLSConfig, expectedStatus, expectedBody)
+		return "", HttpGetWithValidationE(t, url, tlsConfig, expectedStatus, expectedBody)
 	})
 
 	return err
@@ -112,8 +117,8 @@ func HttpGetWithRetryE(t *testing.T, url string, TLSConfig *tls.Config, expected
 
 // HttpGetWithRetryWithCustomValidation repeatedly performs an HTTP GET on the given URL until the given validation function returns true or max retries
 // has been exceeded.
-func HttpGetWithRetryWithCustomValidation(t *testing.T, url string, TLSConfig *tls.Config, retries int, sleepBetweenRetries time.Duration, validateResponse func(int, string) bool) {
-	err := HttpGetWithRetryWithCustomValidationE(t, url, TLSConfig, retries, sleepBetweenRetries, validateResponse)
+func HttpGetWithRetryWithCustomValidation(t *testing.T, url string, tlsConfig *tls.Config, retries int, sleepBetweenRetries time.Duration, validateResponse func(int, string) bool) {
+	err := HttpGetWithRetryWithCustomValidationE(t, url, tlsConfig, retries, sleepBetweenRetries, validateResponse)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -121,9 +126,9 @@ func HttpGetWithRetryWithCustomValidation(t *testing.T, url string, TLSConfig *t
 
 // HttpGetWithRetryWithCustomValidationE repeatedly performs an HTTP GET on the given URL until the given validation function returns true or max retries
 // has been exceeded.
-func HttpGetWithRetryWithCustomValidationE(t *testing.T, url string, TLSConfig *tls.Config, retries int, sleepBetweenRetries time.Duration, validateResponse func(int, string) bool) error {
+func HttpGetWithRetryWithCustomValidationE(t *testing.T, url string, tlsConfig *tls.Config, retries int, sleepBetweenRetries time.Duration, validateResponse func(int, string) bool) error {
 	_, err := retry.DoWithRetryE(t, fmt.Sprintf("HTTP GET to URL %s", url), retries, sleepBetweenRetries, func() (string, error) {
-		return "", HttpGetWithCustomValidationE(t, url, TLSConfig, validateResponse)
+		return "", HttpGetWithCustomValidationE(t, url, tlsConfig, validateResponse)
 	})
 
 	return err

--- a/modules/k8s/tunnel_test.go
+++ b/modules/k8s/tunnel_test.go
@@ -9,6 +9,7 @@
 package k8s
 
 import (
+	"crypto/tls"
 	"fmt"
 	"strings"
 	"testing"
@@ -34,10 +35,14 @@ func TestTunnelOpensAPortForwardTunnelToPod(t *testing.T) {
 	defer tunnel.Close()
 	tunnel.ForwardPort(t)
 
+	// Setup a TLS configuration to submit with the helper, a blank struct is acceptable
+	tlsConfig := tls.Config{}
+
 	// Try to access the nginx service on the local port, retrying until we get a good response for up to 5 minutes
 	http_helper.HttpGetWithRetryWithCustomValidation(
 		t,
 		fmt.Sprintf("http://%s", tunnel.Endpoint()),
+		&tlsConfig,
 		60,
 		5*time.Second,
 		verifyNginxWelcomePage,
@@ -61,10 +66,14 @@ func TestTunnelOpensAPortForwardTunnelToService(t *testing.T) {
 	defer tunnel.Close()
 	tunnel.ForwardPort(t)
 
+	// Setup a TLS configuration to submit with the helper, a blank struct is acceptable
+	tlsConfig := tls.Config{}
+
 	// Try to access the nginx service on the local port, retrying until we get a good response for up to 5 minutes
 	http_helper.HttpGetWithRetryWithCustomValidation(
 		t,
 		fmt.Sprintf("http://%s", tunnel.Endpoint()),
+		&tlsConfig,
 		60,
 		5*time.Second,
 		verifyNginxWelcomePage,

--- a/test/helm_basic_example_integration_test.go
+++ b/test/helm_basic_example_integration_test.go
@@ -8,6 +8,7 @@
 package test
 
 import (
+	"crypto/tls"
 	"fmt"
 	"path/filepath"
 	"strings"

--- a/test/helm_basic_example_integration_test.go
+++ b/test/helm_basic_example_integration_test.go
@@ -83,11 +83,16 @@ func TestHelmBasicExampleDeployment(t *testing.T) {
 	// Now we verify that the service will successfully boot and start serving requests
 	service := k8s.GetService(t, kubectlOptions, serviceName)
 	endpoint := k8s.GetServiceEndpoint(t, kubectlOptions, service, 80)
+
+	// Setup a TLS configuration to submit with the helper, a blank struct is acceptable
+	tlsConfig := tls.Config{}
+
 	// Test the endpoint for up to 5 minutes. This will only fail if we timeout waiting for the service to return a 200
 	// response.
 	http_helper.HttpGetWithRetryWithCustomValidation(
 		t,
 		fmt.Sprintf("http://%s", endpoint),
+		&tlsConfig,
 		30,
 		10*time.Second,
 		func(statusCode int, body string) bool {

--- a/test/kubernetes_basic_example_service_check_test.go
+++ b/test/kubernetes_basic_example_service_check_test.go
@@ -57,11 +57,16 @@ func TestKubernetesBasicExampleServiceCheck(t *testing.T) {
 	// Now we verify that the service will successfully boot and start serving requests
 	service := k8s.GetService(t, options, "nginx-service")
 	endpoint := k8s.GetServiceEndpoint(t, options, service, 80)
+
+	// Setup a TLS configuration to submit with the helper, a blank struct is acceptable
+	tlsConfig := tls.Config{}
+
 	// Test the endpoint for up to 5 minutes. This will only fail if we timeout waiting for the service to return a 200
 	// response.
 	http_helper.HttpGetWithRetryWithCustomValidation(
 		t,
 		fmt.Sprintf("http://%s", endpoint),
+		&tlsConfig,
 		30,
 		10*time.Second,
 		func(statusCode int, body string) bool {

--- a/test/kubernetes_basic_example_service_check_test.go
+++ b/test/kubernetes_basic_example_service_check_test.go
@@ -9,6 +9,7 @@
 package test
 
 import (
+	"crypto/tls"
 	"fmt"
 	"path/filepath"
 	"strings"

--- a/test/packer_docker_example_test.go
+++ b/test/packer_docker_example_test.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"crypto/tls"
 	"fmt"
 	"strconv"
 	"testing"
@@ -58,6 +59,9 @@ func TestPackerDockerExampleLocal(t *testing.T) {
 	timeBetweenRetries := 2 * time.Second
 	url := fmt.Sprintf("http://localhost:%d", serverPort)
 
+	// Setup a TLS configuration to submit with the helper, a blank struct is acceptable
+	tlsConfig := tls.Config{}
+
 	// Verify that we get back a 200 OK with the expected text
-	http_helper.HttpGetWithRetry(t, url, 200, expectedServerText, maxRetries, timeBetweenRetries)
+	http_helper.HttpGetWithRetry(t, url, &tlsConfig, 200, expectedServerText, maxRetries, timeBetweenRetries)
 }

--- a/test/terraform_http_example_test.go
+++ b/test/terraform_http_example_test.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"crypto/tls"
 	"fmt"
 	"testing"
 	"time"
@@ -50,10 +51,13 @@ func TestTerraformHttpExample(t *testing.T) {
 	// Run `terraform output` to get the value of an output variable
 	instanceURL := terraform.Output(t, terraformOptions, "instance_url")
 
+	// Setup a TLS configuration to submit with the helper, a blank struct is acceptable
+	tlsConfig := tls.Config{}
+
 	// It can take a minute or so for the Instance to boot up, so retry a few times
 	maxRetries := 30
 	timeBetweenRetries := 5 * time.Second
 
 	// Verify that we get back a 200 OK with the expected instanceText
-	http_helper.HttpGetWithRetry(t, instanceURL, 200, instanceText, maxRetries, timeBetweenRetries)
+	http_helper.HttpGetWithRetry(t, instanceURL, &tlsConfig, 200, instanceText, maxRetries, timeBetweenRetries)
 }

--- a/test/terraform_packer_example_test.go
+++ b/test/terraform_packer_example_test.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"crypto/tls"
 	"fmt"
 	"testing"
 	"time"
@@ -165,6 +166,9 @@ func validateInstanceRunningWebServer(t *testing.T, workingDir string) {
 	// Run `terraform output` to get the value of an output variable
 	instanceURL := terraform.Output(t, terraformOptions, "instance_url")
 
+	// Setup a TLS configuration to submit with the helper, a blank struct is acceptable
+	tlsConfig := tls.Config{}
+
 	// Figure out what text the instance should return for each request
 	instanceText, _ := terraformOptions.Vars["instance_text"].(string)
 
@@ -173,5 +177,5 @@ func validateInstanceRunningWebServer(t *testing.T, workingDir string) {
 	timeBetweenRetries := 5 * time.Second
 
 	// Verify that we get back a 200 OK with the expected instanceText
-	http_helper.HttpGetWithRetry(t, instanceURL, 200, instanceText, maxRetries, timeBetweenRetries)
+	http_helper.HttpGetWithRetry(t, instanceURL, &tlsConfig, 200, instanceText, maxRetries, timeBetweenRetries)
 }


### PR DESCRIPTION
Based on the comments to complete PR #282 I am submitting the following changes:

Added a TLS configuration pointer argument to all HTTP methods
Split out custom http_helper error types to `errors.go` as in other modules
Updated all references to existing HTTP methods to include blank TLS config struct
Updated all example files that called HTTP methods to include blank TLS config struct