### PR TITLE
Update assert library used in test

### DIFF
--- a/modules/helm/upgrade_test.go
+++ b/modules/helm/upgrade_test.go
@@ -13,12 +13,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	http_helper "github.com/gruntwork-io/terratest/modules/http-helper"
 	"github.com/gruntwork-io/terratest/modules/k8s"
 	"github.com/gruntwork-io/terratest/modules/random"
-	"gotest.tools/assert"
 )
 
 // Test that we can install and upgrade a remote chart (e.g stable/chartmuseum)


### PR DESCRIPTION
The test introduced in https://github.com/gruntwork-io/terratest/pull/335 was using a different assertion library from what we normally use. This PR updates that to use the one we normally depend on.