### PR TITLE
Generic http helper methods

### DIFF
--- a/modules/http-helper/dummy_server.go
+++ b/modules/http-helper/dummy_server.go
@@ -46,24 +46,26 @@ func RunDummyServerE(t *testing.T, text string) (net.Listener, int, error) {
 	return listener, port, err
 }
 
-// RunDummyHandlerServer runs a dummy HTTP server on a unique port that will serve the given handler. Returns the Listener for the server, the
-// port it's listening on, or an error if something went wrong while trying to start the listener. Make sure to call
+// RunDummyHandlerServer runs a dummy HTTP server on a unique port that will serve given handlers. Returns the Listener for the server,
+// the port it's listening on, or an error if something went wrong while trying to start the listener. Make sure to call
 // the Close() method on the Listener when you're done!
-func RunDummyHandlerServer(t *testing.T, path string, handler func(http.ResponseWriter, *http.Request)) (net.Listener, int) {
-	listener, port, err := RunDummyHandlerServerE(t, path, handler)
+func RunDummyHandlerServer(t *testing.T, handlers map[string]func(http.ResponseWriter, *http.Request)) (net.Listener, int) {
+	listener, port, err := RunDummyHandlerServerE(t, handlers)
 	if err != nil {
 		t.Fatal(err)
 	}
 	return listener, port
 }
 
-// RunDummyHandlerServerE runs a dummy HTTP server on a unique port that will server the given handler. Returns the Listener for the server, the
-// port it's listening on, or an error if something went wrong while trying to start the listener. Make sure to call
+// RunDummyHandlerServerE runs a dummy HTTP server on a unique port that will server given handlers. Returns the Listener for the server,
+// the port it's listening on, or an error if something went wrong while trying to start the listener. Make sure to call
 // the Close() method on the Listener when you're done!
-func RunDummyHandlerServerE(t *testing.T, path string, handler func(http.ResponseWriter, *http.Request)) (net.Listener, int, error) {
+func RunDummyHandlerServerE(t *testing.T, handlers map[string]func(http.ResponseWriter, *http.Request)) (net.Listener, int, error) {
 	port := getNextPort()
 
-	http.HandleFunc(path, handler)
+	for path, handler := range handlers {
+		http.HandleFunc(path, handler)
+	}
 
 	logger.Logf(t, "Starting dummy HTTP server in port %d", port)
 

--- a/modules/http-helper/dummy_server.go
+++ b/modules/http-helper/dummy_server.go
@@ -46,6 +46,37 @@ func RunDummyServerE(t *testing.T, text string) (net.Listener, int, error) {
 	return listener, port, err
 }
 
+// RunDummyHandlerServer runs a dummy HTTP server on a unique port that will serve the given handler. Returns the Listener for the server, the
+// port it's listening on, or an error if something went wrong while trying to start the listener. Make sure to call
+// the Close() method on the Listener when you're done!
+func RunDummyHandlerServer(t *testing.T, path string, handler func(http.ResponseWriter, *http.Request)) (net.Listener, int) {
+	listener, port, err := RunDummyHandlerServerE(t, path, handler)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return listener, port
+}
+
+// RunDummyHandlerServerE runs a dummy HTTP server on a unique port that will server the given handler. Returns the Listener for the server, the
+// port it's listening on, or an error if something went wrong while trying to start the listener. Make sure to call
+// the Close() method on the Listener when you're done!
+func RunDummyHandlerServerE(t *testing.T, path string, handler func(http.ResponseWriter, *http.Request)) (net.Listener, int, error) {
+	port := getNextPort()
+
+	http.HandleFunc(path, handler)
+
+	logger.Logf(t, "Starting dummy HTTP server in port %d", port)
+
+	listener, err := net.Listen("tcp", ":"+strconv.Itoa(port))
+	if err != nil {
+		return nil, 0, fmt.Errorf("error listening: %s", err)
+	}
+
+	go http.Serve(listener, nil)
+
+	return listener, port, err
+}
+
 // DO NOT ACCESS THIS VARIABLE DIRECTLY. See getNextPort() below.
 var testServerPort int32 = 8080
 

--- a/modules/http-helper/dummy_server.go
+++ b/modules/http-helper/dummy_server.go
@@ -46,7 +46,7 @@ func RunDummyServerE(t *testing.T, text string) (net.Listener, int, error) {
 	return listener, port, err
 }
 
-// RunDummyHandlerServer runs a dummy HTTP server on a unique port that will serve given handlers. Returns the Listener for the server,
+// RunDummyServerWithHandlers runs a dummy HTTP server on a unique port that will serve given handlers. Returns the Listener for the server,
 // the port it's listening on, or an error if something went wrong while trying to start the listener. Make sure to call
 // the Close() method on the Listener when you're done!
 func RunDummyServerWithHandlers(t *testing.T, handlers map[string]func(http.ResponseWriter, *http.Request)) (net.Listener, int) {
@@ -57,7 +57,7 @@ func RunDummyServerWithHandlers(t *testing.T, handlers map[string]func(http.Resp
 	return listener, port
 }
 
-// RunDummyHandlerServerE runs a dummy HTTP server on a unique port that will server given handlers. Returns the Listener for the server,
+// RunDummyServerWithHandlersE runs a dummy HTTP server on a unique port that will server given handlers. Returns the Listener for the server,
 // the port it's listening on, or an error if something went wrong while trying to start the listener. Make sure to call
 // the Close() method on the Listener when you're done!
 func RunDummyServerWithHandlersE(t *testing.T, handlers map[string]func(http.ResponseWriter, *http.Request)) (net.Listener, int, error) {

--- a/modules/http-helper/dummy_server.go
+++ b/modules/http-helper/dummy_server.go
@@ -49,8 +49,8 @@ func RunDummyServerE(t *testing.T, text string) (net.Listener, int, error) {
 // RunDummyHandlerServer runs a dummy HTTP server on a unique port that will serve given handlers. Returns the Listener for the server,
 // the port it's listening on, or an error if something went wrong while trying to start the listener. Make sure to call
 // the Close() method on the Listener when you're done!
-func RunDummyHandlerServer(t *testing.T, handlers map[string]func(http.ResponseWriter, *http.Request)) (net.Listener, int) {
-	listener, port, err := RunDummyHandlerServerE(t, handlers)
+func RunDummyServerWithHandlers(t *testing.T, handlers map[string]func(http.ResponseWriter, *http.Request)) (net.Listener, int) {
+	listener, port, err := RunDummyServerWithHandlersE(t, handlers)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -60,7 +60,7 @@ func RunDummyHandlerServer(t *testing.T, handlers map[string]func(http.ResponseW
 // RunDummyHandlerServerE runs a dummy HTTP server on a unique port that will server given handlers. Returns the Listener for the server,
 // the port it's listening on, or an error if something went wrong while trying to start the listener. Make sure to call
 // the Close() method on the Listener when you're done!
-func RunDummyHandlerServerE(t *testing.T, handlers map[string]func(http.ResponseWriter, *http.Request)) (net.Listener, int, error) {
+func RunDummyServerWithHandlersE(t *testing.T, handlers map[string]func(http.ResponseWriter, *http.Request)) (net.Listener, int, error) {
 	port := getNextPort()
 
 	for path, handler := range handlers {

--- a/modules/http-helper/http_helper.go
+++ b/modules/http-helper/http_helper.go
@@ -91,7 +91,7 @@ func HttpGetWithCustomValidationE(t *testing.T, url string, tlsConfig *tls.Confi
 	}
 
 	if !validateResponse(statusCode, body) {
-		return ValidationFunctionFailed{URL: url, Status: statusCode, Body: body}
+		return ValidationFunctionFailed{Url: url, Status: statusCode, Body: body}
 	}
 
 	return nil
@@ -192,7 +192,7 @@ func HTTPDoWithRetryE(t *testing.T, method string, url string, body io.Reader, h
 		}
 		logger.Logf(t, "output: %v", out)
 		if statusCode != expectedStatus {
-			return "", ValidationFunctionFailed{URL: url, Status: statusCode}
+			return "", ValidationFunctionFailed{Url: url, Status: statusCode}
 		}
 		return out, nil
 	})
@@ -255,7 +255,7 @@ func HTTPDoWithCustomValidationE(t *testing.T, method string, url string, body i
 	}
 
 	if !validateResponse(statusCode, respBody) {
-		return ValidationFunctionFailed{URL: url, Status: statusCode, Body: respBody}
+		return ValidationFunctionFailed{Url: url, Status: statusCode, Body: respBody}
 	}
 
 	return nil

--- a/modules/http-helper/http_helper.go
+++ b/modules/http-helper/http_helper.go
@@ -4,12 +4,15 @@ package http_helper
 import (
 	"crypto/tls"
 	"fmt"
+	// TODO Guido: remove this import
 	"io"
 	"io/ioutil"
 	"net/http"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/gruntwork-io/terratest/modules/http-helper"
 
 	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/retry"

--- a/modules/http-helper/http_helper.go
+++ b/modules/http-helper/http_helper.go
@@ -57,7 +57,7 @@ func HttpGetE(t *testing.T, url string, tlsConfig *tls.Config) (int, string, err
 	return resp.StatusCode, strings.TrimSpace(string(body)), nil
 }
 
-// HttpGetWithValidation performs an HTTP GET on the given URL and verify that you get back the expected status code and body. If either
+// HTTPGetWithValidation performs an HTTP GET on the given URL and verify that you get back the expected status code and body. If either
 // doesn't match, fail the test.
 func HttpGetWithValidation(t *testing.T, url string, tlsConfig *tls.Config, expectedStatusCode int, expectedBody string) {
 	err := HttpGetWithValidationE(t, url, tlsConfig, expectedStatusCode, expectedBody)
@@ -66,7 +66,7 @@ func HttpGetWithValidation(t *testing.T, url string, tlsConfig *tls.Config, expe
 	}
 }
 
-// HttpGetWithValidationE performs an HTTP GET on the given URL and verify that you get back the expected status code and body. If either
+// HTTPGetWithValidationE performs an HTTP GET on the given URL and verify that you get back the expected status code and body. If either
 // doesn't match, return an error.
 func HttpGetWithValidationE(t *testing.T, url string, tlsConfig *tls.Config, expectedStatusCode int, expectedBody string) error {
 	return HttpGetWithCustomValidationE(t, url, tlsConfig, func(statusCode int, body string) bool {
@@ -91,13 +91,13 @@ func HttpGetWithCustomValidationE(t *testing.T, url string, tlsConfig *tls.Confi
 	}
 
 	if !validateResponse(statusCode, body) {
-		return ValidationFunctionFailed{Url: url, Status: statusCode, Body: body}
+		return ValidationFunctionFailed{URL: url, Status: statusCode, Body: body}
 	}
 
 	return nil
 }
 
-// HttpGetWithRetry repeatedly performs an HTTP GET on the given URL until the given status code and body are returned or until max
+// HTTPGetWithRetry repeatedly performs an HTTP GET on the given URL until the given status code and body are returned or until max
 // retries has been exceeded.
 func HttpGetWithRetry(t *testing.T, url string, tlsConfig *tls.Config, expectedStatus int, expectedBody string, retries int, sleepBetweenRetries time.Duration) {
 	err := HttpGetWithRetryE(t, url, tlsConfig, expectedStatus, expectedBody, retries, sleepBetweenRetries)
@@ -106,7 +106,7 @@ func HttpGetWithRetry(t *testing.T, url string, tlsConfig *tls.Config, expectedS
 	}
 }
 
-// HttpGetWithRetryE repeatedly performs an HTTP GET on the given URL until the given status code and body are returned or until max
+// HTTPGetWithRetryE repeatedly performs an HTTP GET on the given URL until the given status code and body are returned or until max
 // retries has been exceeded.
 func HttpGetWithRetryE(t *testing.T, url string, tlsConfig *tls.Config, expectedStatus int, expectedBody string, retries int, sleepBetweenRetries time.Duration) error {
 	_, err := retry.DoWithRetryE(t, fmt.Sprintf("HTTP GET to URL %s", url), retries, sleepBetweenRetries, func() (string, error) {
@@ -116,7 +116,7 @@ func HttpGetWithRetryE(t *testing.T, url string, tlsConfig *tls.Config, expected
 	return err
 }
 
-// HttpGetWithRetryWithCustomValidation repeatedly performs an HTTP GET on the given URL until the given validation function returns true or max retries
+// HTTPGetWithRetryWithCustomValidation repeatedly performs an HTTP GET on the given URL until the given validation function returns true or max retries
 // has been exceeded.
 func HttpGetWithRetryWithCustomValidation(t *testing.T, url string, tlsConfig *tls.Config, retries int, sleepBetweenRetries time.Duration, validateResponse func(int, string) bool) {
 	err := HttpGetWithRetryWithCustomValidationE(t, url, tlsConfig, retries, sleepBetweenRetries, validateResponse)
@@ -125,7 +125,7 @@ func HttpGetWithRetryWithCustomValidation(t *testing.T, url string, tlsConfig *t
 	}
 }
 
-// HttpGetWithRetryWithCustomValidationE repeatedly performs an HTTP GET on the given URL until the given validation function returns true or max retries
+// HTTPGetWithRetryWithCustomValidationE repeatedly performs an HTTP GET on the given URL until the given validation function returns true or max retries
 // has been exceeded.
 func HttpGetWithRetryWithCustomValidationE(t *testing.T, url string, tlsConfig *tls.Config, retries int, sleepBetweenRetries time.Duration, validateResponse func(int, string) bool) error {
 	_, err := retry.DoWithRetryE(t, fmt.Sprintf("HTTP GET to URL %s", url), retries, sleepBetweenRetries, func() (string, error) {
@@ -135,18 +135,18 @@ func HttpGetWithRetryWithCustomValidationE(t *testing.T, url string, tlsConfig *
 	return err
 }
 
-// HttpDo performs the given HTTP method on the given URL and return the HTTP status code and body.
+// HTTPDo performs the given HTTP method on the given URL and return the HTTP status code and body.
 // If there's any error, fail the test.
-func HttpDo(t *testing.T, method string, url string, body io.Reader, headers map[string]string) (int, string) {
-	statusCode, respBody, err := HttpDoE(t, method, url, body, headers)
+func HTTPDo(t *testing.T, method string, url string, body io.Reader, headers map[string]string) (int, string) {
+	statusCode, respBody, err := HTTPDoE(t, method, url, body, headers)
 	if err != nil {
 		t.Fatal(err)
 	}
 	return statusCode, respBody
 }
 
-// HttpDoE performs the given HTTP method on the given URL and return the HTTP status code, body, and any error.
-func HttpDoE(t *testing.T, method string, url string, body io.Reader, headers map[string]string) (int, string, error) {
+// HTTPDoE performs the given HTTP method on the given URL and return the HTTP status code, body, and any error.
+func HTTPDoE(t *testing.T, method string, url string, body io.Reader, headers map[string]string) (int, string, error) {
 	logger.Logf(t, "Making an HTTP %s call to URL %s", method, url)
 
 	client := http.Client{
@@ -170,29 +170,29 @@ func HttpDoE(t *testing.T, method string, url string, body io.Reader, headers ma
 	return resp.StatusCode, strings.TrimSpace(string(respBody)), nil
 }
 
-// HttpDoWithRetry repeatedly performs the given HTTP method on the given URL until the given status code and body are
+// HTTPDoWithRetry repeatedly performs the given HTTP method on the given URL until the given status code and body are
 // returned or until max retries has been exceeded.
 // The function compares the expected status code against the received one and fails if they don't match.
-func HttpDoWithRetry(t *testing.T, method string, url string, body io.Reader, headers map[string]string, expectedStatus int, retries int, sleepBetweenRetries time.Duration) string {
-	out, err := HttpDoWithRetryE(t, method, url, body, headers, expectedStatus, retries, sleepBetweenRetries)
+func HTTPDoWithRetry(t *testing.T, method string, url string, body io.Reader, headers map[string]string, expectedStatus int, retries int, sleepBetweenRetries time.Duration) string {
+	out, err := HTTPDoWithRetryE(t, method, url, body, headers, expectedStatus, retries, sleepBetweenRetries)
 	if err != nil {
 		t.Fatal(err)
 	}
 	return out
 }
 
-// HttpDoWithRetryE repeatedly performs the given HTTP method on the given URL until the given status code and body are
+// HTTPDoWithRetryE repeatedly performs the given HTTP method on the given URL until the given status code and body are
 // returned or until max retries has been exceeded.
 // The function compares the expected status code against the received one and fails if they don't match.
-func HttpDoWithRetryE(t *testing.T, method string, url string, body io.Reader, headers map[string]string, expectedStatus int, retries int, sleepBetweenRetries time.Duration) (string, error) {
+func HTTPDoWithRetryE(t *testing.T, method string, url string, body io.Reader, headers map[string]string, expectedStatus int, retries int, sleepBetweenRetries time.Duration) (string, error) {
 	out, err := retry.DoWithRetryE(t, fmt.Sprintf("HTTP %s to URL %s", method, url), retries, sleepBetweenRetries, func() (string, error) {
-		statusCode, out, err := HttpDoE(t, method, url, body, headers)
+		statusCode, out, err := HTTPDoE(t, method, url, body, headers)
 		if err != nil {
 			return "", err
 		}
 		logger.Logf(t, "output: %v", out)
 		if statusCode != expectedStatus {
-			return "", http_helper.ValidationFunctionFailed{Url: url, Status: statusCode}
+			return "", ValidationFunctionFailed{URL: url, Status: statusCode}
 		}
 		return out, nil
 	})
@@ -200,62 +200,62 @@ func HttpDoWithRetryE(t *testing.T, method string, url string, body io.Reader, h
 	return out, err
 }
 
-// HttpDoWithValidationRetry repeatedly performs the given HTTP method on the given URL until the given status code and
+// HTTPDoWithValidationRetry repeatedly performs the given HTTP method on the given URL until the given status code and
 // body are returned or until max retries has been exceeded.
-func HttpDoWithValidationRetry(t *testing.T, method string, url string, body io.Reader, headers map[string]string, expectedStatus int, expectedBody string, retries int, sleepBetweenRetries time.Duration) {
-	err := HttpDoWithValidationRetryE(t, method, url, body, headers, expectedStatus, expectedBody, retries, sleepBetweenRetries)
+func HTTPDoWithValidationRetry(t *testing.T, method string, url string, body io.Reader, headers map[string]string, expectedStatus int, expectedBody string, retries int, sleepBetweenRetries time.Duration) {
+	err := HTTPDoWithValidationRetryE(t, method, url, body, headers, expectedStatus, expectedBody, retries, sleepBetweenRetries)
 	if err != nil {
 		t.Fatal(err)
 	}
 }
 
-// HttpDoWithValidaitonRetryE repeatedly performs the given HTTP method on the given URL until the given status code and
+// HTTPDoWithValidaitonRetryE repeatedly performs the given HTTP method on the given URL until the given status code and
 // body are returned or until max retries has been exceeded.
-func HttpDoWithValidationRetryE(t *testing.T, method string, url string, body io.Reader, headers map[string]string, expectedStatus int, expectedBody string, retries int, sleepBetweenRetries time.Duration) error {
+func HTTPDoWithValidationRetryE(t *testing.T, method string, url string, body io.Reader, headers map[string]string, expectedStatus int, expectedBody string, retries int, sleepBetweenRetries time.Duration) error {
 	_, err := retry.DoWithRetryE(t, fmt.Sprintf("HTTP GET to URL %s", url), retries, sleepBetweenRetries, func() (string, error) {
-		return "", HttpDoWithValidationE(t, method, url, body, headers, expectedStatus, expectedBody)
+		return "", HTTPDoWithValidationE(t, method, url, body, headers, expectedStatus, expectedBody)
 	})
 
 	return err
 }
 
-// HttpDoWithValidation performs the given HTTP method on the given URL and verify that you get back the expected status
+// HTTPDoWithValidation performs the given HTTP method on the given URL and verify that you get back the expected status
 // code and body. If either doesn't match, fail the test.
-func HttpDoWithValidation(t *testing.T, method string, url string, body io.Reader, headers map[string]string, expectedStatusCode int, expectedBody string) {
-	err := HttpDoWithValidationE(t, method, url, body, headers, expectedStatusCode, expectedBody)
+func HTTPDoWithValidation(t *testing.T, method string, url string, body io.Reader, headers map[string]string, expectedStatusCode int, expectedBody string) {
+	err := HTTPDoWithValidationE(t, method, url, body, headers, expectedStatusCode, expectedBody)
 	if err != nil {
 		t.Fatal(err)
 	}
 }
 
-// HttpDoWithValidationE performs the given HTTP method on the given URL and verify that you get back the expected status
+// HTTPDoWithValidationE performs the given HTTP method on the given URL and verify that you get back the expected status
 // code and body. If either doesn't match, return an error.
-func HttpDoWithValidationE(t *testing.T, method string, url string, body io.Reader, headers map[string]string, expectedStatusCode int, expectedBody string) error {
-	return HttpDoWithCustomValidationE(t, method, url, body, headers, func(statusCode int, body string) bool {
+func HTTPDoWithValidationE(t *testing.T, method string, url string, body io.Reader, headers map[string]string, expectedStatusCode int, expectedBody string) error {
+	return HTTPDoWithCustomValidationE(t, method, url, body, headers, func(statusCode int, body string) bool {
 		return statusCode == expectedStatusCode && body == expectedBody
 	})
 }
 
-// HttpDoWithCustomValidation performs the given HTTP method on the given URL and validate the returned status code and
+// HTTPDoWithCustomValidation performs the given HTTP method on the given URL and validate the returned status code and
 // body using the given function.
-func HttpDoWithCustomValidation(t *testing.T, method string, url string, body io.Reader, headers map[string]string, validateResponse func(int, string) bool) {
-	err := HttpDoWithCustomValidationE(t, method, url, body, headers, validateResponse)
+func HTTPDoWithCustomValidation(t *testing.T, method string, url string, body io.Reader, headers map[string]string, validateResponse func(int, string) bool) {
+	err := HTTPDoWithCustomValidationE(t, method, url, body, headers, validateResponse)
 	if err != nil {
 		t.Fatal(err)
 	}
 }
 
-// HttpDoWithCustomValidationE performs the given HTTP method on the given URL and validate the returned status code and
+// HTTPDoWithCustomValidationE performs the given HTTP method on the given URL and validate the returned status code and
 // body using the given function.
-func HttpDoWithCustomValidationE(t *testing.T, method string, url string, body io.Reader, headers map[string]string, validateResponse func(int, string) bool) error {
-	statusCode, respBody, err := HttpDoE(t, method, url, body, headers)
+func HTTPDoWithCustomValidationE(t *testing.T, method string, url string, body io.Reader, headers map[string]string, validateResponse func(int, string) bool) error {
+	statusCode, respBody, err := HTTPDoE(t, method, url, body, headers)
 
 	if err != nil {
 		return err
 	}
 
 	if !validateResponse(statusCode, respBody) {
-		return http_helper.ValidationFunctionFailed{Url: url, Status: statusCode, Body: respBody}
+		return ValidationFunctionFailed{URL: url, Status: statusCode, Body: respBody}
 	}
 
 	return nil

--- a/modules/http-helper/http_helper.go
+++ b/modules/http-helper/http_helper.go
@@ -57,7 +57,7 @@ func HttpGetE(t *testing.T, url string, tlsConfig *tls.Config) (int, string, err
 	return resp.StatusCode, strings.TrimSpace(string(body)), nil
 }
 
-// HTTPGetWithValidation performs an HTTP GET on the given URL and verify that you get back the expected status code and body. If either
+// HttpGetWithValidation performs an HTTP GET on the given URL and verify that you get back the expected status code and body. If either
 // doesn't match, fail the test.
 func HttpGetWithValidation(t *testing.T, url string, tlsConfig *tls.Config, expectedStatusCode int, expectedBody string) {
 	err := HttpGetWithValidationE(t, url, tlsConfig, expectedStatusCode, expectedBody)
@@ -66,7 +66,7 @@ func HttpGetWithValidation(t *testing.T, url string, tlsConfig *tls.Config, expe
 	}
 }
 
-// HTTPGetWithValidationE performs an HTTP GET on the given URL and verify that you get back the expected status code and body. If either
+// HttpGetWithValidationE performs an HTTP GET on the given URL and verify that you get back the expected status code and body. If either
 // doesn't match, return an error.
 func HttpGetWithValidationE(t *testing.T, url string, tlsConfig *tls.Config, expectedStatusCode int, expectedBody string) error {
 	return HttpGetWithCustomValidationE(t, url, tlsConfig, func(statusCode int, body string) bool {
@@ -97,7 +97,7 @@ func HttpGetWithCustomValidationE(t *testing.T, url string, tlsConfig *tls.Confi
 	return nil
 }
 
-// HTTPGetWithRetry repeatedly performs an HTTP GET on the given URL until the given status code and body are returned or until max
+// HttpGetWithRetry repeatedly performs an HTTP GET on the given URL until the given status code and body are returned or until max
 // retries has been exceeded.
 func HttpGetWithRetry(t *testing.T, url string, tlsConfig *tls.Config, expectedStatus int, expectedBody string, retries int, sleepBetweenRetries time.Duration) {
 	err := HttpGetWithRetryE(t, url, tlsConfig, expectedStatus, expectedBody, retries, sleepBetweenRetries)
@@ -106,7 +106,7 @@ func HttpGetWithRetry(t *testing.T, url string, tlsConfig *tls.Config, expectedS
 	}
 }
 
-// HTTPGetWithRetryE repeatedly performs an HTTP GET on the given URL until the given status code and body are returned or until max
+// HttpGetWithRetryE repeatedly performs an HTTP GET on the given URL until the given status code and body are returned or until max
 // retries has been exceeded.
 func HttpGetWithRetryE(t *testing.T, url string, tlsConfig *tls.Config, expectedStatus int, expectedBody string, retries int, sleepBetweenRetries time.Duration) error {
 	_, err := retry.DoWithRetryE(t, fmt.Sprintf("HTTP GET to URL %s", url), retries, sleepBetweenRetries, func() (string, error) {
@@ -116,7 +116,7 @@ func HttpGetWithRetryE(t *testing.T, url string, tlsConfig *tls.Config, expected
 	return err
 }
 
-// HTTPGetWithRetryWithCustomValidation repeatedly performs an HTTP GET on the given URL until the given validation function returns true or max retries
+// HttpGetWithRetryWithCustomValidation repeatedly performs an HTTP GET on the given URL until the given validation function returns true or max retries
 // has been exceeded.
 func HttpGetWithRetryWithCustomValidation(t *testing.T, url string, tlsConfig *tls.Config, retries int, sleepBetweenRetries time.Duration, validateResponse func(int, string) bool) {
 	err := HttpGetWithRetryWithCustomValidationE(t, url, tlsConfig, retries, sleepBetweenRetries, validateResponse)
@@ -125,7 +125,7 @@ func HttpGetWithRetryWithCustomValidation(t *testing.T, url string, tlsConfig *t
 	}
 }
 
-// HTTPGetWithRetryWithCustomValidationE repeatedly performs an HTTP GET on the given URL until the given validation function returns true or max retries
+// HttpGetWithRetryWithCustomValidationE repeatedly performs an HTTP GET on the given URL until the given validation function returns true or max retries
 // has been exceeded.
 func HttpGetWithRetryWithCustomValidationE(t *testing.T, url string, tlsConfig *tls.Config, retries int, sleepBetweenRetries time.Duration, validateResponse func(int, string) bool) error {
 	_, err := retry.DoWithRetryE(t, fmt.Sprintf("HTTP GET to URL %s", url), retries, sleepBetweenRetries, func() (string, error) {
@@ -209,7 +209,7 @@ func HTTPDoWithValidationRetry(t *testing.T, method string, url string, body io.
 	}
 }
 
-// HTTPDoWithValidaitonRetryE repeatedly performs the given HTTP method on the given URL until the given status code and
+// HTTPDoWithValidationRetryE repeatedly performs the given HTTP method on the given URL until the given status code and
 // body are returned or until max retries has been exceeded.
 func HTTPDoWithValidationRetryE(t *testing.T, method string, url string, body io.Reader, headers map[string]string, expectedStatus int, expectedBody string, retries int, sleepBetweenRetries time.Duration) error {
 	_, err := retry.DoWithRetryE(t, fmt.Sprintf("HTTP GET to URL %s", url), retries, sleepBetweenRetries, func() (string, error) {

--- a/modules/http-helper/http_helper.go
+++ b/modules/http-helper/http_helper.go
@@ -11,8 +11,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gruntwork-io/terratest/modules/http-helper"
-
 	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/retry"
 )

--- a/modules/http-helper/http_helper.go
+++ b/modules/http-helper/http_helper.go
@@ -4,7 +4,6 @@ package http_helper
 import (
 	"crypto/tls"
 	"fmt"
-	// TODO Guido: remove this import
 	"io"
 	"io/ioutil"
 	"net/http"

--- a/modules/http-helper/http_helper_test.go
+++ b/modules/http-helper/http_helper_test.go
@@ -1,0 +1,76 @@
+package http_helper
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestHttpDoBody(t *testing.T) {
+	t.Parallel()
+
+	path := "/doBody"
+	listener, port := RunDummyHandlerServer(t, path, bodyCopyHandler)
+	defer shutDownServer(t, listener)
+
+	url := fmt.Sprintf("http://localhost:%d%s", port, path)
+	expectedBody := "Hello, Terratest!"
+	body := bytes.NewReader([]byte(expectedBody))
+	statusCode, respBody := HttpDo(t, "POST", url, body, nil)
+
+	expectedCode := 200
+	if statusCode != expectedCode {
+		t.Errorf("handler returned wrong status code: got %q want %q", statusCode, expectedCode)
+	}
+	if respBody != expectedBody {
+		t.Errorf("handler returned wrong body: got %q want %q", respBody, expectedBody)
+	}
+}
+
+func TestHttpDoHeaders(t *testing.T) {
+	t.Parallel()
+
+	path := "/doHeaders"
+	listener, port := RunDummyHandlerServer(t, path, headersCopyHandler)
+	defer shutDownServer(t, listener)
+
+	url := fmt.Sprintf("http://localhost:%d%s", port, path)
+	headers := map[string]string{"Authorization": "Bearer 1a2b3c99ff"}
+	statusCode, respBody := HttpDo(t, "POST", url, nil, headers)
+
+	expectedCode := 200
+	if statusCode != expectedCode {
+		t.Errorf("handler returned wrong status code: got %q want %q", statusCode, expectedCode)
+	}
+	expectedLine := "Authorization: Bearer 1a2b3c99ff"
+	if !strings.Contains(respBody, expectedLine) {
+		t.Errorf("handler returned wrong body: got %q want %q", respBody, expectedLine)
+	}
+}
+
+func bodyCopyHandler(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	body, _ := ioutil.ReadAll(r.Body)
+	w.Write(body)
+}
+
+func headersCopyHandler(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	var buffer bytes.Buffer
+	for key, values := range r.Header {
+		buffer.WriteString(fmt.Sprintf("%s: %s\n", key, strings.Join(values, ",")))
+	}
+	w.Write(buffer.Bytes())
+}
+
+func wrongStatusHandler(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusInternalServerError)
+}
+
+func sleepingHandler(w http.ResponseWriter, r *http.Request) {
+	time.Sleep(time.Second)
+}

--- a/modules/http-helper/http_helper_test.go
+++ b/modules/http-helper/http_helper_test.go
@@ -5,50 +5,118 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
 )
 
-func TestHttpDoBody(t *testing.T) {
+const (
+	doBodyPath         = "/doBody"
+	doHeadersPath      = "/doHeaders"
+	wrongStatusPath    = "/wrongStatus"
+	requestTimeoutPath = "/requestTimeout"
+	retryPath          = "/retry"
+)
+
+var baseUrl string
+
+func TestHttpDo(t *testing.T) {
 	t.Parallel()
 
-	path := "/doBody"
-	listener, port := RunDummyHandlerServer(t, path, bodyCopyHandler)
+	handlers := map[string]func(http.ResponseWriter, *http.Request){
+		doBodyPath:         bodyCopyHandler,
+		doHeadersPath:      headersCopyHandler,
+		wrongStatusPath:    wrongStatusHandler,
+		requestTimeoutPath: sleepingHandler,
+		retryPath:          retryHandler,
+	}
+	listener, port := RunDummyHandlerServer(t, handlers)
 	defer shutDownServer(t, listener)
 
-	url := fmt.Sprintf("http://localhost:%d%s", port, path)
+	baseUrl = fmt.Sprintf("http://localhost:%d", port)
+
+	t.Run("okBody", okBody)
+	t.Run("okHeaders", okHeaders)
+	t.Run("wrongStatus", wrongStatus)
+	t.Run("requestTimeout", requestTimeout)
+	t.Run("okWithRetry", okWithRetry)
+	t.Run("errorWithRetry", errorWithRetry)
+}
+
+func okBody(t *testing.T) {
+	url := fmt.Sprintf("%s%s", baseUrl, doBodyPath)
 	expectedBody := "Hello, Terratest!"
 	body := bytes.NewReader([]byte(expectedBody))
 	statusCode, respBody := HttpDo(t, "POST", url, body, nil)
 
 	expectedCode := 200
 	if statusCode != expectedCode {
-		t.Errorf("handler returned wrong status code: got %q want %q", statusCode, expectedCode)
+		t.Errorf("handler returned wrong status code: got %v want %v", statusCode, expectedCode)
 	}
 	if respBody != expectedBody {
-		t.Errorf("handler returned wrong body: got %q want %q", respBody, expectedBody)
+		t.Errorf("handler returned wrong body: got %v want %v", respBody, expectedBody)
 	}
 }
 
-func TestHttpDoHeaders(t *testing.T) {
-	t.Parallel()
-
-	path := "/doHeaders"
-	listener, port := RunDummyHandlerServer(t, path, headersCopyHandler)
-	defer shutDownServer(t, listener)
-
-	url := fmt.Sprintf("http://localhost:%d%s", port, path)
+func okHeaders(t *testing.T) {
+	url := fmt.Sprintf("%s%s", baseUrl, doHeadersPath)
 	headers := map[string]string{"Authorization": "Bearer 1a2b3c99ff"}
 	statusCode, respBody := HttpDo(t, "POST", url, nil, headers)
 
 	expectedCode := 200
 	if statusCode != expectedCode {
-		t.Errorf("handler returned wrong status code: got %q want %q", statusCode, expectedCode)
+		t.Errorf("handler returned wrong status code: got %v want %v", statusCode, expectedCode)
 	}
 	expectedLine := "Authorization: Bearer 1a2b3c99ff"
 	if !strings.Contains(respBody, expectedLine) {
-		t.Errorf("handler returned wrong body: got %q want %q", respBody, expectedLine)
+		t.Errorf("handler returned wrong body: got %v want %v", respBody, expectedLine)
+	}
+}
+
+func wrongStatus(t *testing.T) {
+	url := fmt.Sprintf("%s%s", baseUrl, wrongStatusPath)
+	statusCode, _ := HttpDo(t, "POST", url, nil, nil)
+
+	expectedCode := 500
+	if statusCode != expectedCode {
+		t.Errorf("handler returned wrong status code: got %v want %v", statusCode, expectedCode)
+	}
+}
+
+func requestTimeout(t *testing.T) {
+	url := fmt.Sprintf("%s%s", baseUrl, requestTimeoutPath)
+	_, _, err := HttpDoE(t, "DELETE", url, nil, nil)
+
+	if err == nil {
+		t.Error("handler didn't return a timeout error")
+	}
+	if !strings.Contains(err.Error(), "request canceled") {
+		t.Errorf("handler didn't return an expected error, got %q", err)
+	}
+}
+
+var counter int
+
+func okWithRetry(t *testing.T) {
+	counter = 3
+	url := fmt.Sprintf("%s%s", baseUrl, retryPath)
+	HttpDoWithRetry(t, "POST", url, nil, nil, 200, 10, time.Second)
+}
+
+func errorWithRetry(t *testing.T) {
+	counter = 3
+	url := fmt.Sprintf("%s%s", baseUrl, retryPath)
+	_, err := HttpDoWithRetryE(t, "POST", url, nil, nil, 200, 2, time.Second)
+
+	if err == nil {
+		t.Error("handler didn't return a retry error")
+	}
+
+	pattern := `unsuccessful after \d+ retries`
+	match, _ := regexp.MatchString(pattern, err.Error())
+	if !match {
+		t.Errorf("handler didn't return an expected error, got %q", err)
 	}
 }
 
@@ -72,5 +140,14 @@ func wrongStatusHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func sleepingHandler(w http.ResponseWriter, r *http.Request) {
-	time.Sleep(time.Second)
+	time.Sleep(time.Second * 15)
+}
+
+func retryHandler(w http.ResponseWriter, r *http.Request) {
+	if counter > 0 {
+		counter--
+		w.WriteHeader(http.StatusServiceUnavailable)
+	} else {
+		w.WriteHeader(http.StatusOK)
+	}
 }


### PR DESCRIPTION
This MR is related to #186 and based upon @sw-samuraj work on #193.

In the original MR @sw-samuraj added HTTP helper methods which mimic current HttpGet* methods. Those new methods allow to:

    add an HTTP header(s),
    add a request body,
    set a HTTP method,
    returns a response body.

I changed the signature from the original proposal to now be:

func HTTPDo(t *testing.T, method string, url string, body io.Reader, headers map[string]string) (int, string)

I additionally changed the original tests to now use httptest.Server. This allows to run the tests in parallel without any interference. Finally, I expanded the test coverage to `HTTPDoWithCustomValidation` and `HTTPDoWithValidation`.

I tried to keep the git history intact to keep @sw-samuraj contributions visible. If there is a better way to do this, please note it and I will happily adapt to it :slightly_smiling_face:  