### PR TITLE
Quote map keys in HCL Strings

### DIFF
--- a/modules/terraform/format.go
+++ b/modules/terraform/format.go
@@ -137,7 +137,7 @@ func mapToHclString(m map[string]interface{}) string {
 	keyValuePairs := []string{}
 
 	for key, value := range m {
-		keyValuePair := fmt.Sprintf("%s = %s", key, toHclString(value, true))
+		keyValuePair := fmt.Sprintf(`"%s" = %s`, key, toHclString(value, true))
 		keyValuePairs = append(keyValuePairs, keyValuePair)
 	}
 

--- a/modules/terraform/format_test.go
+++ b/modules/terraform/format_test.go
@@ -19,10 +19,10 @@ func TestFormatTerraformVarsAsArgs(t *testing.T) {
 		{map[string]interface{}{"foo": 123}, []string{"-var", "foo=123"}},
 		{map[string]interface{}{"foo": true}, []string{"-var", "foo=1"}},
 		{map[string]interface{}{"foo": []int{1, 2, 3}}, []string{"-var", "foo=[1, 2, 3]"}},
-		{map[string]interface{}{"foo": map[string]string{"baz": "blah"}}, []string{"-var", "foo={baz = \"blah\"}"}},
+		{map[string]interface{}{"foo": map[string]string{"baz": "blah"}}, []string{"-var", "foo={\"baz\" = \"blah\"}"}},
 		{
 			map[string]interface{}{"str": "bar", "int": -1, "bool": false, "list": []string{"foo", "bar", "baz"}, "map": map[string]int{"foo": 0}},
-			[]string{"-var", "str=bar", "-var", "int=-1", "-var", "bool=0", "-var", "list=[\"foo\", \"bar\", \"baz\"]", "-var", "map={foo = 0}"},
+			[]string{"-var", "str=bar", "-var", "int=-1", "-var", "bool=0", "-var", "list=[\"foo\", \"bar\", \"baz\"]", "-var", "map={\"foo\" = 0}"},
 		},
 	}
 
@@ -62,11 +62,12 @@ func TestMapToHclString(t *testing.T) {
 		expected string
 	}{
 		{map[string]interface{}{}, "{}"},
-		{map[string]interface{}{"key1": "value1"}, "{key1 = \"value1\"}"},
-		{map[string]interface{}{"key1": 123}, "{key1 = 123}"},
-		{map[string]interface{}{"key1": true}, "{key1 = 1}"},
-		{map[string]interface{}{"key1": []int{1, 2, 3}}, "{key1 = [1, 2, 3]}"}, // Any value that isn't a primitive is forced into a string
-		{map[string]interface{}{"key1": "value1", "key2": 0, "key3": false}, "{key1 = \"value1\", key2 = 0, key3 = 0}"},
+		{map[string]interface{}{"key1": "value1"}, "{\"key1\" = \"value1\"}"},
+		{map[string]interface{}{"key1": 123}, "{\"key1\" = 123}"},
+		{map[string]interface{}{"key1": true}, "{\"key1\" = 1}"},
+		{map[string]interface{}{"key1": []int{1, 2, 3}}, "{\"key1\" = [1, 2, 3]}"}, // Any value that isn't a primitive is forced into a string
+		{map[string]interface{}{"key1": "value1", "key2": 0, "key3": false}, "{\"key1\" = \"value1\", \"key2\" = 0, \"key3\" = 0}"},
+		{map[string]interface{}{"key1.a.b.c": "value1"}, "{\"key1.a.b.c\" = \"value1\"}"},
 	}
 
 	for _, testCase := range testCases {
@@ -121,8 +122,8 @@ func TestSliceToHclString(t *testing.T) {
 		{[]interface{}{true}, "[1]"},
 		{[]interface{}{[]int{1, 2, 3}}, "[[1, 2, 3]]"}, // Any value that isn't a primitive is forced into a string
 		{[]interface{}{"foo", 0, false}, "[\"foo\", 0, 0]"},
-		{[]interface{}{map[string]interface{}{"foo": "bar"}}, "[{foo = \"bar\"}]"},
-		{[]interface{}{map[string]interface{}{"foo": "bar"}, map[string]interface{}{"foo": "bar"}}, "[{foo = \"bar\"}, {foo = \"bar\"}]"},
+		{[]interface{}{map[string]interface{}{"foo": "bar"}}, "[{\"foo\" = \"bar\"}]"},
+		{[]interface{}{map[string]interface{}{"foo": "bar"}, map[string]interface{}{"foo": "bar"}}, "[{\"foo\" = \"bar\"}, {\"foo\" = \"bar\"}]"},
 	}
 
 	for _, testCase := range testCases {
@@ -144,8 +145,8 @@ func TestToHclString(t *testing.T) {
 		{true, "1"},
 		{[]int{1, 2, 3}, "[1, 2, 3]"},
 		{[]string{"foo", "bar", "baz"}, "[\"foo\", \"bar\", \"baz\"]"},
-		{map[string]string{"key1": "value1"}, "{key1 = \"value1\"}"},
-		{map[string]int{"key1": 123}, "{key1 = 123}"},
+		{map[string]string{"key1": "value1"}, "{\"key1\" = \"value1\"}"},
+		{map[string]int{"key1": 123}, "{\"key1\" = 123}"},
 	}
 
 	for _, testCase := range testCases {


### PR DESCRIPTION
Terraform 0.12 requires map keys with dots to be quoted, otherwise they are interpreted as references.

Tests:

```txt
$ go test -count=1 -v .\modules\terraform\format.go .\modules\terraform\format_test.go .\modules\terraform\options.go
=== RUN   TestFormatTerraformVarsAsArgs
=== PAUSE TestFormatTerraformVarsAsArgs
=== RUN   TestPrimitiveToHclString
=== PAUSE TestPrimitiveToHclString
=== RUN   TestMapToHclString
=== PAUSE TestMapToHclString
=== RUN   TestSliceToHclString
=== PAUSE TestSliceToHclString
=== RUN   TestToHclString
=== PAUSE TestToHclString
=== RUN   TestTryToConvertToGenericSlice
=== PAUSE TestTryToConvertToGenericSlice
=== RUN   TestTryToConvertToGenericMap
=== PAUSE TestTryToConvertToGenericMap
=== CONT  TestFormatTerraformVarsAsArgs
=== CONT  TestToHclString
=== CONT  TestTryToConvertToGenericMap
=== CONT  TestMapToHclString
--- PASS: TestToHclString (0.00s)
=== CONT  TestTryToConvertToGenericSlice
--- PASS: TestMapToHclString (0.00s)
=== CONT  TestSliceToHclString
--- PASS: TestTryToConvertToGenericSlice (0.00s)
--- PASS: TestTryToConvertToGenericMap (0.00s)
=== CONT  TestPrimitiveToHclString
--- PASS: TestSliceToHclString (0.00s)
--- PASS: TestFormatTerraformVarsAsArgs (0.00s)
--- PASS: TestPrimitiveToHclString (0.00s)
PASS
ok      command-line-arguments  0.074s
```

Fixes #363