### PR TITLE
[#359] Extend AWS Vpc helpers: GetVpcById

### DIFF
--- a/modules/aws/vpc.go
+++ b/modules/aws/vpc.go
@@ -83,7 +83,7 @@ func GetVpcsE(t *testing.T, filters []*ec2.Filter, region string) ([]*Vpc, error
 
 	numVpcs := len(vpcs.Vpcs)
 	retVal := make([]*Vpc, numVpcs)
-	
+
 	for i, vpc := range vpcs.Vpcs {
 		subnets, err := GetSubnetsForVpcE(t, aws.StringValue(vpc.VpcId), region)
 		if err != nil {
@@ -91,7 +91,7 @@ func GetVpcsE(t *testing.T, filters []*ec2.Filter, region string) ([]*Vpc, error
 		}
 		retVal[i] = &Vpc{Id: aws.StringValue(vpc.VpcId), Name: FindVpcName(vpc), Subnets: subnets}
 	}
-	
+
 	return retVal, nil
 }
 

--- a/modules/aws/vpc.go
+++ b/modules/aws/vpc.go
@@ -9,6 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/gruntwork-io/terratest/modules/random"
+	"github.com/stretchr/testify/require"
 )
 
 // Vpc is an Amazon Virtual Private Cloud.
@@ -31,9 +32,7 @@ var isDefaultFilterValue = "true"
 // GetDefaultVpc fetches information about the default VPC in the given region.
 func GetDefaultVpc(t *testing.T, region string) *Vpc {
 	vpc, err := GetDefaultVpcE(t, region)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	return vpc
 }
 
@@ -50,14 +49,14 @@ func GetDefaultVpcE(t *testing.T, region string) (*Vpc, error) {
 	return vpcs[0], err
 }
 
+// GetVpcById fetches information about a VPC with given Id in the given region.
 func GetVpcById(t *testing.T, vpcId string, region string) *Vpc {
 	vpc, err := GetVpcByIdE(t, vpcId, region)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	return vpc
 }
 
+// GetVpcByIdE fetches information about a VPC with given Id in the given region.
 func GetVpcByIdE(t *testing.T, vpcId string, region string) (*Vpc, error) {
 	vpcIdFilter := ec2.Filter{Name: &vpcIDFilterName, Values: []*string{&vpcId}}
 	vpcs, err := GetVpcsE(t, []*ec2.Filter{&vpcIdFilter}, region)
@@ -70,6 +69,7 @@ func GetVpcByIdE(t *testing.T, vpcId string, region string) (*Vpc, error) {
 	return vpcs[0], err
 }
 
+// GetVpcsE fetches informations about VPCs from given regions limited by filters
 func GetVpcsE(t *testing.T, filters []*ec2.Filter, region string) ([]*Vpc, error) {
 	client, err := NewEc2ClientE(t, region)
 	if err != nil {

--- a/modules/aws/vpc.go
+++ b/modules/aws/vpc.go
@@ -63,7 +63,7 @@ func GetVpcByIdE(t *testing.T, vpcId string, region string) (*Vpc, error) {
 
 	numVpcs := len(vpcs)
 	if numVpcs != 1 {
-		return nil, fmt.Errorf("Expected to find one VPC in region %s but found %s", region, strconv.Itoa(numVpcs))
+		return nil, fmt.Errorf("Expected to find one VPC with ID %s in region %s but found %s", vpcId, region, strconv.Itoa(numVpcs))
 	}
 
 	return vpcs[0], err

--- a/modules/aws/vpc_test.go
+++ b/modules/aws/vpc_test.go
@@ -43,7 +43,7 @@ func TestGetVpcsE(t *testing.T) {
 	assert.Equal(t, len(vpcs), 1)
 	assert.NotEmpty(t, vpcs[0].Name)
 
-	// the default VPS has by default one subnet per availability zone
+	// the default VPC has by default one subnet per availability zone
 	// https://docs.aws.amazon.com/vpc/latest/userguide/default-vpc.html
 	assert.Equal(t, len(vpcs[0].Subnets), len(azs))
 }

--- a/modules/aws/vpc_test.go
+++ b/modules/aws/vpc_test.go
@@ -21,24 +21,24 @@ func TestGetDefaultVpc(t *testing.T) {
 	assert.Regexp(t, "^vpc-[[:alnum:]]+$", vpc.Id)
 }
 
-func TestGetVpcById(t *testing.T){
+func TestGetVpcById(t *testing.T) {
 	region := GetRandomStableRegion(t, nil, nil)
 	vpc := createVpc(t, region)
 	defer deleteVpc(t, *vpc.VpcId, region)
 
-	vpcTest := GetVpcById(t, *vpc.VpcId, region)	
-	assert.Equal(t, *vpc.VpcId, vpcTest.Id)	
+	vpcTest := GetVpcById(t, *vpc.VpcId, region)
+	assert.Equal(t, *vpc.VpcId, vpcTest.Id)
 }
 
-func TestGetVpcsE(t *testing.T){
+func TestGetVpcsE(t *testing.T) {
 	region := GetRandomStableRegion(t, nil, nil)
 	azs := GetAvailabilityZones(t, region)
 
 	var isDefaultFilterName = "isDefault"
 	var isDefaultFilterValue = "true"
-	
+
 	defaultVpcFilter := ec2.Filter{Name: &isDefaultFilterName, Values: []*string{&isDefaultFilterValue}}
-	vpcs, _ := GetVpcsE(t, []*ec2.Filter{&defaultVpcFilter}, region)	
+	vpcs, _ := GetVpcsE(t, []*ec2.Filter{&defaultVpcFilter}, region)
 
 	assert.Equal(t, len(vpcs), 1)
 	assert.NotEmpty(t, vpcs[0].Name)
@@ -68,9 +68,9 @@ func createVpc(t *testing.T, region string) ec2.Vpc {
 	return *createVpcOutput.Vpc
 }
 
-func deleteVpc(t *testing.T, vpcId string, region string){
+func deleteVpc(t *testing.T, vpcId string, region string) {
 	ec2Client := NewEc2Client(t, region)
-	
+
 	_, err := ec2Client.DeleteVpc(&ec2.DeleteVpcInput{
 		VpcId: aws.String(vpcId),
 	})

--- a/modules/aws/vpc_test.go
+++ b/modules/aws/vpc_test.go
@@ -22,6 +22,8 @@ func TestGetDefaultVpc(t *testing.T) {
 }
 
 func TestGetVpcById(t *testing.T) {
+	t.Parallel()
+
 	region := GetRandomStableRegion(t, nil, nil)
 	vpc := createVpc(t, region)
 	defer deleteVpc(t, *vpc.VpcId, region)
@@ -31,6 +33,8 @@ func TestGetVpcById(t *testing.T) {
 }
 
 func TestGetVpcsE(t *testing.T) {
+	t.Parallel()
+
 	region := GetRandomStableRegion(t, nil, nil)
 	azs := GetAvailabilityZones(t, region)
 

--- a/modules/aws/vpc_test.go
+++ b/modules/aws/vpc_test.go
@@ -38,8 +38,8 @@ func TestGetVpcsE(t *testing.T) {
 	region := GetRandomStableRegion(t, nil, nil)
 	azs := GetAvailabilityZones(t, region)
 
-	var isDefaultFilterName = "isDefault"
-	var isDefaultFilterValue = "true"
+	isDefaultFilterName := "isDefault"
+	isDefaultFilterValue := "true"
 
 	defaultVpcFilter := ec2.Filter{Name: &isDefaultFilterName, Values: []*string{&isDefaultFilterValue}}
 	vpcs, _ := GetVpcsE(t, []*ec2.Filter{&defaultVpcFilter}, region)

--- a/modules/aws/vpc_test.go
+++ b/modules/aws/vpc_test.go
@@ -44,7 +44,7 @@ func TestGetVpcsE(t *testing.T) {
 	defaultVpcFilter := ec2.Filter{Name: &isDefaultFilterName, Values: []*string{&isDefaultFilterValue}}
 	vpcs, _ := GetVpcsE(t, []*ec2.Filter{&defaultVpcFilter}, region)
 
-	assert.Equal(t, len(vpcs), 1)
+	require.Equal(t, len(vpcs), 1)
 	assert.NotEmpty(t, vpcs[0].Name)
 
 	// the default VPC has by default one subnet per availability zone

--- a/modules/aws/vpc_test.go
+++ b/modules/aws/vpc_test.go
@@ -4,6 +4,10 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
 )
 
 func TestGetDefaultVpc(t *testing.T) {
@@ -17,6 +21,33 @@ func TestGetDefaultVpc(t *testing.T) {
 	assert.Regexp(t, "^vpc-[[:alnum:]]+$", vpc.Id)
 }
 
+func TestGetVpcById(t *testing.T){
+	region := GetRandomStableRegion(t, nil, nil)
+	vpc := createVpc(t, region)
+	defer deleteVpc(t, *vpc.VpcId, region)
+
+	vpcTest := GetVpcById(t, *vpc.VpcId, region)	
+	assert.Equal(t, *vpc.VpcId, vpcTest.Id)	
+}
+
+func TestGetVpcsE(t *testing.T){
+	region := GetRandomStableRegion(t, nil, nil)
+	azs := GetAvailabilityZones(t, region)
+
+	var isDefaultFilterName = "isDefault"
+	var isDefaultFilterValue = "true"
+	
+	defaultVpcFilter := ec2.Filter{Name: &isDefaultFilterName, Values: []*string{&isDefaultFilterValue}}
+	vpcs, _ := GetVpcsE(t, []*ec2.Filter{&defaultVpcFilter}, region)	
+
+	assert.Equal(t, len(vpcs), 1)
+	assert.NotEmpty(t, vpcs[0].Name)
+
+	// the default VPS has by default one subnet per availability zone
+	// https://docs.aws.amazon.com/vpc/latest/userguide/default-vpc.html
+	assert.Equal(t, len(vpcs[0].Subnets), len(azs))
+}
+
 func TestGetFirstTwoOctets(t *testing.T) {
 	t.Parallel()
 
@@ -24,4 +55,24 @@ func TestGetFirstTwoOctets(t *testing.T) {
 	if firstTwo != "10.100" {
 		t.Errorf("Received: %s, Expected: 10.100", firstTwo)
 	}
+}
+
+func createVpc(t *testing.T, region string) ec2.Vpc {
+	ec2Client := NewEc2Client(t, region)
+
+	createVpcOutput, err := ec2Client.CreateVpc(&ec2.CreateVpcInput{
+		CidrBlock: aws.String("10.10.0.0/16"),
+	})
+
+	require.NoError(t, err)
+	return *createVpcOutput.Vpc
+}
+
+func deleteVpc(t *testing.T, vpcId string, region string){
+	ec2Client := NewEc2Client(t, region)
+	
+	_, err := ec2Client.DeleteVpc(&ec2.DeleteVpcInput{
+		VpcId: aws.String(vpcId),
+	})
+	require.NoError(t, err)
 }


### PR DESCRIPTION
This is the code for the issue: #359
It extends the AWS Vpc module with `GetVpcById`, `GetVpcByIdE`, and `GetVpcsE`. 
Backward compatibility is maintained. The test temporarily creates a Vpc.

Tests output: https://gist.github.com/kasia-kittel/ee1389f395fc85853105c47ad2022e1f
