### PR TITLE
Removed deprecated GOCACHE var from 'avoid test caching' section

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,10 +432,10 @@ running your tests again if you haven't changed any of the Go code. Since you're
 files, you should consider turning the caching of test results off. This ensures that the tests are run every time
 you run `go test` and the result is not just read from the cache.
 
-To turn caching off, you can use the `GOCACHE` environment variable and set it to `off`:
+To turn caching off, you can set the `-count` flag to `1` force the tests to run:
 
 ```shell
-$ GOCACHE=off go test -timeout 30m -p 1 ./...
+$ go test -count=1 -timeout 30m -p 1 ./...
 ```
 
 


### PR DESCRIPTION
Setting GOCACHE=off now generates an error (as of go 1.12):
```
build cache is disabled by GOCACHE=off, but required as of Go 1.12
```
From the [docs](https://golang.org/doc/go1.10#test):
> The idiomatic way to bypass test caching is to use -count=1.