### PR TITLE
Fix more dep issues

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -804,12 +804,12 @@
   revision = "13596e875accbd333e0b5bd5fd9462185acd9958"
 
 [[projects]]
-  digest = "1:51314886250b22f73377febaadd972084684122e2e1d3004f388dff60754ba05"
+  digest = "1:0eb0e54e287f561fa804eba0640e99c857606aa47c04c0a41ce6e395e0ea3b7a"
   name = "k8s.io/kubernetes"
   packages = ["pkg/kubectl/generate"]
   pruneopts = "UT"
-  revision = "721bfa751924da8d1680787490c54b9179b1fed0"
-  version = "v1.13.3"
+  revision = "4485c6f18cee9a5d3c3b4e523bd27972b1b53892"
+  version = "v1.15.1"
 
 [solve-meta]
   analyzer-name = "dep"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -188,6 +188,19 @@
   revision = "4030bb1f1f0c35b30ca7009e9ebd06849dd45306"
 
 [[projects]]
+  digest = "1:2e3c336fc7fde5c984d2841455a658a6d626450b1754a854b3b32e7a8f49a07a"
+  name = "github.com/google/go-cmp"
+  packages = [
+    "cmp",
+    "cmp/internal/diff",
+    "cmp/internal/function",
+    "cmp/internal/value",
+  ]
+  pruneopts = "UT"
+  revision = "3af367b6b30c263d47e8895973edcca9a49cf029"
+  version = "v0.2.0"
+
+[[projects]]
   branch = "master"
   digest = "1:3ee90c0d94da31b442dde97c99635aaafec68d0b8a3c12ee2075c6bdabeec6bb"
   name = "github.com/google/gofuzz"
@@ -368,6 +381,14 @@
   pruneopts = "UT"
   revision = "5f041e8faa004a95c88a202771f4cc3e991971e6"
   version = "v2.0.1"
+
+[[projects]]
+  digest = "1:cf31692c14422fa27c83a05292eb5cbe0fb2775972e8f1f8446a71549bd8980b"
+  name = "github.com/pkg/errors"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "ba968bfe8b2f7e042a574c888954fccecfa385b4"
+  version = "v0.8.1"
 
 [[projects]]
   digest = "1:0028cb19b2e4c3112225cd871870f2d9cf49b9b4276531f03438a88e94be86fe"
@@ -649,6 +670,20 @@
   version = "v2.2.1"
 
 [[projects]]
+  digest = "1:a5cc901b8e54c4b73a62f97dc7c8f6c46e347c148a7a38e09b2e942c2587ba03"
+  name = "gotest.tools"
+  packages = [
+    "assert",
+    "assert/cmp",
+    "internal/difflib",
+    "internal/format",
+    "internal/source",
+  ]
+  pruneopts = "UT"
+  revision = "1083505acf35a0bd8a696b26837e1fb3187a7a83"
+  version = "v2.3.0"
+
+[[projects]]
   digest = "1:aa8baec3af7896083e40bdd77a8bb00c74a0ab9f29672b970ec6001b4daf3105"
   name = "k8s.io/api"
   packages = [
@@ -863,6 +898,7 @@
     "google.golang.org/api/compute/v1",
     "google.golang.org/api/iterator",
     "google.golang.org/api/oslogin/v1",
+    "gotest.tools/assert",
     "k8s.io/api",
     "k8s.io/api/apps/v1",
     "k8s.io/api/authorization/v1",

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -188,19 +188,6 @@
   revision = "4030bb1f1f0c35b30ca7009e9ebd06849dd45306"
 
 [[projects]]
-  digest = "1:2e3c336fc7fde5c984d2841455a658a6d626450b1754a854b3b32e7a8f49a07a"
-  name = "github.com/google/go-cmp"
-  packages = [
-    "cmp",
-    "cmp/internal/diff",
-    "cmp/internal/function",
-    "cmp/internal/value",
-  ]
-  pruneopts = "UT"
-  revision = "3af367b6b30c263d47e8895973edcca9a49cf029"
-  version = "v0.2.0"
-
-[[projects]]
   branch = "master"
   digest = "1:3ee90c0d94da31b442dde97c99635aaafec68d0b8a3c12ee2075c6bdabeec6bb"
   name = "github.com/google/gofuzz"
@@ -381,14 +368,6 @@
   pruneopts = "UT"
   revision = "5f041e8faa004a95c88a202771f4cc3e991971e6"
   version = "v2.0.1"
-
-[[projects]]
-  digest = "1:cf31692c14422fa27c83a05292eb5cbe0fb2775972e8f1f8446a71549bd8980b"
-  name = "github.com/pkg/errors"
-  packages = ["."]
-  pruneopts = "UT"
-  revision = "ba968bfe8b2f7e042a574c888954fccecfa385b4"
-  version = "v0.8.1"
 
 [[projects]]
   digest = "1:0028cb19b2e4c3112225cd871870f2d9cf49b9b4276531f03438a88e94be86fe"
@@ -670,20 +649,6 @@
   version = "v2.2.1"
 
 [[projects]]
-  digest = "1:a5cc901b8e54c4b73a62f97dc7c8f6c46e347c148a7a38e09b2e942c2587ba03"
-  name = "gotest.tools"
-  packages = [
-    "assert",
-    "assert/cmp",
-    "internal/difflib",
-    "internal/format",
-    "internal/source",
-  ]
-  pruneopts = "UT"
-  revision = "1083505acf35a0bd8a696b26837e1fb3187a7a83"
-  version = "v2.3.0"
-
-[[projects]]
   digest = "1:aa8baec3af7896083e40bdd77a8bb00c74a0ab9f29672b970ec6001b4daf3105"
   name = "k8s.io/api"
   packages = [
@@ -898,7 +863,6 @@
     "google.golang.org/api/compute/v1",
     "google.golang.org/api/iterator",
     "google.golang.org/api/oslogin/v1",
-    "gotest.tools/assert",
     "k8s.io/api",
     "k8s.io/api/apps/v1",
     "k8s.io/api/authorization/v1",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -86,12 +86,16 @@ required = [
 # Kubernetes API
 
 [[constraint]]
-  branch = "release-1.12"
   name = "k8s.io/apimachinery"
+  branch = "release-1.12"
 
 [[constraint]]
-  branch = "release-9.0"
   name = "k8s.io/client-go"
+  branch = "release-9.0"
+
+[[constraint]]
+  name = "k8s.io/kubernetes"
+  version = "v1.13.3"
 
 [[constraint]]
   name = "github.com/json-iterator/go"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -97,6 +97,6 @@ required = [
   name = "github.com/json-iterator/go"
   version = "v1.1.5"
 
-[[override]]
+[[constraint]]
   name = "k8s.io/api"
   revision = "a33c8200050fc0751848276811abf3fc029b3133"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -95,7 +95,7 @@ required = [
 
 [[constraint]]
   name = "k8s.io/kubernetes"
-  version = "v1.13.3"
+  version = "v1.15.1"
 
 [[constraint]]
   name = "github.com/json-iterator/go"

--- a/test/packer_basic_example_test.go
+++ b/test/packer_basic_example_test.go
@@ -20,7 +20,8 @@ import (
 // to make our tests resilient to that by specifying those known common errors here and telling our builds to retry if
 // they hit those errors.
 var DefaultRetryablePackerErrors = map[string]string{
-	"Script disconnected unexpectedly": "Occasionally, Packer seems to lose connectivity to AWS, perhaps due to a brief network outage",
+	"Script disconnected unexpectedly":                                                 "Occasionally, Packer seems to lose connectivity to AWS, perhaps due to a brief network outage",
+	"can not open /var/lib/apt/lists/archive.ubuntu.com_ubuntu_dists_xenial_InRelease": "Occasionally, apt-get fails on ubuntu to update the cache",
 }
 var DefaultTimeBetweenPackerRetries = 15 * time.Second
 


### PR DESCRIPTION
Found another dep issue, related to `k8s.io/kubernetes`. This locks that version down. Also replaces `override` with `constraint`, because `override` doesn't propagate down to projects depending on `terratest`.