### PR TITLE
Use []byte for HTTP methods with retry

### DIFF
--- a/modules/http-helper/http_helper.go
+++ b/modules/http-helper/http_helper.go
@@ -138,7 +138,10 @@ func HttpGetWithRetryWithCustomValidationE(t *testing.T, url string, tlsConfig *
 
 // HTTPDo performs the given HTTP method on the given URL and return the HTTP status code and body.
 // If there's any error, fail the test.
-func HTTPDo(t *testing.T, method string, url string, body io.Reader, headers map[string]string) (int, string) {
+func HTTPDo(
+	t *testing.T, method string, url string, body io.Reader,
+	headers map[string]string,
+) (int, string) {
 	statusCode, respBody, err := HTTPDoE(t, method, url, body, headers)
 	if err != nil {
 		t.Fatal(err)
@@ -147,7 +150,10 @@ func HTTPDo(t *testing.T, method string, url string, body io.Reader, headers map
 }
 
 // HTTPDoE performs the given HTTP method on the given URL and return the HTTP status code, body, and any error.
-func HTTPDoE(t *testing.T, method string, url string, body io.Reader, headers map[string]string) (int, string, error) {
+func HTTPDoE(
+	t *testing.T, method string, url string, body io.Reader,
+	headers map[string]string,
+) (int, string, error) {
 	logger.Logf(t, "Making an HTTP %s call to URL %s", method, url)
 
 	client := http.Client{
@@ -174,9 +180,11 @@ func HTTPDoE(t *testing.T, method string, url string, body io.Reader, headers ma
 // HTTPDoWithRetry repeatedly performs the given HTTP method on the given URL until the given status code and body are
 // returned or until max retries has been exceeded.
 // The function compares the expected status code against the received one and fails if they don't match.
-func HTTPDoWithRetry(t *testing.T, method string, url string,
+func HTTPDoWithRetry(
+	t *testing.T, method string, url string,
 	body []byte, headers map[string]string, expectedStatus int,
-	retries int, sleepBetweenRetries time.Duration) string {
+	retries int, sleepBetweenRetries time.Duration,
+) string {
 	out, err := HTTPDoWithRetryE(t, method, url, body,
 		headers, expectedStatus, retries, sleepBetweenRetries)
 	if err != nil {
@@ -188,9 +196,11 @@ func HTTPDoWithRetry(t *testing.T, method string, url string,
 // HTTPDoWithRetryE repeatedly performs the given HTTP method on the given URL until the given status code and body are
 // returned or until max retries has been exceeded.
 // The function compares the expected status code against the received one and fails if they don't match.
-func HTTPDoWithRetryE(t *testing.T, method string, url string,
+func HTTPDoWithRetryE(
+	t *testing.T, method string, url string,
 	body []byte, headers map[string]string, expectedStatus int,
-	retries int, sleepBetweenRetries time.Duration) (string, error) {
+	retries int, sleepBetweenRetries time.Duration,
+) (string, error) {
 	out, err := retry.DoWithRetryE(
 		t, fmt.Sprintf("HTTP %s to URL %s", method, url), retries,
 		sleepBetweenRetries, func() (string, error) {
@@ -211,9 +221,11 @@ func HTTPDoWithRetryE(t *testing.T, method string, url string,
 
 // HTTPDoWithValidationRetry repeatedly performs the given HTTP method on the given URL until the given status code and
 // body are returned or until max retries has been exceeded.
-func HTTPDoWithValidationRetry(t *testing.T, method string, url string,
+func HTTPDoWithValidationRetry(
+	t *testing.T, method string, url string,
 	body []byte, headers map[string]string, expectedStatus int,
-	expectedBody string, retries int, sleepBetweenRetries time.Duration) {
+	expectedBody string, retries int, sleepBetweenRetries time.Duration,
+) {
 	err := HTTPDoWithValidationRetryE(t, method, url, body, headers, expectedStatus, expectedBody, retries, sleepBetweenRetries)
 	if err != nil {
 		t.Fatal(err)
@@ -222,9 +234,11 @@ func HTTPDoWithValidationRetry(t *testing.T, method string, url string,
 
 // HTTPDoWithValidationRetryE repeatedly performs the given HTTP method on the given URL until the given status code and
 // body are returned or until max retries has been exceeded.
-func HTTPDoWithValidationRetryE(t *testing.T, method string, url string,
+func HTTPDoWithValidationRetryE(
+	t *testing.T, method string, url string,
 	body []byte, headers map[string]string, expectedStatus int,
-	expectedBody string, retries int, sleepBetweenRetries time.Duration) error {
+	expectedBody string, retries int, sleepBetweenRetries time.Duration,
+) error {
 	_, err := retry.DoWithRetryE(t, fmt.Sprintf("HTTP GET to URL %s", url), retries,
 		sleepBetweenRetries, func() (string, error) {
 			bodyReader := bytes.NewReader(body)

--- a/modules/http-helper/http_helper.go
+++ b/modules/http-helper/http_helper.go
@@ -2,6 +2,7 @@
 package http_helper
 
 import (
+	"bytes"
 	"crypto/tls"
 	"fmt"
 	"io"
@@ -173,8 +174,11 @@ func HTTPDoE(t *testing.T, method string, url string, body io.Reader, headers ma
 // HTTPDoWithRetry repeatedly performs the given HTTP method on the given URL until the given status code and body are
 // returned or until max retries has been exceeded.
 // The function compares the expected status code against the received one and fails if they don't match.
-func HTTPDoWithRetry(t *testing.T, method string, url string, body io.Reader, headers map[string]string, expectedStatus int, retries int, sleepBetweenRetries time.Duration) string {
-	out, err := HTTPDoWithRetryE(t, method, url, body, headers, expectedStatus, retries, sleepBetweenRetries)
+func HTTPDoWithRetry(t *testing.T, method string, url string,
+	body []byte, headers map[string]string, expectedStatus int,
+	retries int, sleepBetweenRetries time.Duration) string {
+	out, err := HTTPDoWithRetryE(t, method, url, body,
+		headers, expectedStatus, retries, sleepBetweenRetries)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -184,25 +188,32 @@ func HTTPDoWithRetry(t *testing.T, method string, url string, body io.Reader, he
 // HTTPDoWithRetryE repeatedly performs the given HTTP method on the given URL until the given status code and body are
 // returned or until max retries has been exceeded.
 // The function compares the expected status code against the received one and fails if they don't match.
-func HTTPDoWithRetryE(t *testing.T, method string, url string, body io.Reader, headers map[string]string, expectedStatus int, retries int, sleepBetweenRetries time.Duration) (string, error) {
-	out, err := retry.DoWithRetryE(t, fmt.Sprintf("HTTP %s to URL %s", method, url), retries, sleepBetweenRetries, func() (string, error) {
-		statusCode, out, err := HTTPDoE(t, method, url, body, headers)
-		if err != nil {
-			return "", err
-		}
-		logger.Logf(t, "output: %v", out)
-		if statusCode != expectedStatus {
-			return "", ValidationFunctionFailed{Url: url, Status: statusCode}
-		}
-		return out, nil
-	})
+func HTTPDoWithRetryE(t *testing.T, method string, url string,
+	body []byte, headers map[string]string, expectedStatus int,
+	retries int, sleepBetweenRetries time.Duration) (string, error) {
+	out, err := retry.DoWithRetryE(
+		t, fmt.Sprintf("HTTP %s to URL %s", method, url), retries,
+		sleepBetweenRetries, func() (string, error) {
+			bodyReader := bytes.NewReader(body)
+			statusCode, out, err := HTTPDoE(t, method, url, bodyReader, headers)
+			if err != nil {
+				return "", err
+			}
+			logger.Logf(t, "output: %v", out)
+			if statusCode != expectedStatus {
+				return "", ValidationFunctionFailed{Url: url, Status: statusCode}
+			}
+			return out, nil
+		})
 
 	return out, err
 }
 
 // HTTPDoWithValidationRetry repeatedly performs the given HTTP method on the given URL until the given status code and
 // body are returned or until max retries has been exceeded.
-func HTTPDoWithValidationRetry(t *testing.T, method string, url string, body io.Reader, headers map[string]string, expectedStatus int, expectedBody string, retries int, sleepBetweenRetries time.Duration) {
+func HTTPDoWithValidationRetry(t *testing.T, method string, url string,
+	body []byte, headers map[string]string, expectedStatus int,
+	expectedBody string, retries int, sleepBetweenRetries time.Duration) {
 	err := HTTPDoWithValidationRetryE(t, method, url, body, headers, expectedStatus, expectedBody, retries, sleepBetweenRetries)
 	if err != nil {
 		t.Fatal(err)
@@ -211,10 +222,14 @@ func HTTPDoWithValidationRetry(t *testing.T, method string, url string, body io.
 
 // HTTPDoWithValidationRetryE repeatedly performs the given HTTP method on the given URL until the given status code and
 // body are returned or until max retries has been exceeded.
-func HTTPDoWithValidationRetryE(t *testing.T, method string, url string, body io.Reader, headers map[string]string, expectedStatus int, expectedBody string, retries int, sleepBetweenRetries time.Duration) error {
-	_, err := retry.DoWithRetryE(t, fmt.Sprintf("HTTP GET to URL %s", url), retries, sleepBetweenRetries, func() (string, error) {
-		return "", HTTPDoWithValidationE(t, method, url, body, headers, expectedStatus, expectedBody)
-	})
+func HTTPDoWithValidationRetryE(t *testing.T, method string, url string,
+	body []byte, headers map[string]string, expectedStatus int,
+	expectedBody string, retries int, sleepBetweenRetries time.Duration) error {
+	_, err := retry.DoWithRetryE(t, fmt.Sprintf("HTTP GET to URL %s", url), retries,
+		sleepBetweenRetries, func() (string, error) {
+			bodyReader := bytes.NewReader(body)
+			return "", HTTPDoWithValidationE(t, method, url, bodyReader, headers, expectedStatus, expectedBody)
+		})
 
 	return err
 }

--- a/modules/http-helper/http_helper_test.go
+++ b/modules/http-helper/http_helper_test.go
@@ -168,6 +168,7 @@ func retryHandler(w http.ResponseWriter, r *http.Request) {
 	if counter > 0 {
 		counter--
 		w.WriteHeader(http.StatusServiceUnavailable)
+		ioutil.ReadAll(r.Body)
 	} else {
 		w.WriteHeader(http.StatusOK)
 		bytes, _ := ioutil.ReadAll(r.Body)

--- a/modules/http-helper/http_helper_test.go
+++ b/modules/http-helper/http_helper_test.go
@@ -182,6 +182,7 @@ func failRetryHandler(w http.ResponseWriter, r *http.Request) {
 	if failCounter > 0 {
 		failCounter--
 		w.WriteHeader(http.StatusServiceUnavailable)
+		ioutil.ReadAll(r.Body)
 	} else {
 		w.WriteHeader(http.StatusOK)
 		bytes, _ := ioutil.ReadAll(r.Body)


### PR DESCRIPTION
This MR is addressing #364.
It is changing the type of the body argument from `io.Reader` to `[]byte` for all HTTP methods with retry functionality and a body.
This ensures that the body is not read upon the first request and then gone for good.
I additionally added a test, ensuring that this is indeed the case.