### PR TITLE
using a interface instead of *testing.T

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,9 +72,6 @@ jobs:
             pre-commit install
             pre-commit run --all-files
 
-      # verify that the testing.TestingT interface is used instead of testing.T
-      - run: grep -Rw "*testing\.T" modules | grep -v _test.go
-
       # Build any binaries that need to be built
       # We always want to build the binaries, because we will use the terratest_log_parser to parse out the test output
       # during a failure.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,7 +73,7 @@ jobs:
             pre-commit run --all-files
 
       # verify that the testing.TestingT interface is used instead of testing.T
-      - run: grep -Rw "*testing\.T" modules | grep -v _test
+      - run: grep -Rw "*testing\.T" modules | grep -v _test.go
 
       # Build any binaries that need to be built
       # We always want to build the binaries, because we will use the terratest_log_parser to parse out the test output

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,6 +72,9 @@ jobs:
             pre-commit install
             pre-commit run --all-files
 
+      # verify that the testing.TestingT interface is used instead of testing.T
+      - run: grep -Rw "*testing\.T" modules | grep -v _test
+
       # Build any binaries that need to be built
       # We always want to build the binaries, because we will use the terratest_log_parser to parse out the test output
       # during a failure.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,3 +2,11 @@
   rev: v0.0.2
   hooks:
     - id: goimports
+- repo: local
+  hooks:
+    - id: test-interfaces-used
+      name: test-interfaces-used
+      entry: bash -c 'grep -Rw "*testing.T" modules | grep -v _test.go | wc -l'
+      language: system
+      types: [go]
+      pass_filenames: false

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/Azure/azure-sdk-for-go v38.1.0+incompatible
 	github.com/Azure/go-autorest/autorest v0.9.3
 	github.com/Azure/go-autorest/autorest/azure/auth v0.4.2
-	github.com/Azure/go-autorest/autorest/to v0.3.0
 	github.com/Azure/go-autorest/autorest/validation v0.2.0 // indirect
 	github.com/Masterminds/semver v1.5.0 // indirect
 	github.com/aws/aws-lambda-go v1.13.3

--- a/go.sum
+++ b/go.sum
@@ -553,6 +553,7 @@ golang.org/x/tools v0.0.0-20200113040837-eac381796e91 h1:OOkytthzFBKHY5EfEgLUabp
 golang.org/x/tools v0.0.0-20200113040837-eac381796e91/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gonum.org/v1/gonum v0.0.0-20190331200053-3d26580ed485/go.mod h1:2ltnJ7xHfj0zHS40VVPYEAAMTa3ZGguvHGBSJeRWqE0=
 gonum.org/v1/netlib v0.0.0-20190313105609-8cb42192e0e0/go.mod h1:wa6Ws7BG/ESfp6dHfk7C6KdzKA7wR7u/rKwOGE66zvw=

--- a/modules/aws/account.go
+++ b/modules/aws/account.go
@@ -3,14 +3,15 @@ package aws
 import (
 	"errors"
 	"strings"
-	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/sts"
+
+	_ "github.com/gruntwork-io/terratest/modules/testing"
 )
 
 // GetAccountId gets the Account ID for the currently logged in IAM User.
-func GetAccountId(t *testing.T) string {
+func GetAccountId(t TestingT) string {
 	id, err := GetAccountIdE(t)
 	if err != nil {
 		t.Fatal(err)
@@ -19,7 +20,7 @@ func GetAccountId(t *testing.T) string {
 }
 
 // GetAccountIdE gets the Account ID for the currently logged in IAM User.
-func GetAccountIdE(t *testing.T) (string, error) {
+func GetAccountIdE(t TestingT) (string, error) {
 	stsClient, err := NewStsClientE(t, defaultRegion)
 	if err != nil {
 		return "", err
@@ -46,7 +47,7 @@ func extractAccountIDFromARN(arn string) (string, error) {
 }
 
 // NewStsClientE creates a new STS client.
-func NewStsClientE(t *testing.T, region string) (*sts.STS, error) {
+func NewStsClientE(t TestingT, region string) (*sts.STS, error) {
 	sess, err := NewAuthenticatedSession(region)
 	if err != nil {
 		return nil, err

--- a/modules/aws/account.go
+++ b/modules/aws/account.go
@@ -7,11 +7,11 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/sts"
 
-	_ "github.com/gruntwork-io/terratest/modules/testing"
+	"github.com/gruntwork-io/terratest/modules/testing"
 )
 
 // GetAccountId gets the Account ID for the currently logged in IAM User.
-func GetAccountId(t TestingT) string {
+func GetAccountId(t testing.TestingT) string {
 	id, err := GetAccountIdE(t)
 	if err != nil {
 		t.Fatal(err)
@@ -20,7 +20,7 @@ func GetAccountId(t TestingT) string {
 }
 
 // GetAccountIdE gets the Account ID for the currently logged in IAM User.
-func GetAccountIdE(t TestingT) (string, error) {
+func GetAccountIdE(t testing.TestingT) (string, error) {
 	stsClient, err := NewStsClientE(t, defaultRegion)
 	if err != nil {
 		return "", err
@@ -47,7 +47,7 @@ func extractAccountIDFromARN(arn string) (string, error) {
 }
 
 // NewStsClientE creates a new STS client.
-func NewStsClientE(t TestingT, region string) (*sts.STS, error) {
+func NewStsClientE(t testing.TestingT, region string) (*sts.STS, error) {
 	sess, err := NewAuthenticatedSession(region)
 	if err != nil {
 		return nil, err

--- a/modules/aws/acm.go
+++ b/modules/aws/acm.go
@@ -3,11 +3,11 @@ package aws
 import (
 	"github.com/aws/aws-sdk-go/service/acm"
 
-	_ "github.com/gruntwork-io/terratest/modules/testing"
+	"github.com/gruntwork-io/terratest/modules/testing"
 )
 
 // GetAcmCertificateArn gets the ACM certificate for the given domain name in the given region.
-func GetAcmCertificateArn(t TestingT, awsRegion string, certDomainName string) string {
+func GetAcmCertificateArn(t testing.TestingT, awsRegion string, certDomainName string) string {
 	arn, err := GetAcmCertificateArnE(t, awsRegion, certDomainName)
 	if err != nil {
 		t.Fatal(err)
@@ -16,7 +16,7 @@ func GetAcmCertificateArn(t TestingT, awsRegion string, certDomainName string) s
 }
 
 // GetAcmCertificateArnE gets the ACM certificate for the given domain name in the given region.
-func GetAcmCertificateArnE(t TestingT, awsRegion string, certDomainName string) (string, error) {
+func GetAcmCertificateArnE(t testing.TestingT, awsRegion string, certDomainName string) (string, error) {
 	acmClient, err := NewAcmClientE(t, awsRegion)
 	if err != nil {
 		return "", err
@@ -37,7 +37,7 @@ func GetAcmCertificateArnE(t TestingT, awsRegion string, certDomainName string) 
 }
 
 // NewAcmClient create a new ACM client.
-func NewAcmClient(t TestingT, region string) *acm.ACM {
+func NewAcmClient(t testing.TestingT, region string) *acm.ACM {
 	client, err := NewAcmClientE(t, region)
 	if err != nil {
 		t.Fatal(err)
@@ -46,7 +46,7 @@ func NewAcmClient(t TestingT, region string) *acm.ACM {
 }
 
 // NewAcmClientE creates a new ACM client.
-func NewAcmClientE(t TestingT, awsRegion string) (*acm.ACM, error) {
+func NewAcmClientE(t testing.TestingT, awsRegion string) (*acm.ACM, error) {
 	sess, err := NewAuthenticatedSession(awsRegion)
 	if err != nil {
 		return nil, err

--- a/modules/aws/acm.go
+++ b/modules/aws/acm.go
@@ -1,13 +1,13 @@
 package aws
 
 import (
-	"testing"
-
 	"github.com/aws/aws-sdk-go/service/acm"
+
+	_ "github.com/gruntwork-io/terratest/modules/testing"
 )
 
 // GetAcmCertificateArn gets the ACM certificate for the given domain name in the given region.
-func GetAcmCertificateArn(t *testing.T, awsRegion string, certDomainName string) string {
+func GetAcmCertificateArn(t TestingT, awsRegion string, certDomainName string) string {
 	arn, err := GetAcmCertificateArnE(t, awsRegion, certDomainName)
 	if err != nil {
 		t.Fatal(err)
@@ -16,7 +16,7 @@ func GetAcmCertificateArn(t *testing.T, awsRegion string, certDomainName string)
 }
 
 // GetAcmCertificateArnE gets the ACM certificate for the given domain name in the given region.
-func GetAcmCertificateArnE(t *testing.T, awsRegion string, certDomainName string) (string, error) {
+func GetAcmCertificateArnE(t TestingT, awsRegion string, certDomainName string) (string, error) {
 	acmClient, err := NewAcmClientE(t, awsRegion)
 	if err != nil {
 		return "", err
@@ -37,7 +37,7 @@ func GetAcmCertificateArnE(t *testing.T, awsRegion string, certDomainName string
 }
 
 // NewAcmClient create a new ACM client.
-func NewAcmClient(t *testing.T, region string) *acm.ACM {
+func NewAcmClient(t TestingT, region string) *acm.ACM {
 	client, err := NewAcmClientE(t, region)
 	if err != nil {
 		t.Fatal(err)
@@ -46,7 +46,7 @@ func NewAcmClient(t *testing.T, region string) *acm.ACM {
 }
 
 // NewAcmClientE creates a new ACM client.
-func NewAcmClientE(t *testing.T, awsRegion string) (*acm.ACM, error) {
+func NewAcmClientE(t TestingT, awsRegion string) (*acm.ACM, error) {
 	sess, err := NewAuthenticatedSession(awsRegion)
 	if err != nil {
 		return nil, err

--- a/modules/aws/ami.go
+++ b/modules/aws/ami.go
@@ -8,7 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/gruntwork-io/terratest/modules/logger"
-	_ "github.com/gruntwork-io/terratest/modules/testing"
+	"github.com/gruntwork-io/terratest/modules/testing"
 )
 
 // These are commonly used AMI account IDs.
@@ -19,7 +19,7 @@ const (
 )
 
 // DeleteAmiAndAllSnapshots will delete the given AMI along with all EBS snapshots that backed that AMI
-func DeleteAmiAndAllSnapshots(t TestingT, region string, ami string) {
+func DeleteAmiAndAllSnapshots(t testing.TestingT, region string, ami string) {
 	err := DeleteAmiAndAllSnapshotsE(t, region, ami)
 	if err != nil {
 		t.Fatal(err)
@@ -27,7 +27,7 @@ func DeleteAmiAndAllSnapshots(t TestingT, region string, ami string) {
 }
 
 // DeleteAmiAndAllSnapshotsE will delete the given AMI along with all EBS snapshots that backed that AMI
-func DeleteAmiAndAllSnapshotsE(t TestingT, region string, ami string) error {
+func DeleteAmiAndAllSnapshotsE(t testing.TestingT, region string, ami string) error {
 	snapshots, err := GetEbsSnapshotsForAmiE(t, region, ami)
 	if err != nil {
 		return err
@@ -49,7 +49,7 @@ func DeleteAmiAndAllSnapshotsE(t TestingT, region string, ami string) error {
 }
 
 // GetEbsSnapshotsForAmi retrieves the EBS snapshots which back the given AMI
-func GetEbsSnapshotsForAmi(t TestingT, region string, ami string) []string {
+func GetEbsSnapshotsForAmi(t testing.TestingT, region string, ami string) []string {
 	snapshots, err := GetEbsSnapshotsForAmiE(t, region, ami)
 	if err != nil {
 		t.Fatal(err)
@@ -58,7 +58,7 @@ func GetEbsSnapshotsForAmi(t TestingT, region string, ami string) []string {
 }
 
 // GetEbsSnapshotsForAmi retrieves the EBS snapshots which back the given AMI
-func GetEbsSnapshotsForAmiE(t TestingT, region string, ami string) ([]string, error) {
+func GetEbsSnapshotsForAmiE(t testing.TestingT, region string, ami string) ([]string, error) {
 	logger.Logf(t, "Retrieving EBS snapshots backing AMI %s", ami)
 	ec2Client, err := NewEc2ClientE(t, region)
 	if err != nil {
@@ -89,7 +89,7 @@ func GetEbsSnapshotsForAmiE(t TestingT, region string, ami string) ([]string, er
 // GetMostRecentAmiId gets the ID of the most recent AMI in the given region that has the given owner and matches the given filters. Each
 // filter should correspond to the name and values of a filter supported by DescribeImagesInput:
 // https://docs.aws.amazon.com/sdk-for-go/api/service/ec2/#DescribeImagesInput
-func GetMostRecentAmiId(t TestingT, region string, ownerId string, filters map[string][]string) string {
+func GetMostRecentAmiId(t testing.TestingT, region string, ownerId string, filters map[string][]string) string {
 	amiID, err := GetMostRecentAmiIdE(t, region, ownerId, filters)
 	if err != nil {
 		t.Fatal(err)
@@ -100,7 +100,7 @@ func GetMostRecentAmiId(t TestingT, region string, ownerId string, filters map[s
 // GetMostRecentAmiIdE gets the ID of the most recent AMI in the given region that has the given owner and matches the given filters. Each
 // filter should correspond to the name and values of a filter supported by DescribeImagesInput:
 // https://docs.aws.amazon.com/sdk-for-go/api/service/ec2/#DescribeImagesInput
-func GetMostRecentAmiIdE(t TestingT, region string, ownerId string, filters map[string][]string) (string, error) {
+func GetMostRecentAmiIdE(t testing.TestingT, region string, ownerId string, filters map[string][]string) (string, error) {
 	ec2Client, err := NewEc2ClientE(t, region)
 	if err != nil {
 		return "", err
@@ -148,7 +148,7 @@ func mostRecentAMI(images []*ec2.Image) *ec2.Image {
 }
 
 // GetUbuntu1404Ami gets the ID of the most recent Ubuntu 14.04 HVM x86_64 EBS GP2 AMI in the given region.
-func GetUbuntu1404Ami(t TestingT, region string) string {
+func GetUbuntu1404Ami(t testing.TestingT, region string) string {
 	amiID, err := GetUbuntu1404AmiE(t, region)
 	if err != nil {
 		t.Fatal(err)
@@ -157,7 +157,7 @@ func GetUbuntu1404Ami(t TestingT, region string) string {
 }
 
 // GetUbuntu1404AmiE gets the ID of the most recent Ubuntu 14.04 HVM x86_64 EBS GP2 AMI in the given region.
-func GetUbuntu1404AmiE(t TestingT, region string) (string, error) {
+func GetUbuntu1404AmiE(t testing.TestingT, region string) (string, error) {
 	filters := map[string][]string{
 		"name":                             {"*ubuntu-trusty-14.04-amd64-server-*"},
 		"virtualization-type":              {"hvm"},
@@ -170,7 +170,7 @@ func GetUbuntu1404AmiE(t TestingT, region string) (string, error) {
 }
 
 // GetUbuntu1604Ami gets the ID of the most recent Ubuntu 16.04 HVM x86_64 EBS GP2 AMI in the given region.
-func GetUbuntu1604Ami(t TestingT, region string) string {
+func GetUbuntu1604Ami(t testing.TestingT, region string) string {
 	amiID, err := GetUbuntu1604AmiE(t, region)
 	if err != nil {
 		t.Fatal(err)
@@ -179,7 +179,7 @@ func GetUbuntu1604Ami(t TestingT, region string) string {
 }
 
 // GetUbuntu1604AmiE gets the ID of the most recent Ubuntu 16.04 HVM x86_64 EBS GP2 AMI in the given region.
-func GetUbuntu1604AmiE(t TestingT, region string) (string, error) {
+func GetUbuntu1604AmiE(t testing.TestingT, region string) (string, error) {
 	filters := map[string][]string{
 		"name":                             {"*ubuntu-xenial-16.04-amd64-server-*"},
 		"virtualization-type":              {"hvm"},
@@ -194,7 +194,7 @@ func GetUbuntu1604AmiE(t TestingT, region string) (string, error) {
 // GetCentos7Ami returns a CentOS 7 public AMI from the given region.
 // WARNING: you may have to accept the terms & conditions of this AMI in AWS MarketPlace for your AWS Account before
 // you can successfully launch the AMI.
-func GetCentos7Ami(t TestingT, region string) string {
+func GetCentos7Ami(t testing.TestingT, region string) string {
 	amiID, err := GetCentos7AmiE(t, region)
 	if err != nil {
 		t.Fatal(err)
@@ -205,7 +205,7 @@ func GetCentos7Ami(t TestingT, region string) string {
 // GetCentos7AmiE returns a CentOS 7 public AMI from the given region.
 // WARNING: you may have to accept the terms & conditions of this AMI in AWS MarketPlace for your AWS Account before
 // you can successfully launch the AMI.
-func GetCentos7AmiE(t TestingT, region string) (string, error) {
+func GetCentos7AmiE(t testing.TestingT, region string) (string, error) {
 	filters := map[string][]string{
 		"name":                             {"*CentOS Linux 7 x86_64 HVM EBS*"},
 		"virtualization-type":              {"hvm"},
@@ -218,7 +218,7 @@ func GetCentos7AmiE(t TestingT, region string) (string, error) {
 }
 
 // GetAmazonLinuxAmi returns an Amazon Linux AMI HVM, SSD Volume Type public AMI for the given region.
-func GetAmazonLinuxAmi(t TestingT, region string) string {
+func GetAmazonLinuxAmi(t testing.TestingT, region string) string {
 	amiID, err := GetAmazonLinuxAmiE(t, region)
 	if err != nil {
 		t.Fatal(err)
@@ -227,7 +227,7 @@ func GetAmazonLinuxAmi(t TestingT, region string) string {
 }
 
 // GetAmazonLinuxAmiE returns an Amazon Linux AMI HVM, SSD Volume Type public AMI for the given region.
-func GetAmazonLinuxAmiE(t TestingT, region string) (string, error) {
+func GetAmazonLinuxAmiE(t testing.TestingT, region string) (string, error) {
 	filters := map[string][]string{
 		"name":                             {"*amzn-ami-hvm-*-x86_64*"},
 		"virtualization-type":              {"hvm"},
@@ -240,7 +240,7 @@ func GetAmazonLinuxAmiE(t TestingT, region string) (string, error) {
 }
 
 // GetEcsOptimizedAmazonLinuxAmi returns an Amazon ECS-Optimized Amazon Linux AMI for the given region. This AMI is useful for running an ECS cluster.
-func GetEcsOptimizedAmazonLinuxAmi(t TestingT, region string) string {
+func GetEcsOptimizedAmazonLinuxAmi(t testing.TestingT, region string) string {
 	amiID, err := GetEcsOptimizedAmazonLinuxAmiE(t, region)
 	if err != nil {
 		t.Fatal(err)
@@ -249,7 +249,7 @@ func GetEcsOptimizedAmazonLinuxAmi(t TestingT, region string) string {
 }
 
 // GetEcsOptimizedAmazonLinuxAmiE returns an Amazon ECS-Optimized Amazon Linux AMI for the given region. This AMI is useful for running an ECS cluster.
-func GetEcsOptimizedAmazonLinuxAmiE(t TestingT, region string) (string, error) {
+func GetEcsOptimizedAmazonLinuxAmiE(t testing.TestingT, region string) (string, error) {
 	filters := map[string][]string{
 		"name":                             {"*amzn-ami*amazon-ecs-optimized*"},
 		"virtualization-type":              {"hvm"},

--- a/modules/aws/ami.go
+++ b/modules/aws/ami.go
@@ -3,12 +3,12 @@ package aws
 import (
 	"fmt"
 	"sort"
-	"testing"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/gruntwork-io/terratest/modules/logger"
+	_ "github.com/gruntwork-io/terratest/modules/testing"
 )
 
 // These are commonly used AMI account IDs.
@@ -19,7 +19,7 @@ const (
 )
 
 // DeleteAmiAndAllSnapshots will delete the given AMI along with all EBS snapshots that backed that AMI
-func DeleteAmiAndAllSnapshots(t *testing.T, region string, ami string) {
+func DeleteAmiAndAllSnapshots(t TestingT, region string, ami string) {
 	err := DeleteAmiAndAllSnapshotsE(t, region, ami)
 	if err != nil {
 		t.Fatal(err)
@@ -27,7 +27,7 @@ func DeleteAmiAndAllSnapshots(t *testing.T, region string, ami string) {
 }
 
 // DeleteAmiAndAllSnapshotsE will delete the given AMI along with all EBS snapshots that backed that AMI
-func DeleteAmiAndAllSnapshotsE(t *testing.T, region string, ami string) error {
+func DeleteAmiAndAllSnapshotsE(t TestingT, region string, ami string) error {
 	snapshots, err := GetEbsSnapshotsForAmiE(t, region, ami)
 	if err != nil {
 		return err
@@ -49,7 +49,7 @@ func DeleteAmiAndAllSnapshotsE(t *testing.T, region string, ami string) error {
 }
 
 // GetEbsSnapshotsForAmi retrieves the EBS snapshots which back the given AMI
-func GetEbsSnapshotsForAmi(t *testing.T, region string, ami string) []string {
+func GetEbsSnapshotsForAmi(t TestingT, region string, ami string) []string {
 	snapshots, err := GetEbsSnapshotsForAmiE(t, region, ami)
 	if err != nil {
 		t.Fatal(err)
@@ -58,7 +58,7 @@ func GetEbsSnapshotsForAmi(t *testing.T, region string, ami string) []string {
 }
 
 // GetEbsSnapshotsForAmi retrieves the EBS snapshots which back the given AMI
-func GetEbsSnapshotsForAmiE(t *testing.T, region string, ami string) ([]string, error) {
+func GetEbsSnapshotsForAmiE(t TestingT, region string, ami string) ([]string, error) {
 	logger.Logf(t, "Retrieving EBS snapshots backing AMI %s", ami)
 	ec2Client, err := NewEc2ClientE(t, region)
 	if err != nil {
@@ -89,7 +89,7 @@ func GetEbsSnapshotsForAmiE(t *testing.T, region string, ami string) ([]string, 
 // GetMostRecentAmiId gets the ID of the most recent AMI in the given region that has the given owner and matches the given filters. Each
 // filter should correspond to the name and values of a filter supported by DescribeImagesInput:
 // https://docs.aws.amazon.com/sdk-for-go/api/service/ec2/#DescribeImagesInput
-func GetMostRecentAmiId(t *testing.T, region string, ownerId string, filters map[string][]string) string {
+func GetMostRecentAmiId(t TestingT, region string, ownerId string, filters map[string][]string) string {
 	amiID, err := GetMostRecentAmiIdE(t, region, ownerId, filters)
 	if err != nil {
 		t.Fatal(err)
@@ -100,7 +100,7 @@ func GetMostRecentAmiId(t *testing.T, region string, ownerId string, filters map
 // GetMostRecentAmiIdE gets the ID of the most recent AMI in the given region that has the given owner and matches the given filters. Each
 // filter should correspond to the name and values of a filter supported by DescribeImagesInput:
 // https://docs.aws.amazon.com/sdk-for-go/api/service/ec2/#DescribeImagesInput
-func GetMostRecentAmiIdE(t *testing.T, region string, ownerId string, filters map[string][]string) (string, error) {
+func GetMostRecentAmiIdE(t TestingT, region string, ownerId string, filters map[string][]string) (string, error) {
 	ec2Client, err := NewEc2ClientE(t, region)
 	if err != nil {
 		return "", err
@@ -148,7 +148,7 @@ func mostRecentAMI(images []*ec2.Image) *ec2.Image {
 }
 
 // GetUbuntu1404Ami gets the ID of the most recent Ubuntu 14.04 HVM x86_64 EBS GP2 AMI in the given region.
-func GetUbuntu1404Ami(t *testing.T, region string) string {
+func GetUbuntu1404Ami(t TestingT, region string) string {
 	amiID, err := GetUbuntu1404AmiE(t, region)
 	if err != nil {
 		t.Fatal(err)
@@ -157,7 +157,7 @@ func GetUbuntu1404Ami(t *testing.T, region string) string {
 }
 
 // GetUbuntu1404AmiE gets the ID of the most recent Ubuntu 14.04 HVM x86_64 EBS GP2 AMI in the given region.
-func GetUbuntu1404AmiE(t *testing.T, region string) (string, error) {
+func GetUbuntu1404AmiE(t TestingT, region string) (string, error) {
 	filters := map[string][]string{
 		"name":                             {"*ubuntu-trusty-14.04-amd64-server-*"},
 		"virtualization-type":              {"hvm"},
@@ -170,7 +170,7 @@ func GetUbuntu1404AmiE(t *testing.T, region string) (string, error) {
 }
 
 // GetUbuntu1604Ami gets the ID of the most recent Ubuntu 16.04 HVM x86_64 EBS GP2 AMI in the given region.
-func GetUbuntu1604Ami(t *testing.T, region string) string {
+func GetUbuntu1604Ami(t TestingT, region string) string {
 	amiID, err := GetUbuntu1604AmiE(t, region)
 	if err != nil {
 		t.Fatal(err)
@@ -179,7 +179,7 @@ func GetUbuntu1604Ami(t *testing.T, region string) string {
 }
 
 // GetUbuntu1604AmiE gets the ID of the most recent Ubuntu 16.04 HVM x86_64 EBS GP2 AMI in the given region.
-func GetUbuntu1604AmiE(t *testing.T, region string) (string, error) {
+func GetUbuntu1604AmiE(t TestingT, region string) (string, error) {
 	filters := map[string][]string{
 		"name":                             {"*ubuntu-xenial-16.04-amd64-server-*"},
 		"virtualization-type":              {"hvm"},
@@ -194,7 +194,7 @@ func GetUbuntu1604AmiE(t *testing.T, region string) (string, error) {
 // GetCentos7Ami returns a CentOS 7 public AMI from the given region.
 // WARNING: you may have to accept the terms & conditions of this AMI in AWS MarketPlace for your AWS Account before
 // you can successfully launch the AMI.
-func GetCentos7Ami(t *testing.T, region string) string {
+func GetCentos7Ami(t TestingT, region string) string {
 	amiID, err := GetCentos7AmiE(t, region)
 	if err != nil {
 		t.Fatal(err)
@@ -205,7 +205,7 @@ func GetCentos7Ami(t *testing.T, region string) string {
 // GetCentos7AmiE returns a CentOS 7 public AMI from the given region.
 // WARNING: you may have to accept the terms & conditions of this AMI in AWS MarketPlace for your AWS Account before
 // you can successfully launch the AMI.
-func GetCentos7AmiE(t *testing.T, region string) (string, error) {
+func GetCentos7AmiE(t TestingT, region string) (string, error) {
 	filters := map[string][]string{
 		"name":                             {"*CentOS Linux 7 x86_64 HVM EBS*"},
 		"virtualization-type":              {"hvm"},
@@ -218,7 +218,7 @@ func GetCentos7AmiE(t *testing.T, region string) (string, error) {
 }
 
 // GetAmazonLinuxAmi returns an Amazon Linux AMI HVM, SSD Volume Type public AMI for the given region.
-func GetAmazonLinuxAmi(t *testing.T, region string) string {
+func GetAmazonLinuxAmi(t TestingT, region string) string {
 	amiID, err := GetAmazonLinuxAmiE(t, region)
 	if err != nil {
 		t.Fatal(err)
@@ -227,7 +227,7 @@ func GetAmazonLinuxAmi(t *testing.T, region string) string {
 }
 
 // GetAmazonLinuxAmiE returns an Amazon Linux AMI HVM, SSD Volume Type public AMI for the given region.
-func GetAmazonLinuxAmiE(t *testing.T, region string) (string, error) {
+func GetAmazonLinuxAmiE(t TestingT, region string) (string, error) {
 	filters := map[string][]string{
 		"name":                             {"*amzn-ami-hvm-*-x86_64*"},
 		"virtualization-type":              {"hvm"},
@@ -240,7 +240,7 @@ func GetAmazonLinuxAmiE(t *testing.T, region string) (string, error) {
 }
 
 // GetEcsOptimizedAmazonLinuxAmi returns an Amazon ECS-Optimized Amazon Linux AMI for the given region. This AMI is useful for running an ECS cluster.
-func GetEcsOptimizedAmazonLinuxAmi(t *testing.T, region string) string {
+func GetEcsOptimizedAmazonLinuxAmi(t TestingT, region string) string {
 	amiID, err := GetEcsOptimizedAmazonLinuxAmiE(t, region)
 	if err != nil {
 		t.Fatal(err)
@@ -249,7 +249,7 @@ func GetEcsOptimizedAmazonLinuxAmi(t *testing.T, region string) string {
 }
 
 // GetEcsOptimizedAmazonLinuxAmiE returns an Amazon ECS-Optimized Amazon Linux AMI for the given region. This AMI is useful for running an ECS cluster.
-func GetEcsOptimizedAmazonLinuxAmiE(t *testing.T, region string) (string, error) {
+func GetEcsOptimizedAmazonLinuxAmiE(t TestingT, region string) (string, error) {
 	filters := map[string][]string{
 		"name":                             {"*amzn-ami*amazon-ecs-optimized*"},
 		"virtualization-type":              {"hvm"},

--- a/modules/aws/asg.go
+++ b/modules/aws/asg.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/retry"
-	_ "github.com/gruntwork-io/terratest/modules/testing"
+	"github.com/gruntwork-io/terratest/modules/testing"
 )
 
 type AsgCapacityInfo struct {
@@ -21,14 +21,14 @@ type AsgCapacityInfo struct {
 }
 
 // GetCapacityInfoForAsg returns the capacity info for the queried asg as a struct, AsgCapacityInfo.
-func GetCapacityInfoForAsg(t TestingT, asgName string, awsRegion string) AsgCapacityInfo {
+func GetCapacityInfoForAsg(t testing.TestingT, asgName string, awsRegion string) AsgCapacityInfo {
 	capacityInfo, err := GetCapacityInfoForAsgE(t, asgName, awsRegion)
 	require.NoError(t, err)
 	return capacityInfo
 }
 
 // GetCapacityInfoForAsgE returns the capacity info for the queried asg as a struct, AsgCapacityInfo.
-func GetCapacityInfoForAsgE(t TestingT, asgName string, awsRegion string) (AsgCapacityInfo, error) {
+func GetCapacityInfoForAsgE(t testing.TestingT, asgName string, awsRegion string) (AsgCapacityInfo, error) {
 	asgClient, err := NewAsgClientE(t, awsRegion)
 	if err != nil {
 		return AsgCapacityInfo{}, err
@@ -53,7 +53,7 @@ func GetCapacityInfoForAsgE(t TestingT, asgName string, awsRegion string) (AsgCa
 }
 
 // GetInstanceIdsForAsg gets the IDs of EC2 Instances in the given ASG.
-func GetInstanceIdsForAsg(t TestingT, asgName string, awsRegion string) []string {
+func GetInstanceIdsForAsg(t testing.TestingT, asgName string, awsRegion string) []string {
 	ids, err := GetInstanceIdsForAsgE(t, asgName, awsRegion)
 	if err != nil {
 		t.Fatal(err)
@@ -62,7 +62,7 @@ func GetInstanceIdsForAsg(t TestingT, asgName string, awsRegion string) []string
 }
 
 // GetInstanceIdsForAsgE gets the IDs of EC2 Instances in the given ASG.
-func GetInstanceIdsForAsgE(t TestingT, asgName string, awsRegion string) ([]string, error) {
+func GetInstanceIdsForAsgE(t testing.TestingT, asgName string, awsRegion string) ([]string, error) {
 	asgClient, err := NewAsgClientE(t, awsRegion)
 	if err != nil {
 		return nil, err
@@ -86,7 +86,7 @@ func GetInstanceIdsForAsgE(t TestingT, asgName string, awsRegion string) ([]stri
 
 // WaitForCapacity waits for the currently set desired capacity to be reached on the ASG
 func WaitForCapacity(
-	t TestingT,
+	t testing.TestingT,
 	asgName string,
 	region string,
 	maxRetries int,
@@ -98,7 +98,7 @@ func WaitForCapacity(
 
 // WaitForCapacityE waits for the currently set desired capacity to be reached on the ASG
 func WaitForCapacityE(
-	t TestingT,
+	t testing.TestingT,
 	asgName string,
 	region string,
 	maxRetries int,
@@ -125,7 +125,7 @@ func WaitForCapacityE(
 }
 
 // NewAsgClient creates an Auto Scaling Group client.
-func NewAsgClient(t TestingT, region string) *autoscaling.AutoScaling {
+func NewAsgClient(t testing.TestingT, region string) *autoscaling.AutoScaling {
 	client, err := NewAsgClientE(t, region)
 	if err != nil {
 		t.Fatal(err)
@@ -134,7 +134,7 @@ func NewAsgClient(t TestingT, region string) *autoscaling.AutoScaling {
 }
 
 // NewAsgClientE creates an Auto Scaling Group client.
-func NewAsgClientE(t TestingT, region string) (*autoscaling.AutoScaling, error) {
+func NewAsgClientE(t testing.TestingT, region string) (*autoscaling.AutoScaling, error) {
 	sess, err := NewAuthenticatedSession(region)
 	if err != nil {
 		return nil, err

--- a/modules/aws/asg.go
+++ b/modules/aws/asg.go
@@ -2,7 +2,6 @@ package aws
 
 import (
 	"fmt"
-	"testing"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -11,6 +10,7 @@ import (
 
 	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/retry"
+	_ "github.com/gruntwork-io/terratest/modules/testing"
 )
 
 type AsgCapacityInfo struct {
@@ -21,14 +21,14 @@ type AsgCapacityInfo struct {
 }
 
 // GetCapacityInfoForAsg returns the capacity info for the queried asg as a struct, AsgCapacityInfo.
-func GetCapacityInfoForAsg(t *testing.T, asgName string, awsRegion string) AsgCapacityInfo {
+func GetCapacityInfoForAsg(t TestingT, asgName string, awsRegion string) AsgCapacityInfo {
 	capacityInfo, err := GetCapacityInfoForAsgE(t, asgName, awsRegion)
 	require.NoError(t, err)
 	return capacityInfo
 }
 
 // GetCapacityInfoForAsgE returns the capacity info for the queried asg as a struct, AsgCapacityInfo.
-func GetCapacityInfoForAsgE(t *testing.T, asgName string, awsRegion string) (AsgCapacityInfo, error) {
+func GetCapacityInfoForAsgE(t TestingT, asgName string, awsRegion string) (AsgCapacityInfo, error) {
 	asgClient, err := NewAsgClientE(t, awsRegion)
 	if err != nil {
 		return AsgCapacityInfo{}, err
@@ -53,7 +53,7 @@ func GetCapacityInfoForAsgE(t *testing.T, asgName string, awsRegion string) (Asg
 }
 
 // GetInstanceIdsForAsg gets the IDs of EC2 Instances in the given ASG.
-func GetInstanceIdsForAsg(t *testing.T, asgName string, awsRegion string) []string {
+func GetInstanceIdsForAsg(t TestingT, asgName string, awsRegion string) []string {
 	ids, err := GetInstanceIdsForAsgE(t, asgName, awsRegion)
 	if err != nil {
 		t.Fatal(err)
@@ -62,7 +62,7 @@ func GetInstanceIdsForAsg(t *testing.T, asgName string, awsRegion string) []stri
 }
 
 // GetInstanceIdsForAsgE gets the IDs of EC2 Instances in the given ASG.
-func GetInstanceIdsForAsgE(t *testing.T, asgName string, awsRegion string) ([]string, error) {
+func GetInstanceIdsForAsgE(t TestingT, asgName string, awsRegion string) ([]string, error) {
 	asgClient, err := NewAsgClientE(t, awsRegion)
 	if err != nil {
 		return nil, err
@@ -86,7 +86,7 @@ func GetInstanceIdsForAsgE(t *testing.T, asgName string, awsRegion string) ([]st
 
 // WaitForCapacity waits for the currently set desired capacity to be reached on the ASG
 func WaitForCapacity(
-	t *testing.T,
+	t TestingT,
 	asgName string,
 	region string,
 	maxRetries int,
@@ -98,7 +98,7 @@ func WaitForCapacity(
 
 // WaitForCapacityE waits for the currently set desired capacity to be reached on the ASG
 func WaitForCapacityE(
-	t *testing.T,
+	t TestingT,
 	asgName string,
 	region string,
 	maxRetries int,
@@ -125,7 +125,7 @@ func WaitForCapacityE(
 }
 
 // NewAsgClient creates an Auto Scaling Group client.
-func NewAsgClient(t *testing.T, region string) *autoscaling.AutoScaling {
+func NewAsgClient(t TestingT, region string) *autoscaling.AutoScaling {
 	client, err := NewAsgClientE(t, region)
 	if err != nil {
 		t.Fatal(err)
@@ -134,7 +134,7 @@ func NewAsgClient(t *testing.T, region string) *autoscaling.AutoScaling {
 }
 
 // NewAsgClientE creates an Auto Scaling Group client.
-func NewAsgClientE(t *testing.T, region string) (*autoscaling.AutoScaling, error) {
+func NewAsgClientE(t TestingT, region string) (*autoscaling.AutoScaling, error) {
 	sess, err := NewAuthenticatedSession(region)
 	if err != nil {
 		return nil, err

--- a/modules/aws/cloudwatch.go
+++ b/modules/aws/cloudwatch.go
@@ -1,14 +1,13 @@
 package aws
 
 import (
-	"testing"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
+	_ "github.com/gruntwork-io/terratest/modules/testing"
 )
 
 // GetCloudWatchLogEntries returns the CloudWatch log messages in the given region for the given log stream and log group.
-func GetCloudWatchLogEntries(t *testing.T, awsRegion string, logStreamName string, logGroupName string) []string {
+func GetCloudWatchLogEntries(t TestingT, awsRegion string, logStreamName string, logGroupName string) []string {
 	out, err := GetCloudWatchLogEntriesE(t, awsRegion, logStreamName, logGroupName)
 	if err != nil {
 		t.Fatal(err)
@@ -17,7 +16,7 @@ func GetCloudWatchLogEntries(t *testing.T, awsRegion string, logStreamName strin
 }
 
 // GetCloudWatchLogEntriesE returns the CloudWatch log messages in the given region for the given log stream and log group.
-func GetCloudWatchLogEntriesE(t *testing.T, awsRegion string, logStreamName string, logGroupName string) ([]string, error) {
+func GetCloudWatchLogEntriesE(t TestingT, awsRegion string, logStreamName string, logGroupName string) ([]string, error) {
 	client, err := NewCloudWatchLogsClientE(t, awsRegion)
 	if err != nil {
 		return nil, err
@@ -41,7 +40,7 @@ func GetCloudWatchLogEntriesE(t *testing.T, awsRegion string, logStreamName stri
 }
 
 // NewCloudWatchLogsClient creates a new CloudWatch Logs client.
-func NewCloudWatchLogsClient(t *testing.T, region string) *cloudwatchlogs.CloudWatchLogs {
+func NewCloudWatchLogsClient(t TestingT, region string) *cloudwatchlogs.CloudWatchLogs {
 	client, err := NewCloudWatchLogsClientE(t, region)
 	if err != nil {
 		t.Fatal(err)
@@ -50,7 +49,7 @@ func NewCloudWatchLogsClient(t *testing.T, region string) *cloudwatchlogs.CloudW
 }
 
 // NewCloudWatchLogsClientE creates a new CloudWatch Logs client.
-func NewCloudWatchLogsClientE(t *testing.T, region string) (*cloudwatchlogs.CloudWatchLogs, error) {
+func NewCloudWatchLogsClientE(t TestingT, region string) (*cloudwatchlogs.CloudWatchLogs, error) {
 	sess, err := NewAuthenticatedSession(region)
 	if err != nil {
 		return nil, err

--- a/modules/aws/cloudwatch.go
+++ b/modules/aws/cloudwatch.go
@@ -3,11 +3,11 @@ package aws
 import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
-	_ "github.com/gruntwork-io/terratest/modules/testing"
+	"github.com/gruntwork-io/terratest/modules/testing"
 )
 
 // GetCloudWatchLogEntries returns the CloudWatch log messages in the given region for the given log stream and log group.
-func GetCloudWatchLogEntries(t TestingT, awsRegion string, logStreamName string, logGroupName string) []string {
+func GetCloudWatchLogEntries(t testing.TestingT, awsRegion string, logStreamName string, logGroupName string) []string {
 	out, err := GetCloudWatchLogEntriesE(t, awsRegion, logStreamName, logGroupName)
 	if err != nil {
 		t.Fatal(err)
@@ -16,7 +16,7 @@ func GetCloudWatchLogEntries(t TestingT, awsRegion string, logStreamName string,
 }
 
 // GetCloudWatchLogEntriesE returns the CloudWatch log messages in the given region for the given log stream and log group.
-func GetCloudWatchLogEntriesE(t TestingT, awsRegion string, logStreamName string, logGroupName string) ([]string, error) {
+func GetCloudWatchLogEntriesE(t testing.TestingT, awsRegion string, logStreamName string, logGroupName string) ([]string, error) {
 	client, err := NewCloudWatchLogsClientE(t, awsRegion)
 	if err != nil {
 		return nil, err
@@ -40,7 +40,7 @@ func GetCloudWatchLogEntriesE(t TestingT, awsRegion string, logStreamName string
 }
 
 // NewCloudWatchLogsClient creates a new CloudWatch Logs client.
-func NewCloudWatchLogsClient(t TestingT, region string) *cloudwatchlogs.CloudWatchLogs {
+func NewCloudWatchLogsClient(t testing.TestingT, region string) *cloudwatchlogs.CloudWatchLogs {
 	client, err := NewCloudWatchLogsClientE(t, region)
 	if err != nil {
 		t.Fatal(err)
@@ -49,7 +49,7 @@ func NewCloudWatchLogsClient(t TestingT, region string) *cloudwatchlogs.CloudWat
 }
 
 // NewCloudWatchLogsClientE creates a new CloudWatch Logs client.
-func NewCloudWatchLogsClientE(t TestingT, region string) (*cloudwatchlogs.CloudWatchLogs, error) {
+func NewCloudWatchLogsClientE(t testing.TestingT, region string) (*cloudwatchlogs.CloudWatchLogs, error) {
 	sess, err := NewAuthenticatedSession(region)
 	if err != nil {
 		return nil, err

--- a/modules/aws/dynamodb.go
+++ b/modules/aws/dynamodb.go
@@ -3,19 +3,19 @@ package aws
 import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
-	_ "github.com/gruntwork-io/terratest/modules/testing"
+	"github.com/gruntwork-io/terratest/modules/testing"
 	"github.com/stretchr/testify/require"
 )
 
 // GetDynamoDbTableTags fetches resource tags of a specified dynamoDB table. This will fail the test if there are any errors
-func GetDynamoDbTableTags(t TestingT, region string, tableName string) []*dynamodb.Tag {
+func GetDynamoDbTableTags(t testing.TestingT, region string, tableName string) []*dynamodb.Tag {
 	tags, err := GetDynamoDbTableTagsE(t, region, tableName)
 	require.NoError(t, err)
 	return tags
 }
 
 // GetDynamoDbTableTagsE fetches resource tags of a specified dynamoDB table.
-func GetDynamoDbTableTagsE(t TestingT, region string, tableName string) ([]*dynamodb.Tag, error) {
+func GetDynamoDbTableTagsE(t testing.TestingT, region string, tableName string) ([]*dynamodb.Tag, error) {
 	table := GetDynamoDBTable(t, region, tableName)
 	out, err := NewDynamoDBClient(t, region).ListTagsOfResource(&dynamodb.ListTagsOfResourceInput{
 		ResourceArn: table.TableArn,
@@ -27,14 +27,14 @@ func GetDynamoDbTableTagsE(t TestingT, region string, tableName string) ([]*dyna
 }
 
 // GetDynamoDBTableTimeToLive fetches information about the TTL configuration of a specified dynamoDB table. This will fail the test if there are any errors.
-func GetDynamoDBTableTimeToLive(t TestingT, region string, tableName string) *dynamodb.TimeToLiveDescription {
+func GetDynamoDBTableTimeToLive(t testing.TestingT, region string, tableName string) *dynamodb.TimeToLiveDescription {
 	ttl, err := GetDynamoDBTableTimeToLiveE(t, region, tableName)
 	require.NoError(t, err)
 	return ttl
 }
 
 // GetDynamoDBTableTimeToLiveE fetches information about the TTL configuration of a specified dynamoDB table.
-func GetDynamoDBTableTimeToLiveE(t TestingT, region string, tableName string) (*dynamodb.TimeToLiveDescription, error) {
+func GetDynamoDBTableTimeToLiveE(t testing.TestingT, region string, tableName string) (*dynamodb.TimeToLiveDescription, error) {
 	out, err := NewDynamoDBClient(t, region).DescribeTimeToLive(&dynamodb.DescribeTimeToLiveInput{
 		TableName: aws.String(tableName),
 	})
@@ -45,14 +45,14 @@ func GetDynamoDBTableTimeToLiveE(t TestingT, region string, tableName string) (*
 }
 
 // GetDynamoDBTable fetches information about the specified dynamoDB table. This will fail the test if there are any errors.
-func GetDynamoDBTable(t TestingT, region string, tableName string) *dynamodb.TableDescription {
+func GetDynamoDBTable(t testing.TestingT, region string, tableName string) *dynamodb.TableDescription {
 	table, err := GetDynamoDBTableE(t, region, tableName)
 	require.NoError(t, err)
 	return table
 }
 
 // GetDynamoDBTableE fetches information about the specified dynamoDB table.
-func GetDynamoDBTableE(t TestingT, region string, tableName string) (*dynamodb.TableDescription, error) {
+func GetDynamoDBTableE(t testing.TestingT, region string, tableName string) (*dynamodb.TableDescription, error) {
 	out, err := NewDynamoDBClient(t, region).DescribeTable(&dynamodb.DescribeTableInput{
 		TableName: aws.String(tableName),
 	})
@@ -63,14 +63,14 @@ func GetDynamoDBTableE(t TestingT, region string, tableName string) (*dynamodb.T
 }
 
 // NewDynamoDBClient creates a DynamoDB client.
-func NewDynamoDBClient(t TestingT, region string) *dynamodb.DynamoDB {
+func NewDynamoDBClient(t testing.TestingT, region string) *dynamodb.DynamoDB {
 	client, err := NewDynamoDBClientE(t, region)
 	require.NoError(t, err)
 	return client
 }
 
 // NewDynamoDBClientE creates a DynamoDB client.
-func NewDynamoDBClientE(t TestingT, region string) (*dynamodb.DynamoDB, error) {
+func NewDynamoDBClientE(t testing.TestingT, region string) (*dynamodb.DynamoDB, error) {
 	sess, err := NewAuthenticatedSession(region)
 	if err != nil {
 		return nil, err

--- a/modules/aws/dynamodb.go
+++ b/modules/aws/dynamodb.go
@@ -1,22 +1,21 @@
 package aws
 
 import (
-	"testing"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
+	_ "github.com/gruntwork-io/terratest/modules/testing"
 	"github.com/stretchr/testify/require"
 )
 
 // GetDynamoDbTableTags fetches resource tags of a specified dynamoDB table. This will fail the test if there are any errors
-func GetDynamoDbTableTags(t *testing.T, region string, tableName string) []*dynamodb.Tag {
+func GetDynamoDbTableTags(t TestingT, region string, tableName string) []*dynamodb.Tag {
 	tags, err := GetDynamoDbTableTagsE(t, region, tableName)
 	require.NoError(t, err)
 	return tags
 }
 
 // GetDynamoDbTableTagsE fetches resource tags of a specified dynamoDB table.
-func GetDynamoDbTableTagsE(t *testing.T, region string, tableName string) ([]*dynamodb.Tag, error) {
+func GetDynamoDbTableTagsE(t TestingT, region string, tableName string) ([]*dynamodb.Tag, error) {
 	table := GetDynamoDBTable(t, region, tableName)
 	out, err := NewDynamoDBClient(t, region).ListTagsOfResource(&dynamodb.ListTagsOfResourceInput{
 		ResourceArn: table.TableArn,
@@ -28,14 +27,14 @@ func GetDynamoDbTableTagsE(t *testing.T, region string, tableName string) ([]*dy
 }
 
 // GetDynamoDBTableTimeToLive fetches information about the TTL configuration of a specified dynamoDB table. This will fail the test if there are any errors.
-func GetDynamoDBTableTimeToLive(t *testing.T, region string, tableName string) *dynamodb.TimeToLiveDescription {
+func GetDynamoDBTableTimeToLive(t TestingT, region string, tableName string) *dynamodb.TimeToLiveDescription {
 	ttl, err := GetDynamoDBTableTimeToLiveE(t, region, tableName)
 	require.NoError(t, err)
 	return ttl
 }
 
 // GetDynamoDBTableTimeToLiveE fetches information about the TTL configuration of a specified dynamoDB table.
-func GetDynamoDBTableTimeToLiveE(t *testing.T, region string, tableName string) (*dynamodb.TimeToLiveDescription, error) {
+func GetDynamoDBTableTimeToLiveE(t TestingT, region string, tableName string) (*dynamodb.TimeToLiveDescription, error) {
 	out, err := NewDynamoDBClient(t, region).DescribeTimeToLive(&dynamodb.DescribeTimeToLiveInput{
 		TableName: aws.String(tableName),
 	})
@@ -46,14 +45,14 @@ func GetDynamoDBTableTimeToLiveE(t *testing.T, region string, tableName string) 
 }
 
 // GetDynamoDBTable fetches information about the specified dynamoDB table. This will fail the test if there are any errors.
-func GetDynamoDBTable(t *testing.T, region string, tableName string) *dynamodb.TableDescription {
+func GetDynamoDBTable(t TestingT, region string, tableName string) *dynamodb.TableDescription {
 	table, err := GetDynamoDBTableE(t, region, tableName)
 	require.NoError(t, err)
 	return table
 }
 
 // GetDynamoDBTableE fetches information about the specified dynamoDB table.
-func GetDynamoDBTableE(t *testing.T, region string, tableName string) (*dynamodb.TableDescription, error) {
+func GetDynamoDBTableE(t TestingT, region string, tableName string) (*dynamodb.TableDescription, error) {
 	out, err := NewDynamoDBClient(t, region).DescribeTable(&dynamodb.DescribeTableInput{
 		TableName: aws.String(tableName),
 	})
@@ -64,14 +63,14 @@ func GetDynamoDBTableE(t *testing.T, region string, tableName string) (*dynamodb
 }
 
 // NewDynamoDBClient creates a DynamoDB client.
-func NewDynamoDBClient(t *testing.T, region string) *dynamodb.DynamoDB {
+func NewDynamoDBClient(t TestingT, region string) *dynamodb.DynamoDB {
 	client, err := NewDynamoDBClientE(t, region)
 	require.NoError(t, err)
 	return client
 }
 
 // NewDynamoDBClientE creates a DynamoDB client.
-func NewDynamoDBClientE(t *testing.T, region string) (*dynamodb.DynamoDB, error) {
+func NewDynamoDBClientE(t TestingT, region string) (*dynamodb.DynamoDB, error) {
 	sess, err := NewAuthenticatedSession(region)
 	if err != nil {
 		return nil, err

--- a/modules/aws/ebs.go
+++ b/modules/aws/ebs.go
@@ -1,15 +1,14 @@
 package aws
 
 import (
-	"testing"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/gruntwork-io/terratest/modules/logger"
+	_ "github.com/gruntwork-io/terratest/modules/testing"
 )
 
 // DeleteEbsSnapshot deletes the given EBS snapshot
-func DeleteEbsSnapshot(t *testing.T, region string, snapshot string) {
+func DeleteEbsSnapshot(t TestingT, region string, snapshot string) {
 	err := DeleteEbsSnapshotE(t, region, snapshot)
 	if err != nil {
 		t.Fatal(err)
@@ -17,7 +16,7 @@ func DeleteEbsSnapshot(t *testing.T, region string, snapshot string) {
 }
 
 // DeleteEbsSnapshot deletes the given EBS snapshot
-func DeleteEbsSnapshotE(t *testing.T, region string, snapshot string) error {
+func DeleteEbsSnapshotE(t TestingT, region string, snapshot string) error {
 	logger.Logf(t, "Deleting EBS snapshot %s", snapshot)
 	ec2Client, err := NewEc2ClientE(t, region)
 	if err != nil {

--- a/modules/aws/ebs.go
+++ b/modules/aws/ebs.go
@@ -4,11 +4,11 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/gruntwork-io/terratest/modules/logger"
-	_ "github.com/gruntwork-io/terratest/modules/testing"
+	"github.com/gruntwork-io/terratest/modules/testing"
 )
 
 // DeleteEbsSnapshot deletes the given EBS snapshot
-func DeleteEbsSnapshot(t TestingT, region string, snapshot string) {
+func DeleteEbsSnapshot(t testing.TestingT, region string, snapshot string) {
 	err := DeleteEbsSnapshotE(t, region, snapshot)
 	if err != nil {
 		t.Fatal(err)
@@ -16,7 +16,7 @@ func DeleteEbsSnapshot(t TestingT, region string, snapshot string) {
 }
 
 // DeleteEbsSnapshot deletes the given EBS snapshot
-func DeleteEbsSnapshotE(t TestingT, region string, snapshot string) error {
+func DeleteEbsSnapshotE(t testing.TestingT, region string, snapshot string) error {
 	logger.Logf(t, "Deleting EBS snapshot %s", snapshot)
 	ec2Client, err := NewEc2ClientE(t, region)
 	if err != nil {

--- a/modules/aws/ec2-files.go
+++ b/modules/aws/ec2-files.go
@@ -3,11 +3,11 @@ package aws
 import (
 	"os"
 	"path/filepath"
-	"testing"
 
 	"github.com/gruntwork-io/terratest/modules/customerrors"
 	"github.com/gruntwork-io/terratest/modules/files"
 	"github.com/gruntwork-io/terratest/modules/ssh"
+	_ "github.com/gruntwork-io/terratest/modules/testing"
 )
 
 // RemoteFileSpecification describes which files you want to copy from your instances
@@ -23,7 +23,7 @@ type RemoteFileSpecification struct {
 // FetchContentsOfFileFromInstance looks up the public IP address of the EC2 Instance with the given ID, connects to
 // the Instance via SSH using the given username and Key Pair, fetches the contents of the file at the given path
 // (using sudo if useSudo is true), and returns the contents of that file as a string.
-func FetchContentsOfFileFromInstance(t *testing.T, awsRegion string, sshUserName string, keyPair *Ec2Keypair, instanceID string, useSudo bool, filePath string) string {
+func FetchContentsOfFileFromInstance(t TestingT, awsRegion string, sshUserName string, keyPair *Ec2Keypair, instanceID string, useSudo bool, filePath string) string {
 	out, err := FetchContentsOfFileFromInstanceE(t, awsRegion, sshUserName, keyPair, instanceID, useSudo, filePath)
 	if err != nil {
 		t.Fatal(err)
@@ -34,7 +34,7 @@ func FetchContentsOfFileFromInstance(t *testing.T, awsRegion string, sshUserName
 // FetchContentsOfFileFromInstanceE looks up the public IP address of the EC2 Instance with the given ID, connects to
 // the Instance via SSH using the given username and Key Pair, fetches the contents of the file at the given path
 // (using sudo if useSudo is true), and returns the contents of that file as a string.
-func FetchContentsOfFileFromInstanceE(t *testing.T, awsRegion string, sshUserName string, keyPair *Ec2Keypair, instanceID string, useSudo bool, filePath string) (string, error) {
+func FetchContentsOfFileFromInstanceE(t TestingT, awsRegion string, sshUserName string, keyPair *Ec2Keypair, instanceID string, useSudo bool, filePath string) (string, error) {
 	publicIp, err := GetPublicIpOfEc2InstanceE(t, instanceID, awsRegion)
 	if err != nil {
 		return "", err
@@ -52,7 +52,7 @@ func FetchContentsOfFileFromInstanceE(t *testing.T, awsRegion string, sshUserNam
 // FetchContentsOfFilesFromInstance looks up the public IP address of the EC2 Instance with the given ID, connects to
 // the Instance via SSH using the given username and Key Pair, fetches the contents of the files at the given paths
 // (using sudo if useSudo is true), and returns a map from file path to the contents of that file as a string.
-func FetchContentsOfFilesFromInstance(t *testing.T, awsRegion string, sshUserName string, keyPair *Ec2Keypair, instanceID string, useSudo bool, filePaths ...string) map[string]string {
+func FetchContentsOfFilesFromInstance(t TestingT, awsRegion string, sshUserName string, keyPair *Ec2Keypair, instanceID string, useSudo bool, filePaths ...string) map[string]string {
 	out, err := FetchContentsOfFilesFromInstanceE(t, awsRegion, sshUserName, keyPair, instanceID, useSudo, filePaths...)
 	if err != nil {
 		t.Fatal(err)
@@ -63,7 +63,7 @@ func FetchContentsOfFilesFromInstance(t *testing.T, awsRegion string, sshUserNam
 // FetchContentsOfFilesFromInstanceE looks up the public IP address of the EC2 Instance with the given ID, connects to
 // the Instance via SSH using the given username and Key Pair, fetches the contents of the files at the given paths
 // (using sudo if useSudo is true), and returns a map from file path to the contents of that file as a string.
-func FetchContentsOfFilesFromInstanceE(t *testing.T, awsRegion string, sshUserName string, keyPair *Ec2Keypair, instanceID string, useSudo bool, filePaths ...string) (map[string]string, error) {
+func FetchContentsOfFilesFromInstanceE(t TestingT, awsRegion string, sshUserName string, keyPair *Ec2Keypair, instanceID string, useSudo bool, filePaths ...string) (map[string]string, error) {
 	publicIp, err := GetPublicIpOfEc2InstanceE(t, instanceID, awsRegion)
 	if err != nil {
 		return nil, err
@@ -82,7 +82,7 @@ func FetchContentsOfFilesFromInstanceE(t *testing.T, awsRegion string, sshUserNa
 // Instances, connects to each Instance via SSH using the given username and Key Pair, fetches the contents of the file
 // at the given path (using sudo if useSudo is true), and returns a map from Instance ID to the contents of that file
 // as a string.
-func FetchContentsOfFileFromAsg(t *testing.T, awsRegion string, sshUserName string, keyPair *Ec2Keypair, asgName string, useSudo bool, filePath string) map[string]string {
+func FetchContentsOfFileFromAsg(t TestingT, awsRegion string, sshUserName string, keyPair *Ec2Keypair, asgName string, useSudo bool, filePath string) map[string]string {
 	out, err := FetchContentsOfFileFromAsgE(t, awsRegion, sshUserName, keyPair, asgName, useSudo, filePath)
 	if err != nil {
 		t.Fatal(err)
@@ -94,7 +94,7 @@ func FetchContentsOfFileFromAsg(t *testing.T, awsRegion string, sshUserName stri
 // Instances, connects to each Instance via SSH using the given username and Key Pair, fetches the contents of the file
 // at the given path (using sudo if useSudo is true), and returns a map from Instance ID to the contents of that file
 // as a string.
-func FetchContentsOfFileFromAsgE(t *testing.T, awsRegion string, sshUserName string, keyPair *Ec2Keypair, asgName string, useSudo bool, filePath string) (map[string]string, error) {
+func FetchContentsOfFileFromAsgE(t TestingT, awsRegion string, sshUserName string, keyPair *Ec2Keypair, asgName string, useSudo bool, filePath string) (map[string]string, error) {
 	instanceIDs, err := GetInstanceIdsForAsgE(t, asgName, awsRegion)
 	if err != nil {
 		return nil, err
@@ -117,7 +117,7 @@ func FetchContentsOfFileFromAsgE(t *testing.T, awsRegion string, sshUserName str
 // Instances, connects to each Instance via SSH using the given username and Key Pair, fetches the contents of the files
 // at the given paths (using sudo if useSudo is true), and returns a map from Instance ID to a map of file path to the
 // contents of that file as a string.
-func FetchContentsOfFilesFromAsg(t *testing.T, awsRegion string, sshUserName string, keyPair *Ec2Keypair, asgName string, useSudo bool, filePaths ...string) map[string]map[string]string {
+func FetchContentsOfFilesFromAsg(t TestingT, awsRegion string, sshUserName string, keyPair *Ec2Keypair, asgName string, useSudo bool, filePaths ...string) map[string]map[string]string {
 	out, err := FetchContentsOfFilesFromAsgE(t, awsRegion, sshUserName, keyPair, asgName, useSudo, filePaths...)
 	if err != nil {
 		t.Fatal(err)
@@ -129,7 +129,7 @@ func FetchContentsOfFilesFromAsg(t *testing.T, awsRegion string, sshUserName str
 // Instances, connects to each Instance via SSH using the given username and Key Pair, fetches the contents of the files
 // at the given paths (using sudo if useSudo is true), and returns a map from Instance ID to a map of file path to the
 // contents of that file as a string.
-func FetchContentsOfFilesFromAsgE(t *testing.T, awsRegion string, sshUserName string, keyPair *Ec2Keypair, asgName string, useSudo bool, filePaths ...string) (map[string]map[string]string, error) {
+func FetchContentsOfFilesFromAsgE(t TestingT, awsRegion string, sshUserName string, keyPair *Ec2Keypair, asgName string, useSudo bool, filePaths ...string) (map[string]map[string]string, error) {
 	instanceIDs, err := GetInstanceIdsForAsgE(t, asgName, awsRegion)
 	if err != nil {
 		return nil, err
@@ -152,7 +152,7 @@ func FetchContentsOfFilesFromAsgE(t *testing.T, awsRegion string, sshUserName st
 // Instances, connects to each Instance via SSH using the given username and Key Pair, downloads the files
 // matching filenameFilters at the given remoteDirectory (using sudo if useSudo is true), and stores the files locally
 // at localDirectory/<publicip>/<remoteFolderName>
-func FetchFilesFromInstance(t *testing.T, awsRegion string, sshUserName string, keyPair *Ec2Keypair, instanceID string, useSudo bool, remoteDirectory string, localDirectory string, filenameFilters []string) {
+func FetchFilesFromInstance(t TestingT, awsRegion string, sshUserName string, keyPair *Ec2Keypair, instanceID string, useSudo bool, remoteDirectory string, localDirectory string, filenameFilters []string) {
 	err := FetchFilesFromInstanceE(t, awsRegion, sshUserName, keyPair, instanceID, useSudo, remoteDirectory, localDirectory, filenameFilters)
 
 	if err != nil {
@@ -164,7 +164,7 @@ func FetchFilesFromInstance(t *testing.T, awsRegion string, sshUserName string, 
 // Instances, connects to each Instance via SSH using the given username and Key Pair, downloads the files
 // matching filenameFilters at the given remoteDirectory (using sudo if useSudo is true), and stores the files locally
 // at localDirectory/<publicip>/<remoteFolderName>
-func FetchFilesFromInstanceE(t *testing.T, awsRegion string, sshUserName string, keyPair *Ec2Keypair, instanceID string, useSudo bool, remoteDirectory string, localDirectory string, filenameFilters []string) error {
+func FetchFilesFromInstanceE(t TestingT, awsRegion string, sshUserName string, keyPair *Ec2Keypair, instanceID string, useSudo bool, remoteDirectory string, localDirectory string, filenameFilters []string) error {
 	publicIp, err := GetPublicIpOfEc2InstanceE(t, instanceID, awsRegion)
 
 	if err != nil {
@@ -198,7 +198,7 @@ func FetchFilesFromInstanceE(t *testing.T, awsRegion string, sshUserName string,
 // username and Key Pair, downloads the files matching filenameFilters at the given
 // remoteDirectory (using sudo if useSudo is true), and stores the files locally at
 // localDirectory/<publicip>/<remoteFolderName>
-func FetchFilesFromAsgs(t *testing.T, awsRegion string, spec RemoteFileSpecification) {
+func FetchFilesFromAsgs(t TestingT, awsRegion string, spec RemoteFileSpecification) {
 	err := FetchFilesFromAsgsE(t, awsRegion, spec)
 
 	if err != nil {
@@ -211,7 +211,7 @@ func FetchFilesFromAsgs(t *testing.T, awsRegion string, spec RemoteFileSpecifica
 // username and Key Pair, downloads the files matching filenameFilters at the given
 // remoteDirectory (using sudo if useSudo is true), and stores the files locally at
 // localDirectory/<publicip>/<remoteFolderName>
-func FetchFilesFromAsgsE(t *testing.T, awsRegion string, spec RemoteFileSpecification) error {
+func FetchFilesFromAsgsE(t TestingT, awsRegion string, spec RemoteFileSpecification) error {
 	errorsOccurred := []error{}
 
 	for _, curAsg := range spec.AsgNames {

--- a/modules/aws/ec2-files.go
+++ b/modules/aws/ec2-files.go
@@ -7,7 +7,7 @@ import (
 	"github.com/gruntwork-io/terratest/modules/customerrors"
 	"github.com/gruntwork-io/terratest/modules/files"
 	"github.com/gruntwork-io/terratest/modules/ssh"
-	_ "github.com/gruntwork-io/terratest/modules/testing"
+	"github.com/gruntwork-io/terratest/modules/testing"
 )
 
 // RemoteFileSpecification describes which files you want to copy from your instances
@@ -23,7 +23,7 @@ type RemoteFileSpecification struct {
 // FetchContentsOfFileFromInstance looks up the public IP address of the EC2 Instance with the given ID, connects to
 // the Instance via SSH using the given username and Key Pair, fetches the contents of the file at the given path
 // (using sudo if useSudo is true), and returns the contents of that file as a string.
-func FetchContentsOfFileFromInstance(t TestingT, awsRegion string, sshUserName string, keyPair *Ec2Keypair, instanceID string, useSudo bool, filePath string) string {
+func FetchContentsOfFileFromInstance(t testing.TestingT, awsRegion string, sshUserName string, keyPair *Ec2Keypair, instanceID string, useSudo bool, filePath string) string {
 	out, err := FetchContentsOfFileFromInstanceE(t, awsRegion, sshUserName, keyPair, instanceID, useSudo, filePath)
 	if err != nil {
 		t.Fatal(err)
@@ -34,7 +34,7 @@ func FetchContentsOfFileFromInstance(t TestingT, awsRegion string, sshUserName s
 // FetchContentsOfFileFromInstanceE looks up the public IP address of the EC2 Instance with the given ID, connects to
 // the Instance via SSH using the given username and Key Pair, fetches the contents of the file at the given path
 // (using sudo if useSudo is true), and returns the contents of that file as a string.
-func FetchContentsOfFileFromInstanceE(t TestingT, awsRegion string, sshUserName string, keyPair *Ec2Keypair, instanceID string, useSudo bool, filePath string) (string, error) {
+func FetchContentsOfFileFromInstanceE(t testing.TestingT, awsRegion string, sshUserName string, keyPair *Ec2Keypair, instanceID string, useSudo bool, filePath string) (string, error) {
 	publicIp, err := GetPublicIpOfEc2InstanceE(t, instanceID, awsRegion)
 	if err != nil {
 		return "", err
@@ -52,7 +52,7 @@ func FetchContentsOfFileFromInstanceE(t TestingT, awsRegion string, sshUserName 
 // FetchContentsOfFilesFromInstance looks up the public IP address of the EC2 Instance with the given ID, connects to
 // the Instance via SSH using the given username and Key Pair, fetches the contents of the files at the given paths
 // (using sudo if useSudo is true), and returns a map from file path to the contents of that file as a string.
-func FetchContentsOfFilesFromInstance(t TestingT, awsRegion string, sshUserName string, keyPair *Ec2Keypair, instanceID string, useSudo bool, filePaths ...string) map[string]string {
+func FetchContentsOfFilesFromInstance(t testing.TestingT, awsRegion string, sshUserName string, keyPair *Ec2Keypair, instanceID string, useSudo bool, filePaths ...string) map[string]string {
 	out, err := FetchContentsOfFilesFromInstanceE(t, awsRegion, sshUserName, keyPair, instanceID, useSudo, filePaths...)
 	if err != nil {
 		t.Fatal(err)
@@ -63,7 +63,7 @@ func FetchContentsOfFilesFromInstance(t TestingT, awsRegion string, sshUserName 
 // FetchContentsOfFilesFromInstanceE looks up the public IP address of the EC2 Instance with the given ID, connects to
 // the Instance via SSH using the given username and Key Pair, fetches the contents of the files at the given paths
 // (using sudo if useSudo is true), and returns a map from file path to the contents of that file as a string.
-func FetchContentsOfFilesFromInstanceE(t TestingT, awsRegion string, sshUserName string, keyPair *Ec2Keypair, instanceID string, useSudo bool, filePaths ...string) (map[string]string, error) {
+func FetchContentsOfFilesFromInstanceE(t testing.TestingT, awsRegion string, sshUserName string, keyPair *Ec2Keypair, instanceID string, useSudo bool, filePaths ...string) (map[string]string, error) {
 	publicIp, err := GetPublicIpOfEc2InstanceE(t, instanceID, awsRegion)
 	if err != nil {
 		return nil, err
@@ -82,7 +82,7 @@ func FetchContentsOfFilesFromInstanceE(t TestingT, awsRegion string, sshUserName
 // Instances, connects to each Instance via SSH using the given username and Key Pair, fetches the contents of the file
 // at the given path (using sudo if useSudo is true), and returns a map from Instance ID to the contents of that file
 // as a string.
-func FetchContentsOfFileFromAsg(t TestingT, awsRegion string, sshUserName string, keyPair *Ec2Keypair, asgName string, useSudo bool, filePath string) map[string]string {
+func FetchContentsOfFileFromAsg(t testing.TestingT, awsRegion string, sshUserName string, keyPair *Ec2Keypair, asgName string, useSudo bool, filePath string) map[string]string {
 	out, err := FetchContentsOfFileFromAsgE(t, awsRegion, sshUserName, keyPair, asgName, useSudo, filePath)
 	if err != nil {
 		t.Fatal(err)
@@ -94,7 +94,7 @@ func FetchContentsOfFileFromAsg(t TestingT, awsRegion string, sshUserName string
 // Instances, connects to each Instance via SSH using the given username and Key Pair, fetches the contents of the file
 // at the given path (using sudo if useSudo is true), and returns a map from Instance ID to the contents of that file
 // as a string.
-func FetchContentsOfFileFromAsgE(t TestingT, awsRegion string, sshUserName string, keyPair *Ec2Keypair, asgName string, useSudo bool, filePath string) (map[string]string, error) {
+func FetchContentsOfFileFromAsgE(t testing.TestingT, awsRegion string, sshUserName string, keyPair *Ec2Keypair, asgName string, useSudo bool, filePath string) (map[string]string, error) {
 	instanceIDs, err := GetInstanceIdsForAsgE(t, asgName, awsRegion)
 	if err != nil {
 		return nil, err
@@ -117,7 +117,7 @@ func FetchContentsOfFileFromAsgE(t TestingT, awsRegion string, sshUserName strin
 // Instances, connects to each Instance via SSH using the given username and Key Pair, fetches the contents of the files
 // at the given paths (using sudo if useSudo is true), and returns a map from Instance ID to a map of file path to the
 // contents of that file as a string.
-func FetchContentsOfFilesFromAsg(t TestingT, awsRegion string, sshUserName string, keyPair *Ec2Keypair, asgName string, useSudo bool, filePaths ...string) map[string]map[string]string {
+func FetchContentsOfFilesFromAsg(t testing.TestingT, awsRegion string, sshUserName string, keyPair *Ec2Keypair, asgName string, useSudo bool, filePaths ...string) map[string]map[string]string {
 	out, err := FetchContentsOfFilesFromAsgE(t, awsRegion, sshUserName, keyPair, asgName, useSudo, filePaths...)
 	if err != nil {
 		t.Fatal(err)
@@ -129,7 +129,7 @@ func FetchContentsOfFilesFromAsg(t TestingT, awsRegion string, sshUserName strin
 // Instances, connects to each Instance via SSH using the given username and Key Pair, fetches the contents of the files
 // at the given paths (using sudo if useSudo is true), and returns a map from Instance ID to a map of file path to the
 // contents of that file as a string.
-func FetchContentsOfFilesFromAsgE(t TestingT, awsRegion string, sshUserName string, keyPair *Ec2Keypair, asgName string, useSudo bool, filePaths ...string) (map[string]map[string]string, error) {
+func FetchContentsOfFilesFromAsgE(t testing.TestingT, awsRegion string, sshUserName string, keyPair *Ec2Keypair, asgName string, useSudo bool, filePaths ...string) (map[string]map[string]string, error) {
 	instanceIDs, err := GetInstanceIdsForAsgE(t, asgName, awsRegion)
 	if err != nil {
 		return nil, err
@@ -152,7 +152,7 @@ func FetchContentsOfFilesFromAsgE(t TestingT, awsRegion string, sshUserName stri
 // Instances, connects to each Instance via SSH using the given username and Key Pair, downloads the files
 // matching filenameFilters at the given remoteDirectory (using sudo if useSudo is true), and stores the files locally
 // at localDirectory/<publicip>/<remoteFolderName>
-func FetchFilesFromInstance(t TestingT, awsRegion string, sshUserName string, keyPair *Ec2Keypair, instanceID string, useSudo bool, remoteDirectory string, localDirectory string, filenameFilters []string) {
+func FetchFilesFromInstance(t testing.TestingT, awsRegion string, sshUserName string, keyPair *Ec2Keypair, instanceID string, useSudo bool, remoteDirectory string, localDirectory string, filenameFilters []string) {
 	err := FetchFilesFromInstanceE(t, awsRegion, sshUserName, keyPair, instanceID, useSudo, remoteDirectory, localDirectory, filenameFilters)
 
 	if err != nil {
@@ -164,7 +164,7 @@ func FetchFilesFromInstance(t TestingT, awsRegion string, sshUserName string, ke
 // Instances, connects to each Instance via SSH using the given username and Key Pair, downloads the files
 // matching filenameFilters at the given remoteDirectory (using sudo if useSudo is true), and stores the files locally
 // at localDirectory/<publicip>/<remoteFolderName>
-func FetchFilesFromInstanceE(t TestingT, awsRegion string, sshUserName string, keyPair *Ec2Keypair, instanceID string, useSudo bool, remoteDirectory string, localDirectory string, filenameFilters []string) error {
+func FetchFilesFromInstanceE(t testing.TestingT, awsRegion string, sshUserName string, keyPair *Ec2Keypair, instanceID string, useSudo bool, remoteDirectory string, localDirectory string, filenameFilters []string) error {
 	publicIp, err := GetPublicIpOfEc2InstanceE(t, instanceID, awsRegion)
 
 	if err != nil {
@@ -198,7 +198,7 @@ func FetchFilesFromInstanceE(t TestingT, awsRegion string, sshUserName string, k
 // username and Key Pair, downloads the files matching filenameFilters at the given
 // remoteDirectory (using sudo if useSudo is true), and stores the files locally at
 // localDirectory/<publicip>/<remoteFolderName>
-func FetchFilesFromAsgs(t TestingT, awsRegion string, spec RemoteFileSpecification) {
+func FetchFilesFromAsgs(t testing.TestingT, awsRegion string, spec RemoteFileSpecification) {
 	err := FetchFilesFromAsgsE(t, awsRegion, spec)
 
 	if err != nil {
@@ -211,7 +211,7 @@ func FetchFilesFromAsgs(t TestingT, awsRegion string, spec RemoteFileSpecificati
 // username and Key Pair, downloads the files matching filenameFilters at the given
 // remoteDirectory (using sudo if useSudo is true), and stores the files locally at
 // localDirectory/<publicip>/<remoteFolderName>
-func FetchFilesFromAsgsE(t TestingT, awsRegion string, spec RemoteFileSpecification) error {
+func FetchFilesFromAsgsE(t testing.TestingT, awsRegion string, spec RemoteFileSpecification) error {
 	errorsOccurred := []error{}
 
 	for _, curAsg := range spec.AsgNames {

--- a/modules/aws/ec2-syslog.go
+++ b/modules/aws/ec2-syslog.go
@@ -3,20 +3,20 @@ package aws
 import (
 	"encoding/base64"
 	"fmt"
-	"testing"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/retry"
+	_ "github.com/gruntwork-io/terratest/modules/testing"
 )
 
 // (Deprecated) See the FetchContentsOfFileFromInstance method for a more powerful solution.
 //
 // GetSyslogForInstance gets the syslog for the Instance with the given ID in the given region. This should be available ~1 minute after an
 // Instance boots and is very useful for debugging boot-time issues, such as an error in User Data.
-func GetSyslogForInstance(t *testing.T, instanceID string, awsRegion string) string {
+func GetSyslogForInstance(t TestingT, instanceID string, awsRegion string) string {
 	out, err := GetSyslogForInstanceE(t, instanceID, awsRegion)
 	if err != nil {
 		t.Fatal(err)
@@ -28,7 +28,7 @@ func GetSyslogForInstance(t *testing.T, instanceID string, awsRegion string) str
 //
 // GetSyslogForInstanceE gets the syslog for the Instance with the given ID in the given region. This should be available ~1 minute after an
 // Instance boots and is very useful for debugging boot-time issues, such as an error in User Data.
-func GetSyslogForInstanceE(t *testing.T, instanceID string, region string) (string, error) {
+func GetSyslogForInstanceE(t TestingT, instanceID string, region string) (string, error) {
 	description := fmt.Sprintf("Fetching syslog for Instance %s in %s", instanceID, region)
 	maxRetries := 120
 	timeBetweenRetries := 5 * time.Second
@@ -75,7 +75,7 @@ func GetSyslogForInstanceE(t *testing.T, instanceID string, region string) (stri
 // GetSyslogForInstancesInAsg gets the syslog for each of the Instances in the given ASG in the given region. These logs should be available ~1
 // minute after the Instance boots and are very useful for debugging boot-time issues, such as an error in User Data.
 // Returns a map of Instance Id -> Syslog for that Instance.
-func GetSyslogForInstancesInAsg(t *testing.T, asgName string, awsRegion string) map[string]string {
+func GetSyslogForInstancesInAsg(t TestingT, asgName string, awsRegion string) map[string]string {
 	out, err := GetSyslogForInstancesInAsgE(t, asgName, awsRegion)
 	if err != nil {
 		t.Fatal(err)
@@ -88,7 +88,7 @@ func GetSyslogForInstancesInAsg(t *testing.T, asgName string, awsRegion string) 
 // GetSyslogForInstancesInAsgE gets the syslog for each of the Instances in the given ASG in the given region. These logs should be available ~1
 // minute after the Instance boots and are very useful for debugging boot-time issues, such as an error in User Data.
 // Returns a map of Instance Id -> Syslog for that Instance.
-func GetSyslogForInstancesInAsgE(t *testing.T, asgName string, awsRegion string) (map[string]string, error) {
+func GetSyslogForInstancesInAsgE(t TestingT, asgName string, awsRegion string) (map[string]string, error) {
 	logger.Logf(t, "Fetching syslog for each Instance in ASG %s in %s", asgName, awsRegion)
 
 	instanceIDs, err := GetEc2InstanceIdsByTagE(t, awsRegion, "aws:autoscaling:groupName", asgName)

--- a/modules/aws/ec2-syslog.go
+++ b/modules/aws/ec2-syslog.go
@@ -9,14 +9,14 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/retry"
-	_ "github.com/gruntwork-io/terratest/modules/testing"
+	"github.com/gruntwork-io/terratest/modules/testing"
 )
 
 // (Deprecated) See the FetchContentsOfFileFromInstance method for a more powerful solution.
 //
 // GetSyslogForInstance gets the syslog for the Instance with the given ID in the given region. This should be available ~1 minute after an
 // Instance boots and is very useful for debugging boot-time issues, such as an error in User Data.
-func GetSyslogForInstance(t TestingT, instanceID string, awsRegion string) string {
+func GetSyslogForInstance(t testing.TestingT, instanceID string, awsRegion string) string {
 	out, err := GetSyslogForInstanceE(t, instanceID, awsRegion)
 	if err != nil {
 		t.Fatal(err)
@@ -28,7 +28,7 @@ func GetSyslogForInstance(t TestingT, instanceID string, awsRegion string) strin
 //
 // GetSyslogForInstanceE gets the syslog for the Instance with the given ID in the given region. This should be available ~1 minute after an
 // Instance boots and is very useful for debugging boot-time issues, such as an error in User Data.
-func GetSyslogForInstanceE(t TestingT, instanceID string, region string) (string, error) {
+func GetSyslogForInstanceE(t testing.TestingT, instanceID string, region string) (string, error) {
 	description := fmt.Sprintf("Fetching syslog for Instance %s in %s", instanceID, region)
 	maxRetries := 120
 	timeBetweenRetries := 5 * time.Second
@@ -75,7 +75,7 @@ func GetSyslogForInstanceE(t TestingT, instanceID string, region string) (string
 // GetSyslogForInstancesInAsg gets the syslog for each of the Instances in the given ASG in the given region. These logs should be available ~1
 // minute after the Instance boots and are very useful for debugging boot-time issues, such as an error in User Data.
 // Returns a map of Instance Id -> Syslog for that Instance.
-func GetSyslogForInstancesInAsg(t TestingT, asgName string, awsRegion string) map[string]string {
+func GetSyslogForInstancesInAsg(t testing.TestingT, asgName string, awsRegion string) map[string]string {
 	out, err := GetSyslogForInstancesInAsgE(t, asgName, awsRegion)
 	if err != nil {
 		t.Fatal(err)
@@ -88,7 +88,7 @@ func GetSyslogForInstancesInAsg(t TestingT, asgName string, awsRegion string) ma
 // GetSyslogForInstancesInAsgE gets the syslog for each of the Instances in the given ASG in the given region. These logs should be available ~1
 // minute after the Instance boots and are very useful for debugging boot-time issues, such as an error in User Data.
 // Returns a map of Instance Id -> Syslog for that Instance.
-func GetSyslogForInstancesInAsgE(t TestingT, asgName string, awsRegion string) (map[string]string, error) {
+func GetSyslogForInstancesInAsgE(t testing.TestingT, asgName string, awsRegion string) (map[string]string, error) {
 	logger.Logf(t, "Fetching syslog for each Instance in ASG %s in %s", asgName, awsRegion)
 
 	instanceIDs, err := GetEc2InstanceIdsByTagE(t, awsRegion, "aws:autoscaling:groupName", asgName)

--- a/modules/aws/ec2.go
+++ b/modules/aws/ec2.go
@@ -2,23 +2,23 @@ package aws
 
 import (
 	"fmt"
-	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/gruntwork-io/terratest/modules/logger"
+	_ "github.com/gruntwork-io/terratest/modules/testing"
 	"github.com/stretchr/testify/require"
 )
 
 // GetPrivateIpOfEc2Instance gets the private IP address of the given EC2 Instance in the given region.
-func GetPrivateIpOfEc2Instance(t *testing.T, instanceID string, awsRegion string) string {
+func GetPrivateIpOfEc2Instance(t TestingT, instanceID string, awsRegion string) string {
 	ip, err := GetPrivateIpOfEc2InstanceE(t, instanceID, awsRegion)
 	require.NoError(t, err)
 	return ip
 }
 
 // GetPrivateIpOfEc2InstanceE gets the private IP address of the given EC2 Instance in the given region.
-func GetPrivateIpOfEc2InstanceE(t *testing.T, instanceID string, awsRegion string) (string, error) {
+func GetPrivateIpOfEc2InstanceE(t TestingT, instanceID string, awsRegion string) (string, error) {
 	ips, err := GetPrivateIpsOfEc2InstancesE(t, []string{instanceID}, awsRegion)
 	if err != nil {
 		return "", err
@@ -34,14 +34,14 @@ func GetPrivateIpOfEc2InstanceE(t *testing.T, instanceID string, awsRegion strin
 }
 
 // GetPrivateIpsOfEc2Instances gets the private IP address of the given EC2 Instance in the given region. Returns a map of instance ID to IP address.
-func GetPrivateIpsOfEc2Instances(t *testing.T, instanceIDs []string, awsRegion string) map[string]string {
+func GetPrivateIpsOfEc2Instances(t TestingT, instanceIDs []string, awsRegion string) map[string]string {
 	ips, err := GetPrivateIpsOfEc2InstancesE(t, instanceIDs, awsRegion)
 	require.NoError(t, err)
 	return ips
 }
 
 // GetPrivateIpsOfEc2InstancesE gets the private IP address of the given EC2 Instance in the given region. Returns a map of instance ID to IP address.
-func GetPrivateIpsOfEc2InstancesE(t *testing.T, instanceIDs []string, awsRegion string) (map[string]string, error) {
+func GetPrivateIpsOfEc2InstancesE(t TestingT, instanceIDs []string, awsRegion string) (map[string]string, error) {
 	ec2Client := NewEc2Client(t, awsRegion)
 	// TODO: implement pagination for cases that extend beyond limit (1000 instances)
 	input := ec2.DescribeInstancesInput{InstanceIds: aws.StringSlice(instanceIDs)}
@@ -62,14 +62,14 @@ func GetPrivateIpsOfEc2InstancesE(t *testing.T, instanceIDs []string, awsRegion 
 }
 
 // GetPrivateHostnameOfEc2Instance gets the private IP address of the given EC2 Instance in the given region.
-func GetPrivateHostnameOfEc2Instance(t *testing.T, instanceID string, awsRegion string) string {
+func GetPrivateHostnameOfEc2Instance(t TestingT, instanceID string, awsRegion string) string {
 	ip, err := GetPrivateHostnameOfEc2InstanceE(t, instanceID, awsRegion)
 	require.NoError(t, err)
 	return ip
 }
 
 // GetPrivateHostnameOfEc2InstanceE gets the private IP address of the given EC2 Instance in the given region.
-func GetPrivateHostnameOfEc2InstanceE(t *testing.T, instanceID string, awsRegion string) (string, error) {
+func GetPrivateHostnameOfEc2InstanceE(t TestingT, instanceID string, awsRegion string) (string, error) {
 	hostnames, err := GetPrivateHostnamesOfEc2InstancesE(t, []string{instanceID}, awsRegion)
 	if err != nil {
 		return "", err
@@ -85,14 +85,14 @@ func GetPrivateHostnameOfEc2InstanceE(t *testing.T, instanceID string, awsRegion
 }
 
 // GetPrivateHostnamesOfEc2Instances gets the private IP address of the given EC2 Instance in the given region. Returns a map of instance ID to IP address.
-func GetPrivateHostnamesOfEc2Instances(t *testing.T, instanceIDs []string, awsRegion string) map[string]string {
+func GetPrivateHostnamesOfEc2Instances(t TestingT, instanceIDs []string, awsRegion string) map[string]string {
 	ips, err := GetPrivateHostnamesOfEc2InstancesE(t, instanceIDs, awsRegion)
 	require.NoError(t, err)
 	return ips
 }
 
 // GetPrivateHostnamesOfEc2InstancesE gets the private IP address of the given EC2 Instance in the given region. Returns a map of instance ID to IP address.
-func GetPrivateHostnamesOfEc2InstancesE(t *testing.T, instanceIDs []string, awsRegion string) (map[string]string, error) {
+func GetPrivateHostnamesOfEc2InstancesE(t TestingT, instanceIDs []string, awsRegion string) (map[string]string, error) {
 	ec2Client, err := NewEc2ClientE(t, awsRegion)
 	if err != nil {
 		return nil, err
@@ -116,14 +116,14 @@ func GetPrivateHostnamesOfEc2InstancesE(t *testing.T, instanceIDs []string, awsR
 }
 
 // GetPublicIpOfEc2Instance gets the public IP address of the given EC2 Instance in the given region.
-func GetPublicIpOfEc2Instance(t *testing.T, instanceID string, awsRegion string) string {
+func GetPublicIpOfEc2Instance(t TestingT, instanceID string, awsRegion string) string {
 	ip, err := GetPublicIpOfEc2InstanceE(t, instanceID, awsRegion)
 	require.NoError(t, err)
 	return ip
 }
 
 // GetPublicIpOfEc2InstanceE gets the public IP address of the given EC2 Instance in the given region.
-func GetPublicIpOfEc2InstanceE(t *testing.T, instanceID string, awsRegion string) (string, error) {
+func GetPublicIpOfEc2InstanceE(t TestingT, instanceID string, awsRegion string) (string, error) {
 	ips, err := GetPublicIpsOfEc2InstancesE(t, []string{instanceID}, awsRegion)
 	if err != nil {
 		return "", err
@@ -139,14 +139,14 @@ func GetPublicIpOfEc2InstanceE(t *testing.T, instanceID string, awsRegion string
 }
 
 // GetPublicIpsOfEc2Instances gets the public IP address of the given EC2 Instance in the given region. Returns a map of instance ID to IP address.
-func GetPublicIpsOfEc2Instances(t *testing.T, instanceIDs []string, awsRegion string) map[string]string {
+func GetPublicIpsOfEc2Instances(t TestingT, instanceIDs []string, awsRegion string) map[string]string {
 	ips, err := GetPublicIpsOfEc2InstancesE(t, instanceIDs, awsRegion)
 	require.NoError(t, err)
 	return ips
 }
 
 // GetPublicIpsOfEc2InstancesE gets the public IP address of the given EC2 Instance in the given region. Returns a map of instance ID to IP address.
-func GetPublicIpsOfEc2InstancesE(t *testing.T, instanceIDs []string, awsRegion string) (map[string]string, error) {
+func GetPublicIpsOfEc2InstancesE(t TestingT, instanceIDs []string, awsRegion string) (map[string]string, error) {
 	ec2Client := NewEc2Client(t, awsRegion)
 	// TODO: implement pagination for cases that extend beyond limit (1000 instances)
 	input := ec2.DescribeInstancesInput{InstanceIds: aws.StringSlice(instanceIDs)}
@@ -167,14 +167,14 @@ func GetPublicIpsOfEc2InstancesE(t *testing.T, instanceIDs []string, awsRegion s
 }
 
 // GetEc2InstanceIdsByTag returns all the IDs of EC2 instances in the given region with the given tag.
-func GetEc2InstanceIdsByTag(t *testing.T, region string, tagName string, tagValue string) []string {
+func GetEc2InstanceIdsByTag(t TestingT, region string, tagName string, tagValue string) []string {
 	out, err := GetEc2InstanceIdsByTagE(t, region, tagName, tagValue)
 	require.NoError(t, err)
 	return out
 }
 
 // GetEc2InstanceIdsByTagE returns all the IDs of EC2 instances in the given region with the given tag.
-func GetEc2InstanceIdsByTagE(t *testing.T, region string, tagName string, tagValue string) ([]string, error) {
+func GetEc2InstanceIdsByTagE(t TestingT, region string, tagName string, tagValue string) ([]string, error) {
 	ec2Filters := map[string][]string{
 		fmt.Sprintf("tag:%s", tagName): {tagValue},
 	}
@@ -183,7 +183,7 @@ func GetEc2InstanceIdsByTagE(t *testing.T, region string, tagName string, tagVal
 
 // GetEc2InstanceIdsByFilters returns all the IDs of EC2 instances in the given region which match to EC2 filter list
 // as per https://docs.aws.amazon.com/sdk-for-go/api/service/ec2/#DescribeInstancesInput.
-func GetEc2InstanceIdsByFilters(t *testing.T, region string, ec2Filters map[string][]string) []string {
+func GetEc2InstanceIdsByFilters(t TestingT, region string, ec2Filters map[string][]string) []string {
 	out, err := GetEc2InstanceIdsByFiltersE(t, region, ec2Filters)
 	require.NoError(t, err)
 	return out
@@ -191,7 +191,7 @@ func GetEc2InstanceIdsByFilters(t *testing.T, region string, ec2Filters map[stri
 
 // GetEc2InstanceIdsByFilters returns all the IDs of EC2 instances in the given region which match to EC2 filter list
 // as per https://docs.aws.amazon.com/sdk-for-go/api/service/ec2/#DescribeInstancesInput.
-func GetEc2InstanceIdsByFiltersE(t *testing.T, region string, ec2Filters map[string][]string) ([]string, error) {
+func GetEc2InstanceIdsByFiltersE(t TestingT, region string, ec2Filters map[string][]string) ([]string, error) {
 	client, err := NewEc2ClientE(t, region)
 	if err != nil {
 		return nil, err
@@ -221,14 +221,14 @@ func GetEc2InstanceIdsByFiltersE(t *testing.T, region string, ec2Filters map[str
 }
 
 // GetTagsForEc2Instance returns all the tags for the given EC2 Instance.
-func GetTagsForEc2Instance(t *testing.T, region string, instanceID string) map[string]string {
+func GetTagsForEc2Instance(t TestingT, region string, instanceID string) map[string]string {
 	tags, err := GetTagsForEc2InstanceE(t, region, instanceID)
 	require.NoError(t, err)
 	return tags
 }
 
 // GetTagsForEc2InstanceE returns all the tags for the given EC2 Instance.
-func GetTagsForEc2InstanceE(t *testing.T, region string, instanceID string) (map[string]string, error) {
+func GetTagsForEc2InstanceE(t TestingT, region string, instanceID string) (map[string]string, error) {
 	client, err := NewEc2ClientE(t, region)
 	if err != nil {
 		return nil, err
@@ -262,12 +262,12 @@ func GetTagsForEc2InstanceE(t *testing.T, region string, instanceID string) (map
 }
 
 // DeleteAmi deletes the given AMI in the given region.
-func DeleteAmi(t *testing.T, region string, imageID string) {
+func DeleteAmi(t TestingT, region string, imageID string) {
 	require.NoError(t, DeleteAmiE(t, region, imageID))
 }
 
 // DeleteAmiE deletes the given AMI in the given region.
-func DeleteAmiE(t *testing.T, region string, imageID string) error {
+func DeleteAmiE(t TestingT, region string, imageID string) error {
 	logger.Logf(t, "Deregistering AMI %s", imageID)
 
 	client, err := NewEc2ClientE(t, region)
@@ -280,12 +280,12 @@ func DeleteAmiE(t *testing.T, region string, imageID string) error {
 }
 
 // AddTagsToResource adds the tags to the given taggable AWS resource such as EC2, AMI or VPC.
-func AddTagsToResource(t *testing.T, region string, resource string, tags map[string]string) {
+func AddTagsToResource(t TestingT, region string, resource string, tags map[string]string) {
 	require.NoError(t, AddTagsToResourceE(t, region, resource, tags))
 }
 
 // AddTagsToResourceE adds the tags to the given taggable AWS resource such as EC2, AMI or VPC.
-func AddTagsToResourceE(t *testing.T, region string, resource string, tags map[string]string) error {
+func AddTagsToResourceE(t TestingT, region string, resource string, tags map[string]string) error {
 	client, err := NewEc2ClientE(t, region)
 	if err != nil {
 		return err
@@ -308,12 +308,12 @@ func AddTagsToResourceE(t *testing.T, region string, resource string, tags map[s
 }
 
 // TerminateInstance terminates the EC2 instance with the given ID in the given region.
-func TerminateInstance(t *testing.T, region string, instanceID string) {
+func TerminateInstance(t TestingT, region string, instanceID string) {
 	require.NoError(t, TerminateInstanceE(t, region, instanceID))
 }
 
 // TerminateInstanceE terminates the EC2 instance with the given ID in the given region.
-func TerminateInstanceE(t *testing.T, region string, instanceID string) error {
+func TerminateInstanceE(t TestingT, region string, instanceID string) error {
 	logger.Logf(t, "Terminating Instance %s", instanceID)
 
 	client, err := NewEc2ClientE(t, region)
@@ -331,14 +331,14 @@ func TerminateInstanceE(t *testing.T, region string, instanceID string) error {
 }
 
 // GetAmiPubliclyAccessible returns whether the AMI is publicly accessible or not
-func GetAmiPubliclyAccessible(t *testing.T, awsRegion string, amiID string) bool {
+func GetAmiPubliclyAccessible(t TestingT, awsRegion string, amiID string) bool {
 	output, err := GetAmiPubliclyAccessibleE(t, awsRegion, amiID)
 	require.NoError(t, err)
 	return output
 }
 
 // GetAmiPubliclyAccessibleE returns whether the AMI is publicly accessible or not
-func GetAmiPubliclyAccessibleE(t *testing.T, awsRegion string, amiID string) (bool, error) {
+func GetAmiPubliclyAccessibleE(t TestingT, awsRegion string, amiID string) (bool, error) {
 	launchPermissions, err := GetLaunchPermissionsForAmiE(t, awsRegion, amiID)
 	if err != nil {
 		return false, err
@@ -352,14 +352,14 @@ func GetAmiPubliclyAccessibleE(t *testing.T, awsRegion string, amiID string) (bo
 }
 
 // GetAccountsWithLaunchPermissionsForAmi returns list of accounts that the AMI is shared with
-func GetAccountsWithLaunchPermissionsForAmi(t *testing.T, awsRegion string, amiID string) []string {
+func GetAccountsWithLaunchPermissionsForAmi(t TestingT, awsRegion string, amiID string) []string {
 	output, err := GetAccountsWithLaunchPermissionsForAmiE(t, awsRegion, amiID)
 	require.NoError(t, err)
 	return output
 }
 
 // GetAccountsWithLaunchPermissionsForAmiE returns list of accounts that the AMI is shared with
-func GetAccountsWithLaunchPermissionsForAmiE(t *testing.T, awsRegion string, amiID string) ([]string, error) {
+func GetAccountsWithLaunchPermissionsForAmiE(t TestingT, awsRegion string, amiID string) ([]string, error) {
 	accountIDs := []string{}
 	launchPermissions, err := GetLaunchPermissionsForAmiE(t, awsRegion, amiID)
 	if err != nil {
@@ -374,7 +374,7 @@ func GetAccountsWithLaunchPermissionsForAmiE(t *testing.T, awsRegion string, ami
 }
 
 // GetLaunchPermissionsForAmiE returns launchPermissions as configured in AWS
-func GetLaunchPermissionsForAmiE(t *testing.T, awsRegion string, amiID string) ([]*ec2.LaunchPermission, error) {
+func GetLaunchPermissionsForAmiE(t TestingT, awsRegion string, amiID string) ([]*ec2.LaunchPermission, error) {
 	client := NewEc2Client(t, awsRegion)
 	input := &ec2.DescribeImageAttributeInput{
 		Attribute: aws.String("launchPermission"),
@@ -389,14 +389,14 @@ func GetLaunchPermissionsForAmiE(t *testing.T, awsRegion string, amiID string) (
 }
 
 // NewEc2Client creates an EC2 client.
-func NewEc2Client(t *testing.T, region string) *ec2.EC2 {
+func NewEc2Client(t TestingT, region string) *ec2.EC2 {
 	client, err := NewEc2ClientE(t, region)
 	require.NoError(t, err)
 	return client
 }
 
 // NewEc2ClientE creates an EC2 client.
-func NewEc2ClientE(t *testing.T, region string) (*ec2.EC2, error) {
+func NewEc2ClientE(t TestingT, region string) (*ec2.EC2, error) {
 	sess, err := NewAuthenticatedSession(region)
 	if err != nil {
 		return nil, err

--- a/modules/aws/ec2.go
+++ b/modules/aws/ec2.go
@@ -6,19 +6,19 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/gruntwork-io/terratest/modules/logger"
-	_ "github.com/gruntwork-io/terratest/modules/testing"
+	"github.com/gruntwork-io/terratest/modules/testing"
 	"github.com/stretchr/testify/require"
 )
 
 // GetPrivateIpOfEc2Instance gets the private IP address of the given EC2 Instance in the given region.
-func GetPrivateIpOfEc2Instance(t TestingT, instanceID string, awsRegion string) string {
+func GetPrivateIpOfEc2Instance(t testing.TestingT, instanceID string, awsRegion string) string {
 	ip, err := GetPrivateIpOfEc2InstanceE(t, instanceID, awsRegion)
 	require.NoError(t, err)
 	return ip
 }
 
 // GetPrivateIpOfEc2InstanceE gets the private IP address of the given EC2 Instance in the given region.
-func GetPrivateIpOfEc2InstanceE(t TestingT, instanceID string, awsRegion string) (string, error) {
+func GetPrivateIpOfEc2InstanceE(t testing.TestingT, instanceID string, awsRegion string) (string, error) {
 	ips, err := GetPrivateIpsOfEc2InstancesE(t, []string{instanceID}, awsRegion)
 	if err != nil {
 		return "", err
@@ -34,14 +34,14 @@ func GetPrivateIpOfEc2InstanceE(t TestingT, instanceID string, awsRegion string)
 }
 
 // GetPrivateIpsOfEc2Instances gets the private IP address of the given EC2 Instance in the given region. Returns a map of instance ID to IP address.
-func GetPrivateIpsOfEc2Instances(t TestingT, instanceIDs []string, awsRegion string) map[string]string {
+func GetPrivateIpsOfEc2Instances(t testing.TestingT, instanceIDs []string, awsRegion string) map[string]string {
 	ips, err := GetPrivateIpsOfEc2InstancesE(t, instanceIDs, awsRegion)
 	require.NoError(t, err)
 	return ips
 }
 
 // GetPrivateIpsOfEc2InstancesE gets the private IP address of the given EC2 Instance in the given region. Returns a map of instance ID to IP address.
-func GetPrivateIpsOfEc2InstancesE(t TestingT, instanceIDs []string, awsRegion string) (map[string]string, error) {
+func GetPrivateIpsOfEc2InstancesE(t testing.TestingT, instanceIDs []string, awsRegion string) (map[string]string, error) {
 	ec2Client := NewEc2Client(t, awsRegion)
 	// TODO: implement pagination for cases that extend beyond limit (1000 instances)
 	input := ec2.DescribeInstancesInput{InstanceIds: aws.StringSlice(instanceIDs)}
@@ -62,14 +62,14 @@ func GetPrivateIpsOfEc2InstancesE(t TestingT, instanceIDs []string, awsRegion st
 }
 
 // GetPrivateHostnameOfEc2Instance gets the private IP address of the given EC2 Instance in the given region.
-func GetPrivateHostnameOfEc2Instance(t TestingT, instanceID string, awsRegion string) string {
+func GetPrivateHostnameOfEc2Instance(t testing.TestingT, instanceID string, awsRegion string) string {
 	ip, err := GetPrivateHostnameOfEc2InstanceE(t, instanceID, awsRegion)
 	require.NoError(t, err)
 	return ip
 }
 
 // GetPrivateHostnameOfEc2InstanceE gets the private IP address of the given EC2 Instance in the given region.
-func GetPrivateHostnameOfEc2InstanceE(t TestingT, instanceID string, awsRegion string) (string, error) {
+func GetPrivateHostnameOfEc2InstanceE(t testing.TestingT, instanceID string, awsRegion string) (string, error) {
 	hostnames, err := GetPrivateHostnamesOfEc2InstancesE(t, []string{instanceID}, awsRegion)
 	if err != nil {
 		return "", err
@@ -85,14 +85,14 @@ func GetPrivateHostnameOfEc2InstanceE(t TestingT, instanceID string, awsRegion s
 }
 
 // GetPrivateHostnamesOfEc2Instances gets the private IP address of the given EC2 Instance in the given region. Returns a map of instance ID to IP address.
-func GetPrivateHostnamesOfEc2Instances(t TestingT, instanceIDs []string, awsRegion string) map[string]string {
+func GetPrivateHostnamesOfEc2Instances(t testing.TestingT, instanceIDs []string, awsRegion string) map[string]string {
 	ips, err := GetPrivateHostnamesOfEc2InstancesE(t, instanceIDs, awsRegion)
 	require.NoError(t, err)
 	return ips
 }
 
 // GetPrivateHostnamesOfEc2InstancesE gets the private IP address of the given EC2 Instance in the given region. Returns a map of instance ID to IP address.
-func GetPrivateHostnamesOfEc2InstancesE(t TestingT, instanceIDs []string, awsRegion string) (map[string]string, error) {
+func GetPrivateHostnamesOfEc2InstancesE(t testing.TestingT, instanceIDs []string, awsRegion string) (map[string]string, error) {
 	ec2Client, err := NewEc2ClientE(t, awsRegion)
 	if err != nil {
 		return nil, err
@@ -116,14 +116,14 @@ func GetPrivateHostnamesOfEc2InstancesE(t TestingT, instanceIDs []string, awsReg
 }
 
 // GetPublicIpOfEc2Instance gets the public IP address of the given EC2 Instance in the given region.
-func GetPublicIpOfEc2Instance(t TestingT, instanceID string, awsRegion string) string {
+func GetPublicIpOfEc2Instance(t testing.TestingT, instanceID string, awsRegion string) string {
 	ip, err := GetPublicIpOfEc2InstanceE(t, instanceID, awsRegion)
 	require.NoError(t, err)
 	return ip
 }
 
 // GetPublicIpOfEc2InstanceE gets the public IP address of the given EC2 Instance in the given region.
-func GetPublicIpOfEc2InstanceE(t TestingT, instanceID string, awsRegion string) (string, error) {
+func GetPublicIpOfEc2InstanceE(t testing.TestingT, instanceID string, awsRegion string) (string, error) {
 	ips, err := GetPublicIpsOfEc2InstancesE(t, []string{instanceID}, awsRegion)
 	if err != nil {
 		return "", err
@@ -139,14 +139,14 @@ func GetPublicIpOfEc2InstanceE(t TestingT, instanceID string, awsRegion string) 
 }
 
 // GetPublicIpsOfEc2Instances gets the public IP address of the given EC2 Instance in the given region. Returns a map of instance ID to IP address.
-func GetPublicIpsOfEc2Instances(t TestingT, instanceIDs []string, awsRegion string) map[string]string {
+func GetPublicIpsOfEc2Instances(t testing.TestingT, instanceIDs []string, awsRegion string) map[string]string {
 	ips, err := GetPublicIpsOfEc2InstancesE(t, instanceIDs, awsRegion)
 	require.NoError(t, err)
 	return ips
 }
 
 // GetPublicIpsOfEc2InstancesE gets the public IP address of the given EC2 Instance in the given region. Returns a map of instance ID to IP address.
-func GetPublicIpsOfEc2InstancesE(t TestingT, instanceIDs []string, awsRegion string) (map[string]string, error) {
+func GetPublicIpsOfEc2InstancesE(t testing.TestingT, instanceIDs []string, awsRegion string) (map[string]string, error) {
 	ec2Client := NewEc2Client(t, awsRegion)
 	// TODO: implement pagination for cases that extend beyond limit (1000 instances)
 	input := ec2.DescribeInstancesInput{InstanceIds: aws.StringSlice(instanceIDs)}
@@ -167,14 +167,14 @@ func GetPublicIpsOfEc2InstancesE(t TestingT, instanceIDs []string, awsRegion str
 }
 
 // GetEc2InstanceIdsByTag returns all the IDs of EC2 instances in the given region with the given tag.
-func GetEc2InstanceIdsByTag(t TestingT, region string, tagName string, tagValue string) []string {
+func GetEc2InstanceIdsByTag(t testing.TestingT, region string, tagName string, tagValue string) []string {
 	out, err := GetEc2InstanceIdsByTagE(t, region, tagName, tagValue)
 	require.NoError(t, err)
 	return out
 }
 
 // GetEc2InstanceIdsByTagE returns all the IDs of EC2 instances in the given region with the given tag.
-func GetEc2InstanceIdsByTagE(t TestingT, region string, tagName string, tagValue string) ([]string, error) {
+func GetEc2InstanceIdsByTagE(t testing.TestingT, region string, tagName string, tagValue string) ([]string, error) {
 	ec2Filters := map[string][]string{
 		fmt.Sprintf("tag:%s", tagName): {tagValue},
 	}
@@ -183,7 +183,7 @@ func GetEc2InstanceIdsByTagE(t TestingT, region string, tagName string, tagValue
 
 // GetEc2InstanceIdsByFilters returns all the IDs of EC2 instances in the given region which match to EC2 filter list
 // as per https://docs.aws.amazon.com/sdk-for-go/api/service/ec2/#DescribeInstancesInput.
-func GetEc2InstanceIdsByFilters(t TestingT, region string, ec2Filters map[string][]string) []string {
+func GetEc2InstanceIdsByFilters(t testing.TestingT, region string, ec2Filters map[string][]string) []string {
 	out, err := GetEc2InstanceIdsByFiltersE(t, region, ec2Filters)
 	require.NoError(t, err)
 	return out
@@ -191,7 +191,7 @@ func GetEc2InstanceIdsByFilters(t TestingT, region string, ec2Filters map[string
 
 // GetEc2InstanceIdsByFilters returns all the IDs of EC2 instances in the given region which match to EC2 filter list
 // as per https://docs.aws.amazon.com/sdk-for-go/api/service/ec2/#DescribeInstancesInput.
-func GetEc2InstanceIdsByFiltersE(t TestingT, region string, ec2Filters map[string][]string) ([]string, error) {
+func GetEc2InstanceIdsByFiltersE(t testing.TestingT, region string, ec2Filters map[string][]string) ([]string, error) {
 	client, err := NewEc2ClientE(t, region)
 	if err != nil {
 		return nil, err
@@ -221,14 +221,14 @@ func GetEc2InstanceIdsByFiltersE(t TestingT, region string, ec2Filters map[strin
 }
 
 // GetTagsForEc2Instance returns all the tags for the given EC2 Instance.
-func GetTagsForEc2Instance(t TestingT, region string, instanceID string) map[string]string {
+func GetTagsForEc2Instance(t testing.TestingT, region string, instanceID string) map[string]string {
 	tags, err := GetTagsForEc2InstanceE(t, region, instanceID)
 	require.NoError(t, err)
 	return tags
 }
 
 // GetTagsForEc2InstanceE returns all the tags for the given EC2 Instance.
-func GetTagsForEc2InstanceE(t TestingT, region string, instanceID string) (map[string]string, error) {
+func GetTagsForEc2InstanceE(t testing.TestingT, region string, instanceID string) (map[string]string, error) {
 	client, err := NewEc2ClientE(t, region)
 	if err != nil {
 		return nil, err
@@ -262,12 +262,12 @@ func GetTagsForEc2InstanceE(t TestingT, region string, instanceID string) (map[s
 }
 
 // DeleteAmi deletes the given AMI in the given region.
-func DeleteAmi(t TestingT, region string, imageID string) {
+func DeleteAmi(t testing.TestingT, region string, imageID string) {
 	require.NoError(t, DeleteAmiE(t, region, imageID))
 }
 
 // DeleteAmiE deletes the given AMI in the given region.
-func DeleteAmiE(t TestingT, region string, imageID string) error {
+func DeleteAmiE(t testing.TestingT, region string, imageID string) error {
 	logger.Logf(t, "Deregistering AMI %s", imageID)
 
 	client, err := NewEc2ClientE(t, region)
@@ -280,12 +280,12 @@ func DeleteAmiE(t TestingT, region string, imageID string) error {
 }
 
 // AddTagsToResource adds the tags to the given taggable AWS resource such as EC2, AMI or VPC.
-func AddTagsToResource(t TestingT, region string, resource string, tags map[string]string) {
+func AddTagsToResource(t testing.TestingT, region string, resource string, tags map[string]string) {
 	require.NoError(t, AddTagsToResourceE(t, region, resource, tags))
 }
 
 // AddTagsToResourceE adds the tags to the given taggable AWS resource such as EC2, AMI or VPC.
-func AddTagsToResourceE(t TestingT, region string, resource string, tags map[string]string) error {
+func AddTagsToResourceE(t testing.TestingT, region string, resource string, tags map[string]string) error {
 	client, err := NewEc2ClientE(t, region)
 	if err != nil {
 		return err
@@ -308,12 +308,12 @@ func AddTagsToResourceE(t TestingT, region string, resource string, tags map[str
 }
 
 // TerminateInstance terminates the EC2 instance with the given ID in the given region.
-func TerminateInstance(t TestingT, region string, instanceID string) {
+func TerminateInstance(t testing.TestingT, region string, instanceID string) {
 	require.NoError(t, TerminateInstanceE(t, region, instanceID))
 }
 
 // TerminateInstanceE terminates the EC2 instance with the given ID in the given region.
-func TerminateInstanceE(t TestingT, region string, instanceID string) error {
+func TerminateInstanceE(t testing.TestingT, region string, instanceID string) error {
 	logger.Logf(t, "Terminating Instance %s", instanceID)
 
 	client, err := NewEc2ClientE(t, region)
@@ -331,14 +331,14 @@ func TerminateInstanceE(t TestingT, region string, instanceID string) error {
 }
 
 // GetAmiPubliclyAccessible returns whether the AMI is publicly accessible or not
-func GetAmiPubliclyAccessible(t TestingT, awsRegion string, amiID string) bool {
+func GetAmiPubliclyAccessible(t testing.TestingT, awsRegion string, amiID string) bool {
 	output, err := GetAmiPubliclyAccessibleE(t, awsRegion, amiID)
 	require.NoError(t, err)
 	return output
 }
 
 // GetAmiPubliclyAccessibleE returns whether the AMI is publicly accessible or not
-func GetAmiPubliclyAccessibleE(t TestingT, awsRegion string, amiID string) (bool, error) {
+func GetAmiPubliclyAccessibleE(t testing.TestingT, awsRegion string, amiID string) (bool, error) {
 	launchPermissions, err := GetLaunchPermissionsForAmiE(t, awsRegion, amiID)
 	if err != nil {
 		return false, err
@@ -352,14 +352,14 @@ func GetAmiPubliclyAccessibleE(t TestingT, awsRegion string, amiID string) (bool
 }
 
 // GetAccountsWithLaunchPermissionsForAmi returns list of accounts that the AMI is shared with
-func GetAccountsWithLaunchPermissionsForAmi(t TestingT, awsRegion string, amiID string) []string {
+func GetAccountsWithLaunchPermissionsForAmi(t testing.TestingT, awsRegion string, amiID string) []string {
 	output, err := GetAccountsWithLaunchPermissionsForAmiE(t, awsRegion, amiID)
 	require.NoError(t, err)
 	return output
 }
 
 // GetAccountsWithLaunchPermissionsForAmiE returns list of accounts that the AMI is shared with
-func GetAccountsWithLaunchPermissionsForAmiE(t TestingT, awsRegion string, amiID string) ([]string, error) {
+func GetAccountsWithLaunchPermissionsForAmiE(t testing.TestingT, awsRegion string, amiID string) ([]string, error) {
 	accountIDs := []string{}
 	launchPermissions, err := GetLaunchPermissionsForAmiE(t, awsRegion, amiID)
 	if err != nil {
@@ -374,7 +374,7 @@ func GetAccountsWithLaunchPermissionsForAmiE(t TestingT, awsRegion string, amiID
 }
 
 // GetLaunchPermissionsForAmiE returns launchPermissions as configured in AWS
-func GetLaunchPermissionsForAmiE(t TestingT, awsRegion string, amiID string) ([]*ec2.LaunchPermission, error) {
+func GetLaunchPermissionsForAmiE(t testing.TestingT, awsRegion string, amiID string) ([]*ec2.LaunchPermission, error) {
 	client := NewEc2Client(t, awsRegion)
 	input := &ec2.DescribeImageAttributeInput{
 		Attribute: aws.String("launchPermission"),
@@ -389,14 +389,14 @@ func GetLaunchPermissionsForAmiE(t TestingT, awsRegion string, amiID string) ([]
 }
 
 // NewEc2Client creates an EC2 client.
-func NewEc2Client(t TestingT, region string) *ec2.EC2 {
+func NewEc2Client(t testing.TestingT, region string) *ec2.EC2 {
 	client, err := NewEc2ClientE(t, region)
 	require.NoError(t, err)
 	return client
 }
 
 // NewEc2ClientE creates an EC2 client.
-func NewEc2ClientE(t TestingT, region string) (*ec2.EC2, error) {
+func NewEc2ClientE(t testing.TestingT, region string) (*ec2.EC2, error) {
 	sess, err := NewAuthenticatedSession(region)
 	if err != nil {
 		return nil, err

--- a/modules/aws/ecs.go
+++ b/modules/aws/ecs.go
@@ -5,19 +5,19 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ecs"
-	_ "github.com/gruntwork-io/terratest/modules/testing"
+	"github.com/gruntwork-io/terratest/modules/testing"
 	"github.com/stretchr/testify/require"
 )
 
 // GetEcsCluster fetches information about specified ECS cluster.
-func GetEcsCluster(t TestingT, region string, name string) *ecs.Cluster {
+func GetEcsCluster(t testing.TestingT, region string, name string) *ecs.Cluster {
 	cluster, err := GetEcsClusterE(t, region, name)
 	require.NoError(t, err)
 	return cluster
 }
 
 // GetEcsClusterE fetches information about specified ECS cluster.
-func GetEcsClusterE(t TestingT, region string, name string) (*ecs.Cluster, error) {
+func GetEcsClusterE(t testing.TestingT, region string, name string) (*ecs.Cluster, error) {
 	client, err := NewEcsClientE(t, region)
 	if err != nil {
 		return nil, err
@@ -42,24 +42,24 @@ func GetEcsClusterE(t TestingT, region string, name string) (*ecs.Cluster, error
 }
 
 // GetDefaultEcsClusterE fetches information about default ECS cluster.
-func GetDefaultEcsClusterE(t TestingT, region string) (*ecs.Cluster, error) {
+func GetDefaultEcsClusterE(t testing.TestingT, region string) (*ecs.Cluster, error) {
 	return GetEcsClusterE(t, region, "default")
 }
 
 // GetDefaultEcsCluster fetches information about default ECS cluster.
-func GetDefaultEcsCluster(t TestingT, region string) *ecs.Cluster {
+func GetDefaultEcsCluster(t testing.TestingT, region string) *ecs.Cluster {
 	return GetEcsCluster(t, region, "default")
 }
 
 // CreateEcsCluster creates ECS cluster in the given region under the given name.
-func CreateEcsCluster(t TestingT, region string, name string) *ecs.Cluster {
+func CreateEcsCluster(t testing.TestingT, region string, name string) *ecs.Cluster {
 	cluster, err := CreateEcsClusterE(t, region, name)
 	require.NoError(t, err)
 	return cluster
 }
 
 // CreateEcsClusterE creates ECS cluster in the given region under the given name.
-func CreateEcsClusterE(t TestingT, region string, name string) (*ecs.Cluster, error) {
+func CreateEcsClusterE(t testing.TestingT, region string, name string) (*ecs.Cluster, error) {
 	client := NewEcsClient(t, region)
 	cluster, err := client.CreateCluster(&ecs.CreateClusterInput{
 		ClusterName: aws.String(name),
@@ -70,13 +70,13 @@ func CreateEcsClusterE(t TestingT, region string, name string) (*ecs.Cluster, er
 	return cluster.Cluster, nil
 }
 
-func DeleteEcsCluster(t TestingT, region string, cluster *ecs.Cluster) {
+func DeleteEcsCluster(t testing.TestingT, region string, cluster *ecs.Cluster) {
 	err := DeleteEcsClusterE(t, region, cluster)
 	require.NoError(t, err)
 }
 
 // DeleteEcsClusterE deletes existing ECS cluster in the given region.
-func DeleteEcsClusterE(t TestingT, region string, cluster *ecs.Cluster) error {
+func DeleteEcsClusterE(t testing.TestingT, region string, cluster *ecs.Cluster) error {
 	client := NewEcsClient(t, region)
 	_, err := client.DeleteCluster(&ecs.DeleteClusterInput{
 		Cluster: aws.String(*cluster.ClusterName),
@@ -85,14 +85,14 @@ func DeleteEcsClusterE(t TestingT, region string, cluster *ecs.Cluster) error {
 }
 
 // GetEcsService fetches information about specified ECS service.
-func GetEcsService(t TestingT, region string, clusterName string, serviceName string) *ecs.Service {
+func GetEcsService(t testing.TestingT, region string, clusterName string, serviceName string) *ecs.Service {
 	service, err := GetEcsServiceE(t, region, clusterName, serviceName)
 	require.NoError(t, err)
 	return service
 }
 
 // GetEcsServiceE fetches information about specified ECS service.
-func GetEcsServiceE(t TestingT, region string, clusterName string, serviceName string) (*ecs.Service, error) {
+func GetEcsServiceE(t testing.TestingT, region string, clusterName string, serviceName string) (*ecs.Service, error) {
 	output, err := NewEcsClient(t, region).DescribeServices(&ecs.DescribeServicesInput{
 		Cluster: aws.String(clusterName),
 		Services: []*string{
@@ -113,14 +113,14 @@ func GetEcsServiceE(t TestingT, region string, clusterName string, serviceName s
 }
 
 // GetEcsTaskDefinition fetches information about specified ECS task definition.
-func GetEcsTaskDefinition(t TestingT, region string, taskDefinition string) *ecs.TaskDefinition {
+func GetEcsTaskDefinition(t testing.TestingT, region string, taskDefinition string) *ecs.TaskDefinition {
 	task, err := GetEcsTaskDefinitionE(t, region, taskDefinition)
 	require.NoError(t, err)
 	return task
 }
 
 // GetEcsTaskDefinitionE fetches information about specified ECS task definition.
-func GetEcsTaskDefinitionE(t TestingT, region string, taskDefinition string) (*ecs.TaskDefinition, error) {
+func GetEcsTaskDefinitionE(t testing.TestingT, region string, taskDefinition string) (*ecs.TaskDefinition, error) {
 	output, err := NewEcsClient(t, region).DescribeTaskDefinition(&ecs.DescribeTaskDefinitionInput{
 		TaskDefinition: aws.String(taskDefinition),
 	})
@@ -131,14 +131,14 @@ func GetEcsTaskDefinitionE(t TestingT, region string, taskDefinition string) (*e
 }
 
 // NewEcsClient creates en ECS client.
-func NewEcsClient(t TestingT, region string) *ecs.ECS {
+func NewEcsClient(t testing.TestingT, region string) *ecs.ECS {
 	client, err := NewEcsClientE(t, region)
 	require.NoError(t, err)
 	return client
 }
 
 // NewEcsClientE creates an ECS client.
-func NewEcsClientE(t TestingT, region string) (*ecs.ECS, error) {
+func NewEcsClientE(t testing.TestingT, region string) (*ecs.ECS, error) {
 	sess, err := NewAuthenticatedSession(region)
 	if err != nil {
 		return nil, err

--- a/modules/aws/ecs.go
+++ b/modules/aws/ecs.go
@@ -2,22 +2,22 @@ package aws
 
 import (
 	"fmt"
-	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ecs"
+	_ "github.com/gruntwork-io/terratest/modules/testing"
 	"github.com/stretchr/testify/require"
 )
 
 // GetEcsCluster fetches information about specified ECS cluster.
-func GetEcsCluster(t *testing.T, region string, name string) *ecs.Cluster {
+func GetEcsCluster(t TestingT, region string, name string) *ecs.Cluster {
 	cluster, err := GetEcsClusterE(t, region, name)
 	require.NoError(t, err)
 	return cluster
 }
 
 // GetEcsClusterE fetches information about specified ECS cluster.
-func GetEcsClusterE(t *testing.T, region string, name string) (*ecs.Cluster, error) {
+func GetEcsClusterE(t TestingT, region string, name string) (*ecs.Cluster, error) {
 	client, err := NewEcsClientE(t, region)
 	if err != nil {
 		return nil, err
@@ -42,24 +42,24 @@ func GetEcsClusterE(t *testing.T, region string, name string) (*ecs.Cluster, err
 }
 
 // GetDefaultEcsClusterE fetches information about default ECS cluster.
-func GetDefaultEcsClusterE(t *testing.T, region string) (*ecs.Cluster, error) {
+func GetDefaultEcsClusterE(t TestingT, region string) (*ecs.Cluster, error) {
 	return GetEcsClusterE(t, region, "default")
 }
 
 // GetDefaultEcsCluster fetches information about default ECS cluster.
-func GetDefaultEcsCluster(t *testing.T, region string) *ecs.Cluster {
+func GetDefaultEcsCluster(t TestingT, region string) *ecs.Cluster {
 	return GetEcsCluster(t, region, "default")
 }
 
 // CreateEcsCluster creates ECS cluster in the given region under the given name.
-func CreateEcsCluster(t *testing.T, region string, name string) *ecs.Cluster {
+func CreateEcsCluster(t TestingT, region string, name string) *ecs.Cluster {
 	cluster, err := CreateEcsClusterE(t, region, name)
 	require.NoError(t, err)
 	return cluster
 }
 
 // CreateEcsClusterE creates ECS cluster in the given region under the given name.
-func CreateEcsClusterE(t *testing.T, region string, name string) (*ecs.Cluster, error) {
+func CreateEcsClusterE(t TestingT, region string, name string) (*ecs.Cluster, error) {
 	client := NewEcsClient(t, region)
 	cluster, err := client.CreateCluster(&ecs.CreateClusterInput{
 		ClusterName: aws.String(name),
@@ -70,14 +70,13 @@ func CreateEcsClusterE(t *testing.T, region string, name string) (*ecs.Cluster, 
 	return cluster.Cluster, nil
 }
 
-// DeleteEcsCluster deletes existing ECS cluster in the given region.
-func DeleteEcsCluster(t *testing.T, region string, cluster *ecs.Cluster) {
+func DeleteEcsCluster(t TestingT, region string, cluster *ecs.Cluster) {
 	err := DeleteEcsClusterE(t, region, cluster)
 	require.NoError(t, err)
 }
 
 // DeleteEcsClusterE deletes existing ECS cluster in the given region.
-func DeleteEcsClusterE(t *testing.T, region string, cluster *ecs.Cluster) error {
+func DeleteEcsClusterE(t TestingT, region string, cluster *ecs.Cluster) error {
 	client := NewEcsClient(t, region)
 	_, err := client.DeleteCluster(&ecs.DeleteClusterInput{
 		Cluster: aws.String(*cluster.ClusterName),
@@ -86,14 +85,14 @@ func DeleteEcsClusterE(t *testing.T, region string, cluster *ecs.Cluster) error 
 }
 
 // GetEcsService fetches information about specified ECS service.
-func GetEcsService(t *testing.T, region string, clusterName string, serviceName string) *ecs.Service {
+func GetEcsService(t TestingT, region string, clusterName string, serviceName string) *ecs.Service {
 	service, err := GetEcsServiceE(t, region, clusterName, serviceName)
 	require.NoError(t, err)
 	return service
 }
 
 // GetEcsServiceE fetches information about specified ECS service.
-func GetEcsServiceE(t *testing.T, region string, clusterName string, serviceName string) (*ecs.Service, error) {
+func GetEcsServiceE(t TestingT, region string, clusterName string, serviceName string) (*ecs.Service, error) {
 	output, err := NewEcsClient(t, region).DescribeServices(&ecs.DescribeServicesInput{
 		Cluster: aws.String(clusterName),
 		Services: []*string{
@@ -114,14 +113,14 @@ func GetEcsServiceE(t *testing.T, region string, clusterName string, serviceName
 }
 
 // GetEcsTaskDefinition fetches information about specified ECS task definition.
-func GetEcsTaskDefinition(t *testing.T, region string, taskDefinition string) *ecs.TaskDefinition {
+func GetEcsTaskDefinition(t TestingT, region string, taskDefinition string) *ecs.TaskDefinition {
 	task, err := GetEcsTaskDefinitionE(t, region, taskDefinition)
 	require.NoError(t, err)
 	return task
 }
 
 // GetEcsTaskDefinitionE fetches information about specified ECS task definition.
-func GetEcsTaskDefinitionE(t *testing.T, region string, taskDefinition string) (*ecs.TaskDefinition, error) {
+func GetEcsTaskDefinitionE(t TestingT, region string, taskDefinition string) (*ecs.TaskDefinition, error) {
 	output, err := NewEcsClient(t, region).DescribeTaskDefinition(&ecs.DescribeTaskDefinitionInput{
 		TaskDefinition: aws.String(taskDefinition),
 	})
@@ -132,14 +131,14 @@ func GetEcsTaskDefinitionE(t *testing.T, region string, taskDefinition string) (
 }
 
 // NewEcsClient creates en ECS client.
-func NewEcsClient(t *testing.T, region string) *ecs.ECS {
+func NewEcsClient(t TestingT, region string) *ecs.ECS {
 	client, err := NewEcsClientE(t, region)
 	require.NoError(t, err)
 	return client
 }
 
 // NewEcsClientE creates an ECS client.
-func NewEcsClientE(t *testing.T, region string) (*ecs.ECS, error) {
+func NewEcsClientE(t TestingT, region string) (*ecs.ECS, error) {
 	sess, err := NewAuthenticatedSession(region)
 	if err != nil {
 		return nil, err

--- a/modules/aws/iam.go
+++ b/modules/aws/iam.go
@@ -6,11 +6,11 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/gruntwork-io/terratest/modules/logger"
-	_ "github.com/gruntwork-io/terratest/modules/testing"
+	"github.com/gruntwork-io/terratest/modules/testing"
 )
 
 // GetIamCurrentUserName gets the username for the current IAM user.
-func GetIamCurrentUserName(t TestingT) string {
+func GetIamCurrentUserName(t testing.TestingT) string {
 	out, err := GetIamCurrentUserNameE(t)
 	if err != nil {
 		t.Fatal(err)
@@ -19,7 +19,7 @@ func GetIamCurrentUserName(t TestingT) string {
 }
 
 // GetIamCurrentUserNameE gets the username for the current IAM user.
-func GetIamCurrentUserNameE(t TestingT) (string, error) {
+func GetIamCurrentUserNameE(t testing.TestingT) (string, error) {
 	iamClient, err := NewIamClientE(t, defaultRegion)
 	if err != nil {
 		return "", err
@@ -34,7 +34,7 @@ func GetIamCurrentUserNameE(t TestingT) (string, error) {
 }
 
 // GetIamCurrentUserArn gets the ARN for the current IAM user.
-func GetIamCurrentUserArn(t TestingT) string {
+func GetIamCurrentUserArn(t testing.TestingT) string {
 	out, err := GetIamCurrentUserArnE(t)
 	if err != nil {
 		t.Fatal(err)
@@ -43,7 +43,7 @@ func GetIamCurrentUserArn(t TestingT) string {
 }
 
 // GetIamCurrentUserArnE gets the ARN for the current IAM user.
-func GetIamCurrentUserArnE(t TestingT) (string, error) {
+func GetIamCurrentUserArnE(t testing.TestingT) (string, error) {
 	iamClient, err := NewIamClientE(t, defaultRegion)
 	if err != nil {
 		return "", err
@@ -58,7 +58,7 @@ func GetIamCurrentUserArnE(t TestingT) (string, error) {
 }
 
 // CreateMfaDevice creates an MFA device using the given IAM client.
-func CreateMfaDevice(t TestingT, iamClient *iam.IAM, deviceName string) *iam.VirtualMFADevice {
+func CreateMfaDevice(t testing.TestingT, iamClient *iam.IAM, deviceName string) *iam.VirtualMFADevice {
 	mfaDevice, err := CreateMfaDeviceE(t, iamClient, deviceName)
 	if err != nil {
 		t.Fatal(err)
@@ -67,7 +67,7 @@ func CreateMfaDevice(t TestingT, iamClient *iam.IAM, deviceName string) *iam.Vir
 }
 
 // CreateMfaDeviceE creates an MFA device using the given IAM client.
-func CreateMfaDeviceE(t TestingT, iamClient *iam.IAM, deviceName string) (*iam.VirtualMFADevice, error) {
+func CreateMfaDeviceE(t testing.TestingT, iamClient *iam.IAM, deviceName string) (*iam.VirtualMFADevice, error) {
 	logger.Logf(t, "Creating an MFA device called %s", deviceName)
 
 	output, err := iamClient.CreateVirtualMFADevice(&iam.CreateVirtualMFADeviceInput{
@@ -86,7 +86,7 @@ func CreateMfaDeviceE(t TestingT, iamClient *iam.IAM, deviceName string) (*iam.V
 
 // EnableMfaDevice enables a newly created MFA Device by supplying the first two one-time passwords, so that it can be used for future
 // logins by the given IAM User.
-func EnableMfaDevice(t TestingT, iamClient *iam.IAM, mfaDevice *iam.VirtualMFADevice) {
+func EnableMfaDevice(t testing.TestingT, iamClient *iam.IAM, mfaDevice *iam.VirtualMFADevice) {
 	err := EnableMfaDeviceE(t, iamClient, mfaDevice)
 	if err != nil {
 		t.Fatal(err)
@@ -95,7 +95,7 @@ func EnableMfaDevice(t TestingT, iamClient *iam.IAM, mfaDevice *iam.VirtualMFADe
 
 // EnableMfaDeviceE enables a newly created MFA Device by supplying the first two one-time passwords, so that it can be used for future
 // logins by the given IAM User.
-func EnableMfaDeviceE(t TestingT, iamClient *iam.IAM, mfaDevice *iam.VirtualMFADevice) error {
+func EnableMfaDeviceE(t testing.TestingT, iamClient *iam.IAM, mfaDevice *iam.VirtualMFADevice) error {
 	logger.Logf(t, "Enabling MFA device %s", aws.StringValue(mfaDevice.SerialNumber))
 
 	iamUserName, err := GetIamCurrentUserArnE(t)
@@ -134,7 +134,7 @@ func EnableMfaDeviceE(t TestingT, iamClient *iam.IAM, mfaDevice *iam.VirtualMFAD
 }
 
 // NewIamClient creates a new IAM client.
-func NewIamClient(t TestingT, region string) *iam.IAM {
+func NewIamClient(t testing.TestingT, region string) *iam.IAM {
 	client, err := NewIamClientE(t, region)
 	if err != nil {
 		t.Fatal(err)
@@ -143,7 +143,7 @@ func NewIamClient(t TestingT, region string) *iam.IAM {
 }
 
 // NewIamClientE creates a new IAM client.
-func NewIamClientE(t TestingT, region string) (*iam.IAM, error) {
+func NewIamClientE(t testing.TestingT, region string) (*iam.IAM, error) {
 	sess, err := NewAuthenticatedSession(region)
 	if err != nil {
 		return nil, err

--- a/modules/aws/iam.go
+++ b/modules/aws/iam.go
@@ -1,16 +1,16 @@
 package aws
 
 import (
-	"testing"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/gruntwork-io/terratest/modules/logger"
+	_ "github.com/gruntwork-io/terratest/modules/testing"
 )
 
 // GetIamCurrentUserName gets the username for the current IAM user.
-func GetIamCurrentUserName(t *testing.T) string {
+func GetIamCurrentUserName(t TestingT) string {
 	out, err := GetIamCurrentUserNameE(t)
 	if err != nil {
 		t.Fatal(err)
@@ -19,7 +19,7 @@ func GetIamCurrentUserName(t *testing.T) string {
 }
 
 // GetIamCurrentUserNameE gets the username for the current IAM user.
-func GetIamCurrentUserNameE(t *testing.T) (string, error) {
+func GetIamCurrentUserNameE(t TestingT) (string, error) {
 	iamClient, err := NewIamClientE(t, defaultRegion)
 	if err != nil {
 		return "", err
@@ -34,7 +34,7 @@ func GetIamCurrentUserNameE(t *testing.T) (string, error) {
 }
 
 // GetIamCurrentUserArn gets the ARN for the current IAM user.
-func GetIamCurrentUserArn(t *testing.T) string {
+func GetIamCurrentUserArn(t TestingT) string {
 	out, err := GetIamCurrentUserArnE(t)
 	if err != nil {
 		t.Fatal(err)
@@ -43,7 +43,7 @@ func GetIamCurrentUserArn(t *testing.T) string {
 }
 
 // GetIamCurrentUserArnE gets the ARN for the current IAM user.
-func GetIamCurrentUserArnE(t *testing.T) (string, error) {
+func GetIamCurrentUserArnE(t TestingT) (string, error) {
 	iamClient, err := NewIamClientE(t, defaultRegion)
 	if err != nil {
 		return "", err
@@ -58,7 +58,7 @@ func GetIamCurrentUserArnE(t *testing.T) (string, error) {
 }
 
 // CreateMfaDevice creates an MFA device using the given IAM client.
-func CreateMfaDevice(t *testing.T, iamClient *iam.IAM, deviceName string) *iam.VirtualMFADevice {
+func CreateMfaDevice(t TestingT, iamClient *iam.IAM, deviceName string) *iam.VirtualMFADevice {
 	mfaDevice, err := CreateMfaDeviceE(t, iamClient, deviceName)
 	if err != nil {
 		t.Fatal(err)
@@ -67,7 +67,7 @@ func CreateMfaDevice(t *testing.T, iamClient *iam.IAM, deviceName string) *iam.V
 }
 
 // CreateMfaDeviceE creates an MFA device using the given IAM client.
-func CreateMfaDeviceE(t *testing.T, iamClient *iam.IAM, deviceName string) (*iam.VirtualMFADevice, error) {
+func CreateMfaDeviceE(t TestingT, iamClient *iam.IAM, deviceName string) (*iam.VirtualMFADevice, error) {
 	logger.Logf(t, "Creating an MFA device called %s", deviceName)
 
 	output, err := iamClient.CreateVirtualMFADevice(&iam.CreateVirtualMFADeviceInput{
@@ -86,7 +86,7 @@ func CreateMfaDeviceE(t *testing.T, iamClient *iam.IAM, deviceName string) (*iam
 
 // EnableMfaDevice enables a newly created MFA Device by supplying the first two one-time passwords, so that it can be used for future
 // logins by the given IAM User.
-func EnableMfaDevice(t *testing.T, iamClient *iam.IAM, mfaDevice *iam.VirtualMFADevice) {
+func EnableMfaDevice(t TestingT, iamClient *iam.IAM, mfaDevice *iam.VirtualMFADevice) {
 	err := EnableMfaDeviceE(t, iamClient, mfaDevice)
 	if err != nil {
 		t.Fatal(err)
@@ -95,7 +95,7 @@ func EnableMfaDevice(t *testing.T, iamClient *iam.IAM, mfaDevice *iam.VirtualMFA
 
 // EnableMfaDeviceE enables a newly created MFA Device by supplying the first two one-time passwords, so that it can be used for future
 // logins by the given IAM User.
-func EnableMfaDeviceE(t *testing.T, iamClient *iam.IAM, mfaDevice *iam.VirtualMFADevice) error {
+func EnableMfaDeviceE(t TestingT, iamClient *iam.IAM, mfaDevice *iam.VirtualMFADevice) error {
 	logger.Logf(t, "Enabling MFA device %s", aws.StringValue(mfaDevice.SerialNumber))
 
 	iamUserName, err := GetIamCurrentUserArnE(t)
@@ -134,7 +134,7 @@ func EnableMfaDeviceE(t *testing.T, iamClient *iam.IAM, mfaDevice *iam.VirtualMF
 }
 
 // NewIamClient creates a new IAM client.
-func NewIamClient(t *testing.T, region string) *iam.IAM {
+func NewIamClient(t TestingT, region string) *iam.IAM {
 	client, err := NewIamClientE(t, region)
 	if err != nil {
 		t.Fatal(err)
@@ -143,7 +143,7 @@ func NewIamClient(t *testing.T, region string) *iam.IAM {
 }
 
 // NewIamClientE creates a new IAM client.
-func NewIamClientE(t *testing.T, region string) (*iam.IAM, error) {
+func NewIamClientE(t TestingT, region string) (*iam.IAM, error) {
 	sess, err := NewAuthenticatedSession(region)
 	if err != nil {
 		return nil, err

--- a/modules/aws/keypair.go
+++ b/modules/aws/keypair.go
@@ -1,12 +1,11 @@
 package aws
 
 import (
-	"testing"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/ssh"
+	_ "github.com/gruntwork-io/terratest/modules/testing"
 )
 
 // Ec2Keypair is an EC2 key pair.
@@ -17,7 +16,7 @@ type Ec2Keypair struct {
 }
 
 // CreateAndImportEC2KeyPair generates a public/private KeyPair and import it into EC2 in the given region under the given name.
-func CreateAndImportEC2KeyPair(t *testing.T, region string, name string) *Ec2Keypair {
+func CreateAndImportEC2KeyPair(t TestingT, region string, name string) *Ec2Keypair {
 	keyPair, err := CreateAndImportEC2KeyPairE(t, region, name)
 	if err != nil {
 		t.Fatal(err)
@@ -26,7 +25,7 @@ func CreateAndImportEC2KeyPair(t *testing.T, region string, name string) *Ec2Key
 }
 
 // CreateAndImportEC2KeyPairE generates a public/private KeyPair and import it into EC2 in the given region under the given name.
-func CreateAndImportEC2KeyPairE(t *testing.T, region string, name string) (*Ec2Keypair, error) {
+func CreateAndImportEC2KeyPairE(t TestingT, region string, name string) (*Ec2Keypair, error) {
 	keyPair, err := ssh.GenerateRSAKeyPairE(t, 2048)
 	if err != nil {
 		return nil, err
@@ -36,7 +35,7 @@ func CreateAndImportEC2KeyPairE(t *testing.T, region string, name string) (*Ec2K
 }
 
 // ImportEC2KeyPair creates a Key Pair in EC2 by importing an existing public key.
-func ImportEC2KeyPair(t *testing.T, region string, name string, keyPair *ssh.KeyPair) *Ec2Keypair {
+func ImportEC2KeyPair(t TestingT, region string, name string, keyPair *ssh.KeyPair) *Ec2Keypair {
 	ec2KeyPair, err := ImportEC2KeyPairE(t, region, name, keyPair)
 	if err != nil {
 		t.Fatal(err)
@@ -45,7 +44,7 @@ func ImportEC2KeyPair(t *testing.T, region string, name string, keyPair *ssh.Key
 }
 
 // ImportEC2KeyPairE creates a Key Pair in EC2 by importing an existing public key.
-func ImportEC2KeyPairE(t *testing.T, region string, name string, keyPair *ssh.KeyPair) (*Ec2Keypair, error) {
+func ImportEC2KeyPairE(t TestingT, region string, name string, keyPair *ssh.KeyPair) (*Ec2Keypair, error) {
 	logger.Logf(t, "Creating new Key Pair in EC2 region %s named %s", region, name)
 
 	client, err := NewEc2ClientE(t, region)
@@ -67,7 +66,7 @@ func ImportEC2KeyPairE(t *testing.T, region string, name string, keyPair *ssh.Ke
 }
 
 // DeleteEC2KeyPair deletes an EC2 key pair.
-func DeleteEC2KeyPair(t *testing.T, keyPair *Ec2Keypair) {
+func DeleteEC2KeyPair(t TestingT, keyPair *Ec2Keypair) {
 	err := DeleteEC2KeyPairE(t, keyPair)
 	if err != nil {
 		t.Fatal(err)
@@ -75,7 +74,7 @@ func DeleteEC2KeyPair(t *testing.T, keyPair *Ec2Keypair) {
 }
 
 // DeleteEC2KeyPairE deletes an EC2 key pair.
-func DeleteEC2KeyPairE(t *testing.T, keyPair *Ec2Keypair) error {
+func DeleteEC2KeyPairE(t TestingT, keyPair *Ec2Keypair) error {
 	logger.Logf(t, "Deleting Key Pair in EC2 region %s named %s", keyPair.Region, keyPair.Name)
 
 	client, err := NewEc2ClientE(t, keyPair.Region)

--- a/modules/aws/keypair.go
+++ b/modules/aws/keypair.go
@@ -5,7 +5,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/ssh"
-	_ "github.com/gruntwork-io/terratest/modules/testing"
+	"github.com/gruntwork-io/terratest/modules/testing"
 )
 
 // Ec2Keypair is an EC2 key pair.
@@ -16,7 +16,7 @@ type Ec2Keypair struct {
 }
 
 // CreateAndImportEC2KeyPair generates a public/private KeyPair and import it into EC2 in the given region under the given name.
-func CreateAndImportEC2KeyPair(t TestingT, region string, name string) *Ec2Keypair {
+func CreateAndImportEC2KeyPair(t testing.TestingT, region string, name string) *Ec2Keypair {
 	keyPair, err := CreateAndImportEC2KeyPairE(t, region, name)
 	if err != nil {
 		t.Fatal(err)
@@ -25,7 +25,7 @@ func CreateAndImportEC2KeyPair(t TestingT, region string, name string) *Ec2Keypa
 }
 
 // CreateAndImportEC2KeyPairE generates a public/private KeyPair and import it into EC2 in the given region under the given name.
-func CreateAndImportEC2KeyPairE(t TestingT, region string, name string) (*Ec2Keypair, error) {
+func CreateAndImportEC2KeyPairE(t testing.TestingT, region string, name string) (*Ec2Keypair, error) {
 	keyPair, err := ssh.GenerateRSAKeyPairE(t, 2048)
 	if err != nil {
 		return nil, err
@@ -35,7 +35,7 @@ func CreateAndImportEC2KeyPairE(t TestingT, region string, name string) (*Ec2Key
 }
 
 // ImportEC2KeyPair creates a Key Pair in EC2 by importing an existing public key.
-func ImportEC2KeyPair(t TestingT, region string, name string, keyPair *ssh.KeyPair) *Ec2Keypair {
+func ImportEC2KeyPair(t testing.TestingT, region string, name string, keyPair *ssh.KeyPair) *Ec2Keypair {
 	ec2KeyPair, err := ImportEC2KeyPairE(t, region, name, keyPair)
 	if err != nil {
 		t.Fatal(err)
@@ -44,7 +44,7 @@ func ImportEC2KeyPair(t TestingT, region string, name string, keyPair *ssh.KeyPa
 }
 
 // ImportEC2KeyPairE creates a Key Pair in EC2 by importing an existing public key.
-func ImportEC2KeyPairE(t TestingT, region string, name string, keyPair *ssh.KeyPair) (*Ec2Keypair, error) {
+func ImportEC2KeyPairE(t testing.TestingT, region string, name string, keyPair *ssh.KeyPair) (*Ec2Keypair, error) {
 	logger.Logf(t, "Creating new Key Pair in EC2 region %s named %s", region, name)
 
 	client, err := NewEc2ClientE(t, region)
@@ -66,7 +66,7 @@ func ImportEC2KeyPairE(t TestingT, region string, name string, keyPair *ssh.KeyP
 }
 
 // DeleteEC2KeyPair deletes an EC2 key pair.
-func DeleteEC2KeyPair(t TestingT, keyPair *Ec2Keypair) {
+func DeleteEC2KeyPair(t testing.TestingT, keyPair *Ec2Keypair) {
 	err := DeleteEC2KeyPairE(t, keyPair)
 	if err != nil {
 		t.Fatal(err)
@@ -74,7 +74,7 @@ func DeleteEC2KeyPair(t TestingT, keyPair *Ec2Keypair) {
 }
 
 // DeleteEC2KeyPairE deletes an EC2 key pair.
-func DeleteEC2KeyPairE(t TestingT, keyPair *Ec2Keypair) error {
+func DeleteEC2KeyPairE(t testing.TestingT, keyPair *Ec2Keypair) error {
 	logger.Logf(t, "Deleting Key Pair in EC2 region %s named %s", keyPair.Region, keyPair.Name)
 
 	client, err := NewEc2ClientE(t, keyPair.Region)

--- a/modules/aws/kms.go
+++ b/modules/aws/kms.go
@@ -3,12 +3,12 @@ package aws
 import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/kms"
-	_ "github.com/gruntwork-io/terratest/modules/testing"
+	"github.com/gruntwork-io/terratest/modules/testing"
 )
 
 // GetCmkArn gets the ARN of a KMS Customer Master Key (CMK) in the given region with the given ID. The ID can be an alias, such
 // as "alias/my-cmk".
-func GetCmkArn(t TestingT, region string, cmkID string) string {
+func GetCmkArn(t testing.TestingT, region string, cmkID string) string {
 	out, err := GetCmkArnE(t, region, cmkID)
 	if err != nil {
 		t.Fatal(err)
@@ -18,7 +18,7 @@ func GetCmkArn(t TestingT, region string, cmkID string) string {
 
 // GetCmkArnE gets the ARN of a KMS Customer Master Key (CMK) in the given region with the given ID. The ID can be an alias, such
 // as "alias/my-cmk".
-func GetCmkArnE(t TestingT, region string, cmkID string) (string, error) {
+func GetCmkArnE(t testing.TestingT, region string, cmkID string) (string, error) {
 	kmsClient, err := NewKmsClientE(t, region)
 	if err != nil {
 		return "", err
@@ -36,7 +36,7 @@ func GetCmkArnE(t TestingT, region string, cmkID string) (string, error) {
 }
 
 // NewKmsClient creates a KMS client.
-func NewKmsClient(t TestingT, region string) *kms.KMS {
+func NewKmsClient(t testing.TestingT, region string) *kms.KMS {
 	client, err := NewKmsClientE(t, region)
 	if err != nil {
 		t.Fatal(err)
@@ -45,7 +45,7 @@ func NewKmsClient(t TestingT, region string) *kms.KMS {
 }
 
 // NewKmsClientE creates a KMS client.
-func NewKmsClientE(t TestingT, region string) (*kms.KMS, error) {
+func NewKmsClientE(t testing.TestingT, region string) (*kms.KMS, error) {
 	sess, err := NewAuthenticatedSession(region)
 	if err != nil {
 		return nil, err

--- a/modules/aws/kms.go
+++ b/modules/aws/kms.go
@@ -1,15 +1,14 @@
 package aws
 
 import (
-	"testing"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/kms"
+	_ "github.com/gruntwork-io/terratest/modules/testing"
 )
 
 // GetCmkArn gets the ARN of a KMS Customer Master Key (CMK) in the given region with the given ID. The ID can be an alias, such
 // as "alias/my-cmk".
-func GetCmkArn(t *testing.T, region string, cmkID string) string {
+func GetCmkArn(t TestingT, region string, cmkID string) string {
 	out, err := GetCmkArnE(t, region, cmkID)
 	if err != nil {
 		t.Fatal(err)
@@ -19,7 +18,7 @@ func GetCmkArn(t *testing.T, region string, cmkID string) string {
 
 // GetCmkArnE gets the ARN of a KMS Customer Master Key (CMK) in the given region with the given ID. The ID can be an alias, such
 // as "alias/my-cmk".
-func GetCmkArnE(t *testing.T, region string, cmkID string) (string, error) {
+func GetCmkArnE(t TestingT, region string, cmkID string) (string, error) {
 	kmsClient, err := NewKmsClientE(t, region)
 	if err != nil {
 		return "", err
@@ -37,7 +36,7 @@ func GetCmkArnE(t *testing.T, region string, cmkID string) (string, error) {
 }
 
 // NewKmsClient creates a KMS client.
-func NewKmsClient(t *testing.T, region string) *kms.KMS {
+func NewKmsClient(t TestingT, region string) *kms.KMS {
 	client, err := NewKmsClientE(t, region)
 	if err != nil {
 		t.Fatal(err)
@@ -46,7 +45,7 @@ func NewKmsClient(t *testing.T, region string) *kms.KMS {
 }
 
 // NewKmsClientE creates a KMS client.
-func NewKmsClientE(t *testing.T, region string) (*kms.KMS, error) {
+func NewKmsClientE(t TestingT, region string) (*kms.KMS, error) {
 	sess, err := NewAuthenticatedSession(region)
 	if err != nil {
 		return nil, err

--- a/modules/aws/lambda.go
+++ b/modules/aws/lambda.go
@@ -3,21 +3,21 @@ package aws
 import (
 	"encoding/json"
 	"fmt"
-	"testing"
 
 	"github.com/aws/aws-sdk-go/service/lambda"
+	"github.com/gruntwork-io/terratest/modules/testing"
 	"github.com/stretchr/testify/require"
 )
 
 // InvokeFunction invokes a lambda function.
-func InvokeFunction(t *testing.T, region, functionName string, payload interface{}) []byte {
+func InvokeFunction(t testing.TestingT, region, functionName string, payload interface{}) []byte {
 	out, err := InvokeFunctionE(t, region, functionName, payload)
 	require.NoError(t, err)
 	return out
 }
 
 // InvokeFunctionE invokes a lambda function.
-func InvokeFunctionE(t *testing.T, region, functionName string, payload interface{}) ([]byte, error) {
+func InvokeFunctionE(t testing.TestingT, region, functionName string, payload interface{}) ([]byte, error) {
 	lambdaClient, err := NewLambdaClientE(t, region)
 	if err != nil {
 		return nil, err
@@ -60,14 +60,14 @@ func (err *FunctionError) Error() string {
 }
 
 // NewLambdaClient creates a new Lambda client.
-func NewLambdaClient(t *testing.T, region string) *lambda.Lambda {
+func NewLambdaClient(t testing.TestingT, region string) *lambda.Lambda {
 	client, err := NewLambdaClientE(t, region)
 	require.NoError(t, err)
 	return client
 }
 
 // NewLambdaClientE creates a new Lambda client.
-func NewLambdaClientE(t *testing.T, region string) (*lambda.Lambda, error) {
+func NewLambdaClientE(t testing.TestingT, region string) (*lambda.Lambda, error) {
 	sess, err := NewAuthenticatedSession(region)
 	if err != nil {
 		return nil, err

--- a/modules/aws/rds.go
+++ b/modules/aws/rds.go
@@ -8,11 +8,11 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/rds"
 	_ "github.com/go-sql-driver/mysql"
-	_ "github.com/gruntwork-io/terratest/modules/testing"
+	"github.com/gruntwork-io/terratest/modules/testing"
 )
 
 // GetAddressOfRdsInstance gets the address of the given RDS Instance in the given region.
-func GetAddressOfRdsInstance(t TestingT, dbInstanceID string, awsRegion string) string {
+func GetAddressOfRdsInstance(t testing.TestingT, dbInstanceID string, awsRegion string) string {
 	address, err := GetAddressOfRdsInstanceE(t, dbInstanceID, awsRegion)
 	if err != nil {
 		t.Fatal(err)
@@ -21,7 +21,7 @@ func GetAddressOfRdsInstance(t TestingT, dbInstanceID string, awsRegion string) 
 }
 
 // GetAddressOfRdsInstanceE gets the address of the given RDS Instance in the given region.
-func GetAddressOfRdsInstanceE(t TestingT, dbInstanceID string, awsRegion string) (string, error) {
+func GetAddressOfRdsInstanceE(t testing.TestingT, dbInstanceID string, awsRegion string) (string, error) {
 	dbInstance, err := GetRdsInstanceDetailsE(t, dbInstanceID, awsRegion)
 	if err != nil {
 		return "", err
@@ -31,7 +31,7 @@ func GetAddressOfRdsInstanceE(t TestingT, dbInstanceID string, awsRegion string)
 }
 
 // GetPortOfRdsInstance gets the address of the given RDS Instance in the given region.
-func GetPortOfRdsInstance(t TestingT, dbInstanceID string, awsRegion string) int64 {
+func GetPortOfRdsInstance(t testing.TestingT, dbInstanceID string, awsRegion string) int64 {
 	port, err := GetPortOfRdsInstanceE(t, dbInstanceID, awsRegion)
 	if err != nil {
 		t.Fatal(err)
@@ -40,7 +40,7 @@ func GetPortOfRdsInstance(t TestingT, dbInstanceID string, awsRegion string) int
 }
 
 // GetPortOfRdsInstanceE gets the address of the given RDS Instance in the given region.
-func GetPortOfRdsInstanceE(t TestingT, dbInstanceID string, awsRegion string) (int64, error) {
+func GetPortOfRdsInstanceE(t testing.TestingT, dbInstanceID string, awsRegion string) (int64, error) {
 	dbInstance, err := GetRdsInstanceDetailsE(t, dbInstanceID, awsRegion)
 	if err != nil {
 		return -1, err
@@ -50,7 +50,7 @@ func GetPortOfRdsInstanceE(t TestingT, dbInstanceID string, awsRegion string) (i
 }
 
 // GetWhetherSchemaExistsInRdsMySqlInstance checks whether the specified schema/table name exists in the RDS instance
-func GetWhetherSchemaExistsInRdsMySqlInstance(t TestingT, dbUrl string, dbPort int64, dbUsername string, dbPassword string, expectedSchemaName string) bool {
+func GetWhetherSchemaExistsInRdsMySqlInstance(t testing.TestingT, dbUrl string, dbPort int64, dbUsername string, dbPassword string, expectedSchemaName string) bool {
 	output, err := GetWhetherSchemaExistsInRdsMySqlInstanceE(t, dbUrl, dbPort, dbUsername, dbPassword, expectedSchemaName)
 	if err != nil {
 		t.Fatal(err)
@@ -59,7 +59,7 @@ func GetWhetherSchemaExistsInRdsMySqlInstance(t TestingT, dbUrl string, dbPort i
 }
 
 // GetWhetherSchemaExistsInRdsMySqlInstanceE checks whether the specified schema/table name exists in the RDS instance
-func GetWhetherSchemaExistsInRdsMySqlInstanceE(t TestingT, dbUrl string, dbPort int64, dbUsername string, dbPassword string, expectedSchemaName string) (bool, error) {
+func GetWhetherSchemaExistsInRdsMySqlInstanceE(t testing.TestingT, dbUrl string, dbPort int64, dbUsername string, dbPassword string, expectedSchemaName string) (bool, error) {
 	connectionString := fmt.Sprintf("%s:%s@tcp(%s:%d)/", dbUsername, dbPassword, dbUrl, dbPort)
 	db, connErr := sql.Open("mysql", connectionString)
 	if connErr != nil {
@@ -79,7 +79,7 @@ func GetWhetherSchemaExistsInRdsMySqlInstanceE(t TestingT, dbUrl string, dbPort 
 }
 
 // GetParameterValueForParameterOfRdsInstance gets the value of the parameter name specified for the RDS instance in the given region.
-func GetParameterValueForParameterOfRdsInstance(t TestingT, parameterName string, dbInstanceID string, awsRegion string) string {
+func GetParameterValueForParameterOfRdsInstance(t testing.TestingT, parameterName string, dbInstanceID string, awsRegion string) string {
 	parameterValue, err := GetParameterValueForParameterOfRdsInstanceE(t, parameterName, dbInstanceID, awsRegion)
 	if err != nil {
 		t.Fatal(err)
@@ -88,7 +88,7 @@ func GetParameterValueForParameterOfRdsInstance(t TestingT, parameterName string
 }
 
 // GetParameterValueForParameterOfRdsInstanceE gets the value of the parameter name specified for the RDS instance in the given region.
-func GetParameterValueForParameterOfRdsInstanceE(t TestingT, parameterName string, dbInstanceID string, awsRegion string) (string, error) {
+func GetParameterValueForParameterOfRdsInstanceE(t testing.TestingT, parameterName string, dbInstanceID string, awsRegion string) (string, error) {
 	output := GetAllParametersOfRdsInstance(t, dbInstanceID, awsRegion)
 	for _, parameter := range output {
 		if aws.StringValue(parameter.ParameterName) == parameterName {
@@ -99,7 +99,7 @@ func GetParameterValueForParameterOfRdsInstanceE(t TestingT, parameterName strin
 }
 
 // GetOptionSettingForOfRdsInstance gets the value of the option name in the option group specified for the RDS instance in the given region.
-func GetOptionSettingForOfRdsInstance(t TestingT, optionName string, optionSettingName string, dbInstanceID, awsRegion string) string {
+func GetOptionSettingForOfRdsInstance(t testing.TestingT, optionName string, optionSettingName string, dbInstanceID, awsRegion string) string {
 	optionValue, err := GetOptionSettingForOfRdsInstanceE(t, optionName, optionSettingName, dbInstanceID, awsRegion)
 	if err != nil {
 		t.Fatal(err)
@@ -108,7 +108,7 @@ func GetOptionSettingForOfRdsInstance(t TestingT, optionName string, optionSetti
 }
 
 // GetOptionSettingForOfRdsInstanceE gets the value of the option name in the option group specified for the RDS instance in the given region.
-func GetOptionSettingForOfRdsInstanceE(t TestingT, optionName string, optionSettingName string, dbInstanceID, awsRegion string) (string, error) {
+func GetOptionSettingForOfRdsInstanceE(t testing.TestingT, optionName string, optionSettingName string, dbInstanceID, awsRegion string) (string, error) {
 	optionGroupName := GetOptionGroupNameOfRdsInstance(t, dbInstanceID, awsRegion)
 	options := GetOptionsOfOptionGroup(t, optionGroupName, awsRegion)
 	for _, option := range options {
@@ -124,7 +124,7 @@ func GetOptionSettingForOfRdsInstanceE(t TestingT, optionName string, optionSett
 }
 
 // GetOptionGroupNameOfRdsInstance gets the name of the option group associated with the RDS instance
-func GetOptionGroupNameOfRdsInstance(t TestingT, dbInstanceID string, awsRegion string) string {
+func GetOptionGroupNameOfRdsInstance(t testing.TestingT, dbInstanceID string, awsRegion string) string {
 	dbInstance, err := GetOptionGroupNameOfRdsInstanceE(t, dbInstanceID, awsRegion)
 	if err != nil {
 		t.Fatal(err)
@@ -133,7 +133,7 @@ func GetOptionGroupNameOfRdsInstance(t TestingT, dbInstanceID string, awsRegion 
 }
 
 // GetOptionGroupNameOfRdsInstanceE gets the name of the option group associated with the RDS instance
-func GetOptionGroupNameOfRdsInstanceE(t TestingT, dbInstanceID string, awsRegion string) (string, error) {
+func GetOptionGroupNameOfRdsInstanceE(t testing.TestingT, dbInstanceID string, awsRegion string) (string, error) {
 	dbInstance, err := GetRdsInstanceDetailsE(t, dbInstanceID, awsRegion)
 	if err != nil {
 		return "", err
@@ -142,7 +142,7 @@ func GetOptionGroupNameOfRdsInstanceE(t TestingT, dbInstanceID string, awsRegion
 }
 
 // GetOptionsOfOptionGroup gets the options of the option group specified
-func GetOptionsOfOptionGroup(t TestingT, optionGroupName string, awsRegion string) []*rds.Option {
+func GetOptionsOfOptionGroup(t testing.TestingT, optionGroupName string, awsRegion string) []*rds.Option {
 	output, err := GetOptionsOfOptionGroupE(t, optionGroupName, awsRegion)
 	if err != nil {
 		t.Fatal(err)
@@ -151,7 +151,7 @@ func GetOptionsOfOptionGroup(t TestingT, optionGroupName string, awsRegion strin
 }
 
 // GetOptionsOfOptionGroupE gets the options of the option group specified
-func GetOptionsOfOptionGroupE(t TestingT, optionGroupName string, awsRegion string) ([]*rds.Option, error) {
+func GetOptionsOfOptionGroupE(t testing.TestingT, optionGroupName string, awsRegion string) ([]*rds.Option, error) {
 	rdsClient := NewRdsClient(t, awsRegion)
 	input := rds.DescribeOptionGroupsInput{OptionGroupName: aws.String(optionGroupName)}
 	output, err := rdsClient.DescribeOptionGroups(&input)
@@ -162,7 +162,7 @@ func GetOptionsOfOptionGroupE(t TestingT, optionGroupName string, awsRegion stri
 }
 
 // GetAllParametersOfRdsInstance gets all the parameters defined in the parameter group for the RDS instance in the given region.
-func GetAllParametersOfRdsInstance(t TestingT, dbInstanceID string, awsRegion string) []*rds.Parameter {
+func GetAllParametersOfRdsInstance(t testing.TestingT, dbInstanceID string, awsRegion string) []*rds.Parameter {
 	parameters, err := GetAllParametersOfRdsInstanceE(t, dbInstanceID, awsRegion)
 	if err != nil {
 		t.Fatal(err)
@@ -171,7 +171,7 @@ func GetAllParametersOfRdsInstance(t TestingT, dbInstanceID string, awsRegion st
 }
 
 // GetAllParametersOfRdsInstanceE gets all the parameters defined in the parameter group for the RDS instance in the given region.
-func GetAllParametersOfRdsInstanceE(t TestingT, dbInstanceID string, awsRegion string) ([]*rds.Parameter, error) {
+func GetAllParametersOfRdsInstanceE(t testing.TestingT, dbInstanceID string, awsRegion string) ([]*rds.Parameter, error) {
 	dbInstance, dbInstanceErr := GetRdsInstanceDetailsE(t, dbInstanceID, awsRegion)
 	if dbInstanceErr != nil {
 		return []*rds.Parameter{}, dbInstanceErr
@@ -189,7 +189,7 @@ func GetAllParametersOfRdsInstanceE(t TestingT, dbInstanceID string, awsRegion s
 }
 
 // GetRdsInstanceDetailsE gets the details of a single DB instance whose identifier is passed.
-func GetRdsInstanceDetailsE(t TestingT, dbInstanceID string, awsRegion string) (*rds.DBInstance, error) {
+func GetRdsInstanceDetailsE(t testing.TestingT, dbInstanceID string, awsRegion string) (*rds.DBInstance, error) {
 	rdsClient := NewRdsClient(t, awsRegion)
 	input := rds.DescribeDBInstancesInput{DBInstanceIdentifier: aws.String(dbInstanceID)}
 	output, err := rdsClient.DescribeDBInstances(&input)
@@ -200,7 +200,7 @@ func GetRdsInstanceDetailsE(t TestingT, dbInstanceID string, awsRegion string) (
 }
 
 // NewRdsClient creates an RDS client.
-func NewRdsClient(t TestingT, region string) *rds.RDS {
+func NewRdsClient(t testing.TestingT, region string) *rds.RDS {
 	client, err := NewRdsClientE(t, region)
 	if err != nil {
 		t.Fatal(err)
@@ -209,7 +209,7 @@ func NewRdsClient(t TestingT, region string) *rds.RDS {
 }
 
 // NewRdsClientE creates an RDS client.
-func NewRdsClientE(t TestingT, Region string) (*rds.RDS, error) {
+func NewRdsClientE(t testing.TestingT, Region string) (*rds.RDS, error) {
 	sess, err := NewAuthenticatedSession(region)
 	if err != nil {
 		return nil, err

--- a/modules/aws/rds.go
+++ b/modules/aws/rds.go
@@ -3,7 +3,6 @@ package aws
 import (
 	"database/sql"
 	"fmt"
-	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/rds"
@@ -209,7 +208,7 @@ func NewRdsClient(t testing.TestingT, region string) *rds.RDS {
 }
 
 // NewRdsClientE creates an RDS client.
-func NewRdsClientE(t testing.TestingT, Region string) (*rds.RDS, error) {
+func NewRdsClientE(t testing.TestingT, region string) (*rds.RDS, error) {
 	sess, err := NewAuthenticatedSession(region)
 	if err != nil {
 		return nil, err

--- a/modules/aws/rds.go
+++ b/modules/aws/rds.go
@@ -8,10 +8,11 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/rds"
 	_ "github.com/go-sql-driver/mysql"
+	_ "github.com/gruntwork-io/terratest/modules/testing"
 )
 
 // GetAddressOfRdsInstance gets the address of the given RDS Instance in the given region.
-func GetAddressOfRdsInstance(t *testing.T, dbInstanceID string, awsRegion string) string {
+func GetAddressOfRdsInstance(t TestingT, dbInstanceID string, awsRegion string) string {
 	address, err := GetAddressOfRdsInstanceE(t, dbInstanceID, awsRegion)
 	if err != nil {
 		t.Fatal(err)
@@ -20,7 +21,7 @@ func GetAddressOfRdsInstance(t *testing.T, dbInstanceID string, awsRegion string
 }
 
 // GetAddressOfRdsInstanceE gets the address of the given RDS Instance in the given region.
-func GetAddressOfRdsInstanceE(t *testing.T, dbInstanceID string, awsRegion string) (string, error) {
+func GetAddressOfRdsInstanceE(t TestingT, dbInstanceID string, awsRegion string) (string, error) {
 	dbInstance, err := GetRdsInstanceDetailsE(t, dbInstanceID, awsRegion)
 	if err != nil {
 		return "", err
@@ -30,7 +31,7 @@ func GetAddressOfRdsInstanceE(t *testing.T, dbInstanceID string, awsRegion strin
 }
 
 // GetPortOfRdsInstance gets the address of the given RDS Instance in the given region.
-func GetPortOfRdsInstance(t *testing.T, dbInstanceID string, awsRegion string) int64 {
+func GetPortOfRdsInstance(t TestingT, dbInstanceID string, awsRegion string) int64 {
 	port, err := GetPortOfRdsInstanceE(t, dbInstanceID, awsRegion)
 	if err != nil {
 		t.Fatal(err)
@@ -39,7 +40,7 @@ func GetPortOfRdsInstance(t *testing.T, dbInstanceID string, awsRegion string) i
 }
 
 // GetPortOfRdsInstanceE gets the address of the given RDS Instance in the given region.
-func GetPortOfRdsInstanceE(t *testing.T, dbInstanceID string, awsRegion string) (int64, error) {
+func GetPortOfRdsInstanceE(t TestingT, dbInstanceID string, awsRegion string) (int64, error) {
 	dbInstance, err := GetRdsInstanceDetailsE(t, dbInstanceID, awsRegion)
 	if err != nil {
 		return -1, err
@@ -49,7 +50,7 @@ func GetPortOfRdsInstanceE(t *testing.T, dbInstanceID string, awsRegion string) 
 }
 
 // GetWhetherSchemaExistsInRdsMySqlInstance checks whether the specified schema/table name exists in the RDS instance
-func GetWhetherSchemaExistsInRdsMySqlInstance(t *testing.T, dbUrl string, dbPort int64, dbUsername string, dbPassword string, expectedSchemaName string) bool {
+func GetWhetherSchemaExistsInRdsMySqlInstance(t TestingT, dbUrl string, dbPort int64, dbUsername string, dbPassword string, expectedSchemaName string) bool {
 	output, err := GetWhetherSchemaExistsInRdsMySqlInstanceE(t, dbUrl, dbPort, dbUsername, dbPassword, expectedSchemaName)
 	if err != nil {
 		t.Fatal(err)
@@ -58,7 +59,7 @@ func GetWhetherSchemaExistsInRdsMySqlInstance(t *testing.T, dbUrl string, dbPort
 }
 
 // GetWhetherSchemaExistsInRdsMySqlInstanceE checks whether the specified schema/table name exists in the RDS instance
-func GetWhetherSchemaExistsInRdsMySqlInstanceE(t *testing.T, dbUrl string, dbPort int64, dbUsername string, dbPassword string, expectedSchemaName string) (bool, error) {
+func GetWhetherSchemaExistsInRdsMySqlInstanceE(t TestingT, dbUrl string, dbPort int64, dbUsername string, dbPassword string, expectedSchemaName string) (bool, error) {
 	connectionString := fmt.Sprintf("%s:%s@tcp(%s:%d)/", dbUsername, dbPassword, dbUrl, dbPort)
 	db, connErr := sql.Open("mysql", connectionString)
 	if connErr != nil {
@@ -78,7 +79,7 @@ func GetWhetherSchemaExistsInRdsMySqlInstanceE(t *testing.T, dbUrl string, dbPor
 }
 
 // GetParameterValueForParameterOfRdsInstance gets the value of the parameter name specified for the RDS instance in the given region.
-func GetParameterValueForParameterOfRdsInstance(t *testing.T, parameterName string, dbInstanceID string, awsRegion string) string {
+func GetParameterValueForParameterOfRdsInstance(t TestingT, parameterName string, dbInstanceID string, awsRegion string) string {
 	parameterValue, err := GetParameterValueForParameterOfRdsInstanceE(t, parameterName, dbInstanceID, awsRegion)
 	if err != nil {
 		t.Fatal(err)
@@ -87,7 +88,7 @@ func GetParameterValueForParameterOfRdsInstance(t *testing.T, parameterName stri
 }
 
 // GetParameterValueForParameterOfRdsInstanceE gets the value of the parameter name specified for the RDS instance in the given region.
-func GetParameterValueForParameterOfRdsInstanceE(t *testing.T, parameterName string, dbInstanceID string, awsRegion string) (string, error) {
+func GetParameterValueForParameterOfRdsInstanceE(t TestingT, parameterName string, dbInstanceID string, awsRegion string) (string, error) {
 	output := GetAllParametersOfRdsInstance(t, dbInstanceID, awsRegion)
 	for _, parameter := range output {
 		if aws.StringValue(parameter.ParameterName) == parameterName {
@@ -98,7 +99,7 @@ func GetParameterValueForParameterOfRdsInstanceE(t *testing.T, parameterName str
 }
 
 // GetOptionSettingForOfRdsInstance gets the value of the option name in the option group specified for the RDS instance in the given region.
-func GetOptionSettingForOfRdsInstance(t *testing.T, optionName string, optionSettingName string, dbInstanceID, awsRegion string) string {
+func GetOptionSettingForOfRdsInstance(t TestingT, optionName string, optionSettingName string, dbInstanceID, awsRegion string) string {
 	optionValue, err := GetOptionSettingForOfRdsInstanceE(t, optionName, optionSettingName, dbInstanceID, awsRegion)
 	if err != nil {
 		t.Fatal(err)
@@ -107,7 +108,7 @@ func GetOptionSettingForOfRdsInstance(t *testing.T, optionName string, optionSet
 }
 
 // GetOptionSettingForOfRdsInstanceE gets the value of the option name in the option group specified for the RDS instance in the given region.
-func GetOptionSettingForOfRdsInstanceE(t *testing.T, optionName string, optionSettingName string, dbInstanceID, awsRegion string) (string, error) {
+func GetOptionSettingForOfRdsInstanceE(t TestingT, optionName string, optionSettingName string, dbInstanceID, awsRegion string) (string, error) {
 	optionGroupName := GetOptionGroupNameOfRdsInstance(t, dbInstanceID, awsRegion)
 	options := GetOptionsOfOptionGroup(t, optionGroupName, awsRegion)
 	for _, option := range options {
@@ -123,7 +124,7 @@ func GetOptionSettingForOfRdsInstanceE(t *testing.T, optionName string, optionSe
 }
 
 // GetOptionGroupNameOfRdsInstance gets the name of the option group associated with the RDS instance
-func GetOptionGroupNameOfRdsInstance(t *testing.T, dbInstanceID string, awsRegion string) string {
+func GetOptionGroupNameOfRdsInstance(t TestingT, dbInstanceID string, awsRegion string) string {
 	dbInstance, err := GetOptionGroupNameOfRdsInstanceE(t, dbInstanceID, awsRegion)
 	if err != nil {
 		t.Fatal(err)
@@ -132,7 +133,7 @@ func GetOptionGroupNameOfRdsInstance(t *testing.T, dbInstanceID string, awsRegio
 }
 
 // GetOptionGroupNameOfRdsInstanceE gets the name of the option group associated with the RDS instance
-func GetOptionGroupNameOfRdsInstanceE(t *testing.T, dbInstanceID string, awsRegion string) (string, error) {
+func GetOptionGroupNameOfRdsInstanceE(t TestingT, dbInstanceID string, awsRegion string) (string, error) {
 	dbInstance, err := GetRdsInstanceDetailsE(t, dbInstanceID, awsRegion)
 	if err != nil {
 		return "", err
@@ -141,7 +142,7 @@ func GetOptionGroupNameOfRdsInstanceE(t *testing.T, dbInstanceID string, awsRegi
 }
 
 // GetOptionsOfOptionGroup gets the options of the option group specified
-func GetOptionsOfOptionGroup(t *testing.T, optionGroupName string, awsRegion string) []*rds.Option {
+func GetOptionsOfOptionGroup(t TestingT, optionGroupName string, awsRegion string) []*rds.Option {
 	output, err := GetOptionsOfOptionGroupE(t, optionGroupName, awsRegion)
 	if err != nil {
 		t.Fatal(err)
@@ -150,7 +151,7 @@ func GetOptionsOfOptionGroup(t *testing.T, optionGroupName string, awsRegion str
 }
 
 // GetOptionsOfOptionGroupE gets the options of the option group specified
-func GetOptionsOfOptionGroupE(t *testing.T, optionGroupName string, awsRegion string) ([]*rds.Option, error) {
+func GetOptionsOfOptionGroupE(t TestingT, optionGroupName string, awsRegion string) ([]*rds.Option, error) {
 	rdsClient := NewRdsClient(t, awsRegion)
 	input := rds.DescribeOptionGroupsInput{OptionGroupName: aws.String(optionGroupName)}
 	output, err := rdsClient.DescribeOptionGroups(&input)
@@ -161,7 +162,7 @@ func GetOptionsOfOptionGroupE(t *testing.T, optionGroupName string, awsRegion st
 }
 
 // GetAllParametersOfRdsInstance gets all the parameters defined in the parameter group for the RDS instance in the given region.
-func GetAllParametersOfRdsInstance(t *testing.T, dbInstanceID string, awsRegion string) []*rds.Parameter {
+func GetAllParametersOfRdsInstance(t TestingT, dbInstanceID string, awsRegion string) []*rds.Parameter {
 	parameters, err := GetAllParametersOfRdsInstanceE(t, dbInstanceID, awsRegion)
 	if err != nil {
 		t.Fatal(err)
@@ -170,7 +171,7 @@ func GetAllParametersOfRdsInstance(t *testing.T, dbInstanceID string, awsRegion 
 }
 
 // GetAllParametersOfRdsInstanceE gets all the parameters defined in the parameter group for the RDS instance in the given region.
-func GetAllParametersOfRdsInstanceE(t *testing.T, dbInstanceID string, awsRegion string) ([]*rds.Parameter, error) {
+func GetAllParametersOfRdsInstanceE(t TestingT, dbInstanceID string, awsRegion string) ([]*rds.Parameter, error) {
 	dbInstance, dbInstanceErr := GetRdsInstanceDetailsE(t, dbInstanceID, awsRegion)
 	if dbInstanceErr != nil {
 		return []*rds.Parameter{}, dbInstanceErr
@@ -188,7 +189,7 @@ func GetAllParametersOfRdsInstanceE(t *testing.T, dbInstanceID string, awsRegion
 }
 
 // GetRdsInstanceDetailsE gets the details of a single DB instance whose identifier is passed.
-func GetRdsInstanceDetailsE(t *testing.T, dbInstanceID string, awsRegion string) (*rds.DBInstance, error) {
+func GetRdsInstanceDetailsE(t TestingT, dbInstanceID string, awsRegion string) (*rds.DBInstance, error) {
 	rdsClient := NewRdsClient(t, awsRegion)
 	input := rds.DescribeDBInstancesInput{DBInstanceIdentifier: aws.String(dbInstanceID)}
 	output, err := rdsClient.DescribeDBInstances(&input)
@@ -199,7 +200,7 @@ func GetRdsInstanceDetailsE(t *testing.T, dbInstanceID string, awsRegion string)
 }
 
 // NewRdsClient creates an RDS client.
-func NewRdsClient(t *testing.T, region string) *rds.RDS {
+func NewRdsClient(t TestingT, region string) *rds.RDS {
 	client, err := NewRdsClientE(t, region)
 	if err != nil {
 		t.Fatal(err)
@@ -208,7 +209,7 @@ func NewRdsClient(t *testing.T, region string) *rds.RDS {
 }
 
 // NewRdsClientE creates an RDS client.
-func NewRdsClientE(t *testing.T, region string) (*rds.RDS, error) {
+func NewRdsClientE(t TestingT, Region string) (*rds.RDS, error) {
 	sess, err := NewAuthenticatedSession(region)
 	if err != nil {
 		return nil, err

--- a/modules/aws/region.go
+++ b/modules/aws/region.go
@@ -9,7 +9,7 @@ import (
 	"github.com/gruntwork-io/terratest/modules/collections"
 	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/random"
-	_ "github.com/gruntwork-io/terratest/modules/testing"
+	"github.com/gruntwork-io/terratest/modules/testing"
 )
 
 // You can set this environment variable to force Terratest to use a specific region rather than a random one. This is
@@ -44,7 +44,7 @@ var stableRegions = []string{
 // further restrict the stable region list using approvedRegions and forbiddenRegions. We consider stable regions to be
 // those that have been around for at least 1 year.
 // Note that regions in the approvedRegions list that are not considered stable are ignored.
-func GetRandomStableRegion(t TestingT, approvedRegions []string, forbiddenRegions []string) string {
+func GetRandomStableRegion(t testing.TestingT, approvedRegions []string, forbiddenRegions []string) string {
 	regionsToPickFrom := stableRegions
 	if len(approvedRegions) > 0 {
 		regionsToPickFrom = collections.ListIntersection(regionsToPickFrom, approvedRegions)
@@ -58,7 +58,7 @@ func GetRandomStableRegion(t TestingT, approvedRegions []string, forbiddenRegion
 // GetRandomRegion gets a randomly chosen AWS region. If approvedRegions is not empty, this will be a region from the approvedRegions
 // list; otherwise, this method will fetch the latest list of regions from the AWS APIs and pick one of those. If
 // forbiddenRegions is not empty, this method will make sure the returned region is not in the forbiddenRegions list.
-func GetRandomRegion(t TestingT, approvedRegions []string, forbiddenRegions []string) string {
+func GetRandomRegion(t testing.TestingT, approvedRegions []string, forbiddenRegions []string) string {
 	region, err := GetRandomRegionE(t, approvedRegions, forbiddenRegions)
 	if err != nil {
 		t.Fatal(err)
@@ -69,7 +69,7 @@ func GetRandomRegion(t TestingT, approvedRegions []string, forbiddenRegions []st
 // GetRandomRegionE gets a randomly chosen AWS region. If approvedRegions is not empty, this will be a region from the approvedRegions
 // list; otherwise, this method will fetch the latest list of regions from the AWS APIs and pick one of those. If
 // forbiddenRegions is not empty, this method will make sure the returned region is not in the forbiddenRegions list.
-func GetRandomRegionE(t TestingT, approvedRegions []string, forbiddenRegions []string) (string, error) {
+func GetRandomRegionE(t testing.TestingT, approvedRegions []string, forbiddenRegions []string) (string, error) {
 	regionFromEnvVar := os.Getenv(regionOverrideEnvVarName)
 	if regionFromEnvVar != "" {
 		logger.Logf(t, "Using AWS region %s from environment variable %s", regionFromEnvVar, regionOverrideEnvVarName)
@@ -94,7 +94,7 @@ func GetRandomRegionE(t TestingT, approvedRegions []string, forbiddenRegions []s
 }
 
 // GetAllAwsRegions gets the list of AWS regions available in this account.
-func GetAllAwsRegions(t TestingT) []string {
+func GetAllAwsRegions(t testing.TestingT) []string {
 	out, err := GetAllAwsRegionsE(t)
 	if err != nil {
 		t.Fatal(err)
@@ -103,7 +103,7 @@ func GetAllAwsRegions(t TestingT) []string {
 }
 
 // GetAllAwsRegionsE gets the list of AWS regions available in this account.
-func GetAllAwsRegionsE(t TestingT) ([]string, error) {
+func GetAllAwsRegionsE(t testing.TestingT) ([]string, error) {
 	logger.Log(t, "Looking up all AWS regions available in this account")
 
 	ec2Client, err := NewEc2ClientE(t, defaultRegion)
@@ -126,7 +126,7 @@ func GetAllAwsRegionsE(t TestingT) ([]string, error) {
 
 // GetAvailabilityZones gets the Availability Zones for a given AWS region. Note that for certain regions (e.g. us-east-1), different AWS
 // accounts have access to different availability zones.
-func GetAvailabilityZones(t TestingT, region string) []string {
+func GetAvailabilityZones(t testing.TestingT, region string) []string {
 	out, err := GetAvailabilityZonesE(t, region)
 	if err != nil {
 		t.Fatal(err)
@@ -136,7 +136,7 @@ func GetAvailabilityZones(t TestingT, region string) []string {
 
 // GetAvailabilityZonesE gets the Availability Zones for a given AWS region. Note that for certain regions (e.g. us-east-1), different AWS
 // accounts have access to different availability zones.
-func GetAvailabilityZonesE(t TestingT, region string) ([]string, error) {
+func GetAvailabilityZonesE(t testing.TestingT, region string) ([]string, error) {
 	logger.Logf(t, "Looking up all availability zones available in this account for region %s", region)
 
 	ec2Client, err := NewEc2ClientE(t, region)

--- a/modules/aws/region.go
+++ b/modules/aws/region.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gruntwork-io/terratest/modules/collections"
 	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/random"
+	_ "github.com/gruntwork-io/terratest/modules/testing"
 )
 
 // You can set this environment variable to force Terratest to use a specific region rather than a random one. This is
@@ -43,7 +44,7 @@ var stableRegions = []string{
 // further restrict the stable region list using approvedRegions and forbiddenRegions. We consider stable regions to be
 // those that have been around for at least 1 year.
 // Note that regions in the approvedRegions list that are not considered stable are ignored.
-func GetRandomStableRegion(t *testing.T, approvedRegions []string, forbiddenRegions []string) string {
+func GetRandomStableRegion(t TestingT, approvedRegions []string, forbiddenRegions []string) string {
 	regionsToPickFrom := stableRegions
 	if len(approvedRegions) > 0 {
 		regionsToPickFrom = collections.ListIntersection(regionsToPickFrom, approvedRegions)
@@ -57,7 +58,7 @@ func GetRandomStableRegion(t *testing.T, approvedRegions []string, forbiddenRegi
 // GetRandomRegion gets a randomly chosen AWS region. If approvedRegions is not empty, this will be a region from the approvedRegions
 // list; otherwise, this method will fetch the latest list of regions from the AWS APIs and pick one of those. If
 // forbiddenRegions is not empty, this method will make sure the returned region is not in the forbiddenRegions list.
-func GetRandomRegion(t *testing.T, approvedRegions []string, forbiddenRegions []string) string {
+func GetRandomRegion(t TestingT, approvedRegions []string, forbiddenRegions []string) string {
 	region, err := GetRandomRegionE(t, approvedRegions, forbiddenRegions)
 	if err != nil {
 		t.Fatal(err)
@@ -68,7 +69,7 @@ func GetRandomRegion(t *testing.T, approvedRegions []string, forbiddenRegions []
 // GetRandomRegionE gets a randomly chosen AWS region. If approvedRegions is not empty, this will be a region from the approvedRegions
 // list; otherwise, this method will fetch the latest list of regions from the AWS APIs and pick one of those. If
 // forbiddenRegions is not empty, this method will make sure the returned region is not in the forbiddenRegions list.
-func GetRandomRegionE(t *testing.T, approvedRegions []string, forbiddenRegions []string) (string, error) {
+func GetRandomRegionE(t TestingT, approvedRegions []string, forbiddenRegions []string) (string, error) {
 	regionFromEnvVar := os.Getenv(regionOverrideEnvVarName)
 	if regionFromEnvVar != "" {
 		logger.Logf(t, "Using AWS region %s from environment variable %s", regionFromEnvVar, regionOverrideEnvVarName)
@@ -93,7 +94,7 @@ func GetRandomRegionE(t *testing.T, approvedRegions []string, forbiddenRegions [
 }
 
 // GetAllAwsRegions gets the list of AWS regions available in this account.
-func GetAllAwsRegions(t *testing.T) []string {
+func GetAllAwsRegions(t TestingT) []string {
 	out, err := GetAllAwsRegionsE(t)
 	if err != nil {
 		t.Fatal(err)
@@ -102,7 +103,7 @@ func GetAllAwsRegions(t *testing.T) []string {
 }
 
 // GetAllAwsRegionsE gets the list of AWS regions available in this account.
-func GetAllAwsRegionsE(t *testing.T) ([]string, error) {
+func GetAllAwsRegionsE(t TestingT) ([]string, error) {
 	logger.Log(t, "Looking up all AWS regions available in this account")
 
 	ec2Client, err := NewEc2ClientE(t, defaultRegion)
@@ -125,7 +126,7 @@ func GetAllAwsRegionsE(t *testing.T) ([]string, error) {
 
 // GetAvailabilityZones gets the Availability Zones for a given AWS region. Note that for certain regions (e.g. us-east-1), different AWS
 // accounts have access to different availability zones.
-func GetAvailabilityZones(t *testing.T, region string) []string {
+func GetAvailabilityZones(t TestingT, region string) []string {
 	out, err := GetAvailabilityZonesE(t, region)
 	if err != nil {
 		t.Fatal(err)
@@ -135,7 +136,7 @@ func GetAvailabilityZones(t *testing.T, region string) []string {
 
 // GetAvailabilityZonesE gets the Availability Zones for a given AWS region. Note that for certain regions (e.g. us-east-1), different AWS
 // accounts have access to different availability zones.
-func GetAvailabilityZonesE(t *testing.T, region string) ([]string, error) {
+func GetAvailabilityZonesE(t TestingT, region string) ([]string, error) {
 	logger.Logf(t, "Looking up all availability zones available in this account for region %s", region)
 
 	ec2Client, err := NewEc2ClientE(t, region)

--- a/modules/aws/region.go
+++ b/modules/aws/region.go
@@ -2,7 +2,6 @@ package aws
 
 import (
 	"os"
-	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"

--- a/modules/aws/s3.go
+++ b/modules/aws/s3.go
@@ -9,11 +9,12 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
 	"github.com/gruntwork-io/terratest/modules/logger"
+	_ "github.com/gruntwork-io/terratest/modules/testing"
 	"github.com/stretchr/testify/require"
 )
 
 // FindS3BucketWithTag finds the name of the S3 bucket in the given region with the given tag key=value.
-func FindS3BucketWithTag(t *testing.T, awsRegion string, key string, value string) string {
+func FindS3BucketWithTag(t TestingT, awsRegion string, key string, value string) string {
 	bucket, err := FindS3BucketWithTagE(t, awsRegion, key, value)
 	require.NoError(t, err)
 
@@ -21,7 +22,7 @@ func FindS3BucketWithTag(t *testing.T, awsRegion string, key string, value strin
 }
 
 // FindS3BucketWithTagE finds the name of the S3 bucket in the given region with the given tag key=value.
-func FindS3BucketWithTagE(t *testing.T, awsRegion string, key string, value string) (string, error) {
+func FindS3BucketWithTagE(t TestingT, awsRegion string, key string, value string) (string, error) {
 	s3Client, err := NewS3ClientE(t, awsRegion)
 	if err != nil {
 		return "", err
@@ -55,7 +56,7 @@ func FindS3BucketWithTagE(t *testing.T, awsRegion string, key string, value stri
 }
 
 // GetS3ObjectContents fetches the contents of the object in the given bucket with the given key and return it as a string.
-func GetS3ObjectContents(t *testing.T, awsRegion string, bucket string, key string) string {
+func GetS3ObjectContents(t TestingT, awsRegion string, bucket string, key string) string {
 	contents, err := GetS3ObjectContentsE(t, awsRegion, bucket, key)
 	require.NoError(t, err)
 
@@ -63,7 +64,7 @@ func GetS3ObjectContents(t *testing.T, awsRegion string, bucket string, key stri
 }
 
 // GetS3ObjectContentsE fetches the contents of the object in the given bucket with the given key and return it as a string.
-func GetS3ObjectContentsE(t *testing.T, awsRegion string, bucket string, key string) (string, error) {
+func GetS3ObjectContentsE(t TestingT, awsRegion string, bucket string, key string) (string, error) {
 	s3Client, err := NewS3ClientE(t, awsRegion)
 	if err != nil {
 		return "", err
@@ -91,13 +92,13 @@ func GetS3ObjectContentsE(t *testing.T, awsRegion string, bucket string, key str
 }
 
 // CreateS3Bucket creates an S3 bucket in the given region with the given name. Note that S3 bucket names must be globally unique.
-func CreateS3Bucket(t *testing.T, region string, name string) {
+func CreateS3Bucket(t TestingT, region string, name string) {
 	err := CreateS3BucketE(t, region, name)
 	require.NoError(t, err)
 }
 
 // CreateS3BucketE creates an S3 bucket in the given region with the given name. Note that S3 bucket names must be globally unique.
-func CreateS3BucketE(t *testing.T, region string, name string) error {
+func CreateS3BucketE(t TestingT, region string, name string) error {
 	logger.Logf(t, "Creating bucket %s in %s", name, region)
 
 	s3Client, err := NewS3ClientE(t, region)
@@ -113,13 +114,13 @@ func CreateS3BucketE(t *testing.T, region string, name string) error {
 }
 
 // PutS3BucketPolicy applies an IAM resource policy to a given S3 bucket to create it's bucket policy
-func PutS3BucketPolicy(t *testing.T, region string, bucketName string, policyJSONString string) {
+func PutS3BucketPolicy(t TestingT, region string, bucketName string, policyJSONString string) {
 	err := PutS3BucketPolicyE(t, region, bucketName, policyJSONString)
 	require.NoError(t, err)
 }
 
 // PutS3BucketPolicyE applies an IAM resource policy to a given S3 bucket to create it's bucket policy
-func PutS3BucketPolicyE(t *testing.T, region string, bucketName string, policyJSONString string) error {
+func PutS3BucketPolicyE(t TestingT, region string, bucketName string, policyJSONString string) error {
 	logger.Logf(t, "Applying bucket policy for bucket %s in %s", bucketName, region)
 
 	s3Client, err := NewS3ClientE(t, region)
@@ -137,13 +138,13 @@ func PutS3BucketPolicyE(t *testing.T, region string, bucketName string, policyJS
 }
 
 // PutS3BucketVersioning creates an S3 bucket versioning configuration in the given region against the given bucket name, WITHOUT requiring MFA to remove versioning.
-func PutS3BucketVersioning(t *testing.T, region string, bucketName string) {
+func PutS3BucketVersioning(t TestingT, region string, bucketName string) {
 	err := PutS3BucketVersioningE(t, region, bucketName)
 	require.NoError(t, err)
 }
 
 // PutS3BucketVersioningE creates an S3 bucket versioning configuration in the given region against the given bucket name, WITHOUT requiring MFA to remove versioning.
-func PutS3BucketVersioningE(t *testing.T, region string, bucketName string) error {
+func PutS3BucketVersioningE(t TestingT, region string, bucketName string) error {
 	logger.Logf(t, "Creating bucket versioning configuration for bucket %s in %s", bucketName, region)
 
 	s3Client, err := NewS3ClientE(t, region)
@@ -164,13 +165,13 @@ func PutS3BucketVersioningE(t *testing.T, region string, bucketName string) erro
 }
 
 // DeleteS3Bucket destroys the S3 bucket in the given region with the given name.
-func DeleteS3Bucket(t *testing.T, region string, name string) {
+func DeleteS3Bucket(t TestingT, region string, name string) {
 	err := DeleteS3BucketE(t, region, name)
 	require.NoError(t, err)
 }
 
 // DeleteS3BucketE destroys the S3 bucket in the given region with the given name.
-func DeleteS3BucketE(t *testing.T, region string, name string) error {
+func DeleteS3BucketE(t TestingT, region string, name string) error {
 	logger.Logf(t, "Deleting bucket %s in %s", region, name)
 
 	s3Client, err := NewS3ClientE(t, region)
@@ -186,13 +187,13 @@ func DeleteS3BucketE(t *testing.T, region string, name string) error {
 }
 
 // EmptyS3Bucket removes the contents of an S3 bucket in the given region with the given name.
-func EmptyS3Bucket(t *testing.T, region string, name string) {
+func EmptyS3Bucket(t TestingT, region string, name string) {
 	err := EmptyS3BucketE(t, region, name)
 	require.NoError(t, err)
 }
 
 // EmptyS3BucketE removes the contents of an S3 bucket in the given region with the given name.
-func EmptyS3BucketE(t *testing.T, region string, name string) error {
+func EmptyS3BucketE(t TestingT, region string, name string) error {
 	logger.Logf(t, "Emptying bucket %s in %s", name, region)
 
 	s3Client, err := NewS3ClientE(t, region)
@@ -253,7 +254,7 @@ func EmptyS3BucketE(t *testing.T, region string, name string) error {
 }
 
 // GetS3BucketVersioning fetches the given bucket's versioning configuration status and returns it as a string
-func GetS3BucketVersioning(t *testing.T, awsRegion string, bucket string) string {
+func GetS3BucketVersioning(t TestingT, awsRegion string, bucket string) string {
 	versioningStatus, err := GetS3BucketVersioningE(t, awsRegion, bucket)
 	require.NoError(t, err)
 
@@ -261,7 +262,7 @@ func GetS3BucketVersioning(t *testing.T, awsRegion string, bucket string) string
 }
 
 // GetS3BucketVersioningE fetches the given bucket's versioning configuration status and returns it as a string
-func GetS3BucketVersioningE(t *testing.T, awsRegion string, bucket string) (string, error) {
+func GetS3BucketVersioningE(t TestingT, awsRegion string, bucket string) (string, error) {
 	s3Client, err := NewS3ClientE(t, awsRegion)
 	if err != nil {
 		return "", err
@@ -278,7 +279,7 @@ func GetS3BucketVersioningE(t *testing.T, awsRegion string, bucket string) (stri
 }
 
 // GetS3BucketPolicy fetches the given bucket's resource policy and returns it as a string
-func GetS3BucketPolicy(t *testing.T, awsRegion string, bucket string) string {
+func GetS3BucketPolicy(t TestingT, awsRegion string, bucket string) string {
 	bucketPolicy, err := GetS3BucketPolicyE(t, awsRegion, bucket)
 	require.NoError(t, err)
 
@@ -286,7 +287,7 @@ func GetS3BucketPolicy(t *testing.T, awsRegion string, bucket string) string {
 }
 
 // GetS3BucketPolicyE fetches the given bucket's resource policy and returns it as a string
-func GetS3BucketPolicyE(t *testing.T, awsRegion string, bucket string) (string, error) {
+func GetS3BucketPolicyE(t TestingT, awsRegion string, bucket string) (string, error) {
 	s3Client, err := NewS3ClientE(t, awsRegion)
 	if err != nil {
 		return "", err
@@ -303,13 +304,13 @@ func GetS3BucketPolicyE(t *testing.T, awsRegion string, bucket string) (string, 
 }
 
 // AssertS3BucketExists checks if the given S3 bucket exists in the given region and fail the test if it does not.
-func AssertS3BucketExists(t *testing.T, region string, name string) {
+func AssertS3BucketExists(t TestingT, region string, name string) {
 	err := AssertS3BucketExistsE(t, region, name)
 	require.NoError(t, err)
 }
 
 // AssertS3BucketExistsE checks if the given S3 bucket exists in the given region and return an error if it does not.
-func AssertS3BucketExistsE(t *testing.T, region string, name string) error {
+func AssertS3BucketExistsE(t TestingT, region string, name string) error {
 	s3Client, err := NewS3ClientE(t, region)
 	if err != nil {
 		return err
@@ -323,13 +324,13 @@ func AssertS3BucketExistsE(t *testing.T, region string, name string) error {
 }
 
 // AssertS3BucketVersioningExists checks if the given S3 bucket has a versioning configuration enabled and returns an error if it does not.
-func AssertS3BucketVersioningExists(t *testing.T, region string, bucketName string) {
+func AssertS3BucketVersioningExists(t TestingT, region string, bucketName string) {
 	err := AssertS3BucketVersioningExistsE(t, region, bucketName)
 	require.NoError(t, err)
 }
 
 // AssertS3BucketVersioningExistsE checks if the given S3 bucket has a versioning configuration enabled and returns an error if it does not.
-func AssertS3BucketVersioningExistsE(t *testing.T, region string, bucketName string) error {
+func AssertS3BucketVersioningExistsE(t TestingT, region string, bucketName string) error {
 	status, err := GetS3BucketVersioningE(t, region, bucketName)
 	if err != nil {
 		return err
@@ -342,13 +343,13 @@ func AssertS3BucketVersioningExistsE(t *testing.T, region string, bucketName str
 }
 
 // AssertS3BucketPolicyExists checks if the given S3 bucket has a resource policy attached and returns an error if it does not
-func AssertS3BucketPolicyExists(t *testing.T, region string, bucketName string) {
+func AssertS3BucketPolicyExists(t TestingT, region string, bucketName string) {
 	err := AssertS3BucketPolicyExistsE(t, region, bucketName)
 	require.NoError(t, err)
 }
 
 // AssertS3BucketPolicyExistsE checks if the given S3 bucket has a resource policy attached and returns an error if it does not
-func AssertS3BucketPolicyExistsE(t *testing.T, region string, bucketName string) error {
+func AssertS3BucketPolicyExistsE(t TestingT, region string, bucketName string) error {
 	policy, err := GetS3BucketPolicyE(t, region, bucketName)
 	if err != nil {
 		return err
@@ -361,7 +362,7 @@ func AssertS3BucketPolicyExistsE(t *testing.T, region string, bucketName string)
 }
 
 // NewS3Client creates an S3 client.
-func NewS3Client(t *testing.T, region string) *s3.S3 {
+func NewS3Client(t TestingT, region string) *s3.S3 {
 	client, err := NewS3ClientE(t, region)
 	require.NoError(t, err)
 
@@ -369,7 +370,7 @@ func NewS3Client(t *testing.T, region string) *s3.S3 {
 }
 
 // NewS3ClientE creates an S3 client.
-func NewS3ClientE(t *testing.T, region string) (*s3.S3, error) {
+func NewS3ClientE(t TestingT, region string) (*s3.S3, error) {
 	sess, err := NewAuthenticatedSession(region)
 	if err != nil {
 		return nil, err
@@ -379,14 +380,14 @@ func NewS3ClientE(t *testing.T, region string) (*s3.S3, error) {
 }
 
 // NewS3Uploader creates an S3 Uploader.
-func NewS3Uploader(t *testing.T, region string) *s3manager.Uploader {
+func NewS3Uploader(t TestingT, region string) *s3manager.Uploader {
 	uploader, err := NewS3UploaderE(t, region)
 	require.NoError(t, err)
 	return uploader
 }
 
 // NewS3UploaderE creates an S3 Uploader.
-func NewS3UploaderE(t *testing.T, region string) (*s3manager.Uploader, error) {
+func NewS3UploaderE(t TestingT, region string) (*s3manager.Uploader, error) {
 	sess, err := NewAuthenticatedSession(region)
 	if err != nil {
 		return nil, err

--- a/modules/aws/s3.go
+++ b/modules/aws/s3.go
@@ -3,7 +3,6 @@ package aws
 import (
 	"bytes"
 	"strings"
-	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/s3"

--- a/modules/aws/s3.go
+++ b/modules/aws/s3.go
@@ -9,12 +9,12 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
 	"github.com/gruntwork-io/terratest/modules/logger"
-	_ "github.com/gruntwork-io/terratest/modules/testing"
+	"github.com/gruntwork-io/terratest/modules/testing"
 	"github.com/stretchr/testify/require"
 )
 
 // FindS3BucketWithTag finds the name of the S3 bucket in the given region with the given tag key=value.
-func FindS3BucketWithTag(t TestingT, awsRegion string, key string, value string) string {
+func FindS3BucketWithTag(t testing.TestingT, awsRegion string, key string, value string) string {
 	bucket, err := FindS3BucketWithTagE(t, awsRegion, key, value)
 	require.NoError(t, err)
 
@@ -22,7 +22,7 @@ func FindS3BucketWithTag(t TestingT, awsRegion string, key string, value string)
 }
 
 // FindS3BucketWithTagE finds the name of the S3 bucket in the given region with the given tag key=value.
-func FindS3BucketWithTagE(t TestingT, awsRegion string, key string, value string) (string, error) {
+func FindS3BucketWithTagE(t testing.TestingT, awsRegion string, key string, value string) (string, error) {
 	s3Client, err := NewS3ClientE(t, awsRegion)
 	if err != nil {
 		return "", err
@@ -56,7 +56,7 @@ func FindS3BucketWithTagE(t TestingT, awsRegion string, key string, value string
 }
 
 // GetS3ObjectContents fetches the contents of the object in the given bucket with the given key and return it as a string.
-func GetS3ObjectContents(t TestingT, awsRegion string, bucket string, key string) string {
+func GetS3ObjectContents(t testing.TestingT, awsRegion string, bucket string, key string) string {
 	contents, err := GetS3ObjectContentsE(t, awsRegion, bucket, key)
 	require.NoError(t, err)
 
@@ -64,7 +64,7 @@ func GetS3ObjectContents(t TestingT, awsRegion string, bucket string, key string
 }
 
 // GetS3ObjectContentsE fetches the contents of the object in the given bucket with the given key and return it as a string.
-func GetS3ObjectContentsE(t TestingT, awsRegion string, bucket string, key string) (string, error) {
+func GetS3ObjectContentsE(t testing.TestingT, awsRegion string, bucket string, key string) (string, error) {
 	s3Client, err := NewS3ClientE(t, awsRegion)
 	if err != nil {
 		return "", err
@@ -92,13 +92,13 @@ func GetS3ObjectContentsE(t TestingT, awsRegion string, bucket string, key strin
 }
 
 // CreateS3Bucket creates an S3 bucket in the given region with the given name. Note that S3 bucket names must be globally unique.
-func CreateS3Bucket(t TestingT, region string, name string) {
+func CreateS3Bucket(t testing.TestingT, region string, name string) {
 	err := CreateS3BucketE(t, region, name)
 	require.NoError(t, err)
 }
 
 // CreateS3BucketE creates an S3 bucket in the given region with the given name. Note that S3 bucket names must be globally unique.
-func CreateS3BucketE(t TestingT, region string, name string) error {
+func CreateS3BucketE(t testing.TestingT, region string, name string) error {
 	logger.Logf(t, "Creating bucket %s in %s", name, region)
 
 	s3Client, err := NewS3ClientE(t, region)
@@ -114,13 +114,13 @@ func CreateS3BucketE(t TestingT, region string, name string) error {
 }
 
 // PutS3BucketPolicy applies an IAM resource policy to a given S3 bucket to create it's bucket policy
-func PutS3BucketPolicy(t TestingT, region string, bucketName string, policyJSONString string) {
+func PutS3BucketPolicy(t testing.TestingT, region string, bucketName string, policyJSONString string) {
 	err := PutS3BucketPolicyE(t, region, bucketName, policyJSONString)
 	require.NoError(t, err)
 }
 
 // PutS3BucketPolicyE applies an IAM resource policy to a given S3 bucket to create it's bucket policy
-func PutS3BucketPolicyE(t TestingT, region string, bucketName string, policyJSONString string) error {
+func PutS3BucketPolicyE(t testing.TestingT, region string, bucketName string, policyJSONString string) error {
 	logger.Logf(t, "Applying bucket policy for bucket %s in %s", bucketName, region)
 
 	s3Client, err := NewS3ClientE(t, region)
@@ -138,13 +138,13 @@ func PutS3BucketPolicyE(t TestingT, region string, bucketName string, policyJSON
 }
 
 // PutS3BucketVersioning creates an S3 bucket versioning configuration in the given region against the given bucket name, WITHOUT requiring MFA to remove versioning.
-func PutS3BucketVersioning(t TestingT, region string, bucketName string) {
+func PutS3BucketVersioning(t testing.TestingT, region string, bucketName string) {
 	err := PutS3BucketVersioningE(t, region, bucketName)
 	require.NoError(t, err)
 }
 
 // PutS3BucketVersioningE creates an S3 bucket versioning configuration in the given region against the given bucket name, WITHOUT requiring MFA to remove versioning.
-func PutS3BucketVersioningE(t TestingT, region string, bucketName string) error {
+func PutS3BucketVersioningE(t testing.TestingT, region string, bucketName string) error {
 	logger.Logf(t, "Creating bucket versioning configuration for bucket %s in %s", bucketName, region)
 
 	s3Client, err := NewS3ClientE(t, region)
@@ -165,13 +165,13 @@ func PutS3BucketVersioningE(t TestingT, region string, bucketName string) error 
 }
 
 // DeleteS3Bucket destroys the S3 bucket in the given region with the given name.
-func DeleteS3Bucket(t TestingT, region string, name string) {
+func DeleteS3Bucket(t testing.TestingT, region string, name string) {
 	err := DeleteS3BucketE(t, region, name)
 	require.NoError(t, err)
 }
 
 // DeleteS3BucketE destroys the S3 bucket in the given region with the given name.
-func DeleteS3BucketE(t TestingT, region string, name string) error {
+func DeleteS3BucketE(t testing.TestingT, region string, name string) error {
 	logger.Logf(t, "Deleting bucket %s in %s", region, name)
 
 	s3Client, err := NewS3ClientE(t, region)
@@ -187,13 +187,13 @@ func DeleteS3BucketE(t TestingT, region string, name string) error {
 }
 
 // EmptyS3Bucket removes the contents of an S3 bucket in the given region with the given name.
-func EmptyS3Bucket(t TestingT, region string, name string) {
+func EmptyS3Bucket(t testing.TestingT, region string, name string) {
 	err := EmptyS3BucketE(t, region, name)
 	require.NoError(t, err)
 }
 
 // EmptyS3BucketE removes the contents of an S3 bucket in the given region with the given name.
-func EmptyS3BucketE(t TestingT, region string, name string) error {
+func EmptyS3BucketE(t testing.TestingT, region string, name string) error {
 	logger.Logf(t, "Emptying bucket %s in %s", name, region)
 
 	s3Client, err := NewS3ClientE(t, region)
@@ -254,7 +254,7 @@ func EmptyS3BucketE(t TestingT, region string, name string) error {
 }
 
 // GetS3BucketVersioning fetches the given bucket's versioning configuration status and returns it as a string
-func GetS3BucketVersioning(t TestingT, awsRegion string, bucket string) string {
+func GetS3BucketVersioning(t testing.TestingT, awsRegion string, bucket string) string {
 	versioningStatus, err := GetS3BucketVersioningE(t, awsRegion, bucket)
 	require.NoError(t, err)
 
@@ -262,7 +262,7 @@ func GetS3BucketVersioning(t TestingT, awsRegion string, bucket string) string {
 }
 
 // GetS3BucketVersioningE fetches the given bucket's versioning configuration status and returns it as a string
-func GetS3BucketVersioningE(t TestingT, awsRegion string, bucket string) (string, error) {
+func GetS3BucketVersioningE(t testing.TestingT, awsRegion string, bucket string) (string, error) {
 	s3Client, err := NewS3ClientE(t, awsRegion)
 	if err != nil {
 		return "", err
@@ -279,7 +279,7 @@ func GetS3BucketVersioningE(t TestingT, awsRegion string, bucket string) (string
 }
 
 // GetS3BucketPolicy fetches the given bucket's resource policy and returns it as a string
-func GetS3BucketPolicy(t TestingT, awsRegion string, bucket string) string {
+func GetS3BucketPolicy(t testing.TestingT, awsRegion string, bucket string) string {
 	bucketPolicy, err := GetS3BucketPolicyE(t, awsRegion, bucket)
 	require.NoError(t, err)
 
@@ -287,7 +287,7 @@ func GetS3BucketPolicy(t TestingT, awsRegion string, bucket string) string {
 }
 
 // GetS3BucketPolicyE fetches the given bucket's resource policy and returns it as a string
-func GetS3BucketPolicyE(t TestingT, awsRegion string, bucket string) (string, error) {
+func GetS3BucketPolicyE(t testing.TestingT, awsRegion string, bucket string) (string, error) {
 	s3Client, err := NewS3ClientE(t, awsRegion)
 	if err != nil {
 		return "", err
@@ -304,13 +304,13 @@ func GetS3BucketPolicyE(t TestingT, awsRegion string, bucket string) (string, er
 }
 
 // AssertS3BucketExists checks if the given S3 bucket exists in the given region and fail the test if it does not.
-func AssertS3BucketExists(t TestingT, region string, name string) {
+func AssertS3BucketExists(t testing.TestingT, region string, name string) {
 	err := AssertS3BucketExistsE(t, region, name)
 	require.NoError(t, err)
 }
 
 // AssertS3BucketExistsE checks if the given S3 bucket exists in the given region and return an error if it does not.
-func AssertS3BucketExistsE(t TestingT, region string, name string) error {
+func AssertS3BucketExistsE(t testing.TestingT, region string, name string) error {
 	s3Client, err := NewS3ClientE(t, region)
 	if err != nil {
 		return err
@@ -324,13 +324,13 @@ func AssertS3BucketExistsE(t TestingT, region string, name string) error {
 }
 
 // AssertS3BucketVersioningExists checks if the given S3 bucket has a versioning configuration enabled and returns an error if it does not.
-func AssertS3BucketVersioningExists(t TestingT, region string, bucketName string) {
+func AssertS3BucketVersioningExists(t testing.TestingT, region string, bucketName string) {
 	err := AssertS3BucketVersioningExistsE(t, region, bucketName)
 	require.NoError(t, err)
 }
 
 // AssertS3BucketVersioningExistsE checks if the given S3 bucket has a versioning configuration enabled and returns an error if it does not.
-func AssertS3BucketVersioningExistsE(t TestingT, region string, bucketName string) error {
+func AssertS3BucketVersioningExistsE(t testing.TestingT, region string, bucketName string) error {
 	status, err := GetS3BucketVersioningE(t, region, bucketName)
 	if err != nil {
 		return err
@@ -343,13 +343,13 @@ func AssertS3BucketVersioningExistsE(t TestingT, region string, bucketName strin
 }
 
 // AssertS3BucketPolicyExists checks if the given S3 bucket has a resource policy attached and returns an error if it does not
-func AssertS3BucketPolicyExists(t TestingT, region string, bucketName string) {
+func AssertS3BucketPolicyExists(t testing.TestingT, region string, bucketName string) {
 	err := AssertS3BucketPolicyExistsE(t, region, bucketName)
 	require.NoError(t, err)
 }
 
 // AssertS3BucketPolicyExistsE checks if the given S3 bucket has a resource policy attached and returns an error if it does not
-func AssertS3BucketPolicyExistsE(t TestingT, region string, bucketName string) error {
+func AssertS3BucketPolicyExistsE(t testing.TestingT, region string, bucketName string) error {
 	policy, err := GetS3BucketPolicyE(t, region, bucketName)
 	if err != nil {
 		return err
@@ -362,7 +362,7 @@ func AssertS3BucketPolicyExistsE(t TestingT, region string, bucketName string) e
 }
 
 // NewS3Client creates an S3 client.
-func NewS3Client(t TestingT, region string) *s3.S3 {
+func NewS3Client(t testing.TestingT, region string) *s3.S3 {
 	client, err := NewS3ClientE(t, region)
 	require.NoError(t, err)
 
@@ -370,7 +370,7 @@ func NewS3Client(t TestingT, region string) *s3.S3 {
 }
 
 // NewS3ClientE creates an S3 client.
-func NewS3ClientE(t TestingT, region string) (*s3.S3, error) {
+func NewS3ClientE(t testing.TestingT, region string) (*s3.S3, error) {
 	sess, err := NewAuthenticatedSession(region)
 	if err != nil {
 		return nil, err
@@ -380,14 +380,14 @@ func NewS3ClientE(t TestingT, region string) (*s3.S3, error) {
 }
 
 // NewS3Uploader creates an S3 Uploader.
-func NewS3Uploader(t TestingT, region string) *s3manager.Uploader {
+func NewS3Uploader(t testing.TestingT, region string) *s3manager.Uploader {
 	uploader, err := NewS3UploaderE(t, region)
 	require.NoError(t, err)
 	return uploader
 }
 
 // NewS3UploaderE creates an S3 Uploader.
-func NewS3UploaderE(t TestingT, region string) (*s3manager.Uploader, error) {
+func NewS3UploaderE(t testing.TestingT, region string) (*s3manager.Uploader, error) {
 	sess, err := NewAuthenticatedSession(region)
 	if err != nil {
 		return nil, err

--- a/modules/aws/s3_test.go
+++ b/modules/aws/s3_test.go
@@ -6,17 +6,17 @@ import (
 	"math/rand"
 	"strconv"
 	"strings"
-	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
 	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/random"
+	_ "github.com/gruntwork-io/terratest/modules/testing"
 	"github.com/stretchr/testify/require"
 )
 
-func TestCreateAndDestroyS3Bucket(t *testing.T) {
+func TestCreateAndDestroyS3Bucket(t TestingT) {
 	t.Parallel()
 
 	region := GetRandomStableRegion(t, nil, nil)
@@ -29,7 +29,7 @@ func TestCreateAndDestroyS3Bucket(t *testing.T) {
 	DeleteS3Bucket(t, region, s3BucketName)
 }
 
-func TestAssertS3BucketExistsNoFalseNegative(t *testing.T) {
+func TestAssertS3BucketExistsNoFalseNegative(t TestingT) {
 	t.Parallel()
 
 	region := GetRandomStableRegion(t, nil, nil)
@@ -42,7 +42,7 @@ func TestAssertS3BucketExistsNoFalseNegative(t *testing.T) {
 	AssertS3BucketExists(t, region, s3BucketName)
 }
 
-func TestAssertS3BucketExistsNoFalsePositive(t *testing.T) {
+func TestAssertS3BucketExistsNoFalsePositive(t TestingT) {
 	t.Parallel()
 
 	region := GetRandomStableRegion(t, nil, nil)
@@ -58,7 +58,7 @@ func TestAssertS3BucketExistsNoFalsePositive(t *testing.T) {
 	}
 }
 
-func TestAssertS3BucketVersioningEnabled(t *testing.T) {
+func TestAssertS3BucketVersioningEnabled(t TestingT) {
 	t.Parallel()
 
 	region := GetRandomStableRegion(t, nil, nil)
@@ -72,7 +72,7 @@ func TestAssertS3BucketVersioningEnabled(t *testing.T) {
 	AssertS3BucketVersioningExists(t, region, s3BucketName)
 }
 
-func TestEmptyS3Bucket(t *testing.T) {
+func TestEmptyS3Bucket(t TestingT) {
 	t.Parallel()
 
 	// region := GetRandomStableRegion(t, nil, nil)
@@ -93,7 +93,7 @@ func TestEmptyS3Bucket(t *testing.T) {
 	testEmptyBucket(t, s3Client, region, s3BucketName)
 }
 
-func TestEmptyS3BucketVersioned(t *testing.T) {
+func TestEmptyS3BucketVersioned(t TestingT) {
 	t.Parallel()
 
 	region := GetRandomStableRegion(t, nil, nil)
@@ -127,7 +127,7 @@ func TestEmptyS3BucketVersioned(t *testing.T) {
 	testEmptyBucket(t, s3Client, region, s3BucketName)
 }
 
-func TestAssertS3BucketPolicyExists(t *testing.T) {
+func TestAssertS3BucketPolicyExists(t TestingT) {
 	t.Parallel()
 
 	region := GetRandomStableRegion(t, nil, nil)
@@ -146,7 +146,7 @@ func TestAssertS3BucketPolicyExists(t *testing.T) {
 
 }
 
-func testEmptyBucket(t *testing.T, s3Client *s3.S3, region string, s3BucketName string) {
+func testEmptyBucket(t TestingT, s3Client *s3.S3, region string, s3BucketName string) {
 	expectedFileCount := rand.Intn(10000)
 
 	logger.Logf(t, "Uploading %s files to bucket %s", strconv.Itoa(expectedFileCount), s3BucketName)

--- a/modules/aws/s3_test.go
+++ b/modules/aws/s3_test.go
@@ -12,11 +12,11 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
 	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/random"
-	_ "github.com/gruntwork-io/terratest/modules/testing"
+	"github.com/gruntwork-io/terratest/modules/testing"
 	"github.com/stretchr/testify/require"
 )
 
-func TestCreateAndDestroyS3Bucket(t TestingT) {
+func TestCreateAndDestroyS3Bucket(t testing.TestingT) {
 	t.Parallel()
 
 	region := GetRandomStableRegion(t, nil, nil)
@@ -29,7 +29,7 @@ func TestCreateAndDestroyS3Bucket(t TestingT) {
 	DeleteS3Bucket(t, region, s3BucketName)
 }
 
-func TestAssertS3BucketExistsNoFalseNegative(t TestingT) {
+func TestAssertS3BucketExistsNoFalseNegative(t testing.TestingT) {
 	t.Parallel()
 
 	region := GetRandomStableRegion(t, nil, nil)
@@ -42,7 +42,7 @@ func TestAssertS3BucketExistsNoFalseNegative(t TestingT) {
 	AssertS3BucketExists(t, region, s3BucketName)
 }
 
-func TestAssertS3BucketExistsNoFalsePositive(t TestingT) {
+func TestAssertS3BucketExistsNoFalsePositive(t testing.TestingT) {
 	t.Parallel()
 
 	region := GetRandomStableRegion(t, nil, nil)
@@ -58,7 +58,7 @@ func TestAssertS3BucketExistsNoFalsePositive(t TestingT) {
 	}
 }
 
-func TestAssertS3BucketVersioningEnabled(t TestingT) {
+func TestAssertS3BucketVersioningEnabled(t testing.TestingT) {
 	t.Parallel()
 
 	region := GetRandomStableRegion(t, nil, nil)
@@ -72,7 +72,7 @@ func TestAssertS3BucketVersioningEnabled(t TestingT) {
 	AssertS3BucketVersioningExists(t, region, s3BucketName)
 }
 
-func TestEmptyS3Bucket(t TestingT) {
+func TestEmptyS3Bucket(t testing.TestingT) {
 	t.Parallel()
 
 	// region := GetRandomStableRegion(t, nil, nil)
@@ -93,7 +93,7 @@ func TestEmptyS3Bucket(t TestingT) {
 	testEmptyBucket(t, s3Client, region, s3BucketName)
 }
 
-func TestEmptyS3BucketVersioned(t TestingT) {
+func TestEmptyS3BucketVersioned(t testing.TestingT) {
 	t.Parallel()
 
 	region := GetRandomStableRegion(t, nil, nil)
@@ -127,7 +127,7 @@ func TestEmptyS3BucketVersioned(t TestingT) {
 	testEmptyBucket(t, s3Client, region, s3BucketName)
 }
 
-func TestAssertS3BucketPolicyExists(t TestingT) {
+func TestAssertS3BucketPolicyExists(t testing.TestingT) {
 	t.Parallel()
 
 	region := GetRandomStableRegion(t, nil, nil)
@@ -146,7 +146,7 @@ func TestAssertS3BucketPolicyExists(t TestingT) {
 
 }
 
-func testEmptyBucket(t TestingT, s3Client *s3.S3, region string, s3BucketName string) {
+func testEmptyBucket(t testing.TestingT, s3Client *s3.S3, region string, s3BucketName string) {
 	expectedFileCount := rand.Intn(10000)
 
 	logger.Logf(t, "Uploading %s files to bucket %s", strconv.Itoa(expectedFileCount), s3BucketName)

--- a/modules/aws/s3_test.go
+++ b/modules/aws/s3_test.go
@@ -6,17 +6,17 @@ import (
 	"math/rand"
 	"strconv"
 	"strings"
+	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
 	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/random"
-	"github.com/gruntwork-io/terratest/modules/testing"
 	"github.com/stretchr/testify/require"
 )
 
-func TestCreateAndDestroyS3Bucket(t testing.TestingT) {
+func TestCreateAndDestroyS3Bucket(t *testing.T) {
 	t.Parallel()
 
 	region := GetRandomStableRegion(t, nil, nil)
@@ -29,7 +29,7 @@ func TestCreateAndDestroyS3Bucket(t testing.TestingT) {
 	DeleteS3Bucket(t, region, s3BucketName)
 }
 
-func TestAssertS3BucketExistsNoFalseNegative(t testing.TestingT) {
+func TestAssertS3BucketExistsNoFalseNegative(t *testing.T) {
 	t.Parallel()
 
 	region := GetRandomStableRegion(t, nil, nil)
@@ -42,7 +42,7 @@ func TestAssertS3BucketExistsNoFalseNegative(t testing.TestingT) {
 	AssertS3BucketExists(t, region, s3BucketName)
 }
 
-func TestAssertS3BucketExistsNoFalsePositive(t testing.TestingT) {
+func TestAssertS3BucketExistsNoFalsePositive(t *testing.T) {
 	t.Parallel()
 
 	region := GetRandomStableRegion(t, nil, nil)
@@ -58,7 +58,7 @@ func TestAssertS3BucketExistsNoFalsePositive(t testing.TestingT) {
 	}
 }
 
-func TestAssertS3BucketVersioningEnabled(t testing.TestingT) {
+func TestAssertS3BucketVersioningEnabled(t *testing.T) {
 	t.Parallel()
 
 	region := GetRandomStableRegion(t, nil, nil)
@@ -72,7 +72,7 @@ func TestAssertS3BucketVersioningEnabled(t testing.TestingT) {
 	AssertS3BucketVersioningExists(t, region, s3BucketName)
 }
 
-func TestEmptyS3Bucket(t testing.TestingT) {
+func TestEmptyS3Bucket(t *testing.T) {
 	t.Parallel()
 
 	// region := GetRandomStableRegion(t, nil, nil)
@@ -93,7 +93,7 @@ func TestEmptyS3Bucket(t testing.TestingT) {
 	testEmptyBucket(t, s3Client, region, s3BucketName)
 }
 
-func TestEmptyS3BucketVersioned(t testing.TestingT) {
+func TestEmptyS3BucketVersioned(t *testing.T) {
 	t.Parallel()
 
 	region := GetRandomStableRegion(t, nil, nil)
@@ -127,7 +127,7 @@ func TestEmptyS3BucketVersioned(t testing.TestingT) {
 	testEmptyBucket(t, s3Client, region, s3BucketName)
 }
 
-func TestAssertS3BucketPolicyExists(t testing.TestingT) {
+func TestAssertS3BucketPolicyExists(t *testing.T) {
 	t.Parallel()
 
 	region := GetRandomStableRegion(t, nil, nil)
@@ -146,7 +146,7 @@ func TestAssertS3BucketPolicyExists(t testing.TestingT) {
 
 }
 
-func testEmptyBucket(t testing.TestingT, s3Client *s3.S3, region string, s3BucketName string) {
+func testEmptyBucket(t *testing.T, s3Client *s3.S3, region string, s3BucketName string) {
 	expectedFileCount := rand.Intn(10000)
 
 	logger.Logf(t, "Uploading %s files to bucket %s", strconv.Itoa(expectedFileCount), s3BucketName)

--- a/modules/aws/sns.go
+++ b/modules/aws/sns.go
@@ -4,11 +4,11 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/sns"
 	"github.com/gruntwork-io/terratest/modules/logger"
-	_ "github.com/gruntwork-io/terratest/modules/testing"
+	"github.com/gruntwork-io/terratest/modules/testing"
 )
 
 // CreateSnsTopic creates an SNS Topic and return the ARN.
-func CreateSnsTopic(t TestingT, region string, snsTopicName string) string {
+func CreateSnsTopic(t testing.TestingT, region string, snsTopicName string) string {
 	out, err := CreateSnsTopicE(t, region, snsTopicName)
 	if err != nil {
 		t.Fatal(err)
@@ -17,7 +17,7 @@ func CreateSnsTopic(t TestingT, region string, snsTopicName string) string {
 }
 
 // CreateSnsTopicE creates an SNS Topic and return the ARN.
-func CreateSnsTopicE(t TestingT, region string, snsTopicName string) (string, error) {
+func CreateSnsTopicE(t testing.TestingT, region string, snsTopicName string) (string, error) {
 	logger.Logf(t, "Creating SNS topic %s in %s", snsTopicName, region)
 
 	snsClient, err := NewSnsClientE(t, region)
@@ -38,7 +38,7 @@ func CreateSnsTopicE(t TestingT, region string, snsTopicName string) (string, er
 }
 
 // DeleteSNSTopic deletes an SNS Topic.
-func DeleteSNSTopic(t TestingT, region string, snsTopicArn string) {
+func DeleteSNSTopic(t testing.TestingT, region string, snsTopicArn string) {
 	err := DeleteSNSTopicE(t, region, snsTopicArn)
 	if err != nil {
 		t.Fatal(err)
@@ -46,7 +46,7 @@ func DeleteSNSTopic(t TestingT, region string, snsTopicArn string) {
 }
 
 // DeleteSNSTopicE deletes an SNS Topic.
-func DeleteSNSTopicE(t TestingT, region string, snsTopicArn string) error {
+func DeleteSNSTopicE(t testing.TestingT, region string, snsTopicArn string) error {
 	logger.Logf(t, "Deleting SNS topic %s in %s", snsTopicArn, region)
 
 	snsClient, err := NewSnsClientE(t, region)
@@ -63,7 +63,7 @@ func DeleteSNSTopicE(t TestingT, region string, snsTopicArn string) error {
 }
 
 // NewSnsClient creates a new SNS client.
-func NewSnsClient(t TestingT, region string) *sns.SNS {
+func NewSnsClient(t testing.TestingT, region string) *sns.SNS {
 	client, err := NewSnsClientE(t, region)
 	if err != nil {
 		t.Fatal(err)
@@ -72,7 +72,7 @@ func NewSnsClient(t TestingT, region string) *sns.SNS {
 }
 
 // NewSnsClientE creates a new SNS client.
-func NewSnsClientE(t TestingT, region string) (*sns.SNS, error) {
+func NewSnsClientE(t testing.TestingT, region string) (*sns.SNS, error) {
 	sess, err := NewAuthenticatedSession(region)
 	if err != nil {
 		return nil, err

--- a/modules/aws/sns.go
+++ b/modules/aws/sns.go
@@ -1,15 +1,14 @@
 package aws
 
 import (
-	"testing"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/sns"
 	"github.com/gruntwork-io/terratest/modules/logger"
+	_ "github.com/gruntwork-io/terratest/modules/testing"
 )
 
 // CreateSnsTopic creates an SNS Topic and return the ARN.
-func CreateSnsTopic(t *testing.T, region string, snsTopicName string) string {
+func CreateSnsTopic(t TestingT, region string, snsTopicName string) string {
 	out, err := CreateSnsTopicE(t, region, snsTopicName)
 	if err != nil {
 		t.Fatal(err)
@@ -18,7 +17,7 @@ func CreateSnsTopic(t *testing.T, region string, snsTopicName string) string {
 }
 
 // CreateSnsTopicE creates an SNS Topic and return the ARN.
-func CreateSnsTopicE(t *testing.T, region string, snsTopicName string) (string, error) {
+func CreateSnsTopicE(t TestingT, region string, snsTopicName string) (string, error) {
 	logger.Logf(t, "Creating SNS topic %s in %s", snsTopicName, region)
 
 	snsClient, err := NewSnsClientE(t, region)
@@ -39,7 +38,7 @@ func CreateSnsTopicE(t *testing.T, region string, snsTopicName string) (string, 
 }
 
 // DeleteSNSTopic deletes an SNS Topic.
-func DeleteSNSTopic(t *testing.T, region string, snsTopicArn string) {
+func DeleteSNSTopic(t TestingT, region string, snsTopicArn string) {
 	err := DeleteSNSTopicE(t, region, snsTopicArn)
 	if err != nil {
 		t.Fatal(err)
@@ -47,7 +46,7 @@ func DeleteSNSTopic(t *testing.T, region string, snsTopicArn string) {
 }
 
 // DeleteSNSTopicE deletes an SNS Topic.
-func DeleteSNSTopicE(t *testing.T, region string, snsTopicArn string) error {
+func DeleteSNSTopicE(t TestingT, region string, snsTopicArn string) error {
 	logger.Logf(t, "Deleting SNS topic %s in %s", snsTopicArn, region)
 
 	snsClient, err := NewSnsClientE(t, region)
@@ -64,7 +63,7 @@ func DeleteSNSTopicE(t *testing.T, region string, snsTopicArn string) error {
 }
 
 // NewSnsClient creates a new SNS client.
-func NewSnsClient(t *testing.T, region string) *sns.SNS {
+func NewSnsClient(t TestingT, region string) *sns.SNS {
 	client, err := NewSnsClientE(t, region)
 	if err != nil {
 		t.Fatal(err)
@@ -73,7 +72,7 @@ func NewSnsClient(t *testing.T, region string) *sns.SNS {
 }
 
 // NewSnsClientE creates a new SNS client.
-func NewSnsClientE(t *testing.T, region string) (*sns.SNS, error) {
+func NewSnsClientE(t TestingT, region string) (*sns.SNS, error) {
 	sess, err := NewAuthenticatedSession(region)
 	if err != nil {
 		return nil, err

--- a/modules/aws/sqs.go
+++ b/modules/aws/sqs.go
@@ -4,16 +4,16 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
-	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/sqs"
 	"github.com/google/uuid"
 	"github.com/gruntwork-io/terratest/modules/logger"
+	_ "github.com/gruntwork-io/terratest/modules/testing"
 )
 
 // CreateRandomQueue creates a new SQS queue with a random name that starts with the given prefix and return the queue URL.
-func CreateRandomQueue(t *testing.T, awsRegion string, prefix string) string {
+func CreateRandomQueue(t TestingT, awsRegion string, prefix string) string {
 	url, err := CreateRandomQueueE(t, awsRegion, prefix)
 	if err != nil {
 		t.Fatal(err)
@@ -22,7 +22,7 @@ func CreateRandomQueue(t *testing.T, awsRegion string, prefix string) string {
 }
 
 // CreateRandomQueueE creates a new SQS queue with a random name that starts with the given prefix and return the queue URL.
-func CreateRandomQueueE(t *testing.T, awsRegion string, prefix string) (string, error) {
+func CreateRandomQueueE(t TestingT, awsRegion string, prefix string) (string, error) {
 	logger.Logf(t, "Creating randomly named SQS queue with prefix %s", prefix)
 
 	sqsClient, err := NewSqsClientE(t, awsRegion)
@@ -49,7 +49,7 @@ func CreateRandomQueueE(t *testing.T, awsRegion string, prefix string) (string, 
 }
 
 // CreateRandomFifoQueue creates a new FIFO SQS queue with a random name that starts with the given prefix and return the queue URL.
-func CreateRandomFifoQueue(t *testing.T, awsRegion string, prefix string) string {
+func CreateRandomFifoQueue(t TestingT, awsRegion string, prefix string) string {
 	url, err := CreateRandomFifoQueueE(t, awsRegion, prefix)
 	if err != nil {
 		t.Fatal(err)
@@ -58,7 +58,7 @@ func CreateRandomFifoQueue(t *testing.T, awsRegion string, prefix string) string
 }
 
 // CreateRandomFifoQueueE creates a new FIFO SQS queue with a random name that starts with the given prefix and return the queue URL.
-func CreateRandomFifoQueueE(t *testing.T, awsRegion string, prefix string) (string, error) {
+func CreateRandomFifoQueueE(t TestingT, awsRegion string, prefix string) (string, error) {
 	logger.Logf(t, "Creating randomly named FIFO SQS queue with prefix %s", prefix)
 
 	sqsClient, err := NewSqsClientE(t, awsRegion)
@@ -89,7 +89,7 @@ func CreateRandomFifoQueueE(t *testing.T, awsRegion string, prefix string) (stri
 }
 
 // DeleteQueue deletes the SQS queue with the given URL.
-func DeleteQueue(t *testing.T, awsRegion string, queueURL string) {
+func DeleteQueue(t TestingT, awsRegion string, queueURL string) {
 	err := DeleteQueueE(t, awsRegion, queueURL)
 	if err != nil {
 		t.Fatal(err)
@@ -97,7 +97,7 @@ func DeleteQueue(t *testing.T, awsRegion string, queueURL string) {
 }
 
 // DeleteQueueE deletes the SQS queue with the given URL.
-func DeleteQueueE(t *testing.T, awsRegion string, queueURL string) error {
+func DeleteQueueE(t TestingT, awsRegion string, queueURL string) error {
 	logger.Logf(t, "Deleting SQS Queue %s", queueURL)
 
 	sqsClient, err := NewSqsClientE(t, awsRegion)
@@ -113,7 +113,7 @@ func DeleteQueueE(t *testing.T, awsRegion string, queueURL string) error {
 }
 
 // DeleteMessageFromQueue deletes the message with the given receipt from the SQS queue with the given URL.
-func DeleteMessageFromQueue(t *testing.T, awsRegion string, queueURL string, receipt string) {
+func DeleteMessageFromQueue(t TestingT, awsRegion string, queueURL string, receipt string) {
 	err := DeleteMessageFromQueueE(t, awsRegion, queueURL, receipt)
 	if err != nil {
 		t.Fatal(err)
@@ -121,7 +121,7 @@ func DeleteMessageFromQueue(t *testing.T, awsRegion string, queueURL string, rec
 }
 
 // DeleteMessageFromQueueE deletes the message with the given receipt from the SQS queue with the given URL.
-func DeleteMessageFromQueueE(t *testing.T, awsRegion string, queueURL string, receipt string) error {
+func DeleteMessageFromQueueE(t TestingT, awsRegion string, queueURL string, receipt string) error {
 	logger.Logf(t, "Deleting message from queue %s (%s)", queueURL, receipt)
 
 	sqsClient, err := NewSqsClientE(t, awsRegion)
@@ -138,7 +138,7 @@ func DeleteMessageFromQueueE(t *testing.T, awsRegion string, queueURL string, re
 }
 
 // SendMessageToQueue sends the given message to the SQS queue with the given URL.
-func SendMessageToQueue(t *testing.T, awsRegion string, queueURL string, message string) {
+func SendMessageToQueue(t TestingT, awsRegion string, queueURL string, message string) {
 	err := SendMessageToQueueE(t, awsRegion, queueURL, message)
 	if err != nil {
 		t.Fatal(err)
@@ -146,7 +146,7 @@ func SendMessageToQueue(t *testing.T, awsRegion string, queueURL string, message
 }
 
 // SendMessageToQueueE sends the given message to the SQS queue with the given URL.
-func SendMessageToQueueE(t *testing.T, awsRegion string, queueURL string, message string) error {
+func SendMessageToQueueE(t TestingT, awsRegion string, queueURL string, message string) error {
 	logger.Logf(t, "Sending message %s to queue %s", message, queueURL)
 
 	sqsClient, err := NewSqsClientE(t, awsRegion)
@@ -173,7 +173,7 @@ func SendMessageToQueueE(t *testing.T, awsRegion string, queueURL string, messag
 }
 
 // SendMessageToFifoQueue sends the given message to the FIFO SQS queue with the given URL.
-func SendMessageFifoToQueue(t *testing.T, awsRegion string, queueURL string, message string, messageGroupID string) {
+func SendMessageFifoToQueue(t TestingT, awsRegion string, queueURL string, message string, messageGroupID string) {
 	err := SendMessageToFifoQueueE(t, awsRegion, queueURL, message, messageGroupID)
 	if err != nil {
 		t.Fatal(err)
@@ -181,7 +181,7 @@ func SendMessageFifoToQueue(t *testing.T, awsRegion string, queueURL string, mes
 }
 
 // SendMessageToFifoQueueE sends the given message to the FIFO SQS queue with the given URL.
-func SendMessageToFifoQueueE(t *testing.T, awsRegion string, queueURL string, message string, messageGroupID string) error {
+func SendMessageToFifoQueueE(t TestingT, awsRegion string, queueURL string, message string, messageGroupID string) error {
 	logger.Logf(t, "Sending message %s to queue %s", message, queueURL)
 
 	sqsClient, err := NewSqsClientE(t, awsRegion)
@@ -217,7 +217,7 @@ type QueueMessageResponse struct {
 
 // WaitForQueueMessage waits to receive a message from on the queueURL. Since the API only allows us to wait a max 20 seconds for a new
 // message to arrive, we must loop TIMEOUT/20 number of times to be able to wait for a total of TIMEOUT seconds
-func WaitForQueueMessage(t *testing.T, awsRegion string, queueURL string, timeout int) QueueMessageResponse {
+func WaitForQueueMessage(t TestingT, awsRegion string, queueURL string, timeout int) QueueMessageResponse {
 	sqsClient, err := NewSqsClientE(t, awsRegion)
 	if err != nil {
 		return QueueMessageResponse{Error: err}
@@ -254,7 +254,7 @@ func WaitForQueueMessage(t *testing.T, awsRegion string, queueURL string, timeou
 }
 
 // NewSqsClient creates a new SQS client.
-func NewSqsClient(t *testing.T, region string) *sqs.SQS {
+func NewSqsClient(t TestingT, region string) *sqs.SQS {
 	client, err := NewSqsClientE(t, region)
 	if err != nil {
 		t.Fatal(err)
@@ -263,7 +263,7 @@ func NewSqsClient(t *testing.T, region string) *sqs.SQS {
 }
 
 // NewSqsClientE creates a new SQS client.
-func NewSqsClientE(t *testing.T, region string) (*sqs.SQS, error) {
+func NewSqsClientE(t TestingT, region string) (*sqs.SQS, error) {
 	sess, err := NewAuthenticatedSession(region)
 	if err != nil {
 		return nil, err

--- a/modules/aws/sqs.go
+++ b/modules/aws/sqs.go
@@ -9,11 +9,11 @@ import (
 	"github.com/aws/aws-sdk-go/service/sqs"
 	"github.com/google/uuid"
 	"github.com/gruntwork-io/terratest/modules/logger"
-	_ "github.com/gruntwork-io/terratest/modules/testing"
+	"github.com/gruntwork-io/terratest/modules/testing"
 )
 
 // CreateRandomQueue creates a new SQS queue with a random name that starts with the given prefix and return the queue URL.
-func CreateRandomQueue(t TestingT, awsRegion string, prefix string) string {
+func CreateRandomQueue(t testing.TestingT, awsRegion string, prefix string) string {
 	url, err := CreateRandomQueueE(t, awsRegion, prefix)
 	if err != nil {
 		t.Fatal(err)
@@ -22,7 +22,7 @@ func CreateRandomQueue(t TestingT, awsRegion string, prefix string) string {
 }
 
 // CreateRandomQueueE creates a new SQS queue with a random name that starts with the given prefix and return the queue URL.
-func CreateRandomQueueE(t TestingT, awsRegion string, prefix string) (string, error) {
+func CreateRandomQueueE(t testing.TestingT, awsRegion string, prefix string) (string, error) {
 	logger.Logf(t, "Creating randomly named SQS queue with prefix %s", prefix)
 
 	sqsClient, err := NewSqsClientE(t, awsRegion)
@@ -49,7 +49,7 @@ func CreateRandomQueueE(t TestingT, awsRegion string, prefix string) (string, er
 }
 
 // CreateRandomFifoQueue creates a new FIFO SQS queue with a random name that starts with the given prefix and return the queue URL.
-func CreateRandomFifoQueue(t TestingT, awsRegion string, prefix string) string {
+func CreateRandomFifoQueue(t testing.TestingT, awsRegion string, prefix string) string {
 	url, err := CreateRandomFifoQueueE(t, awsRegion, prefix)
 	if err != nil {
 		t.Fatal(err)
@@ -58,7 +58,7 @@ func CreateRandomFifoQueue(t TestingT, awsRegion string, prefix string) string {
 }
 
 // CreateRandomFifoQueueE creates a new FIFO SQS queue with a random name that starts with the given prefix and return the queue URL.
-func CreateRandomFifoQueueE(t TestingT, awsRegion string, prefix string) (string, error) {
+func CreateRandomFifoQueueE(t testing.TestingT, awsRegion string, prefix string) (string, error) {
 	logger.Logf(t, "Creating randomly named FIFO SQS queue with prefix %s", prefix)
 
 	sqsClient, err := NewSqsClientE(t, awsRegion)
@@ -89,7 +89,7 @@ func CreateRandomFifoQueueE(t TestingT, awsRegion string, prefix string) (string
 }
 
 // DeleteQueue deletes the SQS queue with the given URL.
-func DeleteQueue(t TestingT, awsRegion string, queueURL string) {
+func DeleteQueue(t testing.TestingT, awsRegion string, queueURL string) {
 	err := DeleteQueueE(t, awsRegion, queueURL)
 	if err != nil {
 		t.Fatal(err)
@@ -97,7 +97,7 @@ func DeleteQueue(t TestingT, awsRegion string, queueURL string) {
 }
 
 // DeleteQueueE deletes the SQS queue with the given URL.
-func DeleteQueueE(t TestingT, awsRegion string, queueURL string) error {
+func DeleteQueueE(t testing.TestingT, awsRegion string, queueURL string) error {
 	logger.Logf(t, "Deleting SQS Queue %s", queueURL)
 
 	sqsClient, err := NewSqsClientE(t, awsRegion)
@@ -113,7 +113,7 @@ func DeleteQueueE(t TestingT, awsRegion string, queueURL string) error {
 }
 
 // DeleteMessageFromQueue deletes the message with the given receipt from the SQS queue with the given URL.
-func DeleteMessageFromQueue(t TestingT, awsRegion string, queueURL string, receipt string) {
+func DeleteMessageFromQueue(t testing.TestingT, awsRegion string, queueURL string, receipt string) {
 	err := DeleteMessageFromQueueE(t, awsRegion, queueURL, receipt)
 	if err != nil {
 		t.Fatal(err)
@@ -121,7 +121,7 @@ func DeleteMessageFromQueue(t TestingT, awsRegion string, queueURL string, recei
 }
 
 // DeleteMessageFromQueueE deletes the message with the given receipt from the SQS queue with the given URL.
-func DeleteMessageFromQueueE(t TestingT, awsRegion string, queueURL string, receipt string) error {
+func DeleteMessageFromQueueE(t testing.TestingT, awsRegion string, queueURL string, receipt string) error {
 	logger.Logf(t, "Deleting message from queue %s (%s)", queueURL, receipt)
 
 	sqsClient, err := NewSqsClientE(t, awsRegion)
@@ -138,7 +138,7 @@ func DeleteMessageFromQueueE(t TestingT, awsRegion string, queueURL string, rece
 }
 
 // SendMessageToQueue sends the given message to the SQS queue with the given URL.
-func SendMessageToQueue(t TestingT, awsRegion string, queueURL string, message string) {
+func SendMessageToQueue(t testing.TestingT, awsRegion string, queueURL string, message string) {
 	err := SendMessageToQueueE(t, awsRegion, queueURL, message)
 	if err != nil {
 		t.Fatal(err)
@@ -146,7 +146,7 @@ func SendMessageToQueue(t TestingT, awsRegion string, queueURL string, message s
 }
 
 // SendMessageToQueueE sends the given message to the SQS queue with the given URL.
-func SendMessageToQueueE(t TestingT, awsRegion string, queueURL string, message string) error {
+func SendMessageToQueueE(t testing.TestingT, awsRegion string, queueURL string, message string) error {
 	logger.Logf(t, "Sending message %s to queue %s", message, queueURL)
 
 	sqsClient, err := NewSqsClientE(t, awsRegion)
@@ -173,7 +173,7 @@ func SendMessageToQueueE(t TestingT, awsRegion string, queueURL string, message 
 }
 
 // SendMessageToFifoQueue sends the given message to the FIFO SQS queue with the given URL.
-func SendMessageFifoToQueue(t TestingT, awsRegion string, queueURL string, message string, messageGroupID string) {
+func SendMessageFifoToQueue(t testing.TestingT, awsRegion string, queueURL string, message string, messageGroupID string) {
 	err := SendMessageToFifoQueueE(t, awsRegion, queueURL, message, messageGroupID)
 	if err != nil {
 		t.Fatal(err)
@@ -181,7 +181,7 @@ func SendMessageFifoToQueue(t TestingT, awsRegion string, queueURL string, messa
 }
 
 // SendMessageToFifoQueueE sends the given message to the FIFO SQS queue with the given URL.
-func SendMessageToFifoQueueE(t TestingT, awsRegion string, queueURL string, message string, messageGroupID string) error {
+func SendMessageToFifoQueueE(t testing.TestingT, awsRegion string, queueURL string, message string, messageGroupID string) error {
 	logger.Logf(t, "Sending message %s to queue %s", message, queueURL)
 
 	sqsClient, err := NewSqsClientE(t, awsRegion)
@@ -217,7 +217,7 @@ type QueueMessageResponse struct {
 
 // WaitForQueueMessage waits to receive a message from on the queueURL. Since the API only allows us to wait a max 20 seconds for a new
 // message to arrive, we must loop TIMEOUT/20 number of times to be able to wait for a total of TIMEOUT seconds
-func WaitForQueueMessage(t TestingT, awsRegion string, queueURL string, timeout int) QueueMessageResponse {
+func WaitForQueueMessage(t testing.TestingT, awsRegion string, queueURL string, timeout int) QueueMessageResponse {
 	sqsClient, err := NewSqsClientE(t, awsRegion)
 	if err != nil {
 		return QueueMessageResponse{Error: err}
@@ -254,7 +254,7 @@ func WaitForQueueMessage(t TestingT, awsRegion string, queueURL string, timeout 
 }
 
 // NewSqsClient creates a new SQS client.
-func NewSqsClient(t TestingT, region string) *sqs.SQS {
+func NewSqsClient(t testing.TestingT, region string) *sqs.SQS {
 	client, err := NewSqsClientE(t, region)
 	if err != nil {
 		t.Fatal(err)
@@ -263,7 +263,7 @@ func NewSqsClient(t TestingT, region string) *sqs.SQS {
 }
 
 // NewSqsClientE creates a new SQS client.
-func NewSqsClientE(t TestingT, region string) (*sqs.SQS, error) {
+func NewSqsClientE(t testing.TestingT, region string) (*sqs.SQS, error) {
 	sess, err := NewAuthenticatedSession(region)
 	if err != nil {
 		return nil, err

--- a/modules/aws/ssm.go
+++ b/modules/aws/ssm.go
@@ -3,19 +3,19 @@ package aws
 import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ssm"
-	_ "github.com/gruntwork-io/terratest/modules/testing"
+	"github.com/gruntwork-io/terratest/modules/testing"
 	"github.com/stretchr/testify/require"
 )
 
 // GetParameter retrieves the latest version of SSM Parameter at keyName with decryption.
-func GetParameter(t TestingT, awsRegion string, keyName string) string {
+func GetParameter(t testing.TestingT, awsRegion string, keyName string) string {
 	keyValue, err := GetParameterE(t, awsRegion, keyName)
 	require.NoError(t, err)
 	return keyValue
 }
 
 // GetParameterE retrieves the latest version of SSM Parameter at keyName with decryption.
-func GetParameterE(t TestingT, awsRegion string, keyName string) (string, error) {
+func GetParameterE(t testing.TestingT, awsRegion string, keyName string) (string, error) {
 	ssmClient, err := NewSsmClientE(t, awsRegion)
 	if err != nil {
 		return "", err
@@ -31,14 +31,14 @@ func GetParameterE(t TestingT, awsRegion string, keyName string) (string, error)
 }
 
 // PutParameter creates new version of SSM Parameter at keyName with keyValue as SecureString.
-func PutParameter(t TestingT, awsRegion string, keyName string, keyDescription string, keyValue string) int64 {
+func PutParameter(t testing.TestingT, awsRegion string, keyName string, keyDescription string, keyValue string) int64 {
 	version, err := PutParameterE(t, awsRegion, keyName, keyDescription, keyValue)
 	require.NoError(t, err)
 	return version
 }
 
 // PutParameterE creates new version of SSM Parameter at keyName with keyValue as SecureString.
-func PutParameterE(t TestingT, awsRegion string, keyName string, keyDescription string, keyValue string) (int64, error) {
+func PutParameterE(t testing.TestingT, awsRegion string, keyName string, keyDescription string, keyValue string) (int64, error) {
 	ssmClient, err := NewSsmClientE(t, awsRegion)
 	if err != nil {
 		return 0, err
@@ -53,14 +53,14 @@ func PutParameterE(t TestingT, awsRegion string, keyName string, keyDescription 
 }
 
 // NewSsmClient creates a SSM client.
-func NewSsmClient(t TestingT, region string) *ssm.SSM {
+func NewSsmClient(t testing.TestingT, region string) *ssm.SSM {
 	client, err := NewSsmClientE(t, region)
 	require.NoError(t, err)
 	return client
 }
 
 // NewSsmClientE creates an SSM client.
-func NewSsmClientE(t TestingT, region string) (*ssm.SSM, error) {
+func NewSsmClientE(t testing.TestingT, region string) (*ssm.SSM, error) {
 	sess, err := NewAuthenticatedSession(region)
 	if err != nil {
 		return nil, err

--- a/modules/aws/ssm.go
+++ b/modules/aws/ssm.go
@@ -1,22 +1,21 @@
 package aws
 
 import (
-	"testing"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ssm"
+	_ "github.com/gruntwork-io/terratest/modules/testing"
 	"github.com/stretchr/testify/require"
 )
 
 // GetParameter retrieves the latest version of SSM Parameter at keyName with decryption.
-func GetParameter(t *testing.T, awsRegion string, keyName string) string {
+func GetParameter(t TestingT, awsRegion string, keyName string) string {
 	keyValue, err := GetParameterE(t, awsRegion, keyName)
 	require.NoError(t, err)
 	return keyValue
 }
 
 // GetParameterE retrieves the latest version of SSM Parameter at keyName with decryption.
-func GetParameterE(t *testing.T, awsRegion string, keyName string) (string, error) {
+func GetParameterE(t TestingT, awsRegion string, keyName string) (string, error) {
 	ssmClient, err := NewSsmClientE(t, awsRegion)
 	if err != nil {
 		return "", err
@@ -32,14 +31,14 @@ func GetParameterE(t *testing.T, awsRegion string, keyName string) (string, erro
 }
 
 // PutParameter creates new version of SSM Parameter at keyName with keyValue as SecureString.
-func PutParameter(t *testing.T, awsRegion string, keyName string, keyDescription string, keyValue string) int64 {
+func PutParameter(t TestingT, awsRegion string, keyName string, keyDescription string, keyValue string) int64 {
 	version, err := PutParameterE(t, awsRegion, keyName, keyDescription, keyValue)
 	require.NoError(t, err)
 	return version
 }
 
 // PutParameterE creates new version of SSM Parameter at keyName with keyValue as SecureString.
-func PutParameterE(t *testing.T, awsRegion string, keyName string, keyDescription string, keyValue string) (int64, error) {
+func PutParameterE(t TestingT, awsRegion string, keyName string, keyDescription string, keyValue string) (int64, error) {
 	ssmClient, err := NewSsmClientE(t, awsRegion)
 	if err != nil {
 		return 0, err
@@ -54,14 +53,14 @@ func PutParameterE(t *testing.T, awsRegion string, keyName string, keyDescriptio
 }
 
 // NewSsmClient creates a SSM client.
-func NewSsmClient(t *testing.T, region string) *ssm.SSM {
+func NewSsmClient(t TestingT, region string) *ssm.SSM {
 	client, err := NewSsmClientE(t, region)
 	require.NoError(t, err)
 	return client
 }
 
 // NewSsmClientE creates an SSM client.
-func NewSsmClientE(t *testing.T, region string) (*ssm.SSM, error) {
+func NewSsmClientE(t TestingT, region string) (*ssm.SSM, error) {
 	sess, err := NewAuthenticatedSession(region)
 	if err != nil {
 		return nil, err

--- a/modules/aws/vpc.go
+++ b/modules/aws/vpc.go
@@ -144,14 +144,14 @@ func GetSubnetsForVpcE(t testing.TestingT, vpcID string, region string) ([]Subne
 }
 
 // IsPublicSubnet returns True if the subnet identified by the given id in the provided region is public.
-func IsPublicSubnet(t *testing.T, subnetId string, region string) bool {
+func IsPublicSubnet(t testing.TestingT, subnetId string, region string) bool {
 	isPublic, err := IsPublicSubnetE(t, subnetId, region)
 	require.NoError(t, err)
 	return isPublic
 }
 
 // IsPublicSubnetE returns True if the subnet identified by the given id in the provided region is public.
-func IsPublicSubnetE(t *testing.T, subnetId string, region string) (bool, error) {
+func IsPublicSubnetE(t testing.TestingT, subnetId string, region string) (bool, error) {
 	subnetIdFilterName := "association.subnet-id"
 
 	subnetIdFilter := ec2.Filter{

--- a/modules/aws/vpc.go
+++ b/modules/aws/vpc.go
@@ -4,11 +4,11 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
-	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/gruntwork-io/terratest/modules/random"
+	_ "github.com/gruntwork-io/terratest/modules/testing"
 	"github.com/stretchr/testify/require"
 )
 
@@ -30,14 +30,14 @@ var isDefaultFilterName = "isDefault"
 var isDefaultFilterValue = "true"
 
 // GetDefaultVpc fetches information about the default VPC in the given region.
-func GetDefaultVpc(t *testing.T, region string) *Vpc {
+func GetDefaultVpc(t TestingT, region string) *Vpc {
 	vpc, err := GetDefaultVpcE(t, region)
 	require.NoError(t, err)
 	return vpc
 }
 
 // GetDefaultVpcE fetches information about the default VPC in the given region.
-func GetDefaultVpcE(t *testing.T, region string) (*Vpc, error) {
+func GetDefaultVpcE(t TestingT, region string) (*Vpc, error) {
 	defaultVpcFilter := ec2.Filter{Name: &isDefaultFilterName, Values: []*string{&isDefaultFilterValue}}
 	vpcs, err := GetVpcsE(t, []*ec2.Filter{&defaultVpcFilter}, region)
 
@@ -50,14 +50,14 @@ func GetDefaultVpcE(t *testing.T, region string) (*Vpc, error) {
 }
 
 // GetVpcById fetches information about a VPC with given Id in the given region.
-func GetVpcById(t *testing.T, vpcId string, region string) *Vpc {
+func GetVpcById(t TestingT, vpcId string, region string) *Vpc {
 	vpc, err := GetVpcByIdE(t, vpcId, region)
 	require.NoError(t, err)
 	return vpc
 }
 
 // GetVpcByIdE fetches information about a VPC with given Id in the given region.
-func GetVpcByIdE(t *testing.T, vpcId string, region string) (*Vpc, error) {
+func GetVpcByIdE(t TestingT, vpcId string, region string) (*Vpc, error) {
 	vpcIdFilter := ec2.Filter{Name: &vpcIDFilterName, Values: []*string{&vpcId}}
 	vpcs, err := GetVpcsE(t, []*ec2.Filter{&vpcIdFilter}, region)
 
@@ -70,7 +70,7 @@ func GetVpcByIdE(t *testing.T, vpcId string, region string) (*Vpc, error) {
 }
 
 // GetVpcsE fetches informations about VPCs from given regions limited by filters
-func GetVpcsE(t *testing.T, filters []*ec2.Filter, region string) ([]*Vpc, error) {
+func GetVpcsE(t TestingT, filters []*ec2.Filter, region string) ([]*Vpc, error) {
 	client, err := NewEc2ClientE(t, region)
 	if err != nil {
 		return nil, err
@@ -112,7 +112,7 @@ func FindVpcName(vpc *ec2.Vpc) string {
 }
 
 // GetSubnetsForVpc gets the subnets in the specified VPC.
-func GetSubnetsForVpc(t *testing.T, vpcID string, region string) []Subnet {
+func GetSubnetsForVpc(t TestingT, vpcID string, region string) []Subnet {
 	subnets, err := GetSubnetsForVpcE(t, vpcID, region)
 	if err != nil {
 		t.Fatal(err)
@@ -121,7 +121,7 @@ func GetSubnetsForVpc(t *testing.T, vpcID string, region string) []Subnet {
 }
 
 // GetSubnetsForVpcE gets the subnets in the specified VPC.
-func GetSubnetsForVpcE(t *testing.T, vpcID string, region string) ([]Subnet, error) {
+func GetSubnetsForVpcE(t TestingT, vpcID string, region string) ([]Subnet, error) {
 	client, err := NewEc2ClientE(t, region)
 	if err != nil {
 		return nil, err

--- a/modules/aws/vpc.go
+++ b/modules/aws/vpc.go
@@ -8,7 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/gruntwork-io/terratest/modules/random"
-	_ "github.com/gruntwork-io/terratest/modules/testing"
+	"github.com/gruntwork-io/terratest/modules/testing"
 	"github.com/stretchr/testify/require"
 )
 
@@ -30,14 +30,14 @@ var isDefaultFilterName = "isDefault"
 var isDefaultFilterValue = "true"
 
 // GetDefaultVpc fetches information about the default VPC in the given region.
-func GetDefaultVpc(t TestingT, region string) *Vpc {
+func GetDefaultVpc(t testing.TestingT, region string) *Vpc {
 	vpc, err := GetDefaultVpcE(t, region)
 	require.NoError(t, err)
 	return vpc
 }
 
 // GetDefaultVpcE fetches information about the default VPC in the given region.
-func GetDefaultVpcE(t TestingT, region string) (*Vpc, error) {
+func GetDefaultVpcE(t testing.TestingT, region string) (*Vpc, error) {
 	defaultVpcFilter := ec2.Filter{Name: &isDefaultFilterName, Values: []*string{&isDefaultFilterValue}}
 	vpcs, err := GetVpcsE(t, []*ec2.Filter{&defaultVpcFilter}, region)
 
@@ -50,14 +50,14 @@ func GetDefaultVpcE(t TestingT, region string) (*Vpc, error) {
 }
 
 // GetVpcById fetches information about a VPC with given Id in the given region.
-func GetVpcById(t TestingT, vpcId string, region string) *Vpc {
+func GetVpcById(t testing.TestingT, vpcId string, region string) *Vpc {
 	vpc, err := GetVpcByIdE(t, vpcId, region)
 	require.NoError(t, err)
 	return vpc
 }
 
 // GetVpcByIdE fetches information about a VPC with given Id in the given region.
-func GetVpcByIdE(t TestingT, vpcId string, region string) (*Vpc, error) {
+func GetVpcByIdE(t testing.TestingT, vpcId string, region string) (*Vpc, error) {
 	vpcIdFilter := ec2.Filter{Name: &vpcIDFilterName, Values: []*string{&vpcId}}
 	vpcs, err := GetVpcsE(t, []*ec2.Filter{&vpcIdFilter}, region)
 
@@ -70,7 +70,7 @@ func GetVpcByIdE(t TestingT, vpcId string, region string) (*Vpc, error) {
 }
 
 // GetVpcsE fetches informations about VPCs from given regions limited by filters
-func GetVpcsE(t TestingT, filters []*ec2.Filter, region string) ([]*Vpc, error) {
+func GetVpcsE(t testing.TestingT, filters []*ec2.Filter, region string) ([]*Vpc, error) {
 	client, err := NewEc2ClientE(t, region)
 	if err != nil {
 		return nil, err
@@ -112,7 +112,7 @@ func FindVpcName(vpc *ec2.Vpc) string {
 }
 
 // GetSubnetsForVpc gets the subnets in the specified VPC.
-func GetSubnetsForVpc(t TestingT, vpcID string, region string) []Subnet {
+func GetSubnetsForVpc(t testing.TestingT, vpcID string, region string) []Subnet {
 	subnets, err := GetSubnetsForVpcE(t, vpcID, region)
 	if err != nil {
 		t.Fatal(err)
@@ -121,7 +121,7 @@ func GetSubnetsForVpc(t TestingT, vpcID string, region string) []Subnet {
 }
 
 // GetSubnetsForVpcE gets the subnets in the specified VPC.
-func GetSubnetsForVpcE(t TestingT, vpcID string, region string) ([]Subnet, error) {
+func GetSubnetsForVpcE(t testing.TestingT, vpcID string, region string) ([]Subnet, error) {
 	client, err := NewEc2ClientE(t, region)
 	if err != nil {
 		return nil, err

--- a/modules/azure/aks.go
+++ b/modules/azure/aks.go
@@ -2,9 +2,9 @@ package azure
 
 import (
 	"context"
-	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2019-11-01/containerservice"
+	"github.com/gruntwork-io/terratest/module/testing"
 )
 
 // GetManagedClustersClientE is a helper function that will setup an Azure ManagedClusters client on your behalf
@@ -28,7 +28,7 @@ func GetManagedClustersClientE(subscriptionID string) (*containerservice.Managed
 }
 
 // GetManagedClusterE will return ManagedCluster
-func GetManagedClusterE(t *testing.T, resourceGroupName, clusterName, subscriptionID string) (*containerservice.ManagedCluster, error) {
+func GetManagedClusterE(t testing.TestingT, resourceGroupName, clusterName, subscriptionID string) (*containerservice.ManagedCluster, error) {
 	subscriptionID, err := getTargetAzureSubscription(subscriptionID)
 	if err != nil {
 		return nil, err

--- a/modules/azure/aks.go
+++ b/modules/azure/aks.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2019-11-01/containerservice"
-	"github.com/gruntwork-io/terratest/module/testing"
+	"github.com/gruntwork-io/terratest/modules/testing"
 )
 
 // GetManagedClustersClientE is a helper function that will setup an Azure ManagedClusters client on your behalf

--- a/modules/azure/compute.go
+++ b/modules/azure/compute.go
@@ -2,9 +2,9 @@ package azure
 
 import (
 	"context"
-	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-07-01/compute"
+	_ "github.com/gruntwork-io/terratest/modules/testing"
 	"github.com/stretchr/testify/require"
 )
 
@@ -32,7 +32,7 @@ func GetVirtualMachineClient(subscriptionID string) (*compute.VirtualMachinesCli
 }
 
 // GetSizeOfVirtualMachine gets the size type of the given Azure Virtual Machine
-func GetSizeOfVirtualMachine(t *testing.T, vmName string, resGroupName string, subscriptionID string) compute.VirtualMachineSizeTypes {
+func GetSizeOfVirtualMachine(t TestingT, vmName string, resGroupName string, subscriptionID string) compute.VirtualMachineSizeTypes {
 	size, err := GetSizeOfVirtualMachineE(t, vmName, resGroupName, subscriptionID)
 	require.NoError(t, err)
 
@@ -40,7 +40,7 @@ func GetSizeOfVirtualMachine(t *testing.T, vmName string, resGroupName string, s
 }
 
 // GetSizeOfVirtualMachineE gets the size type of the given Azure Virtual Machine
-func GetSizeOfVirtualMachineE(t *testing.T, vmName string, resGroupName string, subscriptionID string) (compute.VirtualMachineSizeTypes, error) {
+func GetSizeOfVirtualMachineE(t TestingT, vmName string, resGroupName string, subscriptionID string) (compute.VirtualMachineSizeTypes, error) {
 	// Validate resource group name and subscription ID
 	resGroupName, err := getTargetAzureResourceGroupName(resGroupName)
 	if err != nil {
@@ -63,7 +63,7 @@ func GetSizeOfVirtualMachineE(t *testing.T, vmName string, resGroupName string, 
 }
 
 // GetTagsForVirtualMachine gets the tags of the given Virtual Machine as a map
-func GetTagsForVirtualMachine(t *testing.T, vmName string, resGroupName string, subscriptionID string) map[string]string {
+func GetTagsForVirtualMachine(t TestingT, vmName string, resGroupName string, subscriptionID string) map[string]string {
 	tags, err := GetTagsForVirtualMachineE(t, vmName, resGroupName, subscriptionID)
 	require.NoError(t, err)
 
@@ -71,7 +71,7 @@ func GetTagsForVirtualMachine(t *testing.T, vmName string, resGroupName string, 
 }
 
 // GetTagsForVirtualMachineE gets the tags of the given Virtual Machine as a map
-func GetTagsForVirtualMachineE(t *testing.T, vmName string, resGroupName string, subscriptionID string) (map[string]string, error) {
+func GetTagsForVirtualMachineE(t TestingT, vmName string, resGroupName string, subscriptionID string) (map[string]string, error) {
 	// Setup a blank map to populate and return
 	tags := make(map[string]string)
 

--- a/modules/azure/compute.go
+++ b/modules/azure/compute.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-07-01/compute"
-	_ "github.com/gruntwork-io/terratest/modules/testing"
+	"github.com/gruntwork-io/terratest/modules/testing"
 	"github.com/stretchr/testify/require"
 )
 
@@ -32,7 +32,7 @@ func GetVirtualMachineClient(subscriptionID string) (*compute.VirtualMachinesCli
 }
 
 // GetSizeOfVirtualMachine gets the size type of the given Azure Virtual Machine
-func GetSizeOfVirtualMachine(t TestingT, vmName string, resGroupName string, subscriptionID string) compute.VirtualMachineSizeTypes {
+func GetSizeOfVirtualMachine(t testing.TestingT, vmName string, resGroupName string, subscriptionID string) compute.VirtualMachineSizeTypes {
 	size, err := GetSizeOfVirtualMachineE(t, vmName, resGroupName, subscriptionID)
 	require.NoError(t, err)
 
@@ -40,7 +40,7 @@ func GetSizeOfVirtualMachine(t TestingT, vmName string, resGroupName string, sub
 }
 
 // GetSizeOfVirtualMachineE gets the size type of the given Azure Virtual Machine
-func GetSizeOfVirtualMachineE(t TestingT, vmName string, resGroupName string, subscriptionID string) (compute.VirtualMachineSizeTypes, error) {
+func GetSizeOfVirtualMachineE(t testing.TestingT, vmName string, resGroupName string, subscriptionID string) (compute.VirtualMachineSizeTypes, error) {
 	// Validate resource group name and subscription ID
 	resGroupName, err := getTargetAzureResourceGroupName(resGroupName)
 	if err != nil {
@@ -63,7 +63,7 @@ func GetSizeOfVirtualMachineE(t TestingT, vmName string, resGroupName string, su
 }
 
 // GetTagsForVirtualMachine gets the tags of the given Virtual Machine as a map
-func GetTagsForVirtualMachine(t TestingT, vmName string, resGroupName string, subscriptionID string) map[string]string {
+func GetTagsForVirtualMachine(t testing.TestingT, vmName string, resGroupName string, subscriptionID string) map[string]string {
 	tags, err := GetTagsForVirtualMachineE(t, vmName, resGroupName, subscriptionID)
 	require.NoError(t, err)
 
@@ -71,7 +71,7 @@ func GetTagsForVirtualMachine(t TestingT, vmName string, resGroupName string, su
 }
 
 // GetTagsForVirtualMachineE gets the tags of the given Virtual Machine as a map
-func GetTagsForVirtualMachineE(t TestingT, vmName string, resGroupName string, subscriptionID string) (map[string]string, error) {
+func GetTagsForVirtualMachineE(t testing.TestingT, vmName string, resGroupName string, subscriptionID string) (map[string]string, error) {
 	// Setup a blank map to populate and return
 	tags := make(map[string]string)
 

--- a/modules/azure/region.go
+++ b/modules/azure/region.go
@@ -6,7 +6,7 @@ import (
 	"github.com/gruntwork-io/terratest/modules/collections"
 	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/random"
-	_ "github.com/gruntwork-io/terratest/modules/testing"
+	"github.com/gruntwork-io/terratest/modules/testing"
 )
 
 // Reference for region list: https://azure.microsoft.com/en-us/global-infrastructure/locations/
@@ -64,7 +64,7 @@ var stableRegions = []string{
 // further restrict the stable region list using approvedRegions and forbiddenRegions. We consider stable regions to be
 // those that have been around for at least 1 year.
 // Note that regions in the approvedRegions list that are not considered stable are ignored.
-func GetRandomStableRegion(t TestingT, approvedRegions []string, forbiddenRegions []string, subscriptionID string) string {
+func GetRandomStableRegion(t testing.TestingT, approvedRegions []string, forbiddenRegions []string, subscriptionID string) string {
 	regionsToPickFrom := stableRegions
 	if len(approvedRegions) > 0 {
 		regionsToPickFrom = collections.ListIntersection(regionsToPickFrom, approvedRegions)
@@ -78,7 +78,7 @@ func GetRandomStableRegion(t TestingT, approvedRegions []string, forbiddenRegion
 // GetRandomRegion gets a randomly chosen Azure region. If approvedRegions is not empty, this will be a region from the approvedRegions
 // list; otherwise, this method will fetch the latest list of regions from the Azure APIs and pick one of those. If
 // forbiddenRegions is not empty, this method will make sure the returned region is not in the forbiddenRegions list.
-func GetRandomRegion(t TestingT, approvedRegions []string, forbiddenRegions []string, subscriptionID string) string {
+func GetRandomRegion(t testing.TestingT, approvedRegions []string, forbiddenRegions []string, subscriptionID string) string {
 	// Validate Azure subscription ID
 	subscriptionID, err := getTargetAzureSubscription(subscriptionID)
 	if err != nil {
@@ -95,7 +95,7 @@ func GetRandomRegion(t TestingT, approvedRegions []string, forbiddenRegions []st
 // GetRandomRegionE gets a randomly chosen Azure region. If approvedRegions is not empty, this will be a region from the approvedRegions
 // list; otherwise, this method will fetch the latest list of regions from the Azure APIs and pick one of those. If
 // forbiddenRegions is not empty, this method will make sure the returned region is not in the forbiddenRegions list.
-func GetRandomRegionE(t TestingT, approvedRegions []string, forbiddenRegions []string, subscriptionID string) (string, error) {
+func GetRandomRegionE(t testing.TestingT, approvedRegions []string, forbiddenRegions []string, subscriptionID string) (string, error) {
 	// Validate Azure subscription ID
 	subscriptionID, err := getTargetAzureSubscription(subscriptionID)
 	if err != nil {
@@ -120,7 +120,7 @@ func GetRandomRegionE(t TestingT, approvedRegions []string, forbiddenRegions []s
 }
 
 // GetAllAzureRegions gets the list of Azure regions available in this subscription.
-func GetAllAzureRegions(t TestingT, subscriptionID string) []string {
+func GetAllAzureRegions(t testing.TestingT, subscriptionID string) []string {
 	// Validate Azure subscription ID
 	subscriptionID, err := getTargetAzureSubscription(subscriptionID)
 	if err != nil {
@@ -137,7 +137,7 @@ func GetAllAzureRegions(t TestingT, subscriptionID string) []string {
 }
 
 // GetAllAzureRegionsE gets the list of Azure regions available in this subscription.
-func GetAllAzureRegionsE(t TestingT, subscriptionID string) ([]string, error) {
+func GetAllAzureRegionsE(t testing.TestingT, subscriptionID string) ([]string, error) {
 	logger.Log(t, "Looking up all Azure regions available in this account")
 
 	// Validate Azure subscription ID

--- a/modules/azure/region.go
+++ b/modules/azure/region.go
@@ -2,11 +2,11 @@ package azure
 
 import (
 	"context"
-	"testing"
 
 	"github.com/gruntwork-io/terratest/modules/collections"
 	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/random"
+	_ "github.com/gruntwork-io/terratest/modules/testing"
 )
 
 // Reference for region list: https://azure.microsoft.com/en-us/global-infrastructure/locations/
@@ -64,7 +64,7 @@ var stableRegions = []string{
 // further restrict the stable region list using approvedRegions and forbiddenRegions. We consider stable regions to be
 // those that have been around for at least 1 year.
 // Note that regions in the approvedRegions list that are not considered stable are ignored.
-func GetRandomStableRegion(t *testing.T, approvedRegions []string, forbiddenRegions []string, subscriptionID string) string {
+func GetRandomStableRegion(t TestingT, approvedRegions []string, forbiddenRegions []string, subscriptionID string) string {
 	regionsToPickFrom := stableRegions
 	if len(approvedRegions) > 0 {
 		regionsToPickFrom = collections.ListIntersection(regionsToPickFrom, approvedRegions)
@@ -78,7 +78,7 @@ func GetRandomStableRegion(t *testing.T, approvedRegions []string, forbiddenRegi
 // GetRandomRegion gets a randomly chosen Azure region. If approvedRegions is not empty, this will be a region from the approvedRegions
 // list; otherwise, this method will fetch the latest list of regions from the Azure APIs and pick one of those. If
 // forbiddenRegions is not empty, this method will make sure the returned region is not in the forbiddenRegions list.
-func GetRandomRegion(t *testing.T, approvedRegions []string, forbiddenRegions []string, subscriptionID string) string {
+func GetRandomRegion(t TestingT, approvedRegions []string, forbiddenRegions []string, subscriptionID string) string {
 	// Validate Azure subscription ID
 	subscriptionID, err := getTargetAzureSubscription(subscriptionID)
 	if err != nil {
@@ -95,7 +95,7 @@ func GetRandomRegion(t *testing.T, approvedRegions []string, forbiddenRegions []
 // GetRandomRegionE gets a randomly chosen Azure region. If approvedRegions is not empty, this will be a region from the approvedRegions
 // list; otherwise, this method will fetch the latest list of regions from the Azure APIs and pick one of those. If
 // forbiddenRegions is not empty, this method will make sure the returned region is not in the forbiddenRegions list.
-func GetRandomRegionE(t *testing.T, approvedRegions []string, forbiddenRegions []string, subscriptionID string) (string, error) {
+func GetRandomRegionE(t TestingT, approvedRegions []string, forbiddenRegions []string, subscriptionID string) (string, error) {
 	// Validate Azure subscription ID
 	subscriptionID, err := getTargetAzureSubscription(subscriptionID)
 	if err != nil {
@@ -120,7 +120,7 @@ func GetRandomRegionE(t *testing.T, approvedRegions []string, forbiddenRegions [
 }
 
 // GetAllAzureRegions gets the list of Azure regions available in this subscription.
-func GetAllAzureRegions(t *testing.T, subscriptionID string) []string {
+func GetAllAzureRegions(t TestingT, subscriptionID string) []string {
 	// Validate Azure subscription ID
 	subscriptionID, err := getTargetAzureSubscription(subscriptionID)
 	if err != nil {
@@ -137,7 +137,7 @@ func GetAllAzureRegions(t *testing.T, subscriptionID string) []string {
 }
 
 // GetAllAzureRegionsE gets the list of Azure regions available in this subscription.
-func GetAllAzureRegionsE(t *testing.T, subscriptionID string) ([]string, error) {
+func GetAllAzureRegionsE(t TestingT, subscriptionID string) ([]string, error) {
 	logger.Log(t, "Looking up all Azure regions available in this account")
 
 	// Validate Azure subscription ID

--- a/modules/docker/build.go
+++ b/modules/docker/build.go
@@ -1,10 +1,9 @@
 package docker
 
 import (
-	"testing"
-
 	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/shell"
+	"github.com/gruntwork-io/terratest/modules/testing"
 	"github.com/stretchr/testify/require"
 )
 
@@ -24,12 +23,12 @@ type BuildOptions struct {
 
 // Build runs the 'docker build' command at the given path with the given options and fails the test if there are any
 // errors.
-func Build(t *testing.T, path string, options *BuildOptions) {
+func Build(t testing.TestingT, path string, options *BuildOptions) {
 	require.NoError(t, BuildE(t, path, options))
 }
 
 // BuildE runs the 'docker build' command at the given path with the given options and returns any errors.
-func BuildE(t *testing.T, path string, options *BuildOptions) error {
+func BuildE(t testing.TestingT, path string, options *BuildOptions) error {
 	logger.Logf(t, "Running 'docker build' in %s", path)
 
 	args, err := formatDockerBuildArgs(path, options)

--- a/modules/docker/docker_compose.go
+++ b/modules/docker/docker_compose.go
@@ -2,7 +2,7 @@ package docker
 
 import (
 	"github.com/gruntwork-io/terratest/modules/shell"
-	_ "github.com/gruntwork-io/terratest/modules/testing"
+	"github.com/gruntwork-io/terratest/modules/testing"
 )
 
 // Options are Docker options.
@@ -12,7 +12,7 @@ type Options struct {
 }
 
 // RunDockerCompose runs docker-compose with the given arguments and options and return stdout/stderr.
-func RunDockerCompose(t TestingT, options *Options, args ...string) string {
+func RunDockerCompose(t testing.TestingT, options *Options, args ...string) string {
 	out, err := RunDockerComposeE(t, options, args...)
 	if err != nil {
 		t.Fatal(err)
@@ -21,7 +21,7 @@ func RunDockerCompose(t TestingT, options *Options, args ...string) string {
 }
 
 // RunDockerComposeE runs docker-compose with the given arguments and options and return stdout/stderr.
-func RunDockerComposeE(t TestingT, options *Options, args ...string) (string, error) {
+func RunDockerComposeE(t testing.TestingT, options *Options, args ...string) (string, error) {
 	cmd := shell.Command{
 		Command: "docker-compose",
 		// We append --project-name to ensure containers from multiple different tests using Docker Compose don't end

--- a/modules/docker/docker_compose.go
+++ b/modules/docker/docker_compose.go
@@ -1,9 +1,8 @@
 package docker
 
 import (
-	"testing"
-
 	"github.com/gruntwork-io/terratest/modules/shell"
+	_ "github.com/gruntwork-io/terratest/modules/testing"
 )
 
 // Options are Docker options.
@@ -13,7 +12,7 @@ type Options struct {
 }
 
 // RunDockerCompose runs docker-compose with the given arguments and options and return stdout/stderr.
-func RunDockerCompose(t *testing.T, options *Options, args ...string) string {
+func RunDockerCompose(t TestingT, options *Options, args ...string) string {
 	out, err := RunDockerComposeE(t, options, args...)
 	if err != nil {
 		t.Fatal(err)
@@ -22,7 +21,7 @@ func RunDockerCompose(t *testing.T, options *Options, args ...string) string {
 }
 
 // RunDockerComposeE runs docker-compose with the given arguments and options and return stdout/stderr.
-func RunDockerComposeE(t *testing.T, options *Options, args ...string) (string, error) {
+func RunDockerComposeE(t TestingT, options *Options, args ...string) (string, error) {
 	cmd := shell.Command{
 		Command: "docker-compose",
 		// We append --project-name to ensure containers from multiple different tests using Docker Compose don't end

--- a/modules/docker/run.go
+++ b/modules/docker/run.go
@@ -1,10 +1,9 @@
 package docker
 
 import (
-	"testing"
-
 	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/shell"
+	"github.com/gruntwork-io/terratest/modules/testing"
 	"github.com/stretchr/testify/require"
 )
 
@@ -52,14 +51,14 @@ type RunOptions struct {
 
 // Run runs the 'docker run' command on the given image with the given options and return stdout/stderr. This method
 // fails the test if there are any errors.
-func Run(t *testing.T, image string, options *RunOptions) string {
+func Run(t testing.TestingT, image string, options *RunOptions) string {
 	out, err := RunE(t, image, options)
 	require.NoError(t, err)
 	return out
 }
 
 // RunE runs the 'docker run' command on the given image with the given options and return stdout/stderr, or any error.
-func RunE(t *testing.T, image string, options *RunOptions) (string, error) {
+func RunE(t testing.TestingT, image string, options *RunOptions) (string, error) {
 	logger.Logf(t, "Running 'docker run' on image '%s'", image)
 
 	args, err := formatDockerRunArgs(image, options)

--- a/modules/docker/stop.go
+++ b/modules/docker/stop.go
@@ -2,10 +2,10 @@ package docker
 
 import (
 	"strconv"
-	"testing"
 
 	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/shell"
+	"github.com/gruntwork-io/terratest/modules/testing"
 	"github.com/stretchr/testify/require"
 )
 
@@ -17,14 +17,14 @@ type StopOptions struct {
 
 // Stop runs the 'docker stop' command for the given containers and return the stdout/stderr. This method fails
 // the test if there are any errors
-func Stop(t *testing.T, containers []string, options *StopOptions) string {
+func Stop(t testing.TestingT, containers []string, options *StopOptions) string {
 	out, err := StopE(t, containers, options)
 	require.NoError(t, err)
 	return out
 }
 
 // StopE runs the 'docker stop' command for the given containers and returns any errors.
-func StopE(t *testing.T, containers []string, options *StopOptions) (string, error) {
+func StopE(t testing.TestingT, containers []string, options *StopOptions) (string, error) {
 	logger.Logf(t, "Running 'docker stop' on containers '%s'", containers)
 
 	args, err := formatDockerStopArgs(containers, options)

--- a/modules/environment/envvar.go
+++ b/modules/environment/envvar.go
@@ -1,8 +1,9 @@
 package environment
 
 import (
-	"github.com/gruntwork-io/terratest/modules/testing"
 	"os"
+
+	"github.com/gruntwork-io/terratest/modules/testing"
 )
 
 // GetFirstNonEmptyEnvVarOrFatal returns the first non-empty environment variable from envVarNames, or throws a fatal

--- a/modules/environment/envvar.go
+++ b/modules/environment/envvar.go
@@ -1,12 +1,12 @@
 package environment
 
 import (
-	_ "github.com/gruntwork-io/terratest/modules/testing"
+	"github.com/gruntwork-io/terratest/modules/testing"
 	"os"
 )
 
 // GetFirstNonEmptyEnvVarOrFatal returns the first non-empty environment variable from envVarNames, or throws a fatal
-func GetFirstNonEmptyEnvVarOrFatal(t TestingT, envVarNames []string) string {
+func GetFirstNonEmptyEnvVarOrFatal(t testing.TestingT, envVarNames []string) string {
 	value := GetFirstNonEmptyEnvVarOrEmptyString(t, envVarNames)
 	if value == "" {
 		t.Fatalf("All of the following env vars %v are empty. At least one must be non-empty.", envVarNames)
@@ -17,7 +17,7 @@ func GetFirstNonEmptyEnvVarOrFatal(t TestingT, envVarNames []string) string {
 
 // GetFirstNonEmptyEnvVarOrEmptyString returns the first non-empty environment variable from envVarNames, or returns the
 // empty string
-func GetFirstNonEmptyEnvVarOrEmptyString(t TestingT, envVarNames []string) string {
+func GetFirstNonEmptyEnvVarOrEmptyString(t testing.TestingT, envVarNames []string) string {
 	for _, name := range envVarNames {
 		if value := os.Getenv(name); value != "" {
 			return value

--- a/modules/environment/envvar.go
+++ b/modules/environment/envvar.go
@@ -1,12 +1,12 @@
 package environment
 
 import (
+	_ "github.com/gruntwork-io/terratest/modules/testing"
 	"os"
-	"testing"
 )
 
 // GetFirstNonEmptyEnvVarOrFatal returns the first non-empty environment variable from envVarNames, or throws a fatal
-func GetFirstNonEmptyEnvVarOrFatal(t *testing.T, envVarNames []string) string {
+func GetFirstNonEmptyEnvVarOrFatal(t TestingT, envVarNames []string) string {
 	value := GetFirstNonEmptyEnvVarOrEmptyString(t, envVarNames)
 	if value == "" {
 		t.Fatalf("All of the following env vars %v are empty. At least one must be non-empty.", envVarNames)
@@ -17,7 +17,7 @@ func GetFirstNonEmptyEnvVarOrFatal(t *testing.T, envVarNames []string) string {
 
 // GetFirstNonEmptyEnvVarOrEmptyString returns the first non-empty environment variable from envVarNames, or returns the
 // empty string
-func GetFirstNonEmptyEnvVarOrEmptyString(t *testing.T, envVarNames []string) string {
+func GetFirstNonEmptyEnvVarOrEmptyString(t TestingT, envVarNames []string) string {
 	for _, name := range envVarNames {
 		if value := os.Getenv(name); value != "" {
 			return value

--- a/modules/gcp/cloudbuild.go
+++ b/modules/gcp/cloudbuild.go
@@ -3,23 +3,23 @@ package gcp
 import (
 	"context"
 	"fmt"
-	"testing"
 
 	cloudbuild "cloud.google.com/go/cloudbuild/apiv1/v2"
+	"github.com/gruntwork-io/terratest/modules/testing"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/api/iterator"
 	cloudbuildpb "google.golang.org/genproto/googleapis/devtools/cloudbuild/v1"
 )
 
 // CreateBuild creates a new build blocking until the operation is complete.
-func CreateBuild(t *testing.T, projectID string, build *cloudbuildpb.Build) *cloudbuildpb.Build {
+func CreateBuild(t testing.TestingT, projectID string, build *cloudbuildpb.Build) *cloudbuildpb.Build {
 	out, err := CreateBuildE(t, projectID, build)
 	require.NoError(t, err)
 	return out
 }
 
 // CreateBuildE creates a new build blocking until the operation is complete.
-func CreateBuildE(t *testing.T, projectID string, build *cloudbuildpb.Build) (*cloudbuildpb.Build, error) {
+func CreateBuildE(t testing.TestingT, projectID string, build *cloudbuildpb.Build) (*cloudbuildpb.Build, error) {
 	ctx := context.Background()
 
 	service, err := NewCloudBuildServiceE(t)
@@ -46,14 +46,14 @@ func CreateBuildE(t *testing.T, projectID string, build *cloudbuildpb.Build) (*c
 }
 
 // GetBuild gets the given build.
-func GetBuild(t *testing.T, projectID string, buildID string) *cloudbuildpb.Build {
+func GetBuild(t testing.TestingT, projectID string, buildID string) *cloudbuildpb.Build {
 	out, err := GetBuildE(t, projectID, buildID)
 	require.NoError(t, err)
 	return out
 }
 
 // GetBuildE gets the given build.
-func GetBuildE(t *testing.T, projectID string, buildID string) (*cloudbuildpb.Build, error) {
+func GetBuildE(t testing.TestingT, projectID string, buildID string) (*cloudbuildpb.Build, error) {
 	ctx := context.Background()
 
 	service, err := NewCloudBuildServiceE(t)
@@ -75,14 +75,14 @@ func GetBuildE(t *testing.T, projectID string, buildID string) (*cloudbuildpb.Bu
 }
 
 // GetBuilds gets the list of builds for a given project.
-func GetBuilds(t *testing.T, projectID string) []*cloudbuildpb.Build {
+func GetBuilds(t testing.TestingT, projectID string) []*cloudbuildpb.Build {
 	out, err := GetBuildsE(t, projectID)
 	require.NoError(t, err)
 	return out
 }
 
 // GetBuildsE gets the list of builds for a given project.
-func GetBuildsE(t *testing.T, projectID string) ([]*cloudbuildpb.Build, error) {
+func GetBuildsE(t testing.TestingT, projectID string) ([]*cloudbuildpb.Build, error) {
 	ctx := context.Background()
 
 	service, err := NewCloudBuildServiceE(t)
@@ -113,14 +113,14 @@ func GetBuildsE(t *testing.T, projectID string) ([]*cloudbuildpb.Build, error) {
 }
 
 // GetBuildsForTrigger gets a list of builds for a specific cloud build trigger.
-func GetBuildsForTrigger(t *testing.T, projectID string, triggerID string) []*cloudbuildpb.Build {
+func GetBuildsForTrigger(t testing.TestingT, projectID string, triggerID string) []*cloudbuildpb.Build {
 	out, err := GetBuildsForTriggerE(t, projectID, triggerID)
 	require.NoError(t, err)
 	return out
 }
 
 // GetBuildsForTriggerE gets a list of builds for a specific cloud build trigger.
-func GetBuildsForTriggerE(t *testing.T, projectID string, triggerID string) ([]*cloudbuildpb.Build, error) {
+func GetBuildsForTriggerE(t testing.TestingT, projectID string, triggerID string) ([]*cloudbuildpb.Build, error) {
 	builds, err := GetBuildsE(t, projectID)
 	if err != nil {
 		return nil, fmt.Errorf("GetBuildsE.ListBuilds(%s) got error: %v", projectID, err)
@@ -137,14 +137,14 @@ func GetBuildsForTriggerE(t *testing.T, projectID string, triggerID string) ([]*
 }
 
 // NewCloudBuildService creates a new Cloud Build service, which is used to make Cloud Build API calls.
-func NewCloudBuildService(t *testing.T) *cloudbuild.Client {
+func NewCloudBuildService(t testing.TestingT) *cloudbuild.Client {
 	service, err := NewCloudBuildServiceE(t)
 	require.NoError(t, err)
 	return service
 }
 
 // NewCloudBuildServiceE creates a new Cloud Build service, which is used to make Cloud Build API calls.
-func NewCloudBuildServiceE(t *testing.T) (*cloudbuild.Client, error) {
+func NewCloudBuildServiceE(t testing.TestingT) (*cloudbuild.Client, error) {
 	ctx := context.Background()
 
 	service, err := cloudbuild.NewClient(ctx)

--- a/modules/gcp/compute.go
+++ b/modules/gcp/compute.go
@@ -9,12 +9,12 @@ import (
 	"time"
 
 	"github.com/gruntwork-io/terratest/modules/retry"
+	"google.golang.org/api/compute/v1"
 
 	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/gruntwork-io/terratest/modules/testing"
 	"golang.org/x/oauth2/google"
-	"google.golang.org/api/compute/v1"
 )
 
 // Corresponds to a GCP Compute Instance (https://cloud.google.com/compute/docs/instances/)

--- a/modules/gcp/compute.go
+++ b/modules/gcp/compute.go
@@ -6,13 +6,13 @@ import (
 	"net/http"
 	"path"
 	"strings"
-	"testing"
 	"time"
 
 	"github.com/gruntwork-io/terratest/modules/retry"
 
 	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/random"
+	_ "github.com/gruntwork-io/terratest/modules/testing"
 	"golang.org/x/oauth2/google"
 	"google.golang.org/api/compute/v1"
 )
@@ -42,12 +42,12 @@ type RegionalInstanceGroup struct {
 }
 
 type InstanceGroup interface {
-	GetInstanceIds(t *testing.T) []string
-	GetInstanceIdsE(t *testing.T) ([]string, error)
+	GetInstanceIds(t TestingT) []string
+	GetInstanceIdsE(t TestingT) ([]string, error)
 }
 
 // FetchInstance queries GCP to return an instance of the (GCP Compute) Instance type
-func FetchInstance(t *testing.T, projectID string, name string) *Instance {
+func FetchInstance(t TestingT, projectID string, name string) *Instance {
 	instance, err := FetchInstanceE(t, projectID, name)
 	if err != nil {
 		t.Fatal(err)
@@ -57,7 +57,7 @@ func FetchInstance(t *testing.T, projectID string, name string) *Instance {
 }
 
 // FetchInstance queries GCP to return an instance of the (GCP Compute) Instance type
-func FetchInstanceE(t *testing.T, projectID string, name string) (*Instance, error) {
+func FetchInstanceE(t TestingT, projectID string, name string) (*Instance, error) {
 	logger.Logf(t, "Getting Compute Instance %s", name)
 
 	ctx := context.Background()
@@ -85,7 +85,7 @@ func FetchInstanceE(t *testing.T, projectID string, name string) (*Instance, err
 }
 
 // FetchImage queries GCP to return a new instance of the (GCP Compute) Image type
-func FetchImage(t *testing.T, projectID string, name string) *Image {
+func FetchImage(t TestingT, projectID string, name string) *Image {
 	image, err := FetchImageE(t, projectID, name)
 	if err != nil {
 		t.Fatal(err)
@@ -95,7 +95,7 @@ func FetchImage(t *testing.T, projectID string, name string) *Image {
 }
 
 // FetchImage queries GCP to return a new instance of the (GCP Compute) Image type
-func FetchImageE(t *testing.T, projectID string, name string) (*Image, error) {
+func FetchImageE(t TestingT, projectID string, name string) (*Image, error) {
 	logger.Logf(t, "Getting Image %s", name)
 
 	ctx := context.Background()
@@ -114,7 +114,7 @@ func FetchImageE(t *testing.T, projectID string, name string) (*Image, error) {
 }
 
 // FetchRegionalInstanceGroup queries GCP to return a new instance of the Regional Instance Group type
-func FetchRegionalInstanceGroup(t *testing.T, projectID string, region string, name string) *RegionalInstanceGroup {
+func FetchRegionalInstanceGroup(t TestingT, projectID string, region string, name string) *RegionalInstanceGroup {
 	instanceGroup, err := FetchRegionalInstanceGroupE(t, projectID, region, name)
 	if err != nil {
 		t.Fatal(err)
@@ -124,7 +124,7 @@ func FetchRegionalInstanceGroup(t *testing.T, projectID string, region string, n
 }
 
 // FetchRegionalInstanceGroup queries GCP to return a new instance of the Regional Instance Group type
-func FetchRegionalInstanceGroupE(t *testing.T, projectID string, region string, name string) (*RegionalInstanceGroup, error) {
+func FetchRegionalInstanceGroupE(t TestingT, projectID string, region string, name string) (*RegionalInstanceGroup, error) {
 	logger.Logf(t, "Getting Regional Instance Group %s", name)
 
 	ctx := context.Background()
@@ -143,7 +143,7 @@ func FetchRegionalInstanceGroupE(t *testing.T, projectID string, region string, 
 }
 
 // FetchZonalInstanceGroup queries GCP to return a new instance of the Regional Instance Group type
-func FetchZonalInstanceGroup(t *testing.T, projectID string, zone string, name string) *ZonalInstanceGroup {
+func FetchZonalInstanceGroup(t TestingT, projectID string, zone string, name string) *ZonalInstanceGroup {
 	instanceGroup, err := FetchZonalInstanceGroupE(t, projectID, zone, name)
 	if err != nil {
 		t.Fatal(err)
@@ -153,7 +153,7 @@ func FetchZonalInstanceGroup(t *testing.T, projectID string, zone string, name s
 }
 
 // FetchZonalInstanceGroup queries GCP to return a new instance of the Regional Instance Group type
-func FetchZonalInstanceGroupE(t *testing.T, projectID string, zone string, name string) (*ZonalInstanceGroup, error) {
+func FetchZonalInstanceGroupE(t TestingT, projectID string, zone string, name string) (*ZonalInstanceGroup, error) {
 	logger.Logf(t, "Getting Zonal Instance Group %s", name)
 
 	ctx := context.Background()
@@ -172,7 +172,7 @@ func FetchZonalInstanceGroupE(t *testing.T, projectID string, zone string, name 
 }
 
 // GetPublicIP gets the public IP address of the given Compute Instance.
-func (i *Instance) GetPublicIp(t *testing.T) string {
+func (i *Instance) GetPublicIp(t TestingT) string {
 	ip, err := i.GetPublicIpE(t)
 	if err != nil {
 		t.Fatal(err)
@@ -181,7 +181,7 @@ func (i *Instance) GetPublicIp(t *testing.T) string {
 }
 
 // GetPublicIpE gets the public IP address of the given Compute Instance.
-func (i *Instance) GetPublicIpE(t *testing.T) (string, error) {
+func (i *Instance) GetPublicIpE(t TestingT) (string, error) {
 	// If there are no accessConfigs specified, then this instance will have no external internet access:
 	// https://cloud.google.com/compute/docs/reference/rest/v1/instances.
 	if len(i.NetworkInterfaces[0].AccessConfigs) == 0 {
@@ -194,17 +194,17 @@ func (i *Instance) GetPublicIpE(t *testing.T) (string, error) {
 }
 
 // GetLabels returns all the tags for the given Compute Instance.
-func (i *Instance) GetLabels(t *testing.T) map[string]string {
+func (i *Instance) GetLabels(t TestingT) map[string]string {
 	return i.Labels
 }
 
 // GetZone returns the Zone in which the Compute Instance is located.
-func (i *Instance) GetZone(t *testing.T) string {
+func (i *Instance) GetZone(t TestingT) string {
 	return ZoneUrlToZone(i.Zone)
 }
 
 // SetLabels adds the tags to the given Compute Instance.
-func (i *Instance) SetLabels(t *testing.T, labels map[string]string) {
+func (i *Instance) SetLabels(t TestingT, labels map[string]string) {
 	err := i.SetLabelsE(t, labels)
 	if err != nil {
 		t.Fatal(err)
@@ -212,7 +212,7 @@ func (i *Instance) SetLabels(t *testing.T, labels map[string]string) {
 }
 
 // SetLabelsE adds the tags to the given Compute Instance.
-func (i *Instance) SetLabelsE(t *testing.T, labels map[string]string) error {
+func (i *Instance) SetLabelsE(t TestingT, labels map[string]string) error {
 	logger.Logf(t, "Adding labels to instance %s in zone %s", i.Name, i.Zone)
 
 	ctx := context.Background()
@@ -230,12 +230,12 @@ func (i *Instance) SetLabelsE(t *testing.T, labels map[string]string) error {
 }
 
 // GetMetadata gets the given Compute Instance's metadata
-func (i *Instance) GetMetadata(t *testing.T) []*compute.MetadataItems {
+func (i *Instance) GetMetadata(t TestingT) []*compute.MetadataItems {
 	return i.Metadata.Items
 }
 
 // SetMetadata sets the given Compute Instance's metadata
-func (i *Instance) SetMetadata(t *testing.T, metadata map[string]string) {
+func (i *Instance) SetMetadata(t TestingT, metadata map[string]string) {
 	err := i.SetMetadataE(t, metadata)
 	if err != nil {
 		t.Fatal(err)
@@ -243,7 +243,7 @@ func (i *Instance) SetMetadata(t *testing.T, metadata map[string]string) {
 }
 
 // SetLabelsE adds the given metadata map to the existing metadata of the given Compute Instance.
-func (i *Instance) SetMetadataE(t *testing.T, metadata map[string]string) error {
+func (i *Instance) SetMetadataE(t TestingT, metadata map[string]string) error {
 	logger.Logf(t, "Adding metadata to instance %s in zone %s", i.Name, i.Zone)
 
 	ctx := context.Background()
@@ -263,7 +263,7 @@ func (i *Instance) SetMetadataE(t *testing.T, metadata map[string]string) error 
 
 // newMetadata takes in a Compute Instance's existing metadata plus a new set of key-value pairs and returns an updated
 // metadata object.
-func newMetadata(t *testing.T, oldMetadata *compute.Metadata, kvs map[string]string) *compute.Metadata {
+func newMetadata(t TestingT, oldMetadata *compute.Metadata, kvs map[string]string) *compute.Metadata {
 	items := []*compute.MetadataItems{}
 
 	for key, val := range kvs {
@@ -284,7 +284,7 @@ func newMetadata(t *testing.T, oldMetadata *compute.Metadata, kvs map[string]str
 }
 
 // Add the given public SSH key to the Compute Instance. Users can SSH in with the given username.
-func (i *Instance) AddSshKey(t *testing.T, username string, publicKey string) {
+func (i *Instance) AddSshKey(t TestingT, username string, publicKey string) {
 	err := i.AddSshKeyE(t, username, publicKey)
 	if err != nil {
 		t.Fatal(err)
@@ -292,7 +292,7 @@ func (i *Instance) AddSshKey(t *testing.T, username string, publicKey string) {
 }
 
 // Add the given public SSH key to the Compute Instance. Users can SSH in with the given username.
-func (i *Instance) AddSshKeyE(t *testing.T, username string, publicKey string) error {
+func (i *Instance) AddSshKeyE(t TestingT, username string, publicKey string) error {
 	logger.Logf(t, "Adding SSH Key to Compute Instance %s for username %s\n", i.Name, username)
 
 	// We represent the key in the format required per GCP docs (https://cloud.google.com/compute/docs/instances/adding-removing-ssh-keys)
@@ -312,7 +312,7 @@ func (i *Instance) AddSshKeyE(t *testing.T, username string, publicKey string) e
 }
 
 // DeleteImage deletes the given Compute Image.
-func (i *Image) DeleteImage(t *testing.T) {
+func (i *Image) DeleteImage(t TestingT) {
 	err := i.DeleteImageE(t)
 	if err != nil {
 		t.Fatal(err)
@@ -320,7 +320,7 @@ func (i *Image) DeleteImage(t *testing.T) {
 }
 
 // DeleteImageE deletes the given Compute Image.
-func (i *Image) DeleteImageE(t *testing.T) error {
+func (i *Image) DeleteImageE(t TestingT) error {
 	logger.Logf(t, "Destroying Image %s", i.Name)
 
 	ctx := context.Background()
@@ -337,7 +337,7 @@ func (i *Image) DeleteImageE(t *testing.T) error {
 }
 
 // GetInstanceIds gets the IDs of Instances in the given Instance Group.
-func (ig *ZonalInstanceGroup) GetInstanceIds(t *testing.T) []string {
+func (ig *ZonalInstanceGroup) GetInstanceIds(t TestingT) []string {
 	ids, err := ig.GetInstanceIdsE(t)
 	if err != nil {
 		t.Fatal(err)
@@ -346,7 +346,7 @@ func (ig *ZonalInstanceGroup) GetInstanceIds(t *testing.T) []string {
 }
 
 // GetInstanceIdsE gets the IDs of Instances in the given Zonal Instance Group.
-func (ig *ZonalInstanceGroup) GetInstanceIdsE(t *testing.T) ([]string, error) {
+func (ig *ZonalInstanceGroup) GetInstanceIdsE(t TestingT) ([]string, error) {
 	logger.Logf(t, "Get instances for Zonal Instance Group %s", ig.Name)
 
 	ctx := context.Background()
@@ -382,7 +382,7 @@ func (ig *ZonalInstanceGroup) GetInstanceIdsE(t *testing.T) ([]string, error) {
 }
 
 // GetInstanceIds gets the IDs of Instances in the given Regional Instance Group.
-func (ig *RegionalInstanceGroup) GetInstanceIds(t *testing.T) []string {
+func (ig *RegionalInstanceGroup) GetInstanceIds(t TestingT) []string {
 	ids, err := ig.GetInstanceIdsE(t)
 	if err != nil {
 		t.Fatal(err)
@@ -391,7 +391,7 @@ func (ig *RegionalInstanceGroup) GetInstanceIds(t *testing.T) []string {
 }
 
 // GetInstanceIdsE gets the IDs of Instances in the given Regional Instance Group.
-func (ig *RegionalInstanceGroup) GetInstanceIdsE(t *testing.T) ([]string, error) {
+func (ig *RegionalInstanceGroup) GetInstanceIdsE(t TestingT) ([]string, error) {
 	logger.Logf(t, "Get instances for Regional Instance Group %s", ig.Name)
 
 	ctx := context.Background()
@@ -428,27 +428,27 @@ func (ig *RegionalInstanceGroup) GetInstanceIdsE(t *testing.T) ([]string, error)
 }
 
 // Return a collection of Instance structs from the given Instance Group
-func (ig *ZonalInstanceGroup) GetInstances(t *testing.T, projectId string) []*Instance {
+func (ig *ZonalInstanceGroup) GetInstances(t TestingT, projectId string) []*Instance {
 	return getInstances(t, ig, projectId)
 }
 
 // Return a collection of Instance structs from the given Instance Group
-func (ig *ZonalInstanceGroup) GetInstancesE(t *testing.T, projectId string) ([]*Instance, error) {
+func (ig *ZonalInstanceGroup) GetInstancesE(t TestingT, projectId string) ([]*Instance, error) {
 	return getInstancesE(t, ig, projectId)
 }
 
 // Return a collection of Instance structs from the given Instance Group
-func (ig *RegionalInstanceGroup) GetInstances(t *testing.T, projectId string) []*Instance {
+func (ig *RegionalInstanceGroup) GetInstances(t TestingT, projectId string) []*Instance {
 	return getInstances(t, ig, projectId)
 }
 
 // Return a collection of Instance structs from the given Instance Group
-func (ig *RegionalInstanceGroup) GetInstancesE(t *testing.T, projectId string) ([]*Instance, error) {
+func (ig *RegionalInstanceGroup) GetInstancesE(t TestingT, projectId string) ([]*Instance, error) {
 	return getInstancesE(t, ig, projectId)
 }
 
 // getInstancesE returns a collection of Instance structs from the given Instance Group
-func getInstances(t *testing.T, ig InstanceGroup, projectId string) []*Instance {
+func getInstances(t TestingT, ig InstanceGroup, projectId string) []*Instance {
 	instances, err := getInstancesE(t, ig, projectId)
 	if err != nil {
 		t.Fatal(err)
@@ -458,7 +458,7 @@ func getInstances(t *testing.T, ig InstanceGroup, projectId string) []*Instance 
 }
 
 // getInstancesE returns a collection of Instance structs from the given Instance Group
-func getInstancesE(t *testing.T, ig InstanceGroup, projectId string) ([]*Instance, error) {
+func getInstancesE(t TestingT, ig InstanceGroup, projectId string) ([]*Instance, error) {
 	instanceIds, err := ig.GetInstanceIdsE(t)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to get Instance Group IDs: %s", err)
@@ -479,27 +479,27 @@ func getInstancesE(t *testing.T, ig InstanceGroup, projectId string) ([]*Instanc
 }
 
 // GetPublicIps returns a slice of the public IPs from the given Instance Group
-func (ig *ZonalInstanceGroup) GetPublicIps(t *testing.T, projectId string) []string {
+func (ig *ZonalInstanceGroup) GetPublicIps(t TestingT, projectId string) []string {
 	return getPublicIps(t, ig, projectId)
 }
 
 // GetPublicIpsE returns a slice of the public IPs from the given Instance Group
-func (ig *ZonalInstanceGroup) GetPublicIpsE(t *testing.T, projectId string) ([]string, error) {
+func (ig *ZonalInstanceGroup) GetPublicIpsE(t TestingT, projectId string) ([]string, error) {
 	return getPublicIpsE(t, ig, projectId)
 }
 
 // GetPublicIps returns a slice of the public IPs from the given Instance Group
-func (ig *RegionalInstanceGroup) GetPublicIps(t *testing.T, projectId string) []string {
+func (ig *RegionalInstanceGroup) GetPublicIps(t TestingT, projectId string) []string {
 	return getPublicIps(t, ig, projectId)
 }
 
 // GetPublicIpsE returns a slice of the public IPs from the given Instance Group
-func (ig *RegionalInstanceGroup) GetPublicIpsE(t *testing.T, projectId string) ([]string, error) {
+func (ig *RegionalInstanceGroup) GetPublicIpsE(t TestingT, projectId string) ([]string, error) {
 	return getPublicIpsE(t, ig, projectId)
 }
 
 // getPublicIps a slice of the public IPs from the given Instance Group
-func getPublicIps(t *testing.T, ig InstanceGroup, projectId string) []string {
+func getPublicIps(t TestingT, ig InstanceGroup, projectId string) []string {
 	ips, err := getPublicIpsE(t, ig, projectId)
 	if err != nil {
 		t.Fatal(err)
@@ -509,7 +509,7 @@ func getPublicIps(t *testing.T, ig InstanceGroup, projectId string) []string {
 }
 
 // getPublicIpsE a slice of the public IPs from the given Instance Group
-func getPublicIpsE(t *testing.T, ig InstanceGroup, projectId string) ([]string, error) {
+func getPublicIpsE(t TestingT, ig InstanceGroup, projectId string) ([]string, error) {
 	instances, err := getInstancesE(t, ig, projectId)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to get Compute Instances from Instance Group: %s", err)
@@ -526,26 +526,26 @@ func getPublicIpsE(t *testing.T, ig InstanceGroup, projectId string) ([]string, 
 }
 
 // getRandomInstance returns a randomly selected Instance from the Regional Instance Group
-func (ig *ZonalInstanceGroup) GetRandomInstance(t *testing.T) *Instance {
+func (ig *ZonalInstanceGroup) GetRandomInstance(t TestingT) *Instance {
 	return getRandomInstance(t, ig, ig.Name, ig.Region, ig.Size, ig.projectID)
 }
 
 // getRandomInstanceE returns a randomly selected Instance from the Regional Instance Group
-func (ig *ZonalInstanceGroup) GetRandomInstanceE(t *testing.T) (*Instance, error) {
+func (ig *ZonalInstanceGroup) GetRandomInstanceE(t TestingT) (*Instance, error) {
 	return getRandomInstanceE(t, ig, ig.Name, ig.Region, ig.Size, ig.projectID)
 }
 
 // getRandomInstance returns a randomly selected Instance from the Regional Instance Group
-func (ig *RegionalInstanceGroup) GetRandomInstance(t *testing.T) *Instance {
+func (ig *RegionalInstanceGroup) GetRandomInstance(t TestingT) *Instance {
 	return getRandomInstance(t, ig, ig.Name, ig.Region, ig.Size, ig.projectID)
 }
 
 // getRandomInstanceE returns a randomly selected Instance from the Regional Instance Group
-func (ig *RegionalInstanceGroup) GetRandomInstanceE(t *testing.T) (*Instance, error) {
+func (ig *RegionalInstanceGroup) GetRandomInstanceE(t TestingT) (*Instance, error) {
 	return getRandomInstanceE(t, ig, ig.Name, ig.Region, ig.Size, ig.projectID)
 }
 
-func getRandomInstance(t *testing.T, ig InstanceGroup, name string, region string, size int64, projectID string) *Instance {
+func getRandomInstance(t TestingT, ig InstanceGroup, name string, region string, size int64, projectID string) *Instance {
 	instance, err := getRandomInstanceE(t, ig, name, region, size, projectID)
 	if err != nil {
 		t.Fatal(err)
@@ -554,7 +554,7 @@ func getRandomInstance(t *testing.T, ig InstanceGroup, name string, region strin
 	return instance
 }
 
-func getRandomInstanceE(t *testing.T, ig InstanceGroup, name string, region string, size int64, projectID string) (*Instance, error) {
+func getRandomInstanceE(t TestingT, ig InstanceGroup, name string, region string, size int64, projectID string) (*Instance, error) {
 	instanceIDs := ig.GetInstanceIds(t)
 	if len(instanceIDs) == 0 {
 		return nil, fmt.Errorf("Could not find any instances in Regional Instance Group %s in Region %s", name, region)
@@ -573,7 +573,7 @@ func getRandomInstanceE(t *testing.T, ig InstanceGroup, name string, region stri
 }
 
 // NewComputeService creates a new Compute service, which is used to make GCE API calls.
-func NewComputeService(t *testing.T) *compute.Service {
+func NewComputeService(t TestingT) *compute.Service {
 	client, err := NewComputeServiceE(t)
 	if err != nil {
 		t.Fatal(err)
@@ -582,7 +582,7 @@ func NewComputeService(t *testing.T) *compute.Service {
 }
 
 // NewComputeServiceE creates a new Compute service, which is used to make GCE API calls.
-func NewComputeServiceE(t *testing.T) (*compute.Service, error) {
+func NewComputeServiceE(t TestingT) (*compute.Service, error) {
 	ctx := context.Background()
 
 	// Retrieve the Google OAuth token using a retry loop as it can sometimes return an error.
@@ -613,7 +613,7 @@ func NewComputeServiceE(t *testing.T) (*compute.Service, error) {
 }
 
 // NewInstancesService creates a new InstancesService service, which is used to make a subset of GCE API calls.
-func NewInstancesService(t *testing.T) *compute.InstancesService {
+func NewInstancesService(t TestingT) *compute.InstancesService {
 	client, err := NewInstancesServiceE(t)
 	if err != nil {
 		t.Fatal(err)
@@ -622,7 +622,7 @@ func NewInstancesService(t *testing.T) *compute.InstancesService {
 }
 
 // NewInstancesServiceE creates a new InstancesService service, which is used to make a subset of GCE API calls.
-func NewInstancesServiceE(t *testing.T) (*compute.InstancesService, error) {
+func NewInstancesServiceE(t TestingT) (*compute.InstancesService, error) {
 	service, err := NewComputeServiceE(t)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to get new Instances Service\n")

--- a/modules/gcp/compute.go
+++ b/modules/gcp/compute.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/random"
-	_ "github.com/gruntwork-io/terratest/modules/testing"
+	"github.com/gruntwork-io/terratest/modules/testing"
 	"golang.org/x/oauth2/google"
 	"google.golang.org/api/compute/v1"
 )
@@ -42,12 +42,12 @@ type RegionalInstanceGroup struct {
 }
 
 type InstanceGroup interface {
-	GetInstanceIds(t TestingT) []string
-	GetInstanceIdsE(t TestingT) ([]string, error)
+	GetInstanceIds(t testing.TestingT) []string
+	GetInstanceIdsE(t testing.TestingT) ([]string, error)
 }
 
 // FetchInstance queries GCP to return an instance of the (GCP Compute) Instance type
-func FetchInstance(t TestingT, projectID string, name string) *Instance {
+func FetchInstance(t testing.TestingT, projectID string, name string) *Instance {
 	instance, err := FetchInstanceE(t, projectID, name)
 	if err != nil {
 		t.Fatal(err)
@@ -57,7 +57,7 @@ func FetchInstance(t TestingT, projectID string, name string) *Instance {
 }
 
 // FetchInstance queries GCP to return an instance of the (GCP Compute) Instance type
-func FetchInstanceE(t TestingT, projectID string, name string) (*Instance, error) {
+func FetchInstanceE(t testing.TestingT, projectID string, name string) (*Instance, error) {
 	logger.Logf(t, "Getting Compute Instance %s", name)
 
 	ctx := context.Background()
@@ -85,7 +85,7 @@ func FetchInstanceE(t TestingT, projectID string, name string) (*Instance, error
 }
 
 // FetchImage queries GCP to return a new instance of the (GCP Compute) Image type
-func FetchImage(t TestingT, projectID string, name string) *Image {
+func FetchImage(t testing.TestingT, projectID string, name string) *Image {
 	image, err := FetchImageE(t, projectID, name)
 	if err != nil {
 		t.Fatal(err)
@@ -95,7 +95,7 @@ func FetchImage(t TestingT, projectID string, name string) *Image {
 }
 
 // FetchImage queries GCP to return a new instance of the (GCP Compute) Image type
-func FetchImageE(t TestingT, projectID string, name string) (*Image, error) {
+func FetchImageE(t testing.TestingT, projectID string, name string) (*Image, error) {
 	logger.Logf(t, "Getting Image %s", name)
 
 	ctx := context.Background()
@@ -114,7 +114,7 @@ func FetchImageE(t TestingT, projectID string, name string) (*Image, error) {
 }
 
 // FetchRegionalInstanceGroup queries GCP to return a new instance of the Regional Instance Group type
-func FetchRegionalInstanceGroup(t TestingT, projectID string, region string, name string) *RegionalInstanceGroup {
+func FetchRegionalInstanceGroup(t testing.TestingT, projectID string, region string, name string) *RegionalInstanceGroup {
 	instanceGroup, err := FetchRegionalInstanceGroupE(t, projectID, region, name)
 	if err != nil {
 		t.Fatal(err)
@@ -124,7 +124,7 @@ func FetchRegionalInstanceGroup(t TestingT, projectID string, region string, nam
 }
 
 // FetchRegionalInstanceGroup queries GCP to return a new instance of the Regional Instance Group type
-func FetchRegionalInstanceGroupE(t TestingT, projectID string, region string, name string) (*RegionalInstanceGroup, error) {
+func FetchRegionalInstanceGroupE(t testing.TestingT, projectID string, region string, name string) (*RegionalInstanceGroup, error) {
 	logger.Logf(t, "Getting Regional Instance Group %s", name)
 
 	ctx := context.Background()
@@ -143,7 +143,7 @@ func FetchRegionalInstanceGroupE(t TestingT, projectID string, region string, na
 }
 
 // FetchZonalInstanceGroup queries GCP to return a new instance of the Regional Instance Group type
-func FetchZonalInstanceGroup(t TestingT, projectID string, zone string, name string) *ZonalInstanceGroup {
+func FetchZonalInstanceGroup(t testing.TestingT, projectID string, zone string, name string) *ZonalInstanceGroup {
 	instanceGroup, err := FetchZonalInstanceGroupE(t, projectID, zone, name)
 	if err != nil {
 		t.Fatal(err)
@@ -153,7 +153,7 @@ func FetchZonalInstanceGroup(t TestingT, projectID string, zone string, name str
 }
 
 // FetchZonalInstanceGroup queries GCP to return a new instance of the Regional Instance Group type
-func FetchZonalInstanceGroupE(t TestingT, projectID string, zone string, name string) (*ZonalInstanceGroup, error) {
+func FetchZonalInstanceGroupE(t testing.TestingT, projectID string, zone string, name string) (*ZonalInstanceGroup, error) {
 	logger.Logf(t, "Getting Zonal Instance Group %s", name)
 
 	ctx := context.Background()
@@ -172,7 +172,7 @@ func FetchZonalInstanceGroupE(t TestingT, projectID string, zone string, name st
 }
 
 // GetPublicIP gets the public IP address of the given Compute Instance.
-func (i *Instance) GetPublicIp(t TestingT) string {
+func (i *Instance) GetPublicIp(t testing.TestingT) string {
 	ip, err := i.GetPublicIpE(t)
 	if err != nil {
 		t.Fatal(err)
@@ -181,7 +181,7 @@ func (i *Instance) GetPublicIp(t TestingT) string {
 }
 
 // GetPublicIpE gets the public IP address of the given Compute Instance.
-func (i *Instance) GetPublicIpE(t TestingT) (string, error) {
+func (i *Instance) GetPublicIpE(t testing.TestingT) (string, error) {
 	// If there are no accessConfigs specified, then this instance will have no external internet access:
 	// https://cloud.google.com/compute/docs/reference/rest/v1/instances.
 	if len(i.NetworkInterfaces[0].AccessConfigs) == 0 {
@@ -194,17 +194,17 @@ func (i *Instance) GetPublicIpE(t TestingT) (string, error) {
 }
 
 // GetLabels returns all the tags for the given Compute Instance.
-func (i *Instance) GetLabels(t TestingT) map[string]string {
+func (i *Instance) GetLabels(t testing.TestingT) map[string]string {
 	return i.Labels
 }
 
 // GetZone returns the Zone in which the Compute Instance is located.
-func (i *Instance) GetZone(t TestingT) string {
+func (i *Instance) GetZone(t testing.TestingT) string {
 	return ZoneUrlToZone(i.Zone)
 }
 
 // SetLabels adds the tags to the given Compute Instance.
-func (i *Instance) SetLabels(t TestingT, labels map[string]string) {
+func (i *Instance) SetLabels(t testing.TestingT, labels map[string]string) {
 	err := i.SetLabelsE(t, labels)
 	if err != nil {
 		t.Fatal(err)
@@ -212,7 +212,7 @@ func (i *Instance) SetLabels(t TestingT, labels map[string]string) {
 }
 
 // SetLabelsE adds the tags to the given Compute Instance.
-func (i *Instance) SetLabelsE(t TestingT, labels map[string]string) error {
+func (i *Instance) SetLabelsE(t testing.TestingT, labels map[string]string) error {
 	logger.Logf(t, "Adding labels to instance %s in zone %s", i.Name, i.Zone)
 
 	ctx := context.Background()
@@ -230,12 +230,12 @@ func (i *Instance) SetLabelsE(t TestingT, labels map[string]string) error {
 }
 
 // GetMetadata gets the given Compute Instance's metadata
-func (i *Instance) GetMetadata(t TestingT) []*compute.MetadataItems {
+func (i *Instance) GetMetadata(t testing.TestingT) []*compute.MetadataItems {
 	return i.Metadata.Items
 }
 
 // SetMetadata sets the given Compute Instance's metadata
-func (i *Instance) SetMetadata(t TestingT, metadata map[string]string) {
+func (i *Instance) SetMetadata(t testing.TestingT, metadata map[string]string) {
 	err := i.SetMetadataE(t, metadata)
 	if err != nil {
 		t.Fatal(err)
@@ -243,7 +243,7 @@ func (i *Instance) SetMetadata(t TestingT, metadata map[string]string) {
 }
 
 // SetLabelsE adds the given metadata map to the existing metadata of the given Compute Instance.
-func (i *Instance) SetMetadataE(t TestingT, metadata map[string]string) error {
+func (i *Instance) SetMetadataE(t testing.TestingT, metadata map[string]string) error {
 	logger.Logf(t, "Adding metadata to instance %s in zone %s", i.Name, i.Zone)
 
 	ctx := context.Background()
@@ -263,7 +263,7 @@ func (i *Instance) SetMetadataE(t TestingT, metadata map[string]string) error {
 
 // newMetadata takes in a Compute Instance's existing metadata plus a new set of key-value pairs and returns an updated
 // metadata object.
-func newMetadata(t TestingT, oldMetadata *compute.Metadata, kvs map[string]string) *compute.Metadata {
+func newMetadata(t testing.TestingT, oldMetadata *compute.Metadata, kvs map[string]string) *compute.Metadata {
 	items := []*compute.MetadataItems{}
 
 	for key, val := range kvs {
@@ -284,7 +284,7 @@ func newMetadata(t TestingT, oldMetadata *compute.Metadata, kvs map[string]strin
 }
 
 // Add the given public SSH key to the Compute Instance. Users can SSH in with the given username.
-func (i *Instance) AddSshKey(t TestingT, username string, publicKey string) {
+func (i *Instance) AddSshKey(t testing.TestingT, username string, publicKey string) {
 	err := i.AddSshKeyE(t, username, publicKey)
 	if err != nil {
 		t.Fatal(err)
@@ -292,7 +292,7 @@ func (i *Instance) AddSshKey(t TestingT, username string, publicKey string) {
 }
 
 // Add the given public SSH key to the Compute Instance. Users can SSH in with the given username.
-func (i *Instance) AddSshKeyE(t TestingT, username string, publicKey string) error {
+func (i *Instance) AddSshKeyE(t testing.TestingT, username string, publicKey string) error {
 	logger.Logf(t, "Adding SSH Key to Compute Instance %s for username %s\n", i.Name, username)
 
 	// We represent the key in the format required per GCP docs (https://cloud.google.com/compute/docs/instances/adding-removing-ssh-keys)
@@ -312,7 +312,7 @@ func (i *Instance) AddSshKeyE(t TestingT, username string, publicKey string) err
 }
 
 // DeleteImage deletes the given Compute Image.
-func (i *Image) DeleteImage(t TestingT) {
+func (i *Image) DeleteImage(t testing.TestingT) {
 	err := i.DeleteImageE(t)
 	if err != nil {
 		t.Fatal(err)
@@ -320,7 +320,7 @@ func (i *Image) DeleteImage(t TestingT) {
 }
 
 // DeleteImageE deletes the given Compute Image.
-func (i *Image) DeleteImageE(t TestingT) error {
+func (i *Image) DeleteImageE(t testing.TestingT) error {
 	logger.Logf(t, "Destroying Image %s", i.Name)
 
 	ctx := context.Background()
@@ -337,7 +337,7 @@ func (i *Image) DeleteImageE(t TestingT) error {
 }
 
 // GetInstanceIds gets the IDs of Instances in the given Instance Group.
-func (ig *ZonalInstanceGroup) GetInstanceIds(t TestingT) []string {
+func (ig *ZonalInstanceGroup) GetInstanceIds(t testing.TestingT) []string {
 	ids, err := ig.GetInstanceIdsE(t)
 	if err != nil {
 		t.Fatal(err)
@@ -346,7 +346,7 @@ func (ig *ZonalInstanceGroup) GetInstanceIds(t TestingT) []string {
 }
 
 // GetInstanceIdsE gets the IDs of Instances in the given Zonal Instance Group.
-func (ig *ZonalInstanceGroup) GetInstanceIdsE(t TestingT) ([]string, error) {
+func (ig *ZonalInstanceGroup) GetInstanceIdsE(t testing.TestingT) ([]string, error) {
 	logger.Logf(t, "Get instances for Zonal Instance Group %s", ig.Name)
 
 	ctx := context.Background()
@@ -382,7 +382,7 @@ func (ig *ZonalInstanceGroup) GetInstanceIdsE(t TestingT) ([]string, error) {
 }
 
 // GetInstanceIds gets the IDs of Instances in the given Regional Instance Group.
-func (ig *RegionalInstanceGroup) GetInstanceIds(t TestingT) []string {
+func (ig *RegionalInstanceGroup) GetInstanceIds(t testing.TestingT) []string {
 	ids, err := ig.GetInstanceIdsE(t)
 	if err != nil {
 		t.Fatal(err)
@@ -391,7 +391,7 @@ func (ig *RegionalInstanceGroup) GetInstanceIds(t TestingT) []string {
 }
 
 // GetInstanceIdsE gets the IDs of Instances in the given Regional Instance Group.
-func (ig *RegionalInstanceGroup) GetInstanceIdsE(t TestingT) ([]string, error) {
+func (ig *RegionalInstanceGroup) GetInstanceIdsE(t testing.TestingT) ([]string, error) {
 	logger.Logf(t, "Get instances for Regional Instance Group %s", ig.Name)
 
 	ctx := context.Background()
@@ -428,27 +428,27 @@ func (ig *RegionalInstanceGroup) GetInstanceIdsE(t TestingT) ([]string, error) {
 }
 
 // Return a collection of Instance structs from the given Instance Group
-func (ig *ZonalInstanceGroup) GetInstances(t TestingT, projectId string) []*Instance {
+func (ig *ZonalInstanceGroup) GetInstances(t testing.TestingT, projectId string) []*Instance {
 	return getInstances(t, ig, projectId)
 }
 
 // Return a collection of Instance structs from the given Instance Group
-func (ig *ZonalInstanceGroup) GetInstancesE(t TestingT, projectId string) ([]*Instance, error) {
+func (ig *ZonalInstanceGroup) GetInstancesE(t testing.TestingT, projectId string) ([]*Instance, error) {
 	return getInstancesE(t, ig, projectId)
 }
 
 // Return a collection of Instance structs from the given Instance Group
-func (ig *RegionalInstanceGroup) GetInstances(t TestingT, projectId string) []*Instance {
+func (ig *RegionalInstanceGroup) GetInstances(t testing.TestingT, projectId string) []*Instance {
 	return getInstances(t, ig, projectId)
 }
 
 // Return a collection of Instance structs from the given Instance Group
-func (ig *RegionalInstanceGroup) GetInstancesE(t TestingT, projectId string) ([]*Instance, error) {
+func (ig *RegionalInstanceGroup) GetInstancesE(t testing.TestingT, projectId string) ([]*Instance, error) {
 	return getInstancesE(t, ig, projectId)
 }
 
 // getInstancesE returns a collection of Instance structs from the given Instance Group
-func getInstances(t TestingT, ig InstanceGroup, projectId string) []*Instance {
+func getInstances(t testing.TestingT, ig InstanceGroup, projectId string) []*Instance {
 	instances, err := getInstancesE(t, ig, projectId)
 	if err != nil {
 		t.Fatal(err)
@@ -458,7 +458,7 @@ func getInstances(t TestingT, ig InstanceGroup, projectId string) []*Instance {
 }
 
 // getInstancesE returns a collection of Instance structs from the given Instance Group
-func getInstancesE(t TestingT, ig InstanceGroup, projectId string) ([]*Instance, error) {
+func getInstancesE(t testing.TestingT, ig InstanceGroup, projectId string) ([]*Instance, error) {
 	instanceIds, err := ig.GetInstanceIdsE(t)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to get Instance Group IDs: %s", err)
@@ -479,27 +479,27 @@ func getInstancesE(t TestingT, ig InstanceGroup, projectId string) ([]*Instance,
 }
 
 // GetPublicIps returns a slice of the public IPs from the given Instance Group
-func (ig *ZonalInstanceGroup) GetPublicIps(t TestingT, projectId string) []string {
+func (ig *ZonalInstanceGroup) GetPublicIps(t testing.TestingT, projectId string) []string {
 	return getPublicIps(t, ig, projectId)
 }
 
 // GetPublicIpsE returns a slice of the public IPs from the given Instance Group
-func (ig *ZonalInstanceGroup) GetPublicIpsE(t TestingT, projectId string) ([]string, error) {
+func (ig *ZonalInstanceGroup) GetPublicIpsE(t testing.TestingT, projectId string) ([]string, error) {
 	return getPublicIpsE(t, ig, projectId)
 }
 
 // GetPublicIps returns a slice of the public IPs from the given Instance Group
-func (ig *RegionalInstanceGroup) GetPublicIps(t TestingT, projectId string) []string {
+func (ig *RegionalInstanceGroup) GetPublicIps(t testing.TestingT, projectId string) []string {
 	return getPublicIps(t, ig, projectId)
 }
 
 // GetPublicIpsE returns a slice of the public IPs from the given Instance Group
-func (ig *RegionalInstanceGroup) GetPublicIpsE(t TestingT, projectId string) ([]string, error) {
+func (ig *RegionalInstanceGroup) GetPublicIpsE(t testing.TestingT, projectId string) ([]string, error) {
 	return getPublicIpsE(t, ig, projectId)
 }
 
 // getPublicIps a slice of the public IPs from the given Instance Group
-func getPublicIps(t TestingT, ig InstanceGroup, projectId string) []string {
+func getPublicIps(t testing.TestingT, ig InstanceGroup, projectId string) []string {
 	ips, err := getPublicIpsE(t, ig, projectId)
 	if err != nil {
 		t.Fatal(err)
@@ -509,7 +509,7 @@ func getPublicIps(t TestingT, ig InstanceGroup, projectId string) []string {
 }
 
 // getPublicIpsE a slice of the public IPs from the given Instance Group
-func getPublicIpsE(t TestingT, ig InstanceGroup, projectId string) ([]string, error) {
+func getPublicIpsE(t testing.TestingT, ig InstanceGroup, projectId string) ([]string, error) {
 	instances, err := getInstancesE(t, ig, projectId)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to get Compute Instances from Instance Group: %s", err)
@@ -526,26 +526,26 @@ func getPublicIpsE(t TestingT, ig InstanceGroup, projectId string) ([]string, er
 }
 
 // getRandomInstance returns a randomly selected Instance from the Regional Instance Group
-func (ig *ZonalInstanceGroup) GetRandomInstance(t TestingT) *Instance {
+func (ig *ZonalInstanceGroup) GetRandomInstance(t testing.TestingT) *Instance {
 	return getRandomInstance(t, ig, ig.Name, ig.Region, ig.Size, ig.projectID)
 }
 
 // getRandomInstanceE returns a randomly selected Instance from the Regional Instance Group
-func (ig *ZonalInstanceGroup) GetRandomInstanceE(t TestingT) (*Instance, error) {
+func (ig *ZonalInstanceGroup) GetRandomInstanceE(t testing.TestingT) (*Instance, error) {
 	return getRandomInstanceE(t, ig, ig.Name, ig.Region, ig.Size, ig.projectID)
 }
 
 // getRandomInstance returns a randomly selected Instance from the Regional Instance Group
-func (ig *RegionalInstanceGroup) GetRandomInstance(t TestingT) *Instance {
+func (ig *RegionalInstanceGroup) GetRandomInstance(t testing.TestingT) *Instance {
 	return getRandomInstance(t, ig, ig.Name, ig.Region, ig.Size, ig.projectID)
 }
 
 // getRandomInstanceE returns a randomly selected Instance from the Regional Instance Group
-func (ig *RegionalInstanceGroup) GetRandomInstanceE(t TestingT) (*Instance, error) {
+func (ig *RegionalInstanceGroup) GetRandomInstanceE(t testing.TestingT) (*Instance, error) {
 	return getRandomInstanceE(t, ig, ig.Name, ig.Region, ig.Size, ig.projectID)
 }
 
-func getRandomInstance(t TestingT, ig InstanceGroup, name string, region string, size int64, projectID string) *Instance {
+func getRandomInstance(t testing.TestingT, ig InstanceGroup, name string, region string, size int64, projectID string) *Instance {
 	instance, err := getRandomInstanceE(t, ig, name, region, size, projectID)
 	if err != nil {
 		t.Fatal(err)
@@ -554,7 +554,7 @@ func getRandomInstance(t TestingT, ig InstanceGroup, name string, region string,
 	return instance
 }
 
-func getRandomInstanceE(t TestingT, ig InstanceGroup, name string, region string, size int64, projectID string) (*Instance, error) {
+func getRandomInstanceE(t testing.TestingT, ig InstanceGroup, name string, region string, size int64, projectID string) (*Instance, error) {
 	instanceIDs := ig.GetInstanceIds(t)
 	if len(instanceIDs) == 0 {
 		return nil, fmt.Errorf("Could not find any instances in Regional Instance Group %s in Region %s", name, region)
@@ -573,7 +573,7 @@ func getRandomInstanceE(t TestingT, ig InstanceGroup, name string, region string
 }
 
 // NewComputeService creates a new Compute service, which is used to make GCE API calls.
-func NewComputeService(t TestingT) *compute.Service {
+func NewComputeService(t testing.TestingT) *compute.Service {
 	client, err := NewComputeServiceE(t)
 	if err != nil {
 		t.Fatal(err)
@@ -582,7 +582,7 @@ func NewComputeService(t TestingT) *compute.Service {
 }
 
 // NewComputeServiceE creates a new Compute service, which is used to make GCE API calls.
-func NewComputeServiceE(t TestingT) (*compute.Service, error) {
+func NewComputeServiceE(t testing.TestingT) (*compute.Service, error) {
 	ctx := context.Background()
 
 	// Retrieve the Google OAuth token using a retry loop as it can sometimes return an error.
@@ -613,7 +613,7 @@ func NewComputeServiceE(t TestingT) (*compute.Service, error) {
 }
 
 // NewInstancesService creates a new InstancesService service, which is used to make a subset of GCE API calls.
-func NewInstancesService(t TestingT) *compute.InstancesService {
+func NewInstancesService(t testing.TestingT) *compute.InstancesService {
 	client, err := NewInstancesServiceE(t)
 	if err != nil {
 		t.Fatal(err)
@@ -622,7 +622,7 @@ func NewInstancesService(t TestingT) *compute.InstancesService {
 }
 
 // NewInstancesServiceE creates a new InstancesService service, which is used to make a subset of GCE API calls.
-func NewInstancesServiceE(t TestingT) (*compute.InstancesService, error) {
+func NewInstancesServiceE(t testing.TestingT) (*compute.InstancesService, error) {
 	service, err := NewComputeServiceE(t)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to get new Instances Service\n")

--- a/modules/gcp/gcr.go
+++ b/modules/gcp/gcr.go
@@ -2,23 +2,23 @@ package gcp
 
 import (
 	"fmt"
-	"testing"
 
 	gcrname "github.com/google/go-containerregistry/pkg/name"
 	gcrgoogle "github.com/google/go-containerregistry/pkg/v1/google"
 	gcrremote "github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/gruntwork-io/terratest/modules/logger"
+	"github.com/gruntwork-io/terratest/modules/testing"
 	"github.com/stretchr/testify/require"
 )
 
 // DeleteGCRRepo deletes a GCR repository including all tagged images
-func DeleteGCRRepo(t *testing.T, repo string) {
+func DeleteGCRRepo(t testing.TestingT, repo string) {
 	err := DeleteGCRRepoE(t, repo)
 	require.NoError(t, err)
 }
 
 // DeleteGCRRepoE deletes a GCR repository including all tagged images
-func DeleteGCRRepoE(t *testing.T, repo string) error {
+func DeleteGCRRepoE(t testing.TestingT, repo string) error {
 	// create a new auther for the API calls
 	auther, err := gcrgoogle.NewEnvAuthenticator()
 	if err != nil {
@@ -57,13 +57,13 @@ func DeleteGCRRepoE(t *testing.T, repo string) error {
 }
 
 // DeleteGCRImageRef deletes a single repo image ref/digest
-func DeleteGCRImageRef(t *testing.T, ref string) {
+func DeleteGCRImageRef(t testing.TestingT, ref string) {
 	err := DeleteGCRImageRefE(t, ref)
 	require.NoError(t, err)
 }
 
 // DeleteGCRImageRefE deletes a single repo image ref/digest
-func DeleteGCRImageRefE(t *testing.T, ref string) error {
+func DeleteGCRImageRefE(t testing.TestingT, ref string) error {
 	name, err := gcrname.ParseReference(ref)
 	if err != nil {
 		return fmt.Errorf("Failed to parse reference %s. Got error: %v", ref, err)

--- a/modules/gcp/oslogin.go
+++ b/modules/gcp/oslogin.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"github.com/gruntwork-io/terratest/modules/logger"
-	_ "github.com/gruntwork-io/terratest/modules/testing"
+	"github.com/gruntwork-io/terratest/modules/testing"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/oauth2/google"
 	"google.golang.org/api/compute/v1"
@@ -16,14 +16,14 @@ import (
 // The `user` parameter should be the email address of the user.
 // The `key` parameter should be the public key of the SSH key being uploaded.
 // This will fail the test if there is an error.
-func ImportSSHKey(t TestingT, user, key string) {
+func ImportSSHKey(t testing.TestingT, user, key string) {
 	require.NoErrorf(t, ImportSSHKeyE(t, user, key), "Could not add SSH Key to user %s", user)
 }
 
 // ImportSSHKeyE will import an SSH key to GCP under the provided user identity.
 // The `user` parameter should be the email address of the user.
 // The `key` parameter should be the public key of the SSH key being uploaded.
-func ImportSSHKeyE(t TestingT, user, key string) error {
+func ImportSSHKeyE(t testing.TestingT, user, key string) error {
 	logger.Logf(t, "Importing SSH key for user %s", user)
 
 	ctx := context.Background()
@@ -50,14 +50,14 @@ func ImportSSHKeyE(t TestingT, user, key string) error {
 // The `user` parameter should be the email address of the user.
 // The `key` parameter should be the public key of the SSH key that was uploaded.
 // This will fail the test if there is an error.
-func DeleteSSHKey(t TestingT, user, key string) {
+func DeleteSSHKey(t testing.TestingT, user, key string) {
 	require.NoErrorf(t, DeleteSSHKeyE(t, user, key), "Could not delete SSH Key for user %s", user)
 }
 
 // DeleteSSHKeyE will delete an SSH key attached to the provided user identity.
 // The `user` parameter should be the email address of the user.
 // The `key` parameter should be the public key of the SSH key that was uploaded.
-func DeleteSSHKeyE(t TestingT, user, key string) error {
+func DeleteSSHKeyE(t testing.TestingT, user, key string) error {
 	logger.Logf(t, "Deleting SSH key for user %s", user)
 
 	ctx := context.Background()
@@ -87,7 +87,7 @@ func DeleteSSHKeyE(t TestingT, user, key string) error {
 // accounts the user will appear as. Generally, this will only be the OS Login key + account, but `gcloud compute ssh` could create temporary keys and profiles.
 // The `user` parameter should be the email address of the user.
 // This will fail the test if there is an error.
-func GetLoginProfile(t TestingT, user string) *oslogin.LoginProfile {
+func GetLoginProfile(t testing.TestingT, user string) *oslogin.LoginProfile {
 	profile, err := GetLoginProfileE(t, user)
 	require.NoErrorf(t, err, "Could not get login profile for user %s", user)
 
@@ -97,7 +97,7 @@ func GetLoginProfile(t TestingT, user string) *oslogin.LoginProfile {
 // GetLoginProfileE will retrieve the login profile for a user's Google identity. The login profile is a combination of OS Login + gcloud SSH keys and POSIX
 // accounts the user will appear as. Generally, this will only be the OS Login key + account, but `gcloud compute ssh` could create temporary keys and profiles.
 // The `user` parameter should be the email address of the user.
-func GetLoginProfileE(t TestingT, user string) (*oslogin.LoginProfile, error) {
+func GetLoginProfileE(t testing.TestingT, user string) (*oslogin.LoginProfile, error) {
 	logger.Logf(t, "Getting login profile for user %s", user)
 
 	ctx := context.Background()
@@ -117,7 +117,7 @@ func GetLoginProfileE(t TestingT, user string) (*oslogin.LoginProfile, error) {
 }
 
 // NewOSLoginServiceE creates a new OS Login service, which is used to make OS Login API calls.
-func NewOSLoginServiceE(t TestingT) (*oslogin.Service, error) {
+func NewOSLoginServiceE(t testing.TestingT) (*oslogin.Service, error) {
 	ctx := context.Background()
 
 	client, err := google.DefaultClient(ctx, compute.CloudPlatformScope)

--- a/modules/gcp/oslogin.go
+++ b/modules/gcp/oslogin.go
@@ -3,9 +3,9 @@ package gcp
 import (
 	"context"
 	"fmt"
-	"testing"
 
 	"github.com/gruntwork-io/terratest/modules/logger"
+	_ "github.com/gruntwork-io/terratest/modules/testing"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/oauth2/google"
 	"google.golang.org/api/compute/v1"
@@ -16,14 +16,14 @@ import (
 // The `user` parameter should be the email address of the user.
 // The `key` parameter should be the public key of the SSH key being uploaded.
 // This will fail the test if there is an error.
-func ImportSSHKey(t *testing.T, user, key string) {
+func ImportSSHKey(t TestingT, user, key string) {
 	require.NoErrorf(t, ImportSSHKeyE(t, user, key), "Could not add SSH Key to user %s", user)
 }
 
 // ImportSSHKeyE will import an SSH key to GCP under the provided user identity.
 // The `user` parameter should be the email address of the user.
 // The `key` parameter should be the public key of the SSH key being uploaded.
-func ImportSSHKeyE(t *testing.T, user, key string) error {
+func ImportSSHKeyE(t TestingT, user, key string) error {
 	logger.Logf(t, "Importing SSH key for user %s", user)
 
 	ctx := context.Background()
@@ -50,14 +50,14 @@ func ImportSSHKeyE(t *testing.T, user, key string) error {
 // The `user` parameter should be the email address of the user.
 // The `key` parameter should be the public key of the SSH key that was uploaded.
 // This will fail the test if there is an error.
-func DeleteSSHKey(t *testing.T, user, key string) {
+func DeleteSSHKey(t TestingT, user, key string) {
 	require.NoErrorf(t, DeleteSSHKeyE(t, user, key), "Could not delete SSH Key for user %s", user)
 }
 
 // DeleteSSHKeyE will delete an SSH key attached to the provided user identity.
 // The `user` parameter should be the email address of the user.
 // The `key` parameter should be the public key of the SSH key that was uploaded.
-func DeleteSSHKeyE(t *testing.T, user, key string) error {
+func DeleteSSHKeyE(t TestingT, user, key string) error {
 	logger.Logf(t, "Deleting SSH key for user %s", user)
 
 	ctx := context.Background()
@@ -87,7 +87,7 @@ func DeleteSSHKeyE(t *testing.T, user, key string) error {
 // accounts the user will appear as. Generally, this will only be the OS Login key + account, but `gcloud compute ssh` could create temporary keys and profiles.
 // The `user` parameter should be the email address of the user.
 // This will fail the test if there is an error.
-func GetLoginProfile(t *testing.T, user string) *oslogin.LoginProfile {
+func GetLoginProfile(t TestingT, user string) *oslogin.LoginProfile {
 	profile, err := GetLoginProfileE(t, user)
 	require.NoErrorf(t, err, "Could not get login profile for user %s", user)
 
@@ -97,7 +97,7 @@ func GetLoginProfile(t *testing.T, user string) *oslogin.LoginProfile {
 // GetLoginProfileE will retrieve the login profile for a user's Google identity. The login profile is a combination of OS Login + gcloud SSH keys and POSIX
 // accounts the user will appear as. Generally, this will only be the OS Login key + account, but `gcloud compute ssh` could create temporary keys and profiles.
 // The `user` parameter should be the email address of the user.
-func GetLoginProfileE(t *testing.T, user string) (*oslogin.LoginProfile, error) {
+func GetLoginProfileE(t TestingT, user string) (*oslogin.LoginProfile, error) {
 	logger.Logf(t, "Getting login profile for user %s", user)
 
 	ctx := context.Background()
@@ -117,7 +117,7 @@ func GetLoginProfileE(t *testing.T, user string) (*oslogin.LoginProfile, error) 
 }
 
 // NewOSLoginServiceE creates a new OS Login service, which is used to make OS Login API calls.
-func NewOSLoginServiceE(t *testing.T) (*oslogin.Service, error) {
+func NewOSLoginServiceE(t TestingT) (*oslogin.Service, error) {
 	ctx := context.Background()
 
 	client, err := google.DefaultClient(ctx, compute.CloudPlatformScope)

--- a/modules/gcp/provider.go
+++ b/modules/gcp/provider.go
@@ -2,7 +2,7 @@ package gcp
 
 import (
 	"github.com/gruntwork-io/terratest/modules/environment"
-	_ "github.com/gruntwork-io/terratest/modules/testing"
+	"github.com/gruntwork-io/terratest/modules/testing"
 )
 
 var credsEnvVars = []string{
@@ -32,21 +32,21 @@ var googleIdentityEmailEnvVars = []string{
 }
 
 // GetGoogleCredentialsFromEnvVar returns the Credentials for use with testing.
-func GetGoogleCredentialsFromEnvVar(t TestingT) string {
+func GetGoogleCredentialsFromEnvVar(t testing.TestingT) string {
 	return environment.GetFirstNonEmptyEnvVarOrEmptyString(t, credsEnvVars)
 }
 
 // GetGoogleProjectIDFromEnvVar returns the Project Id for use with testing.
-func GetGoogleProjectIDFromEnvVar(t TestingT) string {
+func GetGoogleProjectIDFromEnvVar(t testing.TestingT) string {
 	return environment.GetFirstNonEmptyEnvVarOrFatal(t, projectEnvVars)
 }
 
 // GetGoogleRegionFromEnvVar returns the Region for use with testing.
-func GetGoogleRegionFromEnvVar(t TestingT) string {
+func GetGoogleRegionFromEnvVar(t testing.TestingT) string {
 	return environment.GetFirstNonEmptyEnvVarOrFatal(t, regionEnvVars)
 }
 
 // GetGoogleIdentityEmailEnvVar returns a Google identity (user) for use with testing.
-func GetGoogleIdentityEmailEnvVar(t TestingT) string {
+func GetGoogleIdentityEmailEnvVar(t testing.TestingT) string {
 	return environment.GetFirstNonEmptyEnvVarOrFatal(t, googleIdentityEmailEnvVars)
 }

--- a/modules/gcp/provider.go
+++ b/modules/gcp/provider.go
@@ -1,9 +1,8 @@
 package gcp
 
 import (
-	"testing"
-
 	"github.com/gruntwork-io/terratest/modules/environment"
+	_ "github.com/gruntwork-io/terratest/modules/testing"
 )
 
 var credsEnvVars = []string{
@@ -33,21 +32,21 @@ var googleIdentityEmailEnvVars = []string{
 }
 
 // GetGoogleCredentialsFromEnvVar returns the Credentials for use with testing.
-func GetGoogleCredentialsFromEnvVar(t *testing.T) string {
+func GetGoogleCredentialsFromEnvVar(t TestingT) string {
 	return environment.GetFirstNonEmptyEnvVarOrEmptyString(t, credsEnvVars)
 }
 
 // GetGoogleProjectIDFromEnvVar returns the Project Id for use with testing.
-func GetGoogleProjectIDFromEnvVar(t *testing.T) string {
+func GetGoogleProjectIDFromEnvVar(t TestingT) string {
 	return environment.GetFirstNonEmptyEnvVarOrFatal(t, projectEnvVars)
 }
 
 // GetGoogleRegionFromEnvVar returns the Region for use with testing.
-func GetGoogleRegionFromEnvVar(t *testing.T) string {
+func GetGoogleRegionFromEnvVar(t TestingT) string {
 	return environment.GetFirstNonEmptyEnvVarOrFatal(t, regionEnvVars)
 }
 
 // GetGoogleIdentityEmailEnvVar returns a Google identity (user) for use with testing.
-func GetGoogleIdentityEmailEnvVar(t *testing.T) string {
+func GetGoogleIdentityEmailEnvVar(t TestingT) string {
 	return environment.GetFirstNonEmptyEnvVarOrFatal(t, googleIdentityEmailEnvVars)
 }

--- a/modules/gcp/region.go
+++ b/modules/gcp/region.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"os"
 	"strings"
-	"testing"
 
 	"github.com/gruntwork-io/terratest/modules/collections"
 	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/random"
+	_ "github.com/gruntwork-io/terratest/modules/testing"
 	"google.golang.org/api/compute/v1"
 )
 
@@ -33,7 +33,7 @@ const defaultZone = "us-west1-b"
 // GetRandomRegion gets a randomly chosen GCP Region. If approvedRegions is not empty, this will be a Region from the approvedRegions
 // list; otherwise, this method will fetch the latest list of regions from the GCP APIs and pick one of those. If
 // forbiddenRegions is not empty, this method will make sure the returned Region is not in the forbiddenRegions list.
-func GetRandomRegion(t *testing.T, projectID string, approvedRegions []string, forbiddenRegions []string) string {
+func GetRandomRegion(t TestingT, projectID string, approvedRegions []string, forbiddenRegions []string) string {
 	region, err := GetRandomRegionE(t, projectID, approvedRegions, forbiddenRegions)
 	if err != nil {
 		t.Fatal(err)
@@ -44,7 +44,7 @@ func GetRandomRegion(t *testing.T, projectID string, approvedRegions []string, f
 // GetRandomRegionE gets a randomly chosen GCP Region. If approvedRegions is not empty, this will be a Region from the approvedRegions
 // list; otherwise, this method will fetch the latest list of regions from the GCP APIs and pick one of those. If
 // forbiddenRegions is not empty, this method will make sure the returned Region is not in the forbiddenRegions list.
-func GetRandomRegionE(t *testing.T, projectID string, approvedRegions []string, forbiddenRegions []string) (string, error) {
+func GetRandomRegionE(t TestingT, projectID string, approvedRegions []string, forbiddenRegions []string) (string, error) {
 	regionFromEnvVar := os.Getenv(regionOverrideEnvVarName)
 	if regionFromEnvVar != "" {
 		logger.Logf(t, "Using GCP Region %s from environment variable %s", regionFromEnvVar, regionOverrideEnvVarName)
@@ -71,7 +71,7 @@ func GetRandomRegionE(t *testing.T, projectID string, approvedRegions []string, 
 // GetRandomZone gets a randomly chosen GCP Zone. If approvedRegions is not empty, this will be a Zone from the approvedZones
 // list; otherwise, this method will fetch the latest list of Zones from the GCP APIs and pick one of those. If
 // forbiddenZones is not empty, this method will make sure the returned Region is not in the forbiddenZones list.
-func GetRandomZone(t *testing.T, projectID string, approvedZones []string, forbiddenZones []string, forbiddenRegions []string) string {
+func GetRandomZone(t TestingT, projectID string, approvedZones []string, forbiddenZones []string, forbiddenRegions []string) string {
 	zone, err := GetRandomZoneE(t, projectID, approvedZones, forbiddenZones, forbiddenRegions)
 	if err != nil {
 		t.Fatal(err)
@@ -82,7 +82,7 @@ func GetRandomZone(t *testing.T, projectID string, approvedZones []string, forbi
 // GetRandomZoneE gets a randomly chosen GCP Zone. If approvedRegions is not empty, this will be a Zone from the approvedZones
 // list; otherwise, this method will fetch the latest list of Zones from the GCP APIs and pick one of those. If
 // forbiddenZones is not empty, this method will make sure the returned Region is not in the forbiddenZones list.
-func GetRandomZoneE(t *testing.T, projectID string, approvedZones []string, forbiddenZones []string, forbiddenRegions []string) (string, error) {
+func GetRandomZoneE(t TestingT, projectID string, approvedZones []string, forbiddenZones []string, forbiddenRegions []string) (string, error) {
 	zoneFromEnvVar := os.Getenv(zoneOverrideEnvVarName)
 	if zoneFromEnvVar != "" {
 		logger.Logf(t, "Using GCP Zone %s from environment variable %s", zoneFromEnvVar, zoneOverrideEnvVarName)
@@ -114,7 +114,7 @@ func GetRandomZoneE(t *testing.T, projectID string, approvedZones []string, forb
 }
 
 // GetRandomZoneForRegion gets a randomly chosen GCP Zone in the given Region.
-func GetRandomZoneForRegion(t *testing.T, projectID string, region string) string {
+func GetRandomZoneForRegion(t TestingT, projectID string, region string) string {
 	zone, err := GetRandomZoneForRegionE(t, projectID, region)
 	if err != nil {
 		t.Fatal(err)
@@ -123,7 +123,7 @@ func GetRandomZoneForRegion(t *testing.T, projectID string, region string) strin
 }
 
 // GetRandomZoneForRegionE gets a randomly chosen GCP Zone in the given Region.
-func GetRandomZoneForRegionE(t *testing.T, projectID string, region string) (string, error) {
+func GetRandomZoneForRegionE(t TestingT, projectID string, region string) (string, error) {
 	zoneFromEnvVar := os.Getenv(zoneOverrideEnvVarName)
 	if zoneFromEnvVar != "" {
 		logger.Logf(t, "Using GCP Zone %s from environment variable %s", zoneFromEnvVar, zoneOverrideEnvVarName)
@@ -150,7 +150,7 @@ func GetRandomZoneForRegionE(t *testing.T, projectID string, region string) (str
 }
 
 // GetAllGcpRegions gets the list of GCP regions available in this account.
-func GetAllGcpRegions(t *testing.T, projectID string) []string {
+func GetAllGcpRegions(t TestingT, projectID string) []string {
 	out, err := GetAllGcpRegionsE(t, projectID)
 	if err != nil {
 		t.Fatal(err)
@@ -159,7 +159,7 @@ func GetAllGcpRegions(t *testing.T, projectID string) []string {
 }
 
 // GetAllGcpRegionsE gets the list of GCP regions available in this account.
-func GetAllGcpRegionsE(t *testing.T, projectID string) ([]string, error) {
+func GetAllGcpRegionsE(t TestingT, projectID string) ([]string, error) {
 	logger.Log(t, "Looking up all GCP regions available in this account")
 
 	// Note that NewComputeServiceE creates a context, but it appears to be empty so we keep the code simpler by
@@ -188,7 +188,7 @@ func GetAllGcpRegionsE(t *testing.T, projectID string) ([]string, error) {
 }
 
 // GetAllGcpZones gets the list of GCP Zones available in this account.
-func GetAllGcpZones(t *testing.T, projectID string) []string {
+func GetAllGcpZones(t TestingT, projectID string) []string {
 	out, err := GetAllGcpZonesE(t, projectID)
 	if err != nil {
 		t.Fatal(err)
@@ -197,7 +197,7 @@ func GetAllGcpZones(t *testing.T, projectID string) []string {
 }
 
 // GetAllGcpZonesE gets the list of GCP Zones available in this account.
-func GetAllGcpZonesE(t *testing.T, projectID string) ([]string, error) {
+func GetAllGcpZonesE(t TestingT, projectID string) ([]string, error) {
 	// Note that NewComputeServiceE creates a context, but it appears to be empty so we keep the code simpler by
 	// creating a new one here
 	ctx := context.Background()

--- a/modules/gcp/region.go
+++ b/modules/gcp/region.go
@@ -8,7 +8,7 @@ import (
 	"github.com/gruntwork-io/terratest/modules/collections"
 	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/random"
-	_ "github.com/gruntwork-io/terratest/modules/testing"
+	"github.com/gruntwork-io/terratest/modules/testing"
 	"google.golang.org/api/compute/v1"
 )
 
@@ -33,7 +33,7 @@ const defaultZone = "us-west1-b"
 // GetRandomRegion gets a randomly chosen GCP Region. If approvedRegions is not empty, this will be a Region from the approvedRegions
 // list; otherwise, this method will fetch the latest list of regions from the GCP APIs and pick one of those. If
 // forbiddenRegions is not empty, this method will make sure the returned Region is not in the forbiddenRegions list.
-func GetRandomRegion(t TestingT, projectID string, approvedRegions []string, forbiddenRegions []string) string {
+func GetRandomRegion(t testing.TestingT, projectID string, approvedRegions []string, forbiddenRegions []string) string {
 	region, err := GetRandomRegionE(t, projectID, approvedRegions, forbiddenRegions)
 	if err != nil {
 		t.Fatal(err)
@@ -44,7 +44,7 @@ func GetRandomRegion(t TestingT, projectID string, approvedRegions []string, for
 // GetRandomRegionE gets a randomly chosen GCP Region. If approvedRegions is not empty, this will be a Region from the approvedRegions
 // list; otherwise, this method will fetch the latest list of regions from the GCP APIs and pick one of those. If
 // forbiddenRegions is not empty, this method will make sure the returned Region is not in the forbiddenRegions list.
-func GetRandomRegionE(t TestingT, projectID string, approvedRegions []string, forbiddenRegions []string) (string, error) {
+func GetRandomRegionE(t testing.TestingT, projectID string, approvedRegions []string, forbiddenRegions []string) (string, error) {
 	regionFromEnvVar := os.Getenv(regionOverrideEnvVarName)
 	if regionFromEnvVar != "" {
 		logger.Logf(t, "Using GCP Region %s from environment variable %s", regionFromEnvVar, regionOverrideEnvVarName)
@@ -71,7 +71,7 @@ func GetRandomRegionE(t TestingT, projectID string, approvedRegions []string, fo
 // GetRandomZone gets a randomly chosen GCP Zone. If approvedRegions is not empty, this will be a Zone from the approvedZones
 // list; otherwise, this method will fetch the latest list of Zones from the GCP APIs and pick one of those. If
 // forbiddenZones is not empty, this method will make sure the returned Region is not in the forbiddenZones list.
-func GetRandomZone(t TestingT, projectID string, approvedZones []string, forbiddenZones []string, forbiddenRegions []string) string {
+func GetRandomZone(t testing.TestingT, projectID string, approvedZones []string, forbiddenZones []string, forbiddenRegions []string) string {
 	zone, err := GetRandomZoneE(t, projectID, approvedZones, forbiddenZones, forbiddenRegions)
 	if err != nil {
 		t.Fatal(err)
@@ -82,7 +82,7 @@ func GetRandomZone(t TestingT, projectID string, approvedZones []string, forbidd
 // GetRandomZoneE gets a randomly chosen GCP Zone. If approvedRegions is not empty, this will be a Zone from the approvedZones
 // list; otherwise, this method will fetch the latest list of Zones from the GCP APIs and pick one of those. If
 // forbiddenZones is not empty, this method will make sure the returned Region is not in the forbiddenZones list.
-func GetRandomZoneE(t TestingT, projectID string, approvedZones []string, forbiddenZones []string, forbiddenRegions []string) (string, error) {
+func GetRandomZoneE(t testing.TestingT, projectID string, approvedZones []string, forbiddenZones []string, forbiddenRegions []string) (string, error) {
 	zoneFromEnvVar := os.Getenv(zoneOverrideEnvVarName)
 	if zoneFromEnvVar != "" {
 		logger.Logf(t, "Using GCP Zone %s from environment variable %s", zoneFromEnvVar, zoneOverrideEnvVarName)
@@ -114,7 +114,7 @@ func GetRandomZoneE(t TestingT, projectID string, approvedZones []string, forbid
 }
 
 // GetRandomZoneForRegion gets a randomly chosen GCP Zone in the given Region.
-func GetRandomZoneForRegion(t TestingT, projectID string, region string) string {
+func GetRandomZoneForRegion(t testing.TestingT, projectID string, region string) string {
 	zone, err := GetRandomZoneForRegionE(t, projectID, region)
 	if err != nil {
 		t.Fatal(err)
@@ -123,7 +123,7 @@ func GetRandomZoneForRegion(t TestingT, projectID string, region string) string 
 }
 
 // GetRandomZoneForRegionE gets a randomly chosen GCP Zone in the given Region.
-func GetRandomZoneForRegionE(t TestingT, projectID string, region string) (string, error) {
+func GetRandomZoneForRegionE(t testing.TestingT, projectID string, region string) (string, error) {
 	zoneFromEnvVar := os.Getenv(zoneOverrideEnvVarName)
 	if zoneFromEnvVar != "" {
 		logger.Logf(t, "Using GCP Zone %s from environment variable %s", zoneFromEnvVar, zoneOverrideEnvVarName)
@@ -150,7 +150,7 @@ func GetRandomZoneForRegionE(t TestingT, projectID string, region string) (strin
 }
 
 // GetAllGcpRegions gets the list of GCP regions available in this account.
-func GetAllGcpRegions(t TestingT, projectID string) []string {
+func GetAllGcpRegions(t testing.TestingT, projectID string) []string {
 	out, err := GetAllGcpRegionsE(t, projectID)
 	if err != nil {
 		t.Fatal(err)
@@ -159,7 +159,7 @@ func GetAllGcpRegions(t TestingT, projectID string) []string {
 }
 
 // GetAllGcpRegionsE gets the list of GCP regions available in this account.
-func GetAllGcpRegionsE(t TestingT, projectID string) ([]string, error) {
+func GetAllGcpRegionsE(t testing.TestingT, projectID string) ([]string, error) {
 	logger.Log(t, "Looking up all GCP regions available in this account")
 
 	// Note that NewComputeServiceE creates a context, but it appears to be empty so we keep the code simpler by
@@ -188,7 +188,7 @@ func GetAllGcpRegionsE(t TestingT, projectID string) ([]string, error) {
 }
 
 // GetAllGcpZones gets the list of GCP Zones available in this account.
-func GetAllGcpZones(t TestingT, projectID string) []string {
+func GetAllGcpZones(t testing.TestingT, projectID string) []string {
 	out, err := GetAllGcpZonesE(t, projectID)
 	if err != nil {
 		t.Fatal(err)
@@ -197,7 +197,7 @@ func GetAllGcpZones(t TestingT, projectID string) []string {
 }
 
 // GetAllGcpZonesE gets the list of GCP Zones available in this account.
-func GetAllGcpZonesE(t TestingT, projectID string) ([]string, error) {
+func GetAllGcpZonesE(t testing.TestingT, projectID string) ([]string, error) {
 	// Note that NewComputeServiceE creates a context, but it appears to be empty so we keep the code simpler by
 	// creating a new one here
 	ctx := context.Background()

--- a/modules/gcp/storage.go
+++ b/modules/gcp/storage.go
@@ -4,15 +4,15 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"testing"
 
 	"cloud.google.com/go/storage"
 	"github.com/gruntwork-io/terratest/modules/logger"
+	_ "github.com/gruntwork-io/terratest/modules/testing"
 	"google.golang.org/api/iterator"
 )
 
 // CreateStorageBucket creates a Google Cloud bucket with the given BucketAttrs. Note that Google Storage bucket names must be globally unique.
-func CreateStorageBucket(t *testing.T, projectID string, name string, attr *storage.BucketAttrs) {
+func CreateStorageBucket(t TestingT, projectID string, name string, attr *storage.BucketAttrs) {
 	err := CreateStorageBucketE(t, projectID, name, attr)
 	if err != nil {
 		t.Fatal(err)
@@ -20,7 +20,7 @@ func CreateStorageBucket(t *testing.T, projectID string, name string, attr *stor
 }
 
 // CreateStorageBucketE creates a Google Cloud bucket with the given BucketAttrs. Note that Google Storage bucket names must be globally unique.
-func CreateStorageBucketE(t *testing.T, projectID string, name string, attr *storage.BucketAttrs) error {
+func CreateStorageBucketE(t TestingT, projectID string, name string, attr *storage.BucketAttrs) error {
 	logger.Logf(t, "Creating bucket %s", name)
 
 	ctx := context.Background()
@@ -39,7 +39,7 @@ func CreateStorageBucketE(t *testing.T, projectID string, name string, attr *sto
 }
 
 // DeleteStorageBucket destroys the Google Storage bucket.
-func DeleteStorageBucket(t *testing.T, name string) {
+func DeleteStorageBucket(t TestingT, name string) {
 	err := DeleteStorageBucketE(t, name)
 	if err != nil {
 		t.Fatal(err)
@@ -47,7 +47,7 @@ func DeleteStorageBucket(t *testing.T, name string) {
 }
 
 // DeleteStorageBucketE destroys the S3 bucket in the given region with the given name.
-func DeleteStorageBucketE(t *testing.T, name string) error {
+func DeleteStorageBucketE(t TestingT, name string) error {
 	logger.Logf(t, "Deleting bucket %s", name)
 
 	ctx := context.Background()
@@ -61,7 +61,7 @@ func DeleteStorageBucketE(t *testing.T, name string) error {
 }
 
 // ReadBucketObject reads an object from the given Storage Bucket and returns its contents.
-func ReadBucketObject(t *testing.T, bucketName string, filePath string) io.Reader {
+func ReadBucketObject(t TestingT, bucketName string, filePath string) io.Reader {
 	out, err := ReadBucketObjectE(t, bucketName, filePath)
 	if err != nil {
 		t.Fatal(err)
@@ -70,7 +70,7 @@ func ReadBucketObject(t *testing.T, bucketName string, filePath string) io.Reade
 }
 
 // ReadBucketObjectE reads an object from the given Storage Bucket and returns its contents.
-func ReadBucketObjectE(t *testing.T, bucketName string, filePath string) (io.Reader, error) {
+func ReadBucketObjectE(t TestingT, bucketName string, filePath string) (io.Reader, error) {
 	logger.Logf(t, "Reading object from bucket %s using path %s", bucketName, filePath)
 
 	ctx := context.Background()
@@ -90,7 +90,7 @@ func ReadBucketObjectE(t *testing.T, bucketName string, filePath string) (io.Rea
 }
 
 // WriteBucketObject writes an object to the given Storage Bucket and returns its URL.
-func WriteBucketObject(t *testing.T, bucketName string, filePath string, body io.Reader, contentType string) string {
+func WriteBucketObject(t TestingT, bucketName string, filePath string, body io.Reader, contentType string) string {
 	out, err := WriteBucketObjectE(t, bucketName, filePath, body, contentType)
 	if err != nil {
 		t.Fatal(err)
@@ -99,7 +99,7 @@ func WriteBucketObject(t *testing.T, bucketName string, filePath string, body io
 }
 
 // WriteBucketObjectE writes an object to the given Storage Bucket and returns its URL.
-func WriteBucketObjectE(t *testing.T, bucketName string, filePath string, body io.Reader, contentType string) (string, error) {
+func WriteBucketObjectE(t TestingT, bucketName string, filePath string, body io.Reader, contentType string) (string, error) {
 	// set a default content type
 	if contentType == "" {
 		contentType = "application/octet-stream"
@@ -134,7 +134,7 @@ func WriteBucketObjectE(t *testing.T, bucketName string, filePath string, body i
 }
 
 // EmptyStorageBucket removes the contents of a storage bucket with the given name.
-func EmptyStorageBucket(t *testing.T, name string) {
+func EmptyStorageBucket(t TestingT, name string) {
 	err := EmptyStorageBucketE(t, name)
 	if err != nil {
 		t.Fatal(err)
@@ -142,7 +142,7 @@ func EmptyStorageBucket(t *testing.T, name string) {
 }
 
 // EmptyStorageBucketE removes the contents of a storage bucket with the given name.
-func EmptyStorageBucketE(t *testing.T, name string) error {
+func EmptyStorageBucketE(t TestingT, name string) error {
 	logger.Logf(t, "Emptying storage bucket %s", name)
 
 	ctx := context.Background()
@@ -178,7 +178,7 @@ func EmptyStorageBucketE(t *testing.T, name string) error {
 }
 
 // AssertStorageBucketExists checks if the given storage bucket exists and fails the test if it does not.
-func AssertStorageBucketExists(t *testing.T, name string) {
+func AssertStorageBucketExists(t TestingT, name string) {
 	err := AssertStorageBucketExistsE(t, name)
 	if err != nil {
 		t.Fatal(err)
@@ -186,7 +186,7 @@ func AssertStorageBucketExists(t *testing.T, name string) {
 }
 
 // AssertStorageBucketExistsE checks if the given storage bucket exists and returns an error if it does not.
-func AssertStorageBucketExistsE(t *testing.T, name string) error {
+func AssertStorageBucketExistsE(t TestingT, name string) error {
 	logger.Logf(t, "Finding bucket %s", name)
 
 	ctx := context.Background()

--- a/modules/gcp/storage.go
+++ b/modules/gcp/storage.go
@@ -7,12 +7,12 @@ import (
 
 	"cloud.google.com/go/storage"
 	"github.com/gruntwork-io/terratest/modules/logger"
-	_ "github.com/gruntwork-io/terratest/modules/testing"
+	"github.com/gruntwork-io/terratest/modules/testing"
 	"google.golang.org/api/iterator"
 )
 
 // CreateStorageBucket creates a Google Cloud bucket with the given BucketAttrs. Note that Google Storage bucket names must be globally unique.
-func CreateStorageBucket(t TestingT, projectID string, name string, attr *storage.BucketAttrs) {
+func CreateStorageBucket(t testing.TestingT, projectID string, name string, attr *storage.BucketAttrs) {
 	err := CreateStorageBucketE(t, projectID, name, attr)
 	if err != nil {
 		t.Fatal(err)
@@ -20,7 +20,7 @@ func CreateStorageBucket(t TestingT, projectID string, name string, attr *storag
 }
 
 // CreateStorageBucketE creates a Google Cloud bucket with the given BucketAttrs. Note that Google Storage bucket names must be globally unique.
-func CreateStorageBucketE(t TestingT, projectID string, name string, attr *storage.BucketAttrs) error {
+func CreateStorageBucketE(t testing.TestingT, projectID string, name string, attr *storage.BucketAttrs) error {
 	logger.Logf(t, "Creating bucket %s", name)
 
 	ctx := context.Background()
@@ -39,7 +39,7 @@ func CreateStorageBucketE(t TestingT, projectID string, name string, attr *stora
 }
 
 // DeleteStorageBucket destroys the Google Storage bucket.
-func DeleteStorageBucket(t TestingT, name string) {
+func DeleteStorageBucket(t testing.TestingT, name string) {
 	err := DeleteStorageBucketE(t, name)
 	if err != nil {
 		t.Fatal(err)
@@ -47,7 +47,7 @@ func DeleteStorageBucket(t TestingT, name string) {
 }
 
 // DeleteStorageBucketE destroys the S3 bucket in the given region with the given name.
-func DeleteStorageBucketE(t TestingT, name string) error {
+func DeleteStorageBucketE(t testing.TestingT, name string) error {
 	logger.Logf(t, "Deleting bucket %s", name)
 
 	ctx := context.Background()
@@ -61,7 +61,7 @@ func DeleteStorageBucketE(t TestingT, name string) error {
 }
 
 // ReadBucketObject reads an object from the given Storage Bucket and returns its contents.
-func ReadBucketObject(t TestingT, bucketName string, filePath string) io.Reader {
+func ReadBucketObject(t testing.TestingT, bucketName string, filePath string) io.Reader {
 	out, err := ReadBucketObjectE(t, bucketName, filePath)
 	if err != nil {
 		t.Fatal(err)
@@ -70,7 +70,7 @@ func ReadBucketObject(t TestingT, bucketName string, filePath string) io.Reader 
 }
 
 // ReadBucketObjectE reads an object from the given Storage Bucket and returns its contents.
-func ReadBucketObjectE(t TestingT, bucketName string, filePath string) (io.Reader, error) {
+func ReadBucketObjectE(t testing.TestingT, bucketName string, filePath string) (io.Reader, error) {
 	logger.Logf(t, "Reading object from bucket %s using path %s", bucketName, filePath)
 
 	ctx := context.Background()
@@ -90,7 +90,7 @@ func ReadBucketObjectE(t TestingT, bucketName string, filePath string) (io.Reade
 }
 
 // WriteBucketObject writes an object to the given Storage Bucket and returns its URL.
-func WriteBucketObject(t TestingT, bucketName string, filePath string, body io.Reader, contentType string) string {
+func WriteBucketObject(t testing.TestingT, bucketName string, filePath string, body io.Reader, contentType string) string {
 	out, err := WriteBucketObjectE(t, bucketName, filePath, body, contentType)
 	if err != nil {
 		t.Fatal(err)
@@ -99,7 +99,7 @@ func WriteBucketObject(t TestingT, bucketName string, filePath string, body io.R
 }
 
 // WriteBucketObjectE writes an object to the given Storage Bucket and returns its URL.
-func WriteBucketObjectE(t TestingT, bucketName string, filePath string, body io.Reader, contentType string) (string, error) {
+func WriteBucketObjectE(t testing.TestingT, bucketName string, filePath string, body io.Reader, contentType string) (string, error) {
 	// set a default content type
 	if contentType == "" {
 		contentType = "application/octet-stream"
@@ -134,7 +134,7 @@ func WriteBucketObjectE(t TestingT, bucketName string, filePath string, body io.
 }
 
 // EmptyStorageBucket removes the contents of a storage bucket with the given name.
-func EmptyStorageBucket(t TestingT, name string) {
+func EmptyStorageBucket(t testing.TestingT, name string) {
 	err := EmptyStorageBucketE(t, name)
 	if err != nil {
 		t.Fatal(err)
@@ -142,7 +142,7 @@ func EmptyStorageBucket(t TestingT, name string) {
 }
 
 // EmptyStorageBucketE removes the contents of a storage bucket with the given name.
-func EmptyStorageBucketE(t TestingT, name string) error {
+func EmptyStorageBucketE(t testing.TestingT, name string) error {
 	logger.Logf(t, "Emptying storage bucket %s", name)
 
 	ctx := context.Background()
@@ -178,7 +178,7 @@ func EmptyStorageBucketE(t TestingT, name string) error {
 }
 
 // AssertStorageBucketExists checks if the given storage bucket exists and fails the test if it does not.
-func AssertStorageBucketExists(t TestingT, name string) {
+func AssertStorageBucketExists(t testing.TestingT, name string) {
 	err := AssertStorageBucketExistsE(t, name)
 	if err != nil {
 		t.Fatal(err)
@@ -186,7 +186,7 @@ func AssertStorageBucketExists(t TestingT, name string) {
 }
 
 // AssertStorageBucketExistsE checks if the given storage bucket exists and returns an error if it does not.
-func AssertStorageBucketExistsE(t TestingT, name string) error {
+func AssertStorageBucketExistsE(t testing.TestingT, name string) error {
 	logger.Logf(t, "Finding bucket %s", name)
 
 	ctx := context.Background()

--- a/modules/git/git.go
+++ b/modules/git/git.go
@@ -5,11 +5,11 @@ import (
 	"os/exec"
 	"strings"
 
-	_ "github.com/gruntwork-io/terratest/modules/testing"
+	"github.com/gruntwork-io/terratest/modules/testing"
 )
 
 // GetCurrentBranchName retrieves the current branch name.
-func GetCurrentBranchName(t TestingT) string {
+func GetCurrentBranchName(t testing.TestingT) string {
 	out, err := GetCurrentBranchNameE(t)
 	if err != nil {
 		t.Fatal(err)
@@ -18,7 +18,7 @@ func GetCurrentBranchName(t TestingT) string {
 }
 
 // GetCurrentBranchNameE retrieves the current branch name.
-func GetCurrentBranchNameE(t TestingT) (string, error) {
+func GetCurrentBranchNameE(t testing.TestingT) (string, error) {
 	cmd := exec.Command("git", "rev-parse", "--abbrev-ref", "HEAD")
 	bytes, err := cmd.Output()
 	if err != nil {

--- a/modules/git/git.go
+++ b/modules/git/git.go
@@ -4,11 +4,12 @@ package git
 import (
 	"os/exec"
 	"strings"
-	"testing"
+
+	_ "github.com/gruntwork-io/terratest/modules/testing"
 )
 
 // GetCurrentBranchName retrieves the current branch name.
-func GetCurrentBranchName(t *testing.T) string {
+func GetCurrentBranchName(t TestingT) string {
 	out, err := GetCurrentBranchNameE(t)
 	if err != nil {
 		t.Fatal(err)
@@ -17,7 +18,7 @@ func GetCurrentBranchName(t *testing.T) string {
 }
 
 // GetCurrentBranchNameE retrieves the current branch name.
-func GetCurrentBranchNameE(t *testing.T) (string, error) {
+func GetCurrentBranchNameE(t TestingT) (string, error) {
 	cmd := exec.Command("git", "rev-parse", "--abbrev-ref", "HEAD")
 	bytes, err := cmd.Output()
 	if err != nil {

--- a/modules/helm/cmd.go
+++ b/modules/helm/cmd.go
@@ -3,7 +3,7 @@ package helm
 import (
 	"github.com/gruntwork-io/gruntwork-cli/errors"
 	"github.com/gruntwork-io/terratest/modules/shell"
-	_ "github.com/gruntwork-io/terratest/modules/testing"
+	"github.com/gruntwork-io/terratest/modules/testing"
 )
 
 // getCommonArgs extracts common helm options. In this case, these are:
@@ -32,7 +32,7 @@ func getNamespaceArgs(options *Options) []string {
 }
 
 // getValuesArgsE computes the args to pass in for setting values
-func getValuesArgsE(t TestingT, options *Options, args ...string) ([]string, error) {
+func getValuesArgsE(t testing.TestingT, options *Options, args ...string) ([]string, error) {
 	args = append(args, formatSetValuesAsArgs(options.SetValues, "--set")...)
 	args = append(args, formatSetValuesAsArgs(options.SetStrValues, "--set-string")...)
 
@@ -51,7 +51,7 @@ func getValuesArgsE(t TestingT, options *Options, args ...string) ([]string, err
 }
 
 // RunHelmCommandAndGetOutputE runs helm with the given arguments and options and returns stdout/stderr.
-func RunHelmCommandAndGetOutputE(t TestingT, options *Options, cmd string, additionalArgs ...string) (string, error) {
+func RunHelmCommandAndGetOutputE(t testing.TestingT, options *Options, cmd string, additionalArgs ...string) (string, error) {
 	args := []string{cmd}
 	args = getCommonArgs(options, args...)
 	args = append(args, additionalArgs...)

--- a/modules/helm/cmd.go
+++ b/modules/helm/cmd.go
@@ -1,10 +1,9 @@
 package helm
 
 import (
-	"testing"
-
 	"github.com/gruntwork-io/gruntwork-cli/errors"
 	"github.com/gruntwork-io/terratest/modules/shell"
+	_ "github.com/gruntwork-io/terratest/modules/testing"
 )
 
 // getCommonArgs extracts common helm options. In this case, these are:
@@ -33,7 +32,7 @@ func getNamespaceArgs(options *Options) []string {
 }
 
 // getValuesArgsE computes the args to pass in for setting values
-func getValuesArgsE(t *testing.T, options *Options, args ...string) ([]string, error) {
+func getValuesArgsE(t TestingT, options *Options, args ...string) ([]string, error) {
 	args = append(args, formatSetValuesAsArgs(options.SetValues, "--set")...)
 	args = append(args, formatSetValuesAsArgs(options.SetStrValues, "--set-string")...)
 
@@ -52,7 +51,7 @@ func getValuesArgsE(t *testing.T, options *Options, args ...string) ([]string, e
 }
 
 // RunHelmCommandAndGetOutputE runs helm with the given arguments and options and returns stdout/stderr.
-func RunHelmCommandAndGetOutputE(t *testing.T, options *Options, cmd string, additionalArgs ...string) (string, error) {
+func RunHelmCommandAndGetOutputE(t TestingT, options *Options, cmd string, additionalArgs ...string) (string, error) {
 	args := []string{cmd}
 	args = getCommonArgs(options, args...)
 	args = append(args, additionalArgs...)

--- a/modules/helm/delete.go
+++ b/modules/helm/delete.go
@@ -1,19 +1,19 @@
 package helm
 
 import (
-	_ "github.com/gruntwork-io/terratest/modules/testing"
+	"github.com/gruntwork-io/terratest/modules/testing"
 	"github.com/stretchr/testify/require"
 )
 
 // Delete will delete the provided release from Tiller. If you set purge to true, Tiller will delete the release object
 // as well so that the release name can be reused. This will fail the test if there is an error.
-func Delete(t TestingT, options *Options, releaseName string, purge bool) {
+func Delete(t testing.TestingT, options *Options, releaseName string, purge bool) {
 	require.NoError(t, DeleteE(t, options, releaseName, purge))
 }
 
 // DeleteE will delete the provided release from Tiller. If you set purge to true, Tiller will delete the release object
 // as well so that the release name can be reused.
-func DeleteE(t TestingT, options *Options, releaseName string, purge bool) error {
+func DeleteE(t testing.TestingT, options *Options, releaseName string, purge bool) error {
 	args := []string{}
 	if !purge {
 		args = append(args, "--keep-history")

--- a/modules/helm/delete.go
+++ b/modules/helm/delete.go
@@ -1,20 +1,19 @@
 package helm
 
 import (
-	"testing"
-
+	_ "github.com/gruntwork-io/terratest/modules/testing"
 	"github.com/stretchr/testify/require"
 )
 
 // Delete will delete the provided release from Tiller. If you set purge to true, Tiller will delete the release object
 // as well so that the release name can be reused. This will fail the test if there is an error.
-func Delete(t *testing.T, options *Options, releaseName string, purge bool) {
+func Delete(t TestingT, options *Options, releaseName string, purge bool) {
 	require.NoError(t, DeleteE(t, options, releaseName, purge))
 }
 
 // DeleteE will delete the provided release from Tiller. If you set purge to true, Tiller will delete the release object
 // as well so that the release name can be reused.
-func DeleteE(t *testing.T, options *Options, releaseName string, purge bool) error {
+func DeleteE(t TestingT, options *Options, releaseName string, purge bool) error {
 	args := []string{}
 	if !purge {
 		args = append(args, "--keep-history")

--- a/modules/helm/format.go
+++ b/modules/helm/format.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/gruntwork-io/terratest/modules/files"
-	_ "github.com/gruntwork-io/terratest/modules/testing"
+	"github.com/gruntwork-io/terratest/modules/testing"
 )
 
 // formatSetValuesAsArgs formats the given values as command line args for helm using the given flag (e.g flags of
@@ -30,7 +30,7 @@ func formatSetValuesAsArgs(setValues map[string]string, flag string) []string {
 
 // formatValuesFilesAsArgs formats the given list of values file paths as command line args for helm (e.g of the format
 // -f path). This will fail the test if one of the paths do not exist or the absolute path can not be determined.
-func formatValuesFilesAsArgs(t TestingT, valuesFiles []string) []string {
+func formatValuesFilesAsArgs(t testing.TestingT, valuesFiles []string) []string {
 	args, err := formatValuesFilesAsArgsE(t, valuesFiles)
 	require.NoError(t, err)
 	return args
@@ -38,7 +38,7 @@ func formatValuesFilesAsArgs(t TestingT, valuesFiles []string) []string {
 
 // formatValuesFilesAsArgsE formats the given list of values file paths as command line args for helm (e.g of the format
 // -f path). This will error if the file does not exist.
-func formatValuesFilesAsArgsE(t TestingT, valuesFiles []string) ([]string, error) {
+func formatValuesFilesAsArgsE(t testing.TestingT, valuesFiles []string) ([]string, error) {
 	args := []string{}
 
 	for _, valuesFilePath := range valuesFiles {
@@ -59,7 +59,7 @@ func formatValuesFilesAsArgsE(t TestingT, valuesFiles []string) ([]string, error
 // formatSetFilesAsArgs formats the given list of keys and file paths as command line args for helm to set from file
 // (e.g of the format --set-file key=path). This will fail the test if one of the paths do not exist or the absolute
 // path can not be determined.
-func formatSetFilesAsArgs(t TestingT, setFiles map[string]string) []string {
+func formatSetFilesAsArgs(t testing.TestingT, setFiles map[string]string) []string {
 	args, err := formatSetFilesAsArgsE(t, setFiles)
 	require.NoError(t, err)
 	return args
@@ -67,7 +67,7 @@ func formatSetFilesAsArgs(t TestingT, setFiles map[string]string) []string {
 
 // formatSetFilesAsArgsE formats the given list of keys and file paths as command line args for helm to set from file
 // (e.g of the format --set-file key=path)
-func formatSetFilesAsArgsE(t TestingT, setFiles map[string]string) ([]string, error) {
+func formatSetFilesAsArgsE(t testing.TestingT, setFiles map[string]string) ([]string, error) {
 	args := []string{}
 
 	// To make it easier to test, go through the keys in sorted order

--- a/modules/helm/format.go
+++ b/modules/helm/format.go
@@ -3,13 +3,13 @@ package helm
 import (
 	"fmt"
 	"path/filepath"
-	"testing"
 
 	"github.com/gruntwork-io/gruntwork-cli/collections"
 	"github.com/gruntwork-io/gruntwork-cli/errors"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gruntwork-io/terratest/modules/files"
+	_ "github.com/gruntwork-io/terratest/modules/testing"
 )
 
 // formatSetValuesAsArgs formats the given values as command line args for helm using the given flag (e.g flags of
@@ -30,7 +30,7 @@ func formatSetValuesAsArgs(setValues map[string]string, flag string) []string {
 
 // formatValuesFilesAsArgs formats the given list of values file paths as command line args for helm (e.g of the format
 // -f path). This will fail the test if one of the paths do not exist or the absolute path can not be determined.
-func formatValuesFilesAsArgs(t *testing.T, valuesFiles []string) []string {
+func formatValuesFilesAsArgs(t TestingT, valuesFiles []string) []string {
 	args, err := formatValuesFilesAsArgsE(t, valuesFiles)
 	require.NoError(t, err)
 	return args
@@ -38,7 +38,7 @@ func formatValuesFilesAsArgs(t *testing.T, valuesFiles []string) []string {
 
 // formatValuesFilesAsArgsE formats the given list of values file paths as command line args for helm (e.g of the format
 // -f path). This will error if the file does not exist.
-func formatValuesFilesAsArgsE(t *testing.T, valuesFiles []string) ([]string, error) {
+func formatValuesFilesAsArgsE(t TestingT, valuesFiles []string) ([]string, error) {
 	args := []string{}
 
 	for _, valuesFilePath := range valuesFiles {
@@ -59,7 +59,7 @@ func formatValuesFilesAsArgsE(t *testing.T, valuesFiles []string) ([]string, err
 // formatSetFilesAsArgs formats the given list of keys and file paths as command line args for helm to set from file
 // (e.g of the format --set-file key=path). This will fail the test if one of the paths do not exist or the absolute
 // path can not be determined.
-func formatSetFilesAsArgs(t *testing.T, setFiles map[string]string) []string {
+func formatSetFilesAsArgs(t TestingT, setFiles map[string]string) []string {
 	args, err := formatSetFilesAsArgsE(t, setFiles)
 	require.NoError(t, err)
 	return args
@@ -67,7 +67,7 @@ func formatSetFilesAsArgs(t *testing.T, setFiles map[string]string) []string {
 
 // formatSetFilesAsArgsE formats the given list of keys and file paths as command line args for helm to set from file
 // (e.g of the format --set-file key=path)
-func formatSetFilesAsArgsE(t *testing.T, setFiles map[string]string) ([]string, error) {
+func formatSetFilesAsArgsE(t TestingT, setFiles map[string]string) ([]string, error) {
 	args := []string{}
 
 	// To make it easier to test, go through the keys in sorted order

--- a/modules/helm/install.go
+++ b/modules/helm/install.go
@@ -7,17 +7,17 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/gruntwork-io/terratest/modules/files"
-	_ "github.com/gruntwork-io/terratest/modules/testing"
+	"github.com/gruntwork-io/terratest/modules/testing"
 )
 
 // Install will install the selected helm chart with the provided options under the given release name. This will fail
 // the test if there is an error.
-func Install(t TestingT, options *Options, chart string, releaseName string) {
+func Install(t testing.TestingT, options *Options, chart string, releaseName string) {
 	require.NoError(t, InstallE(t, options, chart, releaseName))
 }
 
 // InstallE will install the selected helm chart with the provided options under the given release name.
-func InstallE(t TestingT, options *Options, chart string, releaseName string) error {
+func InstallE(t testing.TestingT, options *Options, chart string, releaseName string) error {
 	// If the chart refers to a path, convert to absolute path. Otherwise, pass straight through as it may be a remote
 	// chart.
 	if files.FileExists(chart) {

--- a/modules/helm/install.go
+++ b/modules/helm/install.go
@@ -2,22 +2,22 @@ package helm
 
 import (
 	"path/filepath"
-	"testing"
 
 	"github.com/gruntwork-io/gruntwork-cli/errors"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gruntwork-io/terratest/modules/files"
+	_ "github.com/gruntwork-io/terratest/modules/testing"
 )
 
 // Install will install the selected helm chart with the provided options under the given release name. This will fail
 // the test if there is an error.
-func Install(t *testing.T, options *Options, chart string, releaseName string) {
+func Install(t TestingT, options *Options, chart string, releaseName string) {
 	require.NoError(t, InstallE(t, options, chart, releaseName))
 }
 
 // InstallE will install the selected helm chart with the provided options under the given release name.
-func InstallE(t *testing.T, options *Options, chart string, releaseName string) error {
+func InstallE(t TestingT, options *Options, chart string, releaseName string) error {
 	// If the chart refers to a path, convert to absolute path. Otherwise, pass straight through as it may be a remote
 	// chart.
 	if files.FileExists(chart) {

--- a/modules/helm/rollback.go
+++ b/modules/helm/rollback.go
@@ -1,19 +1,18 @@
 package helm
 
 import (
-	"testing"
-
+	_ "github.com/gruntwork-io/terratest/modules/testing"
 	"github.com/stretchr/testify/require"
 )
 
 // Rollback will downgrade the release to the specified version. This will fail
 // the test if there is an error.
-func Rollback(t *testing.T, options *Options, releaseName string, revision string) {
+func Rollback(t TestingT, options *Options, releaseName string, revision string) {
 	require.NoError(t, RollbackE(t, options, releaseName, revision))
 }
 
 // RollbackE will downgrade the release to the specified version
-func RollbackE(t *testing.T, options *Options, releaseName string, revision string) error {
+func RollbackE(t TestingT, options *Options, releaseName string, revision string) error {
 	var err error
 	args := []string{}
 	args = append(args, releaseName, revision)

--- a/modules/helm/rollback.go
+++ b/modules/helm/rollback.go
@@ -1,18 +1,18 @@
 package helm
 
 import (
-	_ "github.com/gruntwork-io/terratest/modules/testing"
+	"github.com/gruntwork-io/terratest/modules/testing"
 	"github.com/stretchr/testify/require"
 )
 
 // Rollback will downgrade the release to the specified version. This will fail
 // the test if there is an error.
-func Rollback(t TestingT, options *Options, releaseName string, revision string) {
+func Rollback(t testing.TestingT, options *Options, releaseName string, revision string) {
 	require.NoError(t, RollbackE(t, options, releaseName, revision))
 }
 
 // RollbackE will downgrade the release to the specified version
-func RollbackE(t TestingT, options *Options, releaseName string, revision string) error {
+func RollbackE(t testing.TestingT, options *Options, releaseName string, revision string) error {
 	var err error
 	args := []string{}
 	args = append(args, releaseName, revision)

--- a/modules/helm/template.go
+++ b/modules/helm/template.go
@@ -9,13 +9,13 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/gruntwork-io/terratest/modules/files"
-	_ "github.com/gruntwork-io/terratest/modules/testing"
+	"github.com/gruntwork-io/terratest/modules/testing"
 )
 
 // RenderTemplate runs `helm template` to render the template given the provided options and returns stdout/stderr from
 // the template command. If you pass in templateFiles, this will only render those templates. This function will fail
 // the test if there is an error rendering the template.
-func RenderTemplate(t TestingT, options *Options, chartDir string, releaseName string, templateFiles []string) string {
+func RenderTemplate(t testing.TestingT, options *Options, chartDir string, releaseName string, templateFiles []string) string {
 	out, err := RenderTemplateE(t, options, chartDir, releaseName, templateFiles)
 	require.NoError(t, err)
 	return out
@@ -23,7 +23,7 @@ func RenderTemplate(t TestingT, options *Options, chartDir string, releaseName s
 
 // RenderTemplateE runs `helm template` to render the template given the provided options and returns stdout/stderr from
 // the template command. If you pass in templateFiles, this will only render those templates.
-func RenderTemplateE(t TestingT, options *Options, chartDir string, releaseName string, templateFiles []string) (string, error) {
+func RenderTemplateE(t testing.TestingT, options *Options, chartDir string, releaseName string, templateFiles []string) (string, error) {
 	// First, verify the charts dir exists
 	absChartDir, err := filepath.Abs(chartDir)
 	if err != nil {
@@ -62,7 +62,7 @@ func RenderTemplateE(t TestingT, options *Options, chartDir string, releaseName 
 }
 
 // UnmarshalK8SYaml is the same as UnmarshalK8SYamlE, but will fail the test if there is an error.
-func UnmarshalK8SYaml(t TestingT, yamlData string, destinationObj interface{}) {
+func UnmarshalK8SYaml(t testing.TestingT, yamlData string, destinationObj interface{}) {
 	require.NoError(t, UnmarshalK8SYamlE(t, yamlData, destinationObj))
 }
 
@@ -73,7 +73,7 @@ func UnmarshalK8SYaml(t TestingT, yamlData string, destinationObj interface{}) {
 // UnmarshalK8SYamlE(t, renderedOutput, &deployment)
 //
 // At the end of this, the deployment variable will be populated.
-func UnmarshalK8SYamlE(t TestingT, yamlData string, destinationObj interface{}) error {
+func UnmarshalK8SYamlE(t testing.TestingT, yamlData string, destinationObj interface{}) error {
 	// NOTE: the client-go library can only decode json, so we will first convert the yaml to json before unmarshaling
 	jsonData, err := yaml.YAMLToJSON([]byte(yamlData))
 	if err != nil {

--- a/modules/helm/template.go
+++ b/modules/helm/template.go
@@ -3,19 +3,19 @@ package helm
 import (
 	"encoding/json"
 	"path/filepath"
-	"testing"
 
 	"github.com/ghodss/yaml"
 	"github.com/gruntwork-io/gruntwork-cli/errors"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gruntwork-io/terratest/modules/files"
+	_ "github.com/gruntwork-io/terratest/modules/testing"
 )
 
 // RenderTemplate runs `helm template` to render the template given the provided options and returns stdout/stderr from
 // the template command. If you pass in templateFiles, this will only render those templates. This function will fail
 // the test if there is an error rendering the template.
-func RenderTemplate(t *testing.T, options *Options, chartDir string, releaseName string, templateFiles []string) string {
+func RenderTemplate(t TestingT, options *Options, chartDir string, releaseName string, templateFiles []string) string {
 	out, err := RenderTemplateE(t, options, chartDir, releaseName, templateFiles)
 	require.NoError(t, err)
 	return out
@@ -23,7 +23,7 @@ func RenderTemplate(t *testing.T, options *Options, chartDir string, releaseName
 
 // RenderTemplateE runs `helm template` to render the template given the provided options and returns stdout/stderr from
 // the template command. If you pass in templateFiles, this will only render those templates.
-func RenderTemplateE(t *testing.T, options *Options, chartDir string, releaseName string, templateFiles []string) (string, error) {
+func RenderTemplateE(t TestingT, options *Options, chartDir string, releaseName string, templateFiles []string) (string, error) {
 	// First, verify the charts dir exists
 	absChartDir, err := filepath.Abs(chartDir)
 	if err != nil {
@@ -62,7 +62,7 @@ func RenderTemplateE(t *testing.T, options *Options, chartDir string, releaseNam
 }
 
 // UnmarshalK8SYaml is the same as UnmarshalK8SYamlE, but will fail the test if there is an error.
-func UnmarshalK8SYaml(t *testing.T, yamlData string, destinationObj interface{}) {
+func UnmarshalK8SYaml(t TestingT, yamlData string, destinationObj interface{}) {
 	require.NoError(t, UnmarshalK8SYamlE(t, yamlData, destinationObj))
 }
 
@@ -73,7 +73,7 @@ func UnmarshalK8SYaml(t *testing.T, yamlData string, destinationObj interface{})
 // UnmarshalK8SYamlE(t, renderedOutput, &deployment)
 //
 // At the end of this, the deployment variable will be populated.
-func UnmarshalK8SYamlE(t *testing.T, yamlData string, destinationObj interface{}) error {
+func UnmarshalK8SYamlE(t TestingT, yamlData string, destinationObj interface{}) error {
 	// NOTE: the client-go library can only decode json, so we will first convert the yaml to json before unmarshaling
 	jsonData, err := yaml.YAMLToJSON([]byte(yamlData))
 	if err != nil {

--- a/modules/helm/upgrade.go
+++ b/modules/helm/upgrade.go
@@ -2,21 +2,21 @@ package helm
 
 import (
 	"path/filepath"
-	"testing"
 
 	"github.com/gruntwork-io/gruntwork-cli/errors"
 	"github.com/gruntwork-io/terratest/modules/files"
+	_ "github.com/gruntwork-io/terratest/modules/testing"
 	"github.com/stretchr/testify/require"
 )
 
 // Upgrade will upgrade the release and chart will be deployed with the lastest configuration. This will fail
 // the test if there is an error.
-func Upgrade(t *testing.T, options *Options, chart string, releaseName string) {
+func Upgrade(t TestingT, options *Options, chart string, releaseName string) {
 	require.NoError(t, UpgradeE(t, options, chart, releaseName))
 }
 
 // UpgradeE will upgrade the release and chart will be deployed with the lastest configuration.
-func UpgradeE(t *testing.T, options *Options, chart string, releaseName string) error {
+func UpgradeE(t TestingT, options *Options, chart string, releaseName string) error {
 	// If the chart refers to a path, convert to absolute path. Otherwise, pass straight through as it may be a remote
 	// chart.
 	if files.FileExists(chart) {

--- a/modules/helm/upgrade.go
+++ b/modules/helm/upgrade.go
@@ -5,18 +5,18 @@ import (
 
 	"github.com/gruntwork-io/gruntwork-cli/errors"
 	"github.com/gruntwork-io/terratest/modules/files"
-	_ "github.com/gruntwork-io/terratest/modules/testing"
+	"github.com/gruntwork-io/terratest/modules/testing"
 	"github.com/stretchr/testify/require"
 )
 
 // Upgrade will upgrade the release and chart will be deployed with the lastest configuration. This will fail
 // the test if there is an error.
-func Upgrade(t TestingT, options *Options, chart string, releaseName string) {
+func Upgrade(t testing.TestingT, options *Options, chart string, releaseName string) {
 	require.NoError(t, UpgradeE(t, options, chart, releaseName))
 }
 
 // UpgradeE will upgrade the release and chart will be deployed with the lastest configuration.
-func UpgradeE(t TestingT, options *Options, chart string, releaseName string) error {
+func UpgradeE(t testing.TestingT, options *Options, chart string, releaseName string) error {
 	// If the chart refers to a path, convert to absolute path. Otherwise, pass straight through as it may be a remote
 	// chart.
 	if files.FileExists(chart) {

--- a/modules/http-helper/continuous.go
+++ b/modules/http-helper/continuous.go
@@ -3,10 +3,10 @@ package http_helper
 import (
 	"crypto/tls"
 	"sync"
-	"testing"
 	"time"
 
 	"github.com/gruntwork-io/terratest/modules/logger"
+	"github.com/gruntwork-io/terratest/modules/testing"
 )
 
 type GetResponse struct {
@@ -19,7 +19,7 @@ type GetResponse struct {
 // to stream the responses for each check.
 // Note that the channel has a buffer of 1000, after which it will start to drop the send events
 func ContinuouslyCheckUrl(
-	t *testing.T,
+	t testing.TestingT,
 	url string,
 	stopChecking <-chan bool,
 	sleepBetweenChecks time.Duration,

--- a/modules/http-helper/dummy_server.go
+++ b/modules/http-helper/dummy_server.go
@@ -6,15 +6,15 @@ import (
 	"net/http"
 	"strconv"
 	"sync/atomic"
-	"testing"
 
 	"github.com/gruntwork-io/terratest/modules/logger"
+	"github.com/gruntwork-io/terratest/modules/testing"
 )
 
 // RunDummyServer runs a dummy HTTP server on a unique port that will return the given text. Returns the Listener for the server, the
 // port it's listening on, or an error if something went wrong while trying to start the listener. Make sure to call
 // the Close() method on the Listener when you're done!
-func RunDummyServer(t *testing.T, text string) (net.Listener, int) {
+func RunDummyServer(t testing.TestingT, text string) (net.Listener, int) {
 	listener, port, err := RunDummyServerE(t, text)
 	if err != nil {
 		t.Fatal(err)
@@ -25,7 +25,7 @@ func RunDummyServer(t *testing.T, text string) (net.Listener, int) {
 // RunDummyServerE runs a dummy HTTP server on a unique port that will return the given text. Returns the Listener for the server, the
 // port it's listening on, or an error if something went wrong while trying to start the listener. Make sure to call
 // the Close() method on the Listener when you're done!
-func RunDummyServerE(t *testing.T, text string) (net.Listener, int, error) {
+func RunDummyServerE(t testing.TestingT, text string) (net.Listener, int, error) {
 	port := getNextPort()
 
 	// Create new serve mux so that multiple handlers can be created
@@ -49,7 +49,7 @@ func RunDummyServerE(t *testing.T, text string) (net.Listener, int, error) {
 // RunDummyServerWithHandlers runs a dummy HTTP server on a unique port that will serve given handlers. Returns the Listener for the server,
 // the port it's listening on, or an error if something went wrong while trying to start the listener. Make sure to call
 // the Close() method on the Listener when you're done!
-func RunDummyServerWithHandlers(t *testing.T, handlers map[string]func(http.ResponseWriter, *http.Request)) (net.Listener, int) {
+func RunDummyServerWithHandlers(t testing.TestingT, handlers map[string]func(http.ResponseWriter, *http.Request)) (net.Listener, int) {
 	listener, port, err := RunDummyServerWithHandlersE(t, handlers)
 	if err != nil {
 		t.Fatal(err)
@@ -60,7 +60,7 @@ func RunDummyServerWithHandlers(t *testing.T, handlers map[string]func(http.Resp
 // RunDummyServerWithHandlersE runs a dummy HTTP server on a unique port that will server given handlers. Returns the Listener for the server,
 // the port it's listening on, or an error if something went wrong while trying to start the listener. Make sure to call
 // the Close() method on the Listener when you're done!
-func RunDummyServerWithHandlersE(t *testing.T, handlers map[string]func(http.ResponseWriter, *http.Request)) (net.Listener, int, error) {
+func RunDummyServerWithHandlersE(t testing.TestingT, handlers map[string]func(http.ResponseWriter, *http.Request)) (net.Listener, int, error) {
 	port := getNextPort()
 
 	for path, handler := range handlers {

--- a/modules/http-helper/http_helper.go
+++ b/modules/http-helper/http_helper.go
@@ -9,16 +9,16 @@ import (
 	"io/ioutil"
 	"net/http"
 	"strings"
-	"testing"
 	"time"
 
 	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/retry"
+	"github.com/gruntwork-io/terratest/modules/testing"
 )
 
 // HttpGet performs an HTTP GET, with an optional pointer to a custom TLS configuration, on the given URL and
 // return the HTTP status code and body. If there's any error, fail the test.
-func HttpGet(t *testing.T, url string, tlsConfig *tls.Config) (int, string) {
+func HttpGet(t testing.TestingT, url string, tlsConfig *tls.Config) (int, string) {
 	statusCode, body, err := HttpGetE(t, url, tlsConfig)
 	if err != nil {
 		t.Fatal(err)
@@ -28,7 +28,7 @@ func HttpGet(t *testing.T, url string, tlsConfig *tls.Config) (int, string) {
 
 // HttpGetE performs an HTTP GET, with an optional pointer to a custom TLS configuration, on the given URL and
 // return the HTTP status code, body, and any error.
-func HttpGetE(t *testing.T, url string, tlsConfig *tls.Config) (int, string, error) {
+func HttpGetE(t testing.TestingT, url string, tlsConfig *tls.Config) (int, string, error) {
 	logger.Logf(t, "Making an HTTP GET call to URL %s", url)
 
 	// Set HTTP client transport config
@@ -60,7 +60,7 @@ func HttpGetE(t *testing.T, url string, tlsConfig *tls.Config) (int, string, err
 
 // HttpGetWithValidation performs an HTTP GET on the given URL and verify that you get back the expected status code and body. If either
 // doesn't match, fail the test.
-func HttpGetWithValidation(t *testing.T, url string, tlsConfig *tls.Config, expectedStatusCode int, expectedBody string) {
+func HttpGetWithValidation(t testing.TestingT, url string, tlsConfig *tls.Config, expectedStatusCode int, expectedBody string) {
 	err := HttpGetWithValidationE(t, url, tlsConfig, expectedStatusCode, expectedBody)
 	if err != nil {
 		t.Fatal(err)
@@ -69,14 +69,14 @@ func HttpGetWithValidation(t *testing.T, url string, tlsConfig *tls.Config, expe
 
 // HttpGetWithValidationE performs an HTTP GET on the given URL and verify that you get back the expected status code and body. If either
 // doesn't match, return an error.
-func HttpGetWithValidationE(t *testing.T, url string, tlsConfig *tls.Config, expectedStatusCode int, expectedBody string) error {
+func HttpGetWithValidationE(t testing.TestingT, url string, tlsConfig *tls.Config, expectedStatusCode int, expectedBody string) error {
 	return HttpGetWithCustomValidationE(t, url, tlsConfig, func(statusCode int, body string) bool {
 		return statusCode == expectedStatusCode && body == expectedBody
 	})
 }
 
 // HttpGetWithCustomValidation performs an HTTP GET on the given URL and validate the returned status code and body using the given function.
-func HttpGetWithCustomValidation(t *testing.T, url string, tlsConfig *tls.Config, validateResponse func(int, string) bool) {
+func HttpGetWithCustomValidation(t testing.TestingT, url string, tlsConfig *tls.Config, validateResponse func(int, string) bool) {
 	err := HttpGetWithCustomValidationE(t, url, tlsConfig, validateResponse)
 	if err != nil {
 		t.Fatal(err)
@@ -84,7 +84,7 @@ func HttpGetWithCustomValidation(t *testing.T, url string, tlsConfig *tls.Config
 }
 
 // HttpGetWithCustomValidationE performs an HTTP GET on the given URL and validate the returned status code and body using the given function.
-func HttpGetWithCustomValidationE(t *testing.T, url string, tlsConfig *tls.Config, validateResponse func(int, string) bool) error {
+func HttpGetWithCustomValidationE(t testing.TestingT, url string, tlsConfig *tls.Config, validateResponse func(int, string) bool) error {
 	statusCode, body, err := HttpGetE(t, url, tlsConfig)
 
 	if err != nil {
@@ -100,7 +100,7 @@ func HttpGetWithCustomValidationE(t *testing.T, url string, tlsConfig *tls.Confi
 
 // HttpGetWithRetry repeatedly performs an HTTP GET on the given URL until the given status code and body are returned or until max
 // retries has been exceeded.
-func HttpGetWithRetry(t *testing.T, url string, tlsConfig *tls.Config, expectedStatus int, expectedBody string, retries int, sleepBetweenRetries time.Duration) {
+func HttpGetWithRetry(t testing.TestingT, url string, tlsConfig *tls.Config, expectedStatus int, expectedBody string, retries int, sleepBetweenRetries time.Duration) {
 	err := HttpGetWithRetryE(t, url, tlsConfig, expectedStatus, expectedBody, retries, sleepBetweenRetries)
 	if err != nil {
 		t.Fatal(err)
@@ -109,7 +109,7 @@ func HttpGetWithRetry(t *testing.T, url string, tlsConfig *tls.Config, expectedS
 
 // HttpGetWithRetryE repeatedly performs an HTTP GET on the given URL until the given status code and body are returned or until max
 // retries has been exceeded.
-func HttpGetWithRetryE(t *testing.T, url string, tlsConfig *tls.Config, expectedStatus int, expectedBody string, retries int, sleepBetweenRetries time.Duration) error {
+func HttpGetWithRetryE(t testing.TestingT, url string, tlsConfig *tls.Config, expectedStatus int, expectedBody string, retries int, sleepBetweenRetries time.Duration) error {
 	_, err := retry.DoWithRetryE(t, fmt.Sprintf("HTTP GET to URL %s", url), retries, sleepBetweenRetries, func() (string, error) {
 		return "", HttpGetWithValidationE(t, url, tlsConfig, expectedStatus, expectedBody)
 	})
@@ -119,7 +119,7 @@ func HttpGetWithRetryE(t *testing.T, url string, tlsConfig *tls.Config, expected
 
 // HttpGetWithRetryWithCustomValidation repeatedly performs an HTTP GET on the given URL until the given validation function returns true or max retries
 // has been exceeded.
-func HttpGetWithRetryWithCustomValidation(t *testing.T, url string, tlsConfig *tls.Config, retries int, sleepBetweenRetries time.Duration, validateResponse func(int, string) bool) {
+func HttpGetWithRetryWithCustomValidation(t testing.TestingT, url string, tlsConfig *tls.Config, retries int, sleepBetweenRetries time.Duration, validateResponse func(int, string) bool) {
 	err := HttpGetWithRetryWithCustomValidationE(t, url, tlsConfig, retries, sleepBetweenRetries, validateResponse)
 	if err != nil {
 		t.Fatal(err)
@@ -128,7 +128,7 @@ func HttpGetWithRetryWithCustomValidation(t *testing.T, url string, tlsConfig *t
 
 // HttpGetWithRetryWithCustomValidationE repeatedly performs an HTTP GET on the given URL until the given validation function returns true or max retries
 // has been exceeded.
-func HttpGetWithRetryWithCustomValidationE(t *testing.T, url string, tlsConfig *tls.Config, retries int, sleepBetweenRetries time.Duration, validateResponse func(int, string) bool) error {
+func HttpGetWithRetryWithCustomValidationE(t testing.TestingT, url string, tlsConfig *tls.Config, retries int, sleepBetweenRetries time.Duration, validateResponse func(int, string) bool) error {
 	_, err := retry.DoWithRetryE(t, fmt.Sprintf("HTTP GET to URL %s", url), retries, sleepBetweenRetries, func() (string, error) {
 		return "", HttpGetWithCustomValidationE(t, url, tlsConfig, validateResponse)
 	})
@@ -139,7 +139,7 @@ func HttpGetWithRetryWithCustomValidationE(t *testing.T, url string, tlsConfig *
 // HTTPDo performs the given HTTP method on the given URL and return the HTTP status code and body.
 // If there's any error, fail the test.
 func HTTPDo(
-	t *testing.T, method string, url string, body io.Reader,
+	t testing.TestingT, method string, url string, body io.Reader,
 	headers map[string]string, tlsConfig *tls.Config,
 ) (int, string) {
 	statusCode, respBody, err := HTTPDoE(t, method, url, body, headers, tlsConfig)
@@ -151,7 +151,7 @@ func HTTPDo(
 
 // HTTPDoE performs the given HTTP method on the given URL and return the HTTP status code, body, and any error.
 func HTTPDoE(
-	t *testing.T, method string, url string, body io.Reader,
+	t testing.TestingT, method string, url string, body io.Reader,
 	headers map[string]string, tlsConfig *tls.Config,
 ) (int, string, error) {
 	logger.Logf(t, "Making an HTTP %s call to URL %s", method, url)
@@ -186,7 +186,7 @@ func HTTPDoE(
 // returned or until max retries has been exceeded.
 // The function compares the expected status code against the received one and fails if they don't match.
 func HTTPDoWithRetry(
-	t *testing.T, method string, url string,
+	t testing.TestingT, method string, url string,
 	body []byte, headers map[string]string, expectedStatus int,
 	retries int, sleepBetweenRetries time.Duration, tlsConfig *tls.Config,
 ) string {
@@ -202,7 +202,7 @@ func HTTPDoWithRetry(
 // returned or until max retries has been exceeded.
 // The function compares the expected status code against the received one and fails if they don't match.
 func HTTPDoWithRetryE(
-	t *testing.T, method string, url string,
+	t testing.TestingT, method string, url string,
 	body []byte, headers map[string]string, expectedStatus int,
 	retries int, sleepBetweenRetries time.Duration, tlsConfig *tls.Config,
 ) (string, error) {
@@ -227,7 +227,7 @@ func HTTPDoWithRetryE(
 // HTTPDoWithValidationRetry repeatedly performs the given HTTP method on the given URL until the given status code and
 // body are returned or until max retries has been exceeded.
 func HTTPDoWithValidationRetry(
-	t *testing.T, method string, url string,
+	t testing.TestingT, method string, url string,
 	body []byte, headers map[string]string, expectedStatus int,
 	expectedBody string, retries int, sleepBetweenRetries time.Duration, tlsConfig *tls.Config,
 ) {
@@ -240,7 +240,7 @@ func HTTPDoWithValidationRetry(
 // HTTPDoWithValidationRetryE repeatedly performs the given HTTP method on the given URL until the given status code and
 // body are returned or until max retries has been exceeded.
 func HTTPDoWithValidationRetryE(
-	t *testing.T, method string, url string,
+	t testing.TestingT, method string, url string,
 	body []byte, headers map[string]string, expectedStatus int,
 	expectedBody string, retries int, sleepBetweenRetries time.Duration, tlsConfig *tls.Config,
 ) error {
@@ -255,7 +255,7 @@ func HTTPDoWithValidationRetryE(
 
 // HTTPDoWithValidation performs the given HTTP method on the given URL and verify that you get back the expected status
 // code and body. If either doesn't match, fail the test.
-func HTTPDoWithValidation(t *testing.T, method string, url string, body io.Reader, headers map[string]string, expectedStatusCode int, expectedBody string, tlsConfig *tls.Config) {
+func HTTPDoWithValidation(t testing.TestingT, method string, url string, body io.Reader, headers map[string]string, expectedStatusCode int, expectedBody string, tlsConfig *tls.Config) {
 	err := HTTPDoWithValidationE(t, method, url, body, headers, expectedStatusCode, expectedBody, tlsConfig)
 	if err != nil {
 		t.Fatal(err)
@@ -264,7 +264,7 @@ func HTTPDoWithValidation(t *testing.T, method string, url string, body io.Reade
 
 // HTTPDoWithValidationE performs the given HTTP method on the given URL and verify that you get back the expected status
 // code and body. If either doesn't match, return an error.
-func HTTPDoWithValidationE(t *testing.T, method string, url string, body io.Reader, headers map[string]string, expectedStatusCode int, expectedBody string, tlsConfig *tls.Config) error {
+func HTTPDoWithValidationE(t testing.TestingT, method string, url string, body io.Reader, headers map[string]string, expectedStatusCode int, expectedBody string, tlsConfig *tls.Config) error {
 	return HTTPDoWithCustomValidationE(t, method, url, body, headers, func(statusCode int, body string) bool {
 		return statusCode == expectedStatusCode && body == expectedBody
 	}, tlsConfig)
@@ -272,7 +272,7 @@ func HTTPDoWithValidationE(t *testing.T, method string, url string, body io.Read
 
 // HTTPDoWithCustomValidation performs the given HTTP method on the given URL and validate the returned status code and
 // body using the given function.
-func HTTPDoWithCustomValidation(t *testing.T, method string, url string, body io.Reader, headers map[string]string, validateResponse func(int, string) bool, tlsConfig *tls.Config) {
+func HTTPDoWithCustomValidation(t testing.TestingT, method string, url string, body io.Reader, headers map[string]string, validateResponse func(int, string) bool, tlsConfig *tls.Config) {
 	err := HTTPDoWithCustomValidationE(t, method, url, body, headers, validateResponse, tlsConfig)
 	if err != nil {
 		t.Fatal(err)
@@ -281,7 +281,7 @@ func HTTPDoWithCustomValidation(t *testing.T, method string, url string, body io
 
 // HTTPDoWithCustomValidationE performs the given HTTP method on the given URL and validate the returned status code and
 // body using the given function.
-func HTTPDoWithCustomValidationE(t *testing.T, method string, url string, body io.Reader, headers map[string]string, validateResponse func(int, string) bool, tlsConfig *tls.Config) error {
+func HTTPDoWithCustomValidationE(t testing.TestingT, method string, url string, body io.Reader, headers map[string]string, validateResponse func(int, string) bool, tlsConfig *tls.Config) error {
 	statusCode, respBody, err := HTTPDoE(t, method, url, body, headers, tlsConfig)
 
 	if err != nil {

--- a/modules/k8s/client.go
+++ b/modules/k8s/client.go
@@ -10,10 +10,11 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 
 	"github.com/gruntwork-io/terratest/modules/logger"
+	_ "github.com/gruntwork-io/terratest/modules/testing"
 )
 
 // GetKubernetesClientE returns a Kubernetes API client that can be used to make requests.
-func GetKubernetesClientE(t *testing.T) (*kubernetes.Clientset, error) {
+func GetKubernetesClientE(t TestingT) (*kubernetes.Clientset, error) {
 	kubeConfigPath, err := GetKubeConfigPathE(t)
 	if err != nil {
 		return nil, err
@@ -24,7 +25,7 @@ func GetKubernetesClientE(t *testing.T) (*kubernetes.Clientset, error) {
 }
 
 // GetKubernetesClientFromOptionsE returns a Kubernetes API client given a configured KubectlOptions object.
-func GetKubernetesClientFromOptionsE(t *testing.T, options *KubectlOptions) (*kubernetes.Clientset, error) {
+func GetKubernetesClientFromOptionsE(t TestingT, options *KubectlOptions) (*kubernetes.Clientset, error) {
 	var err error
 
 	kubeConfigPath, err := options.GetConfigPath(t)

--- a/modules/k8s/client.go
+++ b/modules/k8s/client.go
@@ -1,8 +1,6 @@
 package k8s
 
 import (
-	"testing"
-
 	"k8s.io/client-go/kubernetes"
 
 	// The following line loads the gcp plugin which is required to authenticate against GKE clusters.

--- a/modules/k8s/client.go
+++ b/modules/k8s/client.go
@@ -10,11 +10,11 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 
 	"github.com/gruntwork-io/terratest/modules/logger"
-	_ "github.com/gruntwork-io/terratest/modules/testing"
+	"github.com/gruntwork-io/terratest/modules/testing"
 )
 
 // GetKubernetesClientE returns a Kubernetes API client that can be used to make requests.
-func GetKubernetesClientE(t TestingT) (*kubernetes.Clientset, error) {
+func GetKubernetesClientE(t testing.TestingT) (*kubernetes.Clientset, error) {
 	kubeConfigPath, err := GetKubeConfigPathE(t)
 	if err != nil {
 		return nil, err
@@ -25,7 +25,7 @@ func GetKubernetesClientE(t TestingT) (*kubernetes.Clientset, error) {
 }
 
 // GetKubernetesClientFromOptionsE returns a Kubernetes API client given a configured KubectlOptions object.
-func GetKubernetesClientFromOptionsE(t TestingT, options *KubectlOptions) (*kubernetes.Clientset, error) {
+func GetKubernetesClientFromOptionsE(t testing.TestingT, options *KubectlOptions) (*kubernetes.Clientset, error) {
 	var err error
 
 	kubeConfigPath, err := options.GetConfigPath(t)

--- a/modules/k8s/cluster_role.go
+++ b/modules/k8s/cluster_role.go
@@ -1,22 +1,21 @@
 package k8s
 
 import (
-	"testing"
-
+	_ "github.com/gruntwork-io/terratest/modules/testing"
 	"github.com/stretchr/testify/require"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // GetClusterRole returns a Kubernetes ClusterRole resource with the given name. This will fail the test if there is an error.
-func GetClusterRole(t *testing.T, options *KubectlOptions, roleName string) *rbacv1.ClusterRole {
+func GetClusterRole(t TestingT, options *KubectlOptions, roleName string) *rbacv1.ClusterRole {
 	role, err := GetClusterRoleE(t, options, roleName)
 	require.NoError(t, err)
 	return role
 }
 
 // GetClusterRoleE returns a Kubernetes ClusterRole resource with the given name.
-func GetClusterRoleE(t *testing.T, options *KubectlOptions, roleName string) (*rbacv1.ClusterRole, error) {
+func GetClusterRoleE(t TestingT, options *KubectlOptions, roleName string) (*rbacv1.ClusterRole, error) {
 	clientset, err := GetKubernetesClientFromOptionsE(t, options)
 	if err != nil {
 		return nil, err

--- a/modules/k8s/cluster_role.go
+++ b/modules/k8s/cluster_role.go
@@ -1,21 +1,21 @@
 package k8s
 
 import (
-	_ "github.com/gruntwork-io/terratest/modules/testing"
+	"github.com/gruntwork-io/terratest/modules/testing"
 	"github.com/stretchr/testify/require"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // GetClusterRole returns a Kubernetes ClusterRole resource with the given name. This will fail the test if there is an error.
-func GetClusterRole(t TestingT, options *KubectlOptions, roleName string) *rbacv1.ClusterRole {
+func GetClusterRole(t testing.TestingT, options *KubectlOptions, roleName string) *rbacv1.ClusterRole {
 	role, err := GetClusterRoleE(t, options, roleName)
 	require.NoError(t, err)
 	return role
 }
 
 // GetClusterRoleE returns a Kubernetes ClusterRole resource with the given name.
-func GetClusterRoleE(t TestingT, options *KubectlOptions, roleName string) (*rbacv1.ClusterRole, error) {
+func GetClusterRoleE(t testing.TestingT, options *KubectlOptions, roleName string) (*rbacv1.ClusterRole, error) {
 	clientset, err := GetKubernetesClientFromOptionsE(t, options)
 	if err != nil {
 		return nil, err

--- a/modules/k8s/cluster_role_test.go
+++ b/modules/k8s/cluster_role_test.go
@@ -9,11 +9,12 @@
 package k8s
 
 import (
-	"github.com/gruntwork-io/terratest/modules/testing"
+	"testing"
+
 	"github.com/stretchr/testify/require"
 )
 
-func TestGetClusterRoleEReturnsErrorForNonExistantClusterRole(t testing.TestingT) {
+func TestGetClusterRoleEReturnsErrorForNonExistantClusterRole(t *testing.T) {
 	t.Parallel()
 
 	options := NewKubectlOptions("", "", "default")
@@ -21,7 +22,7 @@ func TestGetClusterRoleEReturnsErrorForNonExistantClusterRole(t testing.TestingT
 	require.Error(t, err)
 }
 
-func TestGetClusterRoleEReturnsCorrectClusterRoleInCorrectNamespace(t testing.TestingT) {
+func TestGetClusterRoleEReturnsCorrectClusterRoleInCorrectNamespace(t *testing.T) {
 	t.Parallel()
 
 	options := NewKubectlOptions("", "", "default")

--- a/modules/k8s/cluster_role_test.go
+++ b/modules/k8s/cluster_role_test.go
@@ -9,11 +9,11 @@
 package k8s
 
 import (
-	_ "github.com/gruntwork-io/terratest/modules/testing"
+	"github.com/gruntwork-io/terratest/modules/testing"
 	"github.com/stretchr/testify/require"
 )
 
-func TestGetClusterRoleEReturnsErrorForNonExistantClusterRole(t TestingT) {
+func TestGetClusterRoleEReturnsErrorForNonExistantClusterRole(t testing.TestingT) {
 	t.Parallel()
 
 	options := NewKubectlOptions("", "", "default")
@@ -21,7 +21,7 @@ func TestGetClusterRoleEReturnsErrorForNonExistantClusterRole(t TestingT) {
 	require.Error(t, err)
 }
 
-func TestGetClusterRoleEReturnsCorrectClusterRoleInCorrectNamespace(t TestingT) {
+func TestGetClusterRoleEReturnsCorrectClusterRoleInCorrectNamespace(t testing.TestingT) {
 	t.Parallel()
 
 	options := NewKubectlOptions("", "", "default")

--- a/modules/k8s/cluster_role_test.go
+++ b/modules/k8s/cluster_role_test.go
@@ -9,12 +9,11 @@
 package k8s
 
 import (
-	"testing"
-
+	_ "github.com/gruntwork-io/terratest/modules/testing"
 	"github.com/stretchr/testify/require"
 )
 
-func TestGetClusterRoleEReturnsErrorForNonExistantClusterRole(t *testing.T) {
+func TestGetClusterRoleEReturnsErrorForNonExistantClusterRole(t TestingT) {
 	t.Parallel()
 
 	options := NewKubectlOptions("", "", "default")
@@ -22,7 +21,7 @@ func TestGetClusterRoleEReturnsErrorForNonExistantClusterRole(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestGetClusterRoleEReturnsCorrectClusterRoleInCorrectNamespace(t *testing.T) {
+func TestGetClusterRoleEReturnsCorrectClusterRoleInCorrectNamespace(t TestingT) {
 	t.Parallel()
 
 	options := NewKubectlOptions("", "", "default")

--- a/modules/k8s/config.go
+++ b/modules/k8s/config.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
-	"testing"
 
 	gwErrors "github.com/gruntwork-io/gruntwork-cli/errors"
 	homedir "github.com/mitchellh/go-homedir"
@@ -17,6 +16,7 @@ import (
 	"github.com/gruntwork-io/terratest/modules/environment"
 	"github.com/gruntwork-io/terratest/modules/files"
 	"github.com/gruntwork-io/terratest/modules/logger"
+	_ "github.com/gruntwork-io/terratest/modules/testing"
 )
 
 // LoadConfigFromPath will load a ClientConfig object from a file path that points to a location on disk containing a
@@ -44,7 +44,7 @@ func LoadApiClientConfigE(configPath string, contextName string) (*restclient.Co
 // DeleteConfigContextE will remove the context specified at the provided name, and remove any clusters and authinfos
 // that are orphaned as a result of it. The config path is either specified in the environment variable KUBECONFIG or at
 // the user's home directory under `.kube/config`.
-func DeleteConfigContextE(t *testing.T, contextName string) error {
+func DeleteConfigContextE(t TestingT, contextName string) error {
 	kubeConfigPath, err := GetKubeConfigPathE(t)
 	if err != nil {
 		return err
@@ -55,7 +55,7 @@ func DeleteConfigContextE(t *testing.T, contextName string) error {
 
 // DeleteConfigContextWithPathE will remove the context specified at the provided name, and remove any clusters and
 // authinfos that are orphaned as a result of it.
-func DeleteConfigContextWithPathE(t *testing.T, kubeConfigPath string, contextName string) error {
+func DeleteConfigContextWithPathE(t TestingT, kubeConfigPath string, contextName string) error {
 	logger.Logf(t, "Removing kubectl config context %s from config at path %s", contextName, kubeConfigPath)
 
 	// Load config and get data structure representing config info
@@ -125,7 +125,7 @@ func RemoveOrphanedClusterAndAuthInfoConfig(config *api.Config) {
 }
 
 // GetKubeConfigPathE determines which file path to use as the kubectl config path
-func GetKubeConfigPathE(t *testing.T) (string, error) {
+func GetKubeConfigPathE(t TestingT) (string, error) {
 	kubeConfigPath := environment.GetFirstNonEmptyEnvVarOrEmptyString(t, []string{"KUBECONFIG"})
 	if kubeConfigPath == "" {
 		configPath, err := KubeConfigPathFromHomeDirE()
@@ -150,7 +150,7 @@ func KubeConfigPathFromHomeDirE() (string, error) {
 
 // CopyHomeKubeConfigToTemp will copy the kubeconfig in the home directory to a temp file. This will fail the test if
 // there are any errors.
-func CopyHomeKubeConfigToTemp(t *testing.T) string {
+func CopyHomeKubeConfigToTemp(t TestingT) string {
 	path, err := CopyHomeKubeConfigToTempE(t)
 	if err != nil {
 		if path != "" {
@@ -162,7 +162,7 @@ func CopyHomeKubeConfigToTemp(t *testing.T) string {
 }
 
 // CopyHomeKubeConfigToTempE will copy the kubeconfig in the home directory to a temp file.
-func CopyHomeKubeConfigToTempE(t *testing.T) (string, error) {
+func CopyHomeKubeConfigToTempE(t TestingT) (string, error) {
 	configPath, err := KubeConfigPathFromHomeDirE()
 	if err != nil {
 		return "", err

--- a/modules/k8s/config.go
+++ b/modules/k8s/config.go
@@ -16,7 +16,7 @@ import (
 	"github.com/gruntwork-io/terratest/modules/environment"
 	"github.com/gruntwork-io/terratest/modules/files"
 	"github.com/gruntwork-io/terratest/modules/logger"
-	_ "github.com/gruntwork-io/terratest/modules/testing"
+	"github.com/gruntwork-io/terratest/modules/testing"
 )
 
 // LoadConfigFromPath will load a ClientConfig object from a file path that points to a location on disk containing a
@@ -44,7 +44,7 @@ func LoadApiClientConfigE(configPath string, contextName string) (*restclient.Co
 // DeleteConfigContextE will remove the context specified at the provided name, and remove any clusters and authinfos
 // that are orphaned as a result of it. The config path is either specified in the environment variable KUBECONFIG or at
 // the user's home directory under `.kube/config`.
-func DeleteConfigContextE(t TestingT, contextName string) error {
+func DeleteConfigContextE(t testing.TestingT, contextName string) error {
 	kubeConfigPath, err := GetKubeConfigPathE(t)
 	if err != nil {
 		return err
@@ -55,7 +55,7 @@ func DeleteConfigContextE(t TestingT, contextName string) error {
 
 // DeleteConfigContextWithPathE will remove the context specified at the provided name, and remove any clusters and
 // authinfos that are orphaned as a result of it.
-func DeleteConfigContextWithPathE(t TestingT, kubeConfigPath string, contextName string) error {
+func DeleteConfigContextWithPathE(t testing.TestingT, kubeConfigPath string, contextName string) error {
 	logger.Logf(t, "Removing kubectl config context %s from config at path %s", contextName, kubeConfigPath)
 
 	// Load config and get data structure representing config info
@@ -125,7 +125,7 @@ func RemoveOrphanedClusterAndAuthInfoConfig(config *api.Config) {
 }
 
 // GetKubeConfigPathE determines which file path to use as the kubectl config path
-func GetKubeConfigPathE(t TestingT) (string, error) {
+func GetKubeConfigPathE(t testing.TestingT) (string, error) {
 	kubeConfigPath := environment.GetFirstNonEmptyEnvVarOrEmptyString(t, []string{"KUBECONFIG"})
 	if kubeConfigPath == "" {
 		configPath, err := KubeConfigPathFromHomeDirE()
@@ -150,7 +150,7 @@ func KubeConfigPathFromHomeDirE() (string, error) {
 
 // CopyHomeKubeConfigToTemp will copy the kubeconfig in the home directory to a temp file. This will fail the test if
 // there are any errors.
-func CopyHomeKubeConfigToTemp(t TestingT) string {
+func CopyHomeKubeConfigToTemp(t testing.TestingT) string {
 	path, err := CopyHomeKubeConfigToTempE(t)
 	if err != nil {
 		if path != "" {
@@ -162,7 +162,7 @@ func CopyHomeKubeConfigToTemp(t TestingT) string {
 }
 
 // CopyHomeKubeConfigToTempE will copy the kubeconfig in the home directory to a temp file.
-func CopyHomeKubeConfigToTempE(t TestingT) (string, error) {
+func CopyHomeKubeConfigToTempE(t testing.TestingT) (string, error) {
 	configPath, err := KubeConfigPathFromHomeDirE()
 	if err != nil {
 		return "", err

--- a/modules/k8s/daemonset.go
+++ b/modules/k8s/daemonset.go
@@ -1,23 +1,23 @@
 package k8s
 
 import (
-	"testing"
-
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/gruntwork-io/terratest/modules/testing"
 )
 
 // ListDaemonSets will look for daemonsets in the given namespace that match the given filters and return them. This will
 // fail the test if there is an error.
-func ListDaemonSets(t *testing.T, options *KubectlOptions, filters metav1.ListOptions) []appsv1.DaemonSet {
+func ListDaemonSets(t testing.TestingT, options *KubectlOptions, filters metav1.ListOptions) []appsv1.DaemonSet {
 	daemonset, err := ListDaemonSetsE(t, options, filters)
 	require.NoError(t, err)
 	return daemonset
 }
 
 // ListDaemonSetsE will look for daemonsets in the given namespace that match the given filters and return them.
-func ListDaemonSetsE(t *testing.T, options *KubectlOptions, filters metav1.ListOptions) ([]appsv1.DaemonSet, error) {
+func ListDaemonSetsE(t testing.TestingT, options *KubectlOptions, filters metav1.ListOptions) ([]appsv1.DaemonSet, error) {
 	clientset, err := GetKubernetesClientFromOptionsE(t, options)
 	if err != nil {
 		return nil, err
@@ -31,14 +31,14 @@ func ListDaemonSetsE(t *testing.T, options *KubectlOptions, filters metav1.ListO
 
 // GetDaemonSet returns a Kubernetes daemonset resource in the provided namespace with the given name. This will
 // fail the test if there is an error.
-func GetDaemonSet(t *testing.T, options *KubectlOptions, daemonSetName string) *appsv1.DaemonSet {
+func GetDaemonSet(t testing.TestingT, options *KubectlOptions, daemonSetName string) *appsv1.DaemonSet {
 	daemonset, err := GetDaemonSetE(t, options, daemonSetName)
 	require.NoError(t, err)
 	return daemonset
 }
 
 // GetDaemonSetE returns a Kubernetes daemonset resource in the provided namespace with the given name.
-func GetDaemonSetE(t *testing.T, options *KubectlOptions, daemonSetName string) (*appsv1.DaemonSet, error) {
+func GetDaemonSetE(t testing.TestingT, options *KubectlOptions, daemonSetName string) (*appsv1.DaemonSet, error) {
 	clientset, err := GetKubernetesClientFromOptionsE(t, options)
 	if err != nil {
 		return nil, err

--- a/modules/k8s/ingress.go
+++ b/modules/k8s/ingress.go
@@ -2,7 +2,6 @@ package k8s
 
 import (
 	"fmt"
-	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
@@ -11,18 +10,19 @@ import (
 
 	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/retry"
+	_ "github.com/gruntwork-io/terratest/modules/testing"
 )
 
 // ListIngresses will look for Ingress resources in the given namespace that match the given filters and return them.
 // This will fail the test if there is an error.
-func ListIngresses(t *testing.T, options *KubectlOptions, filters metav1.ListOptions) []extensionsv1beta1.Ingress {
+func ListIngresses(t TestingT, options *KubectlOptions, filters metav1.ListOptions) []extensionsv1beta1.Ingress {
 	ingresses, err := ListIngressesE(t, options, filters)
 	require.NoError(t, err)
 	return ingresses
 }
 
 // ListIngressesE will look for Ingress resources in the given namespace that match the given filters and return them.
-func ListIngressesE(t *testing.T, options *KubectlOptions, filters metav1.ListOptions) ([]extensionsv1beta1.Ingress, error) {
+func ListIngressesE(t TestingT, options *KubectlOptions, filters metav1.ListOptions) ([]extensionsv1beta1.Ingress, error) {
 	clientset, err := GetKubernetesClientFromOptionsE(t, options)
 	if err != nil {
 		return nil, err
@@ -37,14 +37,14 @@ func ListIngressesE(t *testing.T, options *KubectlOptions, filters metav1.ListOp
 
 // GetIngress returns a Kubernetes Ingress resource in the provided namespace with the given name. This will fail the
 // test if there is an error.
-func GetIngress(t *testing.T, options *KubectlOptions, ingressName string) *extensionsv1beta1.Ingress {
+func GetIngress(t TestingT, options *KubectlOptions, ingressName string) *extensionsv1beta1.Ingress {
 	ingress, err := GetIngressE(t, options, ingressName)
 	require.NoError(t, err)
 	return ingress
 }
 
 // GetIngressE returns a Kubernetes Ingress resource in the provided namespace with the given name.
-func GetIngressE(t *testing.T, options *KubectlOptions, ingressName string) (*extensionsv1beta1.Ingress, error) {
+func GetIngressE(t TestingT, options *KubectlOptions, ingressName string) (*extensionsv1beta1.Ingress, error) {
 	clientset, err := GetKubernetesClientFromOptionsE(t, options)
 	if err != nil {
 		return nil, err
@@ -60,7 +60,7 @@ func IsIngressAvailable(ingress *extensionsv1beta1.Ingress) bool {
 }
 
 // WaitUntilIngressAvailable waits until the Ingress resource has an endpoint provisioned for it.
-func WaitUntilIngressAvailable(t *testing.T, options *KubectlOptions, ingressName string, retries int, sleepBetweenRetries time.Duration) {
+func WaitUntilIngressAvailable(t TestingT, options *KubectlOptions, ingressName string, retries int, sleepBetweenRetries time.Duration) {
 	statusMsg := fmt.Sprintf("Wait for ingress %s to be provisioned.", ingressName)
 	message := retry.DoWithRetry(
 		t,

--- a/modules/k8s/ingress.go
+++ b/modules/k8s/ingress.go
@@ -10,19 +10,19 @@ import (
 
 	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/retry"
-	_ "github.com/gruntwork-io/terratest/modules/testing"
+	"github.com/gruntwork-io/terratest/modules/testing"
 )
 
 // ListIngresses will look for Ingress resources in the given namespace that match the given filters and return them.
 // This will fail the test if there is an error.
-func ListIngresses(t TestingT, options *KubectlOptions, filters metav1.ListOptions) []extensionsv1beta1.Ingress {
+func ListIngresses(t testing.TestingT, options *KubectlOptions, filters metav1.ListOptions) []extensionsv1beta1.Ingress {
 	ingresses, err := ListIngressesE(t, options, filters)
 	require.NoError(t, err)
 	return ingresses
 }
 
 // ListIngressesE will look for Ingress resources in the given namespace that match the given filters and return them.
-func ListIngressesE(t TestingT, options *KubectlOptions, filters metav1.ListOptions) ([]extensionsv1beta1.Ingress, error) {
+func ListIngressesE(t testing.TestingT, options *KubectlOptions, filters metav1.ListOptions) ([]extensionsv1beta1.Ingress, error) {
 	clientset, err := GetKubernetesClientFromOptionsE(t, options)
 	if err != nil {
 		return nil, err
@@ -37,14 +37,14 @@ func ListIngressesE(t TestingT, options *KubectlOptions, filters metav1.ListOpti
 
 // GetIngress returns a Kubernetes Ingress resource in the provided namespace with the given name. This will fail the
 // test if there is an error.
-func GetIngress(t TestingT, options *KubectlOptions, ingressName string) *extensionsv1beta1.Ingress {
+func GetIngress(t testing.TestingT, options *KubectlOptions, ingressName string) *extensionsv1beta1.Ingress {
 	ingress, err := GetIngressE(t, options, ingressName)
 	require.NoError(t, err)
 	return ingress
 }
 
 // GetIngressE returns a Kubernetes Ingress resource in the provided namespace with the given name.
-func GetIngressE(t TestingT, options *KubectlOptions, ingressName string) (*extensionsv1beta1.Ingress, error) {
+func GetIngressE(t testing.TestingT, options *KubectlOptions, ingressName string) (*extensionsv1beta1.Ingress, error) {
 	clientset, err := GetKubernetesClientFromOptionsE(t, options)
 	if err != nil {
 		return nil, err
@@ -60,7 +60,7 @@ func IsIngressAvailable(ingress *extensionsv1beta1.Ingress) bool {
 }
 
 // WaitUntilIngressAvailable waits until the Ingress resource has an endpoint provisioned for it.
-func WaitUntilIngressAvailable(t TestingT, options *KubectlOptions, ingressName string, retries int, sleepBetweenRetries time.Duration) {
+func WaitUntilIngressAvailable(t testing.TestingT, options *KubectlOptions, ingressName string, retries int, sleepBetweenRetries time.Duration) {
 	statusMsg := fmt.Sprintf("Wait for ingress %s to be provisioned.", ingressName)
 	message := retry.DoWithRetry(
 		t,

--- a/modules/k8s/kubectl.go
+++ b/modules/k8s/kubectl.go
@@ -8,23 +8,23 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/gruntwork-io/terratest/modules/shell"
-	_ "github.com/gruntwork-io/terratest/modulest/testing"
+	"github.com/gruntwork-io/terratest/modulest/testing"
 )
 
 // RunKubectl will call kubectl using the provided options and args, failing the test on error.
-func RunKubectl(t TestingT, options *KubectlOptions, args ...string) {
+func RunKubectl(t testing.TestingT, options *KubectlOptions, args ...string) {
 	require.NoError(t, RunKubectlE(t, options, args...))
 }
 
 // RunKubectlE will call kubectl using the provided options and args.
-func RunKubectlE(t TestingT, options *KubectlOptions, args ...string) error {
+func RunKubectlE(t testing.TestingT, options *KubectlOptions, args ...string) error {
 	_, err := RunKubectlAndGetOutputE(t, options, args...)
 	return err
 }
 
 // RunKubectlAndGetOutputE will call kubectl using the provided options and args, returning the output of stdout and
 // stderr.
-func RunKubectlAndGetOutputE(t TestingT, options *KubectlOptions, args ...string) (string, error) {
+func RunKubectlAndGetOutputE(t testing.TestingT, options *KubectlOptions, args ...string) (string, error) {
 	cmdArgs := []string{}
 	if options.ContextName != "" {
 		cmdArgs = append(cmdArgs, "--context", options.ContextName)
@@ -46,24 +46,24 @@ func RunKubectlAndGetOutputE(t TestingT, options *KubectlOptions, args ...string
 
 // KubectlDelete will take in a file path and delete it from the cluster targeted by KubectlOptions. If there are any
 // errors, fail the test immediately.
-func KubectlDelete(t TestingT, options *KubectlOptions, configPath string) {
+func KubectlDelete(t testing.TestingT, options *KubectlOptions, configPath string) {
 	require.NoError(t, KubectlDeleteE(t, options, configPath))
 }
 
 // KubectlDeleteE will take in a file path and delete it from the cluster targeted by KubectlOptions.
-func KubectlDeleteE(t TestingT, options *KubectlOptions, configPath string) error {
+func KubectlDeleteE(t testing.TestingT, options *KubectlOptions, configPath string) error {
 	return RunKubectlE(t, options, "delete", "-f", configPath)
 }
 
 // KubectlDeleteFromString will take in a kubernetes resource config as a string and delete it on the cluster specified
 // by the provided kubectl options.
-func KubectlDeleteFromString(t TestingT, options *KubectlOptions, configData string) {
+func KubectlDeleteFromString(t testing.TestingT, options *KubectlOptions, configData string) {
 	require.NoError(t, KubectlDeleteFromStringE(t, options, configData))
 }
 
 // KubectlDeleteFromStringE will take in a kubernetes resource config as a string and delete it on the cluster specified
 // by the provided kubectl options. If it fails, this will return the error.
-func KubectlDeleteFromStringE(t TestingT, options *KubectlOptions, configData string) error {
+func KubectlDeleteFromStringE(t testing.TestingT, options *KubectlOptions, configData string) error {
 	tmpfile, err := StoreConfigToTempFileE(t, configData)
 	if err != nil {
 		return err
@@ -74,24 +74,24 @@ func KubectlDeleteFromStringE(t TestingT, options *KubectlOptions, configData st
 
 // KubectlApply will take in a file path and apply it to the cluster targeted by KubectlOptions. If there are any
 // errors, fail the test immediately.
-func KubectlApply(t TestingT, options *KubectlOptions, configPath string) {
+func KubectlApply(t testing.TestingT, options *KubectlOptions, configPath string) {
 	require.NoError(t, KubectlApplyE(t, options, configPath))
 }
 
 // KubectlApplyE will take in a file path and apply it to the cluster targeted by KubectlOptions.
-func KubectlApplyE(t TestingT, options *KubectlOptions, configPath string) error {
+func KubectlApplyE(t testing.TestingT, options *KubectlOptions, configPath string) error {
 	return RunKubectlE(t, options, "apply", "-f", configPath)
 }
 
 // KubectlApplyFromString will take in a kubernetes resource config as a string and apply it on the cluster specified
 // by the provided kubectl options.
-func KubectlApplyFromString(t TestingT, options *KubectlOptions, configData string) {
+func KubectlApplyFromString(t testing.TestingT, options *KubectlOptions, configData string) {
 	require.NoError(t, KubectlApplyFromStringE(t, options, configData))
 }
 
 // KubectlApplyFromStringE will take in a kubernetes resource config as a string and apply it on the cluster specified
 // by the provided kubectl options. If it fails, this will return the error.
-func KubectlApplyFromStringE(t TestingT, options *KubectlOptions, configData string) error {
+func KubectlApplyFromStringE(t testing.TestingT, options *KubectlOptions, configData string) error {
 	tmpfile, err := StoreConfigToTempFileE(t, configData)
 	if err != nil {
 		return err
@@ -102,7 +102,7 @@ func KubectlApplyFromStringE(t TestingT, options *KubectlOptions, configData str
 
 // StoreConfigToTempFile will store the provided config data to a temporary file created on the os and return the
 // filename.
-func StoreConfigToTempFile(t TestingT, configData string) string {
+func StoreConfigToTempFile(t testing.TestingT, configData string) string {
 	out, err := StoreConfigToTempFileE(t, configData)
 	require.NoError(t, err)
 	return out
@@ -110,7 +110,7 @@ func StoreConfigToTempFile(t TestingT, configData string) string {
 
 // StoreConfigToTempFileE will store the provided config data to a temporary file created on the os and return the
 // filename, or error.
-func StoreConfigToTempFileE(t TestingT, configData string) (string, error) {
+func StoreConfigToTempFileE(t testing.TestingT, configData string) (string, error) {
 	escapedTestName := url.PathEscape(t.Name())
 	tmpfile, err := ioutil.TempFile("", escapedTestName)
 	if err != nil {

--- a/modules/k8s/kubectl.go
+++ b/modules/k8s/kubectl.go
@@ -4,27 +4,27 @@ import (
 	"io/ioutil"
 	"net/url"
 	"os"
-	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/gruntwork-io/terratest/modules/shell"
+	_ "github.com/gruntwork-io/terratest/modulest/testing"
 )
 
 // RunKubectl will call kubectl using the provided options and args, failing the test on error.
-func RunKubectl(t *testing.T, options *KubectlOptions, args ...string) {
+func RunKubectl(t TestingT, options *KubectlOptions, args ...string) {
 	require.NoError(t, RunKubectlE(t, options, args...))
 }
 
 // RunKubectlE will call kubectl using the provided options and args.
-func RunKubectlE(t *testing.T, options *KubectlOptions, args ...string) error {
+func RunKubectlE(t TestingT, options *KubectlOptions, args ...string) error {
 	_, err := RunKubectlAndGetOutputE(t, options, args...)
 	return err
 }
 
 // RunKubectlAndGetOutputE will call kubectl using the provided options and args, returning the output of stdout and
 // stderr.
-func RunKubectlAndGetOutputE(t *testing.T, options *KubectlOptions, args ...string) (string, error) {
+func RunKubectlAndGetOutputE(t TestingT, options *KubectlOptions, args ...string) (string, error) {
 	cmdArgs := []string{}
 	if options.ContextName != "" {
 		cmdArgs = append(cmdArgs, "--context", options.ContextName)
@@ -46,24 +46,24 @@ func RunKubectlAndGetOutputE(t *testing.T, options *KubectlOptions, args ...stri
 
 // KubectlDelete will take in a file path and delete it from the cluster targeted by KubectlOptions. If there are any
 // errors, fail the test immediately.
-func KubectlDelete(t *testing.T, options *KubectlOptions, configPath string) {
+func KubectlDelete(t TestingT, options *KubectlOptions, configPath string) {
 	require.NoError(t, KubectlDeleteE(t, options, configPath))
 }
 
 // KubectlDeleteE will take in a file path and delete it from the cluster targeted by KubectlOptions.
-func KubectlDeleteE(t *testing.T, options *KubectlOptions, configPath string) error {
+func KubectlDeleteE(t TestingT, options *KubectlOptions, configPath string) error {
 	return RunKubectlE(t, options, "delete", "-f", configPath)
 }
 
 // KubectlDeleteFromString will take in a kubernetes resource config as a string and delete it on the cluster specified
 // by the provided kubectl options.
-func KubectlDeleteFromString(t *testing.T, options *KubectlOptions, configData string) {
+func KubectlDeleteFromString(t TestingT, options *KubectlOptions, configData string) {
 	require.NoError(t, KubectlDeleteFromStringE(t, options, configData))
 }
 
 // KubectlDeleteFromStringE will take in a kubernetes resource config as a string and delete it on the cluster specified
 // by the provided kubectl options. If it fails, this will return the error.
-func KubectlDeleteFromStringE(t *testing.T, options *KubectlOptions, configData string) error {
+func KubectlDeleteFromStringE(t TestingT, options *KubectlOptions, configData string) error {
 	tmpfile, err := StoreConfigToTempFileE(t, configData)
 	if err != nil {
 		return err
@@ -74,24 +74,24 @@ func KubectlDeleteFromStringE(t *testing.T, options *KubectlOptions, configData 
 
 // KubectlApply will take in a file path and apply it to the cluster targeted by KubectlOptions. If there are any
 // errors, fail the test immediately.
-func KubectlApply(t *testing.T, options *KubectlOptions, configPath string) {
+func KubectlApply(t TestingT, options *KubectlOptions, configPath string) {
 	require.NoError(t, KubectlApplyE(t, options, configPath))
 }
 
 // KubectlApplyE will take in a file path and apply it to the cluster targeted by KubectlOptions.
-func KubectlApplyE(t *testing.T, options *KubectlOptions, configPath string) error {
+func KubectlApplyE(t TestingT, options *KubectlOptions, configPath string) error {
 	return RunKubectlE(t, options, "apply", "-f", configPath)
 }
 
 // KubectlApplyFromString will take in a kubernetes resource config as a string and apply it on the cluster specified
 // by the provided kubectl options.
-func KubectlApplyFromString(t *testing.T, options *KubectlOptions, configData string) {
+func KubectlApplyFromString(t TestingT, options *KubectlOptions, configData string) {
 	require.NoError(t, KubectlApplyFromStringE(t, options, configData))
 }
 
 // KubectlApplyFromStringE will take in a kubernetes resource config as a string and apply it on the cluster specified
 // by the provided kubectl options. If it fails, this will return the error.
-func KubectlApplyFromStringE(t *testing.T, options *KubectlOptions, configData string) error {
+func KubectlApplyFromStringE(t TestingT, options *KubectlOptions, configData string) error {
 	tmpfile, err := StoreConfigToTempFileE(t, configData)
 	if err != nil {
 		return err
@@ -102,7 +102,7 @@ func KubectlApplyFromStringE(t *testing.T, options *KubectlOptions, configData s
 
 // StoreConfigToTempFile will store the provided config data to a temporary file created on the os and return the
 // filename.
-func StoreConfigToTempFile(t *testing.T, configData string) string {
+func StoreConfigToTempFile(t TestingT, configData string) string {
 	out, err := StoreConfigToTempFileE(t, configData)
 	require.NoError(t, err)
 	return out
@@ -110,7 +110,7 @@ func StoreConfigToTempFile(t *testing.T, configData string) string {
 
 // StoreConfigToTempFileE will store the provided config data to a temporary file created on the os and return the
 // filename, or error.
-func StoreConfigToTempFileE(t *testing.T, configData string) (string, error) {
+func StoreConfigToTempFileE(t TestingT, configData string) (string, error) {
 	escapedTestName := url.PathEscape(t.Name())
 	tmpfile, err := ioutil.TempFile("", escapedTestName)
 	if err != nil {

--- a/modules/k8s/kubectl.go
+++ b/modules/k8s/kubectl.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/gruntwork-io/terratest/modules/shell"
-	"github.com/gruntwork-io/terratest/modulest/testing"
+	"github.com/gruntwork-io/terratest/modules/testing"
 )
 
 // RunKubectl will call kubectl using the provided options and args, failing the test on error.

--- a/modules/k8s/kubectl_options.go
+++ b/modules/k8s/kubectl_options.go
@@ -1,7 +1,7 @@
 package k8s
 
 import (
-	_ "github.com/gruntwork-io/terratest/modules/testing"
+	"github.com/gruntwork-io/terratest/modules/testing"
 )
 
 // KubectlOptions represents common options necessary to specify for all Kubectl calls
@@ -23,7 +23,7 @@ func NewKubectlOptions(contextName string, configPath string, namespace string) 
 }
 
 // GetConfigPath will return a sensible default if the config path is not set on the options.
-func (kubectlOptions *KubectlOptions) GetConfigPath(t TestingT) (string, error) {
+func (kubectlOptions *KubectlOptions) GetConfigPath(t testing.TestingT) (string, error) {
 	// We predeclare `err` here so that we can update `kubeConfigPath` in the if block below. Otherwise, go complains
 	// saying `err` is undefined.
 	var err error

--- a/modules/k8s/kubectl_options.go
+++ b/modules/k8s/kubectl_options.go
@@ -1,6 +1,8 @@
 package k8s
 
-import "testing"
+import (
+	_ "github.com/gruntwork-io/terratest/modules/testing"
+)
 
 // KubectlOptions represents common options necessary to specify for all Kubectl calls
 type KubectlOptions struct {
@@ -21,7 +23,7 @@ func NewKubectlOptions(contextName string, configPath string, namespace string) 
 }
 
 // GetConfigPath will return a sensible default if the config path is not set on the options.
-func (kubectlOptions *KubectlOptions) GetConfigPath(t *testing.T) (string, error) {
+func (kubectlOptions *KubectlOptions) GetConfigPath(t TestingT) (string, error) {
 	// We predeclare `err` here so that we can update `kubeConfigPath` in the if block below. Otherwise, go complains
 	// saying `err` is undefined.
 	var err error

--- a/modules/k8s/minikube.go
+++ b/modules/k8s/minikube.go
@@ -1,12 +1,12 @@
 package k8s
 
-import "testing"
+import "github.com/gruntwork-io/terratest/modules/testing"
 
 // IsMinikubeE returns true if the underlying kubernetes cluster is Minikube. This is determined by getting the
 // associated nodes and checking if:
 // - there is only one node
 // - the node is named "minikube"
-func IsMinikubeE(t *testing.T, options *KubectlOptions) (bool, error) {
+func IsMinikubeE(t testing.TestingT, options *KubectlOptions) (bool, error) {
 	nodes, err := GetNodesE(t, options)
 	if err != nil {
 		return false, err

--- a/modules/k8s/namespace.go
+++ b/modules/k8s/namespace.go
@@ -1,7 +1,7 @@
 package k8s
 
 import (
-	_ "github.com/gruntwork-io/terratest/modules/testing"
+	"github.com/gruntwork-io/terratest/modules/testing"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -9,12 +9,12 @@ import (
 
 // CreateNamespace will create a new Kubernetes namespace on the cluster targeted by the provided options. This will
 // fail the test if there is an error in creating the namespace.
-func CreateNamespace(t TestingT, options *KubectlOptions, namespaceName string) {
+func CreateNamespace(t testing.TestingT, options *KubectlOptions, namespaceName string) {
 	require.NoError(t, CreateNamespaceE(t, options, namespaceName))
 }
 
 // CreateNamespaceE will create a new Kubernetes namespace on the cluster targeted by the provided options.
-func CreateNamespaceE(t TestingT, options *KubectlOptions, namespaceName string) error {
+func CreateNamespaceE(t testing.TestingT, options *KubectlOptions, namespaceName string) error {
 	clientset, err := GetKubernetesClientFromOptionsE(t, options)
 	if err != nil {
 		return err
@@ -31,7 +31,7 @@ func CreateNamespaceE(t TestingT, options *KubectlOptions, namespaceName string)
 
 // GetNamespace will query the Kubernetes cluster targeted by the provided options for the requested namespace. This will
 // fail the test if there is an error in getting the namespace or if the namespace doesn't exist.
-func GetNamespace(t TestingT, options *KubectlOptions, namespaceName string) *corev1.Namespace {
+func GetNamespace(t testing.TestingT, options *KubectlOptions, namespaceName string) *corev1.Namespace {
 	namespace, err := GetNamespaceE(t, options, namespaceName)
 	require.NoError(t, err)
 	require.NotNil(t, namespace)
@@ -39,7 +39,7 @@ func GetNamespace(t TestingT, options *KubectlOptions, namespaceName string) *co
 }
 
 // GetNamespaceE will query the Kubernetes cluster targeted by the provided options for the requested namespace.
-func GetNamespaceE(t TestingT, options *KubectlOptions, namespaceName string) (*corev1.Namespace, error) {
+func GetNamespaceE(t testing.TestingT, options *KubectlOptions, namespaceName string) (*corev1.Namespace, error) {
 	clientset, err := GetKubernetesClientFromOptionsE(t, options)
 	if err != nil {
 		return nil, err
@@ -50,12 +50,12 @@ func GetNamespaceE(t TestingT, options *KubectlOptions, namespaceName string) (*
 
 // DeleteNamespace will delete the requested namespace from the Kubernetes cluster targeted by the provided options. This will
 // fail the test if there is an error in creating the namespace.
-func DeleteNamespace(t TestingT, options *KubectlOptions, namespaceName string) {
+func DeleteNamespace(t testing.TestingT, options *KubectlOptions, namespaceName string) {
 	require.NoError(t, DeleteNamespaceE(t, options, namespaceName))
 }
 
 // DeleteNamespaceE will delete the requested namespace from the Kubernetes cluster targeted by the provided options.
-func DeleteNamespaceE(t TestingT, options *KubectlOptions, namespaceName string) error {
+func DeleteNamespaceE(t testing.TestingT, options *KubectlOptions, namespaceName string) error {
 	clientset, err := GetKubernetesClientFromOptionsE(t, options)
 	if err != nil {
 		return err

--- a/modules/k8s/namespace.go
+++ b/modules/k8s/namespace.go
@@ -1,8 +1,7 @@
 package k8s
 
 import (
-	"testing"
-
+	_ "github.com/gruntwork-io/terratest/modules/testing"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -10,12 +9,12 @@ import (
 
 // CreateNamespace will create a new Kubernetes namespace on the cluster targeted by the provided options. This will
 // fail the test if there is an error in creating the namespace.
-func CreateNamespace(t *testing.T, options *KubectlOptions, namespaceName string) {
+func CreateNamespace(t TestingT, options *KubectlOptions, namespaceName string) {
 	require.NoError(t, CreateNamespaceE(t, options, namespaceName))
 }
 
 // CreateNamespaceE will create a new Kubernetes namespace on the cluster targeted by the provided options.
-func CreateNamespaceE(t *testing.T, options *KubectlOptions, namespaceName string) error {
+func CreateNamespaceE(t TestingT, options *KubectlOptions, namespaceName string) error {
 	clientset, err := GetKubernetesClientFromOptionsE(t, options)
 	if err != nil {
 		return err
@@ -32,7 +31,7 @@ func CreateNamespaceE(t *testing.T, options *KubectlOptions, namespaceName strin
 
 // GetNamespace will query the Kubernetes cluster targeted by the provided options for the requested namespace. This will
 // fail the test if there is an error in getting the namespace or if the namespace doesn't exist.
-func GetNamespace(t *testing.T, options *KubectlOptions, namespaceName string) *corev1.Namespace {
+func GetNamespace(t TestingT, options *KubectlOptions, namespaceName string) *corev1.Namespace {
 	namespace, err := GetNamespaceE(t, options, namespaceName)
 	require.NoError(t, err)
 	require.NotNil(t, namespace)
@@ -40,7 +39,7 @@ func GetNamespace(t *testing.T, options *KubectlOptions, namespaceName string) *
 }
 
 // GetNamespaceE will query the Kubernetes cluster targeted by the provided options for the requested namespace.
-func GetNamespaceE(t *testing.T, options *KubectlOptions, namespaceName string) (*corev1.Namespace, error) {
+func GetNamespaceE(t TestingT, options *KubectlOptions, namespaceName string) (*corev1.Namespace, error) {
 	clientset, err := GetKubernetesClientFromOptionsE(t, options)
 	if err != nil {
 		return nil, err
@@ -51,12 +50,12 @@ func GetNamespaceE(t *testing.T, options *KubectlOptions, namespaceName string) 
 
 // DeleteNamespace will delete the requested namespace from the Kubernetes cluster targeted by the provided options. This will
 // fail the test if there is an error in creating the namespace.
-func DeleteNamespace(t *testing.T, options *KubectlOptions, namespaceName string) {
+func DeleteNamespace(t TestingT, options *KubectlOptions, namespaceName string) {
 	require.NoError(t, DeleteNamespaceE(t, options, namespaceName))
 }
 
 // DeleteNamespaceE will delete the requested namespace from the Kubernetes cluster targeted by the provided options.
-func DeleteNamespaceE(t *testing.T, options *KubectlOptions, namespaceName string) error {
+func DeleteNamespaceE(t TestingT, options *KubectlOptions, namespaceName string) error {
 	clientset, err := GetKubernetesClientFromOptionsE(t, options)
 	if err != nil {
 		return err

--- a/modules/k8s/node.go
+++ b/modules/k8s/node.go
@@ -2,7 +2,6 @@ package k8s
 
 import (
 	"errors"
-	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
@@ -11,24 +10,25 @@ import (
 
 	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/retry"
+	_ "github.com/gruntwork-io/terratest/modules/testing"
 )
 
 // GetNodes queries Kubernetes for information about the worker nodes registered to the cluster. If anything goes wrong,
 // the function will automatically fail the test.
-func GetNodes(t *testing.T, options *KubectlOptions) []corev1.Node {
+func GetNodes(t TestingT, options *KubectlOptions) []corev1.Node {
 	nodes, err := GetNodesE(t, options)
 	require.NoError(t, err)
 	return nodes
 }
 
 // GetNodesE queries Kubernetes for information about the worker nodes registered to the cluster.
-func GetNodesE(t *testing.T, options *KubectlOptions) ([]corev1.Node, error) {
+func GetNodesE(t TestingT, options *KubectlOptions) ([]corev1.Node, error) {
 	return GetNodesByFilterE(t, options, metav1.ListOptions{})
 }
 
 // GetNodesByFilterE queries Kubernetes for information about the worker nodes registered to the cluster, filtering the
 // list of nodes using the provided ListOptions.
-func GetNodesByFilterE(t *testing.T, options *KubectlOptions, filter metav1.ListOptions) ([]corev1.Node, error) {
+func GetNodesByFilterE(t TestingT, options *KubectlOptions, filter metav1.ListOptions) ([]corev1.Node, error) {
 	logger.Logf(t, "Getting list of nodes from Kubernetes")
 
 	clientset, err := GetKubernetesClientFromOptionsE(t, options)
@@ -45,7 +45,7 @@ func GetNodesByFilterE(t *testing.T, options *KubectlOptions, filter metav1.List
 
 // GetReadyNodes queries Kubernetes for information about the worker nodes registered to the cluster and only returns
 // those that are in the ready state. If anything goes wrong, the function will automatically fail the test.
-func GetReadyNodes(t *testing.T, options *KubectlOptions) []corev1.Node {
+func GetReadyNodes(t TestingT, options *KubectlOptions) []corev1.Node {
 	nodes, err := GetReadyNodesE(t, options)
 	require.NoError(t, err)
 	return nodes
@@ -53,7 +53,7 @@ func GetReadyNodes(t *testing.T, options *KubectlOptions) []corev1.Node {
 
 // GetReadyNodesE queries Kubernetes for information about the worker nodes registered to the cluster and only returns
 // those that are in the ready state.
-func GetReadyNodesE(t *testing.T, options *KubectlOptions) ([]corev1.Node, error) {
+func GetReadyNodesE(t TestingT, options *KubectlOptions) ([]corev1.Node, error) {
 	nodes, err := GetNodesE(t, options)
 	if err != nil {
 		return nil, err
@@ -80,14 +80,14 @@ func IsNodeReady(node corev1.Node) bool {
 
 // WaitUntilAllNodesReady continuously polls the Kubernetes cluster until all nodes in the cluster reach the ready
 // state, or runs out of retries. Will fail the test immediately if it times out.
-func WaitUntilAllNodesReady(t *testing.T, options *KubectlOptions, retries int, sleepBetweenRetries time.Duration) {
+func WaitUntilAllNodesReady(t TestingT, options *KubectlOptions, retries int, sleepBetweenRetries time.Duration) {
 	err := WaitUntilAllNodesReadyE(t, options, retries, sleepBetweenRetries)
 	require.NoError(t, err)
 }
 
 // WaitUntilAllNodesReadyE continuously polls the Kubernetes cluster until all nodes in the cluster reach the ready
 // state, or runs out of retries.
-func WaitUntilAllNodesReadyE(t *testing.T, options *KubectlOptions, retries int, sleepBetweenRetries time.Duration) error {
+func WaitUntilAllNodesReadyE(t TestingT, options *KubectlOptions, retries int, sleepBetweenRetries time.Duration) error {
 	message, err := retry.DoWithRetryE(
 		t,
 		"Wait for all Kube Nodes to be ready",
@@ -106,14 +106,14 @@ func WaitUntilAllNodesReadyE(t *testing.T, options *KubectlOptions, retries int,
 }
 
 // AreAllNodesReady checks if all nodes are ready in the Kubernetes cluster targeted by the current config context
-func AreAllNodesReady(t *testing.T, options *KubectlOptions) bool {
+func AreAllNodesReady(t TestingT, options *KubectlOptions) bool {
 	nodesReady, _ := AreAllNodesReadyE(t, options)
 	return nodesReady
 }
 
 // AreAllNodesReadyE checks if all nodes are ready in the Kubernetes cluster targeted by the current config context. If
 // false, returns an error indicating the reason.
-func AreAllNodesReadyE(t *testing.T, options *KubectlOptions) (bool, error) {
+func AreAllNodesReadyE(t TestingT, options *KubectlOptions) (bool, error) {
 	nodes, err := GetNodesE(t, options)
 	if err != nil {
 		return false, err

--- a/modules/k8s/node.go
+++ b/modules/k8s/node.go
@@ -10,25 +10,25 @@ import (
 
 	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/retry"
-	_ "github.com/gruntwork-io/terratest/modules/testing"
+	"github.com/gruntwork-io/terratest/modules/testing"
 )
 
 // GetNodes queries Kubernetes for information about the worker nodes registered to the cluster. If anything goes wrong,
 // the function will automatically fail the test.
-func GetNodes(t TestingT, options *KubectlOptions) []corev1.Node {
+func GetNodes(t testing.TestingT, options *KubectlOptions) []corev1.Node {
 	nodes, err := GetNodesE(t, options)
 	require.NoError(t, err)
 	return nodes
 }
 
 // GetNodesE queries Kubernetes for information about the worker nodes registered to the cluster.
-func GetNodesE(t TestingT, options *KubectlOptions) ([]corev1.Node, error) {
+func GetNodesE(t testing.TestingT, options *KubectlOptions) ([]corev1.Node, error) {
 	return GetNodesByFilterE(t, options, metav1.ListOptions{})
 }
 
 // GetNodesByFilterE queries Kubernetes for information about the worker nodes registered to the cluster, filtering the
 // list of nodes using the provided ListOptions.
-func GetNodesByFilterE(t TestingT, options *KubectlOptions, filter metav1.ListOptions) ([]corev1.Node, error) {
+func GetNodesByFilterE(t testing.TestingT, options *KubectlOptions, filter metav1.ListOptions) ([]corev1.Node, error) {
 	logger.Logf(t, "Getting list of nodes from Kubernetes")
 
 	clientset, err := GetKubernetesClientFromOptionsE(t, options)
@@ -45,7 +45,7 @@ func GetNodesByFilterE(t TestingT, options *KubectlOptions, filter metav1.ListOp
 
 // GetReadyNodes queries Kubernetes for information about the worker nodes registered to the cluster and only returns
 // those that are in the ready state. If anything goes wrong, the function will automatically fail the test.
-func GetReadyNodes(t TestingT, options *KubectlOptions) []corev1.Node {
+func GetReadyNodes(t testing.TestingT, options *KubectlOptions) []corev1.Node {
 	nodes, err := GetReadyNodesE(t, options)
 	require.NoError(t, err)
 	return nodes
@@ -53,7 +53,7 @@ func GetReadyNodes(t TestingT, options *KubectlOptions) []corev1.Node {
 
 // GetReadyNodesE queries Kubernetes for information about the worker nodes registered to the cluster and only returns
 // those that are in the ready state.
-func GetReadyNodesE(t TestingT, options *KubectlOptions) ([]corev1.Node, error) {
+func GetReadyNodesE(t testing.TestingT, options *KubectlOptions) ([]corev1.Node, error) {
 	nodes, err := GetNodesE(t, options)
 	if err != nil {
 		return nil, err
@@ -80,14 +80,14 @@ func IsNodeReady(node corev1.Node) bool {
 
 // WaitUntilAllNodesReady continuously polls the Kubernetes cluster until all nodes in the cluster reach the ready
 // state, or runs out of retries. Will fail the test immediately if it times out.
-func WaitUntilAllNodesReady(t TestingT, options *KubectlOptions, retries int, sleepBetweenRetries time.Duration) {
+func WaitUntilAllNodesReady(t testing.TestingT, options *KubectlOptions, retries int, sleepBetweenRetries time.Duration) {
 	err := WaitUntilAllNodesReadyE(t, options, retries, sleepBetweenRetries)
 	require.NoError(t, err)
 }
 
 // WaitUntilAllNodesReadyE continuously polls the Kubernetes cluster until all nodes in the cluster reach the ready
 // state, or runs out of retries.
-func WaitUntilAllNodesReadyE(t TestingT, options *KubectlOptions, retries int, sleepBetweenRetries time.Duration) error {
+func WaitUntilAllNodesReadyE(t testing.TestingT, options *KubectlOptions, retries int, sleepBetweenRetries time.Duration) error {
 	message, err := retry.DoWithRetryE(
 		t,
 		"Wait for all Kube Nodes to be ready",
@@ -106,14 +106,14 @@ func WaitUntilAllNodesReadyE(t TestingT, options *KubectlOptions, retries int, s
 }
 
 // AreAllNodesReady checks if all nodes are ready in the Kubernetes cluster targeted by the current config context
-func AreAllNodesReady(t TestingT, options *KubectlOptions) bool {
+func AreAllNodesReady(t testing.TestingT, options *KubectlOptions) bool {
 	nodesReady, _ := AreAllNodesReadyE(t, options)
 	return nodesReady
 }
 
 // AreAllNodesReadyE checks if all nodes are ready in the Kubernetes cluster targeted by the current config context. If
 // false, returns an error indicating the reason.
-func AreAllNodesReadyE(t TestingT, options *KubectlOptions) (bool, error) {
+func AreAllNodesReadyE(t testing.TestingT, options *KubectlOptions) (bool, error) {
 	nodes, err := GetNodesE(t, options)
 	if err != nil {
 		return false, err

--- a/modules/k8s/pod.go
+++ b/modules/k8s/pod.go
@@ -2,7 +2,6 @@ package k8s
 
 import (
 	"fmt"
-	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
@@ -11,18 +10,19 @@ import (
 
 	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/retry"
+	_ "github.com/gruntwork-io/terratest/modules/testing"
 )
 
 // ListPods will look for pods in the given namespace that match the given filters and return them. This will fail the
 // test if there is an error.
-func ListPods(t *testing.T, options *KubectlOptions, filters metav1.ListOptions) []corev1.Pod {
+func ListPods(t TestingT, options *KubectlOptions, filters metav1.ListOptions) []corev1.Pod {
 	pods, err := ListPodsE(t, options, filters)
 	require.NoError(t, err)
 	return pods
 }
 
 // ListPodsE will look for pods in the given namespace that match the given filters and return them.
-func ListPodsE(t *testing.T, options *KubectlOptions, filters metav1.ListOptions) ([]corev1.Pod, error) {
+func ListPodsE(t TestingT, options *KubectlOptions, filters metav1.ListOptions) ([]corev1.Pod, error) {
 	clientset, err := GetKubernetesClientFromOptionsE(t, options)
 	if err != nil {
 		return nil, err
@@ -37,14 +37,14 @@ func ListPodsE(t *testing.T, options *KubectlOptions, filters metav1.ListOptions
 
 // GetPod returns a Kubernetes pod resource in the provided namespace with the given name. This will
 // fail the test if there is an error.
-func GetPod(t *testing.T, options *KubectlOptions, podName string) *corev1.Pod {
+func GetPod(t TestingT, options *KubectlOptions, podName string) *corev1.Pod {
 	pod, err := GetPodE(t, options, podName)
 	require.NoError(t, err)
 	return pod
 }
 
 // GetPodE returns a Kubernetes pod resource in the provided namespace with the given name.
-func GetPodE(t *testing.T, options *KubectlOptions, podName string) (*corev1.Pod, error) {
+func GetPodE(t TestingT, options *KubectlOptions, podName string) (*corev1.Pod, error) {
 	clientset, err := GetKubernetesClientFromOptionsE(t, options)
 	if err != nil {
 		return nil, err
@@ -56,7 +56,7 @@ func GetPodE(t *testing.T, options *KubectlOptions, podName string) (*corev1.Pod
 // retry the check for the specified amount of times, sleeping for the provided duration between each try. This will
 // fail the test if the retry times out.
 func WaitUntilNumPodsCreated(
-	t *testing.T,
+	t TestingT,
 	options *KubectlOptions,
 	filters metav1.ListOptions,
 	desiredCount int,
@@ -69,7 +69,7 @@ func WaitUntilNumPodsCreated(
 // WaitUntilNumPodsCreatedE waits until the desired number of pods are created that match the provided filter. This will
 // retry the check for the specified amount of times, sleeping for the provided duration between each try.
 func WaitUntilNumPodsCreatedE(
-	t *testing.T,
+	t TestingT,
 	options *KubectlOptions,
 	filters metav1.ListOptions,
 	desiredCount int,
@@ -103,13 +103,13 @@ func WaitUntilNumPodsCreatedE(
 
 // WaitUntilPodAvailable waits until the pod is running, retrying the check for the specified amount of times, sleeping
 // for the provided duration between each try. This will fail the test if there is an error or if the check times out.
-func WaitUntilPodAvailable(t *testing.T, options *KubectlOptions, podName string, retries int, sleepBetweenRetries time.Duration) {
+func WaitUntilPodAvailable(t TestingT, options *KubectlOptions, podName string, retries int, sleepBetweenRetries time.Duration) {
 	require.NoError(t, WaitUntilPodAvailableE(t, options, podName, retries, sleepBetweenRetries))
 }
 
 // WaitUntilPodAvailableE waits until the pod is running, retrying the check for the specified amount of times, sleeping
 // for the provided duration between each try.
-func WaitUntilPodAvailableE(t *testing.T, options *KubectlOptions, podName string, retries int, sleepBetweenRetries time.Duration) error {
+func WaitUntilPodAvailableE(t TestingT, options *KubectlOptions, podName string, retries int, sleepBetweenRetries time.Duration) error {
 	statusMsg := fmt.Sprintf("Wait for pod %s to be provisioned.", podName)
 	message, err := retry.DoWithRetryE(
 		t,

--- a/modules/k8s/pod.go
+++ b/modules/k8s/pod.go
@@ -10,19 +10,19 @@ import (
 
 	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/retry"
-	_ "github.com/gruntwork-io/terratest/modules/testing"
+	"github.com/gruntwork-io/terratest/modules/testing"
 )
 
 // ListPods will look for pods in the given namespace that match the given filters and return them. This will fail the
 // test if there is an error.
-func ListPods(t TestingT, options *KubectlOptions, filters metav1.ListOptions) []corev1.Pod {
+func ListPods(t testing.TestingT, options *KubectlOptions, filters metav1.ListOptions) []corev1.Pod {
 	pods, err := ListPodsE(t, options, filters)
 	require.NoError(t, err)
 	return pods
 }
 
 // ListPodsE will look for pods in the given namespace that match the given filters and return them.
-func ListPodsE(t TestingT, options *KubectlOptions, filters metav1.ListOptions) ([]corev1.Pod, error) {
+func ListPodsE(t testing.TestingT, options *KubectlOptions, filters metav1.ListOptions) ([]corev1.Pod, error) {
 	clientset, err := GetKubernetesClientFromOptionsE(t, options)
 	if err != nil {
 		return nil, err
@@ -37,14 +37,14 @@ func ListPodsE(t TestingT, options *KubectlOptions, filters metav1.ListOptions) 
 
 // GetPod returns a Kubernetes pod resource in the provided namespace with the given name. This will
 // fail the test if there is an error.
-func GetPod(t TestingT, options *KubectlOptions, podName string) *corev1.Pod {
+func GetPod(t testing.TestingT, options *KubectlOptions, podName string) *corev1.Pod {
 	pod, err := GetPodE(t, options, podName)
 	require.NoError(t, err)
 	return pod
 }
 
 // GetPodE returns a Kubernetes pod resource in the provided namespace with the given name.
-func GetPodE(t TestingT, options *KubectlOptions, podName string) (*corev1.Pod, error) {
+func GetPodE(t testing.TestingT, options *KubectlOptions, podName string) (*corev1.Pod, error) {
 	clientset, err := GetKubernetesClientFromOptionsE(t, options)
 	if err != nil {
 		return nil, err
@@ -56,7 +56,7 @@ func GetPodE(t TestingT, options *KubectlOptions, podName string) (*corev1.Pod, 
 // retry the check for the specified amount of times, sleeping for the provided duration between each try. This will
 // fail the test if the retry times out.
 func WaitUntilNumPodsCreated(
-	t TestingT,
+	t testing.TestingT,
 	options *KubectlOptions,
 	filters metav1.ListOptions,
 	desiredCount int,
@@ -69,7 +69,7 @@ func WaitUntilNumPodsCreated(
 // WaitUntilNumPodsCreatedE waits until the desired number of pods are created that match the provided filter. This will
 // retry the check for the specified amount of times, sleeping for the provided duration between each try.
 func WaitUntilNumPodsCreatedE(
-	t TestingT,
+	t testing.TestingT,
 	options *KubectlOptions,
 	filters metav1.ListOptions,
 	desiredCount int,
@@ -103,13 +103,13 @@ func WaitUntilNumPodsCreatedE(
 
 // WaitUntilPodAvailable waits until the pod is running, retrying the check for the specified amount of times, sleeping
 // for the provided duration between each try. This will fail the test if there is an error or if the check times out.
-func WaitUntilPodAvailable(t TestingT, options *KubectlOptions, podName string, retries int, sleepBetweenRetries time.Duration) {
+func WaitUntilPodAvailable(t testing.TestingT, options *KubectlOptions, podName string, retries int, sleepBetweenRetries time.Duration) {
 	require.NoError(t, WaitUntilPodAvailableE(t, options, podName, retries, sleepBetweenRetries))
 }
 
 // WaitUntilPodAvailableE waits until the pod is running, retrying the check for the specified amount of times, sleeping
 // for the provided duration between each try.
-func WaitUntilPodAvailableE(t TestingT, options *KubectlOptions, podName string, retries int, sleepBetweenRetries time.Duration) error {
+func WaitUntilPodAvailableE(t testing.TestingT, options *KubectlOptions, podName string, retries int, sleepBetweenRetries time.Duration) error {
 	statusMsg := fmt.Sprintf("Wait for pod %s to be provisioned.", podName)
 	message, err := retry.DoWithRetryE(
 		t,

--- a/modules/k8s/role.go
+++ b/modules/k8s/role.go
@@ -1,7 +1,7 @@
 package k8s
 
 import (
-	_ "github.com/gruntwork-io/terratest/modules/testing"
+	"github.com/gruntwork-io/terratest/modules/testing"
 	"github.com/stretchr/testify/require"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -9,7 +9,7 @@ import (
 
 // GetRole returns a Kubernetes role resource in the provided namespace with the given name. The namespace used
 // is the one provided in the KubectlOptions. This will fail the test if there is an error.
-func GetRole(t TestingT, options *KubectlOptions, roleName string) *rbacv1.Role {
+func GetRole(t testing.TestingT, options *KubectlOptions, roleName string) *rbacv1.Role {
 	role, err := GetRoleE(t, options, roleName)
 	require.NoError(t, err)
 	return role
@@ -17,7 +17,7 @@ func GetRole(t TestingT, options *KubectlOptions, roleName string) *rbacv1.Role 
 
 // GetRoleE returns a Kubernetes role resource in the provided namespace with the given name. The namespace used
 // is the one provided in the KubectlOptions.
-func GetRoleE(t TestingT, options *KubectlOptions, roleName string) (*rbacv1.Role, error) {
+func GetRoleE(t testing.TestingT, options *KubectlOptions, roleName string) (*rbacv1.Role, error) {
 	clientset, err := GetKubernetesClientFromOptionsE(t, options)
 	if err != nil {
 		return nil, err

--- a/modules/k8s/role.go
+++ b/modules/k8s/role.go
@@ -1,8 +1,7 @@
 package k8s
 
 import (
-	"testing"
-
+	_ "github.com/gruntwork-io/terratest/modules/testing"
 	"github.com/stretchr/testify/require"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -10,7 +9,7 @@ import (
 
 // GetRole returns a Kubernetes role resource in the provided namespace with the given name. The namespace used
 // is the one provided in the KubectlOptions. This will fail the test if there is an error.
-func GetRole(t *testing.T, options *KubectlOptions, roleName string) *rbacv1.Role {
+func GetRole(t TestingT, options *KubectlOptions, roleName string) *rbacv1.Role {
 	role, err := GetRoleE(t, options, roleName)
 	require.NoError(t, err)
 	return role
@@ -18,7 +17,7 @@ func GetRole(t *testing.T, options *KubectlOptions, roleName string) *rbacv1.Rol
 
 // GetRoleE returns a Kubernetes role resource in the provided namespace with the given name. The namespace used
 // is the one provided in the KubectlOptions.
-func GetRoleE(t *testing.T, options *KubectlOptions, roleName string) (*rbacv1.Role, error) {
+func GetRoleE(t TestingT, options *KubectlOptions, roleName string) (*rbacv1.Role, error) {
 	clientset, err := GetKubernetesClientFromOptionsE(t, options)
 	if err != nil {
 		return nil, err

--- a/modules/k8s/secret.go
+++ b/modules/k8s/secret.go
@@ -1,7 +1,7 @@
 package k8s
 
 import (
-	_ "github.com/gruntwork-io/terratest/modules/testing"
+	"github.com/gruntwork-io/terratest/modules/testing"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -9,7 +9,7 @@ import (
 
 // GetSecret returns a Kubernetes secret resource in the provided namespace with the given name. The namespace used
 // is the one provided in the KubectlOptions. This will fail the test if there is an error.
-func GetSecret(t TestingT, options *KubectlOptions, secretName string) *corev1.Secret {
+func GetSecret(t testing.TestingT, options *KubectlOptions, secretName string) *corev1.Secret {
 	secret, err := GetSecretE(t, options, secretName)
 	require.NoError(t, err)
 	return secret
@@ -17,7 +17,7 @@ func GetSecret(t TestingT, options *KubectlOptions, secretName string) *corev1.S
 
 // GetSecretE returns a Kubernetes secret resource in the provided namespace with the given name. The namespace used
 // is the one provided in the KubectlOptions.
-func GetSecretE(t TestingT, options *KubectlOptions, secretName string) (*corev1.Secret, error) {
+func GetSecretE(t testing.TestingT, options *KubectlOptions, secretName string) (*corev1.Secret, error) {
 	clientset, err := GetKubernetesClientFromOptionsE(t, options)
 	if err != nil {
 		return nil, err

--- a/modules/k8s/secret.go
+++ b/modules/k8s/secret.go
@@ -1,8 +1,7 @@
 package k8s
 
 import (
-	"testing"
-
+	_ "github.com/gruntwork-io/terratest/modules/testing"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -10,7 +9,7 @@ import (
 
 // GetSecret returns a Kubernetes secret resource in the provided namespace with the given name. The namespace used
 // is the one provided in the KubectlOptions. This will fail the test if there is an error.
-func GetSecret(t *testing.T, options *KubectlOptions, secretName string) *corev1.Secret {
+func GetSecret(t TestingT, options *KubectlOptions, secretName string) *corev1.Secret {
 	secret, err := GetSecretE(t, options, secretName)
 	require.NoError(t, err)
 	return secret
@@ -18,7 +17,7 @@ func GetSecret(t *testing.T, options *KubectlOptions, secretName string) *corev1
 
 // GetSecretE returns a Kubernetes secret resource in the provided namespace with the given name. The namespace used
 // is the one provided in the KubectlOptions.
-func GetSecretE(t *testing.T, options *KubectlOptions, secretName string) (*corev1.Secret, error) {
+func GetSecretE(t TestingT, options *KubectlOptions, secretName string) (*corev1.Secret, error) {
 	clientset, err := GetKubernetesClientFromOptionsE(t, options)
 	if err != nil {
 		return nil, err

--- a/modules/k8s/self_subject_access_review.go
+++ b/modules/k8s/self_subject_access_review.go
@@ -6,12 +6,12 @@ import (
 	authv1 "k8s.io/api/authorization/v1"
 
 	"github.com/gruntwork-io/terratest/modules/logger"
-	_ "github.com/gruntwork-io/terratest/modules/testing"
+	"github.com/gruntwork-io/terratest/modules/testing"
 )
 
 // CanIDo returns whether or not the provided action is allowed by the client configured by the provided kubectl option.
 // This will fail if there are any errors accessing the kubernetes API (but not if the action is denied).
-func CanIDo(t TestingT, options *KubectlOptions, action authv1.ResourceAttributes) bool {
+func CanIDo(t testing.TestingT, options *KubectlOptions, action authv1.ResourceAttributes) bool {
 	allowed, err := CanIDoE(t, options, action)
 	require.NoError(t, err)
 	return allowed
@@ -19,7 +19,7 @@ func CanIDo(t TestingT, options *KubectlOptions, action authv1.ResourceAttribute
 
 // CanIDoE returns whether or not the provided action is allowed by the client configured by the provided kubectl option.
 // This will an error if there are problems accessing the kubernetes API (but not if the action is simply denied).
-func CanIDoE(t TestingT, options *KubectlOptions, action authv1.ResourceAttributes) (bool, error) {
+func CanIDoE(t testing.TestingT, options *KubectlOptions, action authv1.ResourceAttributes) (bool, error) {
 	clientset, err := GetKubernetesClientFromOptionsE(t, options)
 	if err != nil {
 		return false, err

--- a/modules/k8s/self_subject_access_review.go
+++ b/modules/k8s/self_subject_access_review.go
@@ -1,18 +1,17 @@
 package k8s
 
 import (
-	"testing"
-
 	"github.com/gruntwork-io/gruntwork-cli/errors"
 	"github.com/stretchr/testify/require"
 	authv1 "k8s.io/api/authorization/v1"
 
 	"github.com/gruntwork-io/terratest/modules/logger"
+	_ "github.com/gruntwork-io/terratest/modules/testing"
 )
 
 // CanIDo returns whether or not the provided action is allowed by the client configured by the provided kubectl option.
 // This will fail if there are any errors accessing the kubernetes API (but not if the action is denied).
-func CanIDo(t *testing.T, options *KubectlOptions, action authv1.ResourceAttributes) bool {
+func CanIDo(t TestingT, options *KubectlOptions, action authv1.ResourceAttributes) bool {
 	allowed, err := CanIDoE(t, options, action)
 	require.NoError(t, err)
 	return allowed
@@ -20,7 +19,7 @@ func CanIDo(t *testing.T, options *KubectlOptions, action authv1.ResourceAttribu
 
 // CanIDoE returns whether or not the provided action is allowed by the client configured by the provided kubectl option.
 // This will an error if there are problems accessing the kubernetes API (but not if the action is simply denied).
-func CanIDoE(t *testing.T, options *KubectlOptions, action authv1.ResourceAttributes) (bool, error) {
+func CanIDoE(t TestingT, options *KubectlOptions, action authv1.ResourceAttributes) (bool, error) {
 	clientset, err := GetKubernetesClientFromOptionsE(t, options)
 	if err != nil {
 		return false, err

--- a/modules/k8s/service.go
+++ b/modules/k8s/service.go
@@ -14,19 +14,19 @@ import (
 	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/gruntwork-io/terratest/modules/retry"
-	_ "github.com/gruntwork-io/terratest/modules/testing"
+	"github.com/gruntwork-io/terratest/modules/testing"
 )
 
 // ListServices will look for services in the given namespace that match the given filters and return them. This will
 // fail the test if there is an error.
-func ListServices(t TestingT, options *KubectlOptions, filters metav1.ListOptions) []corev1.Service {
+func ListServices(t testing.TestingT, options *KubectlOptions, filters metav1.ListOptions) []corev1.Service {
 	service, err := ListServicesE(t, options, filters)
 	require.NoError(t, err)
 	return service
 }
 
 // ListServicesE will look for services in the given namespace that match the given filters and return them.
-func ListServicesE(t TestingT, options *KubectlOptions, filters metav1.ListOptions) ([]corev1.Service, error) {
+func ListServicesE(t testing.TestingT, options *KubectlOptions, filters metav1.ListOptions) ([]corev1.Service, error) {
 	clientset, err := GetKubernetesClientFromOptionsE(t, options)
 	if err != nil {
 		return nil, err
@@ -40,14 +40,14 @@ func ListServicesE(t TestingT, options *KubectlOptions, filters metav1.ListOptio
 
 // GetService returns a Kubernetes service resource in the provided namespace with the given name. This will
 // fail the test if there is an error.
-func GetService(t TestingT, options *KubectlOptions, serviceName string) *corev1.Service {
+func GetService(t testing.TestingT, options *KubectlOptions, serviceName string) *corev1.Service {
 	service, err := GetServiceE(t, options, serviceName)
 	require.NoError(t, err)
 	return service
 }
 
 // GetServiceE returns a Kubernetes service resource in the provided namespace with the given name.
-func GetServiceE(t TestingT, options *KubectlOptions, serviceName string) (*corev1.Service, error) {
+func GetServiceE(t testing.TestingT, options *KubectlOptions, serviceName string) (*corev1.Service, error) {
 	clientset, err := GetKubernetesClientFromOptionsE(t, options)
 	if err != nil {
 		return nil, err
@@ -56,7 +56,7 @@ func GetServiceE(t TestingT, options *KubectlOptions, serviceName string) (*core
 }
 
 // WaitUntilServiceAvailable waits until the service endpoint is ready to accept traffic.
-func WaitUntilServiceAvailable(t TestingT, options *KubectlOptions, serviceName string, retries int, sleepBetweenRetries time.Duration) {
+func WaitUntilServiceAvailable(t testing.TestingT, options *KubectlOptions, serviceName string, retries int, sleepBetweenRetries time.Duration) {
 	statusMsg := fmt.Sprintf("Wait for service %s to be provisioned.", serviceName)
 	message := retry.DoWithRetry(
 		t,
@@ -101,7 +101,7 @@ func IsServiceAvailable(service *corev1.Service) bool {
 
 // GetServiceEndpoint will return the service access point. If the service endpoint is not ready, will fail the test
 // immediately.
-func GetServiceEndpoint(t TestingT, options *KubectlOptions, service *corev1.Service, servicePort int) string {
+func GetServiceEndpoint(t testing.TestingT, options *KubectlOptions, service *corev1.Service, servicePort int) string {
 	endpoint, err := GetServiceEndpointE(t, options, service, servicePort)
 	require.NoError(t, err)
 	return endpoint
@@ -114,7 +114,7 @@ func GetServiceEndpoint(t TestingT, options *KubectlOptions, service *corev1.Ser
 // - For LoadBalancer service type, return the publicly accessible hostname of the load balancer.
 //   If the hostname is empty, it will return the public IP of the LoadBalancer.
 // - All other service types are not supported.
-func GetServiceEndpointE(t TestingT, options *KubectlOptions, service *corev1.Service, servicePort int) (string, error) {
+func GetServiceEndpointE(t testing.TestingT, options *KubectlOptions, service *corev1.Service, servicePort int) (string, error) {
 	switch service.Spec.Type {
 	case corev1.ServiceTypeClusterIP:
 		// ClusterIP service type will map directly to service port
@@ -148,7 +148,7 @@ func GetServiceEndpointE(t TestingT, options *KubectlOptions, service *corev1.Se
 // Extracts a endpoint that can be reached outside the kubernetes cluster. NodePort type needs to find the right
 // allocated node port mapped to the service port, as well as find out the externally reachable ip (if available).
 func findEndpointForNodePortService(
-	t TestingT,
+	t testing.TestingT,
 	options *KubectlOptions,
 	service *corev1.Service,
 	servicePort int32,
@@ -179,7 +179,7 @@ func FindNodePortE(service *corev1.Service, servicePort int32) (int32, error) {
 }
 
 // pickRandomNode will pick a random node in the kubernetes cluster
-func pickRandomNodeE(t TestingT, options *KubectlOptions) (corev1.Node, error) {
+func pickRandomNodeE(t testing.TestingT, options *KubectlOptions) (corev1.Node, error) {
 	nodes, err := GetNodesE(t, options)
 	if err != nil {
 		return corev1.Node{}, err
@@ -192,7 +192,7 @@ func pickRandomNodeE(t TestingT, options *KubectlOptions) (corev1.Node, error) {
 }
 
 // Given a node, return the ip address, preferring the external IP
-func FindNodeHostnameE(t TestingT, node corev1.Node) (string, error) {
+func FindNodeHostnameE(t testing.TestingT, node corev1.Node) (string, error) {
 	nodeIDUri, err := url.Parse(node.Spec.ProviderID)
 	if err != nil {
 		return "", err
@@ -208,7 +208,7 @@ func FindNodeHostnameE(t TestingT, node corev1.Node) (string, error) {
 // findAwsNodeHostname will return the public ip of the node, assuming the node is an AWS EC2 instance.
 // If the instance does not have a public IP, will return the internal hostname as recorded on the Kubernetes node
 // object.
-func findAwsNodeHostnameE(t TestingT, node corev1.Node, awsIDUri *url.URL) (string, error) {
+func findAwsNodeHostnameE(t testing.TestingT, node corev1.Node, awsIDUri *url.URL) (string, error) {
 	// Path is /AVAILABILITY_ZONE/INSTANCE_ID
 	parts := strings.Split(awsIDUri.Path, "/")
 	if len(parts) != 3 {

--- a/modules/k8s/service.go
+++ b/modules/k8s/service.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"net/url"
 	"strings"
-	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
@@ -15,18 +14,19 @@ import (
 	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/gruntwork-io/terratest/modules/retry"
+	_ "github.com/gruntwork-io/terratest/modules/testing"
 )
 
 // ListServices will look for services in the given namespace that match the given filters and return them. This will
 // fail the test if there is an error.
-func ListServices(t *testing.T, options *KubectlOptions, filters metav1.ListOptions) []corev1.Service {
+func ListServices(t TestingT, options *KubectlOptions, filters metav1.ListOptions) []corev1.Service {
 	service, err := ListServicesE(t, options, filters)
 	require.NoError(t, err)
 	return service
 }
 
 // ListServicesE will look for services in the given namespace that match the given filters and return them.
-func ListServicesE(t *testing.T, options *KubectlOptions, filters metav1.ListOptions) ([]corev1.Service, error) {
+func ListServicesE(t TestingT, options *KubectlOptions, filters metav1.ListOptions) ([]corev1.Service, error) {
 	clientset, err := GetKubernetesClientFromOptionsE(t, options)
 	if err != nil {
 		return nil, err
@@ -40,14 +40,14 @@ func ListServicesE(t *testing.T, options *KubectlOptions, filters metav1.ListOpt
 
 // GetService returns a Kubernetes service resource in the provided namespace with the given name. This will
 // fail the test if there is an error.
-func GetService(t *testing.T, options *KubectlOptions, serviceName string) *corev1.Service {
+func GetService(t TestingT, options *KubectlOptions, serviceName string) *corev1.Service {
 	service, err := GetServiceE(t, options, serviceName)
 	require.NoError(t, err)
 	return service
 }
 
 // GetServiceE returns a Kubernetes service resource in the provided namespace with the given name.
-func GetServiceE(t *testing.T, options *KubectlOptions, serviceName string) (*corev1.Service, error) {
+func GetServiceE(t TestingT, options *KubectlOptions, serviceName string) (*corev1.Service, error) {
 	clientset, err := GetKubernetesClientFromOptionsE(t, options)
 	if err != nil {
 		return nil, err
@@ -56,7 +56,7 @@ func GetServiceE(t *testing.T, options *KubectlOptions, serviceName string) (*co
 }
 
 // WaitUntilServiceAvailable waits until the service endpoint is ready to accept traffic.
-func WaitUntilServiceAvailable(t *testing.T, options *KubectlOptions, serviceName string, retries int, sleepBetweenRetries time.Duration) {
+func WaitUntilServiceAvailable(t TestingT, options *KubectlOptions, serviceName string, retries int, sleepBetweenRetries time.Duration) {
 	statusMsg := fmt.Sprintf("Wait for service %s to be provisioned.", serviceName)
 	message := retry.DoWithRetry(
 		t,
@@ -101,7 +101,7 @@ func IsServiceAvailable(service *corev1.Service) bool {
 
 // GetServiceEndpoint will return the service access point. If the service endpoint is not ready, will fail the test
 // immediately.
-func GetServiceEndpoint(t *testing.T, options *KubectlOptions, service *corev1.Service, servicePort int) string {
+func GetServiceEndpoint(t TestingT, options *KubectlOptions, service *corev1.Service, servicePort int) string {
 	endpoint, err := GetServiceEndpointE(t, options, service, servicePort)
 	require.NoError(t, err)
 	return endpoint
@@ -114,7 +114,7 @@ func GetServiceEndpoint(t *testing.T, options *KubectlOptions, service *corev1.S
 // - For LoadBalancer service type, return the publicly accessible hostname of the load balancer.
 //   If the hostname is empty, it will return the public IP of the LoadBalancer.
 // - All other service types are not supported.
-func GetServiceEndpointE(t *testing.T, options *KubectlOptions, service *corev1.Service, servicePort int) (string, error) {
+func GetServiceEndpointE(t TestingT, options *KubectlOptions, service *corev1.Service, servicePort int) (string, error) {
 	switch service.Spec.Type {
 	case corev1.ServiceTypeClusterIP:
 		// ClusterIP service type will map directly to service port
@@ -148,7 +148,7 @@ func GetServiceEndpointE(t *testing.T, options *KubectlOptions, service *corev1.
 // Extracts a endpoint that can be reached outside the kubernetes cluster. NodePort type needs to find the right
 // allocated node port mapped to the service port, as well as find out the externally reachable ip (if available).
 func findEndpointForNodePortService(
-	t *testing.T,
+	t TestingT,
 	options *KubectlOptions,
 	service *corev1.Service,
 	servicePort int32,
@@ -179,7 +179,7 @@ func FindNodePortE(service *corev1.Service, servicePort int32) (int32, error) {
 }
 
 // pickRandomNode will pick a random node in the kubernetes cluster
-func pickRandomNodeE(t *testing.T, options *KubectlOptions) (corev1.Node, error) {
+func pickRandomNodeE(t TestingT, options *KubectlOptions) (corev1.Node, error) {
 	nodes, err := GetNodesE(t, options)
 	if err != nil {
 		return corev1.Node{}, err
@@ -192,7 +192,7 @@ func pickRandomNodeE(t *testing.T, options *KubectlOptions) (corev1.Node, error)
 }
 
 // Given a node, return the ip address, preferring the external IP
-func FindNodeHostnameE(t *testing.T, node corev1.Node) (string, error) {
+func FindNodeHostnameE(t TestingT, node corev1.Node) (string, error) {
 	nodeIDUri, err := url.Parse(node.Spec.ProviderID)
 	if err != nil {
 		return "", err
@@ -208,7 +208,7 @@ func FindNodeHostnameE(t *testing.T, node corev1.Node) (string, error) {
 // findAwsNodeHostname will return the public ip of the node, assuming the node is an AWS EC2 instance.
 // If the instance does not have a public IP, will return the internal hostname as recorded on the Kubernetes node
 // object.
-func findAwsNodeHostnameE(t *testing.T, node corev1.Node, awsIDUri *url.URL) (string, error) {
+func findAwsNodeHostnameE(t TestingT, node corev1.Node, awsIDUri *url.URL) (string, error) {
 	// Path is /AVAILABILITY_ZONE/INSTANCE_ID
 	parts := strings.Split(awsIDUri.Path, "/")
 	if len(parts) != 3 {

--- a/modules/k8s/service_account.go
+++ b/modules/k8s/service_account.go
@@ -2,7 +2,6 @@ package k8s
 
 import (
 	"fmt"
-	"testing"
 	"time"
 
 	"github.com/gruntwork-io/gruntwork-cli/errors"
@@ -14,11 +13,12 @@ import (
 
 	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/retry"
+	_ "github.com/gruntwork-io/terratest/modules/testing"
 )
 
 // GetServiceAccount returns a Kubernetes service account resource in the provided namespace with the given name. The
 // namespace used is the one provided in the KubectlOptions. This will fail the test if there is an error.
-func GetServiceAccount(t *testing.T, options *KubectlOptions, serviceAccountName string) *corev1.ServiceAccount {
+func GetServiceAccount(t TestingT, options *KubectlOptions, serviceAccountName string) *corev1.ServiceAccount {
 	serviceAccount, err := GetServiceAccountE(t, options, serviceAccountName)
 	require.NoError(t, err)
 	return serviceAccount
@@ -26,7 +26,7 @@ func GetServiceAccount(t *testing.T, options *KubectlOptions, serviceAccountName
 
 // GetServiceAccountE returns a Kubernetes service account resource in the provided namespace with the given name. The
 // namespace used is the one provided in the KubectlOptions.
-func GetServiceAccountE(t *testing.T, options *KubectlOptions, serviceAccountName string) (*corev1.ServiceAccount, error) {
+func GetServiceAccountE(t TestingT, options *KubectlOptions, serviceAccountName string) (*corev1.ServiceAccount, error) {
 	clientset, err := GetKubernetesClientFromOptionsE(t, options)
 	if err != nil {
 		return nil, err
@@ -36,13 +36,13 @@ func GetServiceAccountE(t *testing.T, options *KubectlOptions, serviceAccountNam
 
 // CreateServiceAccount will create a new service account resource in the provided namespace with the given name. The
 // namespace used is the one provided in the KubectlOptions. This will fail the test if there is an error.
-func CreateServiceAccount(t *testing.T, options *KubectlOptions, serviceAccountName string) {
+func CreateServiceAccount(t TestingT, options *KubectlOptions, serviceAccountName string) {
 	require.NoError(t, CreateServiceAccountE(t, options, serviceAccountName))
 }
 
 // CreateServiceAccountE will create a new service account resource in the provided namespace with the given name. The
 // namespace used is the one provided in the KubectlOptions.
-func CreateServiceAccountE(t *testing.T, options *KubectlOptions, serviceAccountName string) error {
+func CreateServiceAccountE(t TestingT, options *KubectlOptions, serviceAccountName string) error {
 	clientset, err := GetKubernetesClientFromOptionsE(t, options)
 	if err != nil {
 		return err
@@ -60,7 +60,7 @@ func CreateServiceAccountE(t *testing.T, options *KubectlOptions, serviceAccount
 
 // GetServiceAccountAuthToken will retrieve the ServiceAccount token from the cluster so it can be used to
 // authenticate requests as that ServiceAccount. This will fail the test if there is an error.
-func GetServiceAccountAuthToken(t *testing.T, kubectlOptions *KubectlOptions, serviceAccountName string) string {
+func GetServiceAccountAuthToken(t TestingT, kubectlOptions *KubectlOptions, serviceAccountName string) string {
 	token, err := GetServiceAccountAuthTokenE(t, kubectlOptions, serviceAccountName)
 	require.NoError(t, err)
 	return token
@@ -68,7 +68,7 @@ func GetServiceAccountAuthToken(t *testing.T, kubectlOptions *KubectlOptions, se
 
 // GetServiceAccountAuthTokenE will retrieve the ServiceAccount token from the cluster so it can be used to
 // authenticate requests as that ServiceAccount.
-func GetServiceAccountAuthTokenE(t *testing.T, kubectlOptions *KubectlOptions, serviceAccountName string) (string, error) {
+func GetServiceAccountAuthTokenE(t TestingT, kubectlOptions *KubectlOptions, serviceAccountName string) (string, error) {
 	// Wait for the TokenController to provision a ServiceAccount token
 	msg, err := retry.DoWithRetryE(
 		t,
@@ -106,7 +106,7 @@ func GetServiceAccountAuthTokenE(t *testing.T, kubectlOptions *KubectlOptions, s
 // AddConfigContextForServiceAccountE will add a new config context that binds the ServiceAccount auth token to the
 // Kubernetes cluster of the current config context.
 func AddConfigContextForServiceAccountE(
-	t *testing.T,
+	t TestingT,
 	kubectlOptions *KubectlOptions,
 	contextName string,
 	serviceAccountName string,

--- a/modules/k8s/service_account.go
+++ b/modules/k8s/service_account.go
@@ -13,12 +13,12 @@ import (
 
 	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/retry"
-	_ "github.com/gruntwork-io/terratest/modules/testing"
+	"github.com/gruntwork-io/terratest/modules/testing"
 )
 
 // GetServiceAccount returns a Kubernetes service account resource in the provided namespace with the given name. The
 // namespace used is the one provided in the KubectlOptions. This will fail the test if there is an error.
-func GetServiceAccount(t TestingT, options *KubectlOptions, serviceAccountName string) *corev1.ServiceAccount {
+func GetServiceAccount(t testing.TestingT, options *KubectlOptions, serviceAccountName string) *corev1.ServiceAccount {
 	serviceAccount, err := GetServiceAccountE(t, options, serviceAccountName)
 	require.NoError(t, err)
 	return serviceAccount
@@ -26,7 +26,7 @@ func GetServiceAccount(t TestingT, options *KubectlOptions, serviceAccountName s
 
 // GetServiceAccountE returns a Kubernetes service account resource in the provided namespace with the given name. The
 // namespace used is the one provided in the KubectlOptions.
-func GetServiceAccountE(t TestingT, options *KubectlOptions, serviceAccountName string) (*corev1.ServiceAccount, error) {
+func GetServiceAccountE(t testing.TestingT, options *KubectlOptions, serviceAccountName string) (*corev1.ServiceAccount, error) {
 	clientset, err := GetKubernetesClientFromOptionsE(t, options)
 	if err != nil {
 		return nil, err
@@ -36,13 +36,13 @@ func GetServiceAccountE(t TestingT, options *KubectlOptions, serviceAccountName 
 
 // CreateServiceAccount will create a new service account resource in the provided namespace with the given name. The
 // namespace used is the one provided in the KubectlOptions. This will fail the test if there is an error.
-func CreateServiceAccount(t TestingT, options *KubectlOptions, serviceAccountName string) {
+func CreateServiceAccount(t testing.TestingT, options *KubectlOptions, serviceAccountName string) {
 	require.NoError(t, CreateServiceAccountE(t, options, serviceAccountName))
 }
 
 // CreateServiceAccountE will create a new service account resource in the provided namespace with the given name. The
 // namespace used is the one provided in the KubectlOptions.
-func CreateServiceAccountE(t TestingT, options *KubectlOptions, serviceAccountName string) error {
+func CreateServiceAccountE(t testing.TestingT, options *KubectlOptions, serviceAccountName string) error {
 	clientset, err := GetKubernetesClientFromOptionsE(t, options)
 	if err != nil {
 		return err
@@ -60,7 +60,7 @@ func CreateServiceAccountE(t TestingT, options *KubectlOptions, serviceAccountNa
 
 // GetServiceAccountAuthToken will retrieve the ServiceAccount token from the cluster so it can be used to
 // authenticate requests as that ServiceAccount. This will fail the test if there is an error.
-func GetServiceAccountAuthToken(t TestingT, kubectlOptions *KubectlOptions, serviceAccountName string) string {
+func GetServiceAccountAuthToken(t testing.TestingT, kubectlOptions *KubectlOptions, serviceAccountName string) string {
 	token, err := GetServiceAccountAuthTokenE(t, kubectlOptions, serviceAccountName)
 	require.NoError(t, err)
 	return token
@@ -68,7 +68,7 @@ func GetServiceAccountAuthToken(t TestingT, kubectlOptions *KubectlOptions, serv
 
 // GetServiceAccountAuthTokenE will retrieve the ServiceAccount token from the cluster so it can be used to
 // authenticate requests as that ServiceAccount.
-func GetServiceAccountAuthTokenE(t TestingT, kubectlOptions *KubectlOptions, serviceAccountName string) (string, error) {
+func GetServiceAccountAuthTokenE(t testing.TestingT, kubectlOptions *KubectlOptions, serviceAccountName string) (string, error) {
 	// Wait for the TokenController to provision a ServiceAccount token
 	msg, err := retry.DoWithRetryE(
 		t,
@@ -106,7 +106,7 @@ func GetServiceAccountAuthTokenE(t TestingT, kubectlOptions *KubectlOptions, ser
 // AddConfigContextForServiceAccountE will add a new config context that binds the ServiceAccount auth token to the
 // Kubernetes cluster of the current config context.
 func AddConfigContextForServiceAccountE(
-	t TestingT,
+	t testing.TestingT,
 	kubectlOptions *KubectlOptions,
 	contextName string,
 	serviceAccountName string,

--- a/modules/k8s/tunnel.go
+++ b/modules/k8s/tunnel.go
@@ -21,7 +21,7 @@ import (
 	"k8s.io/client-go/transport/spdy"
 
 	"github.com/gruntwork-io/terratest/modules/logger"
-	_ "github.com/gruntwork-io/terratest/modules/testing"
+	"github.com/gruntwork-io/terratest/modules/testing"
 )
 
 // Global lock to synchronize port selections
@@ -97,7 +97,7 @@ func (tunnel *Tunnel) Close() {
 
 // getAttachablePodForResource will find a pod that can be port forwarded to given the provided resource type and return
 // the name.
-func (tunnel *Tunnel) getAttachablePodForResourceE(t TestingT) (string, error) {
+func (tunnel *Tunnel) getAttachablePodForResourceE(t testing.TestingT) (string, error) {
 	switch tunnel.resourceType {
 	case ResourceTypePod:
 		return tunnel.resourceName, nil
@@ -109,7 +109,7 @@ func (tunnel *Tunnel) getAttachablePodForResourceE(t TestingT) (string, error) {
 }
 
 // getAttachablePodForServiceE will find an active pod associated with the Service and return the pod name.
-func (tunnel *Tunnel) getAttachablePodForServiceE(t TestingT) (string, error) {
+func (tunnel *Tunnel) getAttachablePodForServiceE(t testing.TestingT) (string, error) {
 	service, err := GetServiceE(t, tunnel.kubectlOptions, tunnel.resourceName)
 	if err != nil {
 		return "", err
@@ -129,12 +129,12 @@ func (tunnel *Tunnel) getAttachablePodForServiceE(t TestingT) (string, error) {
 
 // ForwardPort opens a tunnel to a kubernetes resource, as specified by the provided tunnel struct. This will fail the
 // test if there is an error attempting to open the port.
-func (tunnel *Tunnel) ForwardPort(t TestingT) {
+func (tunnel *Tunnel) ForwardPort(t testing.TestingT) {
 	require.NoError(t, tunnel.ForwardPortE(t))
 }
 
 // ForwardPortE opens a tunnel to a kubernetes resource, as specified by the provided tunnel struct.
-func (tunnel *Tunnel) ForwardPortE(t TestingT) error {
+func (tunnel *Tunnel) ForwardPortE(t testing.TestingT) error {
 	logger.Logf(
 		t,
 		"Creating a port forwarding tunnel for resource %s/%s routing local port %d to remote port %d",
@@ -237,7 +237,7 @@ func (tunnel *Tunnel) ForwardPortE(t TestingT) error {
 // GetAvailablePort retrieves an available port on the host machine. This delegates the port selection to the golang net
 // library by starting a server and then checking the port that the server is using. This will fail the test if it could
 // not find an available port.
-func GetAvailablePort(t TestingT) int {
+func GetAvailablePort(t testing.TestingT) int {
 	port, err := GetAvailablePortE(t)
 	require.NoError(t, err)
 	return port
@@ -245,7 +245,7 @@ func GetAvailablePort(t TestingT) int {
 
 // GetAvailablePortE retrieves an available port on the host machine. This delegates the port selection to the golang net
 // library by starting a server and then checking the port that the server is using.
-func GetAvailablePortE(t TestingT) (int, error) {
+func GetAvailablePortE(t testing.TestingT) (int, error) {
 	l, err := net.Listen("tcp", ":0")
 	if err != nil {
 		return 0, err

--- a/modules/k8s/tunnel.go
+++ b/modules/k8s/tunnel.go
@@ -14,7 +14,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"testing"
 
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -22,6 +21,7 @@ import (
 	"k8s.io/client-go/transport/spdy"
 
 	"github.com/gruntwork-io/terratest/modules/logger"
+	_ "github.com/gruntwork-io/terratest/modules/testing"
 )
 
 // Global lock to synchronize port selections
@@ -97,7 +97,7 @@ func (tunnel *Tunnel) Close() {
 
 // getAttachablePodForResource will find a pod that can be port forwarded to given the provided resource type and return
 // the name.
-func (tunnel *Tunnel) getAttachablePodForResourceE(t *testing.T) (string, error) {
+func (tunnel *Tunnel) getAttachablePodForResourceE(t TestingT) (string, error) {
 	switch tunnel.resourceType {
 	case ResourceTypePod:
 		return tunnel.resourceName, nil
@@ -109,7 +109,7 @@ func (tunnel *Tunnel) getAttachablePodForResourceE(t *testing.T) (string, error)
 }
 
 // getAttachablePodForServiceE will find an active pod associated with the Service and return the pod name.
-func (tunnel *Tunnel) getAttachablePodForServiceE(t *testing.T) (string, error) {
+func (tunnel *Tunnel) getAttachablePodForServiceE(t TestingT) (string, error) {
 	service, err := GetServiceE(t, tunnel.kubectlOptions, tunnel.resourceName)
 	if err != nil {
 		return "", err
@@ -129,12 +129,12 @@ func (tunnel *Tunnel) getAttachablePodForServiceE(t *testing.T) (string, error) 
 
 // ForwardPort opens a tunnel to a kubernetes resource, as specified by the provided tunnel struct. This will fail the
 // test if there is an error attempting to open the port.
-func (tunnel *Tunnel) ForwardPort(t *testing.T) {
+func (tunnel *Tunnel) ForwardPort(t TestingT) {
 	require.NoError(t, tunnel.ForwardPortE(t))
 }
 
 // ForwardPortE opens a tunnel to a kubernetes resource, as specified by the provided tunnel struct.
-func (tunnel *Tunnel) ForwardPortE(t *testing.T) error {
+func (tunnel *Tunnel) ForwardPortE(t TestingT) error {
 	logger.Logf(
 		t,
 		"Creating a port forwarding tunnel for resource %s/%s routing local port %d to remote port %d",
@@ -237,7 +237,7 @@ func (tunnel *Tunnel) ForwardPortE(t *testing.T) error {
 // GetAvailablePort retrieves an available port on the host machine. This delegates the port selection to the golang net
 // library by starting a server and then checking the port that the server is using. This will fail the test if it could
 // not find an available port.
-func GetAvailablePort(t *testing.T) int {
+func GetAvailablePort(t TestingT) int {
 	port, err := GetAvailablePortE(t)
 	require.NoError(t, err)
 	return port
@@ -245,7 +245,7 @@ func GetAvailablePort(t *testing.T) int {
 
 // GetAvailablePortE retrieves an available port on the host machine. This delegates the port selection to the golang net
 // library by starting a server and then checking the port that the server is using.
-func GetAvailablePortE(t *testing.T) (int, error) {
+func GetAvailablePortE(t TestingT) (int, error) {
 	l, err := net.Listen("tcp", ":0")
 	if err != nil {
 		return 0, err

--- a/modules/logger/logger.go
+++ b/modules/logger/logger.go
@@ -7,8 +7,9 @@ import (
 	"os"
 	"runtime"
 	"strings"
-	"testing"
 	"time"
+
+	_ "github.com/gruntwork-io/terratest/modules/testing"
 )
 
 // Logf logs the given format and arguments, formatted using fmt.Sprintf, to stdout, along with a timestamp and information
@@ -28,20 +29,20 @@ import (
 //
 // Note that there is a proposal to improve t.Logf (https://github.com/golang/go/issues/24929), but until that's
 // implemented, this method is our best bet.
-func Logf(t *testing.T, format string, args ...interface{}) {
+func Logf(t TestingT, format string, args ...interface{}) {
 	DoLog(t, 2, os.Stdout, fmt.Sprintf(format, args...))
 }
 
 // Log logs the given arguments to stdout, along with a timestamp and information about what test and file is doing the
 // logging. This is an alternative to t.Logf that logs to stdout immediately, rather than buffering all log output and
 // only displaying it at the very end of the test. See the Logf method for more info.
-func Log(t *testing.T, args ...interface{}) {
+func Log(t TestingT, args ...interface{}) {
 	DoLog(t, 2, os.Stdout, args...)
 }
 
 // DoLog logs the given arguments to the given writer, along with a timestamp and information about what test and file is
 // doing the logging.
-func DoLog(t *testing.T, callDepth int, writer io.Writer, args ...interface{}) {
+func DoLog(t TestingT, callDepth int, writer io.Writer, args ...interface{}) {
 	date := time.Now()
 	prefix := fmt.Sprintf("%s %s %s:", t.Name(), date.Format(time.RFC3339), CallerPrefix(callDepth+1))
 	allArgs := append([]interface{}{prefix}, args...)

--- a/modules/logger/logger.go
+++ b/modules/logger/logger.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"time"
 
-	_ "github.com/gruntwork-io/terratest/modules/testing"
+	"github.com/gruntwork-io/terratest/modules/testing"
 )
 
 // Logf logs the given format and arguments, formatted using fmt.Sprintf, to stdout, along with a timestamp and information
@@ -29,20 +29,20 @@ import (
 //
 // Note that there is a proposal to improve t.Logf (https://github.com/golang/go/issues/24929), but until that's
 // implemented, this method is our best bet.
-func Logf(t TestingT, format string, args ...interface{}) {
+func Logf(t testing.TestingT, format string, args ...interface{}) {
 	DoLog(t, 2, os.Stdout, fmt.Sprintf(format, args...))
 }
 
 // Log logs the given arguments to stdout, along with a timestamp and information about what test and file is doing the
 // logging. This is an alternative to t.Logf that logs to stdout immediately, rather than buffering all log output and
 // only displaying it at the very end of the test. See the Logf method for more info.
-func Log(t TestingT, args ...interface{}) {
+func Log(t testing.TestingT, args ...interface{}) {
 	DoLog(t, 2, os.Stdout, args...)
 }
 
 // DoLog logs the given arguments to the given writer, along with a timestamp and information about what test and file is
 // doing the logging.
-func DoLog(t TestingT, callDepth int, writer io.Writer, args ...interface{}) {
+func DoLog(t testing.TestingT, callDepth int, writer io.Writer, args ...interface{}) {
 	date := time.Now()
 	prefix := fmt.Sprintf("%s %s %s:", t.Name(), date.Format(time.RFC3339), CallerPrefix(callDepth+1))
 	allArgs := append([]interface{}{prefix}, args...)

--- a/modules/oci/compute.go
+++ b/modules/oci/compute.go
@@ -4,15 +4,15 @@ import (
 	"context"
 	"fmt"
 	"sort"
-	"testing"
 
 	"github.com/gruntwork-io/terratest/modules/logger"
+	_ "github.com/gruntwork-io/terratest/modules/testing"
 	"github.com/oracle/oci-go-sdk/common"
 	"github.com/oracle/oci-go-sdk/core"
 )
 
 // DeleteImage deletes a custom image with given OCID.
-func DeleteImage(t *testing.T, ocid string) {
+func DeleteImage(t TestingT, ocid string) {
 	err := DeleteImageE(t, ocid)
 	if err != nil {
 		t.Fatal(err)
@@ -20,7 +20,7 @@ func DeleteImage(t *testing.T, ocid string) {
 }
 
 // DeleteImageE deletes a custom image with given OCID.
-func DeleteImageE(t *testing.T, ocid string) error {
+func DeleteImageE(t TestingT, ocid string) error {
 	logger.Logf(t, "Deleting image with OCID %s", ocid)
 
 	configProvider := common.DefaultConfigProvider()
@@ -35,7 +35,7 @@ func DeleteImageE(t *testing.T, ocid string) error {
 }
 
 // GetMostRecentImageID gets the OCID of the most recent image in the given compartment that has the given OS name and version.
-func GetMostRecentImageID(t *testing.T, compartmentID string, osName string, osVersion string) string {
+func GetMostRecentImageID(t TestingT, compartmentID string, osName string, osVersion string) string {
 	ocid, err := GetMostRecentImageIDE(t, compartmentID, osName, osVersion)
 	if err != nil {
 		t.Fatal(err)
@@ -44,7 +44,7 @@ func GetMostRecentImageID(t *testing.T, compartmentID string, osName string, osV
 }
 
 // GetMostRecentImageIDE gets the OCID of the most recent image in the given compartment that has the given OS name and version.
-func GetMostRecentImageIDE(t *testing.T, compartmentID string, osName string, osVersion string) (string, error) {
+func GetMostRecentImageIDE(t TestingT, compartmentID string, osName string, osVersion string) (string, error) {
 	configProvider := common.DefaultConfigProvider()
 	client, err := core.NewComputeClientWithConfigurationProvider(configProvider)
 	if err != nil {

--- a/modules/oci/compute.go
+++ b/modules/oci/compute.go
@@ -6,13 +6,13 @@ import (
 	"sort"
 
 	"github.com/gruntwork-io/terratest/modules/logger"
-	_ "github.com/gruntwork-io/terratest/modules/testing"
+	"github.com/gruntwork-io/terratest/modules/testing"
 	"github.com/oracle/oci-go-sdk/common"
 	"github.com/oracle/oci-go-sdk/core"
 )
 
 // DeleteImage deletes a custom image with given OCID.
-func DeleteImage(t TestingT, ocid string) {
+func DeleteImage(t testing.TestingT, ocid string) {
 	err := DeleteImageE(t, ocid)
 	if err != nil {
 		t.Fatal(err)
@@ -20,7 +20,7 @@ func DeleteImage(t TestingT, ocid string) {
 }
 
 // DeleteImageE deletes a custom image with given OCID.
-func DeleteImageE(t TestingT, ocid string) error {
+func DeleteImageE(t testing.TestingT, ocid string) error {
 	logger.Logf(t, "Deleting image with OCID %s", ocid)
 
 	configProvider := common.DefaultConfigProvider()
@@ -35,7 +35,7 @@ func DeleteImageE(t TestingT, ocid string) error {
 }
 
 // GetMostRecentImageID gets the OCID of the most recent image in the given compartment that has the given OS name and version.
-func GetMostRecentImageID(t TestingT, compartmentID string, osName string, osVersion string) string {
+func GetMostRecentImageID(t testing.TestingT, compartmentID string, osName string, osVersion string) string {
 	ocid, err := GetMostRecentImageIDE(t, compartmentID, osName, osVersion)
 	if err != nil {
 		t.Fatal(err)
@@ -44,7 +44,7 @@ func GetMostRecentImageID(t TestingT, compartmentID string, osName string, osVer
 }
 
 // GetMostRecentImageIDE gets the OCID of the most recent image in the given compartment that has the given OS name and version.
-func GetMostRecentImageIDE(t TestingT, compartmentID string, osName string, osVersion string) (string, error) {
+func GetMostRecentImageIDE(t testing.TestingT, compartmentID string, osName string, osVersion string) (string, error) {
 	configProvider := common.DefaultConfigProvider()
 	client, err := core.NewComputeClientWithConfigurationProvider(configProvider)
 	if err != nil {

--- a/modules/oci/identity.go
+++ b/modules/oci/identity.go
@@ -4,17 +4,17 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"testing"
 
 	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/random"
+	_ "github.com/gruntwork-io/terratest/modules/testing"
 	"github.com/oracle/oci-go-sdk/common"
 	"github.com/oracle/oci-go-sdk/identity"
 )
 
 // GetRandomAvailabilityDomain gets a randomly chosen availability domain for given compartment.
 // The returned value can be overridden by of the environment variable TF_VAR_availability_domain.
-func GetRandomAvailabilityDomain(t *testing.T, compartmentID string) string {
+func GetRandomAvailabilityDomain(t TestingT, compartmentID string) string {
 	ad, err := GetRandomAvailabilityDomainE(t, compartmentID)
 	if err != nil {
 		t.Fatal(err)
@@ -24,7 +24,7 @@ func GetRandomAvailabilityDomain(t *testing.T, compartmentID string) string {
 
 // GetRandomAvailabilityDomainE gets a randomly chosen availability domain for given compartment.
 // The returned value can be overridden by of the environment variable TF_VAR_availability_domain.
-func GetRandomAvailabilityDomainE(t *testing.T, compartmentID string) (string, error) {
+func GetRandomAvailabilityDomainE(t TestingT, compartmentID string) (string, error) {
 	adFromEnvVar := os.Getenv(availabilityDomainEnvVar)
 	if adFromEnvVar != "" {
 		logger.Logf(t, "Using availability domain %s from environment variable %s", adFromEnvVar, availabilityDomainEnvVar)
@@ -43,7 +43,7 @@ func GetRandomAvailabilityDomainE(t *testing.T, compartmentID string) (string, e
 }
 
 // GetAllAvailabilityDomains gets the list of availability domains available in the given compartment.
-func GetAllAvailabilityDomains(t *testing.T, compartmentID string) []string {
+func GetAllAvailabilityDomains(t TestingT, compartmentID string) []string {
 	ads, err := GetAllAvailabilityDomainsE(t, compartmentID)
 	if err != nil {
 		t.Fatal(err)
@@ -52,7 +52,7 @@ func GetAllAvailabilityDomains(t *testing.T, compartmentID string) []string {
 }
 
 // GetAllAvailabilityDomainsE gets the list of availability domains available in the given compartment.
-func GetAllAvailabilityDomainsE(t *testing.T, compartmentID string) ([]string, error) {
+func GetAllAvailabilityDomainsE(t TestingT, compartmentID string) ([]string, error) {
 	configProvider := common.DefaultConfigProvider()
 	client, err := identity.NewIdentityClientWithConfigurationProvider(configProvider)
 	if err != nil {

--- a/modules/oci/identity.go
+++ b/modules/oci/identity.go
@@ -7,14 +7,14 @@ import (
 
 	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/random"
-	_ "github.com/gruntwork-io/terratest/modules/testing"
+	"github.com/gruntwork-io/terratest/modules/testing"
 	"github.com/oracle/oci-go-sdk/common"
 	"github.com/oracle/oci-go-sdk/identity"
 )
 
 // GetRandomAvailabilityDomain gets a randomly chosen availability domain for given compartment.
 // The returned value can be overridden by of the environment variable TF_VAR_availability_domain.
-func GetRandomAvailabilityDomain(t TestingT, compartmentID string) string {
+func GetRandomAvailabilityDomain(t testing.TestingT, compartmentID string) string {
 	ad, err := GetRandomAvailabilityDomainE(t, compartmentID)
 	if err != nil {
 		t.Fatal(err)
@@ -24,7 +24,7 @@ func GetRandomAvailabilityDomain(t TestingT, compartmentID string) string {
 
 // GetRandomAvailabilityDomainE gets a randomly chosen availability domain for given compartment.
 // The returned value can be overridden by of the environment variable TF_VAR_availability_domain.
-func GetRandomAvailabilityDomainE(t TestingT, compartmentID string) (string, error) {
+func GetRandomAvailabilityDomainE(t testing.TestingT, compartmentID string) (string, error) {
 	adFromEnvVar := os.Getenv(availabilityDomainEnvVar)
 	if adFromEnvVar != "" {
 		logger.Logf(t, "Using availability domain %s from environment variable %s", adFromEnvVar, availabilityDomainEnvVar)
@@ -43,7 +43,7 @@ func GetRandomAvailabilityDomainE(t TestingT, compartmentID string) (string, err
 }
 
 // GetAllAvailabilityDomains gets the list of availability domains available in the given compartment.
-func GetAllAvailabilityDomains(t TestingT, compartmentID string) []string {
+func GetAllAvailabilityDomains(t testing.TestingT, compartmentID string) []string {
 	ads, err := GetAllAvailabilityDomainsE(t, compartmentID)
 	if err != nil {
 		t.Fatal(err)
@@ -52,7 +52,7 @@ func GetAllAvailabilityDomains(t TestingT, compartmentID string) []string {
 }
 
 // GetAllAvailabilityDomainsE gets the list of availability domains available in the given compartment.
-func GetAllAvailabilityDomainsE(t TestingT, compartmentID string) ([]string, error) {
+func GetAllAvailabilityDomainsE(t testing.TestingT, compartmentID string) ([]string, error) {
 	configProvider := common.DefaultConfigProvider()
 	client, err := identity.NewIdentityClientWithConfigurationProvider(configProvider)
 	if err != nil {

--- a/modules/oci/network.go
+++ b/modules/oci/network.go
@@ -6,14 +6,14 @@ import (
 
 	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/random"
-	_ "github.com/gruntwork-io/terratest/modules/testing"
+	"github.com/gruntwork-io/terratest/modules/testing"
 	"github.com/oracle/oci-go-sdk/common"
 	"github.com/oracle/oci-go-sdk/core"
 )
 
 // GetRandomSubnetID gets a randomly chosen subnet OCID in the given availability domain.
 // The returned value can be overridden by of the environment variable TF_VAR_subnet_ocid.
-func GetRandomSubnetID(t TestingT, compartmentID string, availabilityDomain string) string {
+func GetRandomSubnetID(t testing.TestingT, compartmentID string, availabilityDomain string) string {
 	ocid, err := GetRandomSubnetIDE(t, compartmentID, availabilityDomain)
 	if err != nil {
 		t.Fatal(err)
@@ -23,7 +23,7 @@ func GetRandomSubnetID(t TestingT, compartmentID string, availabilityDomain stri
 
 // GetRandomSubnetIDE gets a randomly chosen subnet OCID in the given availability domain.
 // The returned value can be overridden by of the environment variable TF_VAR_subnet_ocid.
-func GetRandomSubnetIDE(t TestingT, compartmentID string, availabilityDomain string) (string, error) {
+func GetRandomSubnetIDE(t testing.TestingT, compartmentID string, availabilityDomain string) (string, error) {
 	configProvider := common.DefaultConfigProvider()
 	client, err := core.NewVirtualNetworkClientWithConfigurationProvider(configProvider)
 	if err != nil {
@@ -56,7 +56,7 @@ func GetRandomSubnetIDE(t TestingT, compartmentID string, availabilityDomain str
 }
 
 // GetAllVcnIDs gets the list of VCNs available in the given compartment.
-func GetAllVcnIDs(t TestingT, compartmentID string) []string {
+func GetAllVcnIDs(t testing.TestingT, compartmentID string) []string {
 	vcnIDS, err := GetAllVcnIDsE(t, compartmentID)
 	if err != nil {
 		t.Fatal(err)
@@ -65,7 +65,7 @@ func GetAllVcnIDs(t TestingT, compartmentID string) []string {
 }
 
 // GetAllVcnIDsE gets the list of VCNs available in the given compartment.
-func GetAllVcnIDsE(t TestingT, compartmentID string) ([]string, error) {
+func GetAllVcnIDsE(t testing.TestingT, compartmentID string) ([]string, error) {
 	configProvider := common.DefaultConfigProvider()
 	client, err := core.NewVirtualNetworkClientWithConfigurationProvider(configProvider)
 	if err != nil {

--- a/modules/oci/network.go
+++ b/modules/oci/network.go
@@ -3,17 +3,17 @@ package oci
 import (
 	"context"
 	"fmt"
-	"testing"
 
 	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/random"
+	_ "github.com/gruntwork-io/terratest/modules/testing"
 	"github.com/oracle/oci-go-sdk/common"
 	"github.com/oracle/oci-go-sdk/core"
 )
 
 // GetRandomSubnetID gets a randomly chosen subnet OCID in the given availability domain.
 // The returned value can be overridden by of the environment variable TF_VAR_subnet_ocid.
-func GetRandomSubnetID(t *testing.T, compartmentID string, availabilityDomain string) string {
+func GetRandomSubnetID(t TestingT, compartmentID string, availabilityDomain string) string {
 	ocid, err := GetRandomSubnetIDE(t, compartmentID, availabilityDomain)
 	if err != nil {
 		t.Fatal(err)
@@ -23,7 +23,7 @@ func GetRandomSubnetID(t *testing.T, compartmentID string, availabilityDomain st
 
 // GetRandomSubnetIDE gets a randomly chosen subnet OCID in the given availability domain.
 // The returned value can be overridden by of the environment variable TF_VAR_subnet_ocid.
-func GetRandomSubnetIDE(t *testing.T, compartmentID string, availabilityDomain string) (string, error) {
+func GetRandomSubnetIDE(t TestingT, compartmentID string, availabilityDomain string) (string, error) {
 	configProvider := common.DefaultConfigProvider()
 	client, err := core.NewVirtualNetworkClientWithConfigurationProvider(configProvider)
 	if err != nil {
@@ -56,7 +56,7 @@ func GetRandomSubnetIDE(t *testing.T, compartmentID string, availabilityDomain s
 }
 
 // GetAllVcnIDs gets the list of VCNs available in the given compartment.
-func GetAllVcnIDs(t *testing.T, compartmentID string) []string {
+func GetAllVcnIDs(t TestingT, compartmentID string) []string {
 	vcnIDS, err := GetAllVcnIDsE(t, compartmentID)
 	if err != nil {
 		t.Fatal(err)
@@ -65,7 +65,7 @@ func GetAllVcnIDs(t *testing.T, compartmentID string) []string {
 }
 
 // GetAllVcnIDsE gets the list of VCNs available in the given compartment.
-func GetAllVcnIDsE(t *testing.T, compartmentID string) ([]string, error) {
+func GetAllVcnIDsE(t TestingT, compartmentID string) ([]string, error) {
 	configProvider := common.DefaultConfigProvider()
 	client, err := core.NewVirtualNetworkClientWithConfigurationProvider(configProvider)
 	if err != nil {

--- a/modules/oci/provider.go
+++ b/modules/oci/provider.go
@@ -2,9 +2,9 @@ package oci
 
 import (
 	"os"
-	"testing"
 
 	"github.com/oracle/oci-go-sdk/common"
+	_ "github.com/gruntwork-io/terratest/modules/testing"
 )
 
 // You can set this environment variable to force Terratest to use a specific compartment.
@@ -21,7 +21,7 @@ const subnetIDEnvVar = "TF_VAR_subnet_ocid"
 const passPhraseEnvVar = "TF_VAR_pass_phrase"
 
 // GetRootComparmentID gets an OCID of the root compartment (a.k.a. tenancy OCID).
-func GetRootCompartmentID(t *testing.T) string {
+func GetRootCompartmentID(t TestingT) string {
 	tenancyID, err := GetRootCompartmentIDE(t)
 	if err != nil {
 		t.Fatal(err)
@@ -30,7 +30,7 @@ func GetRootCompartmentID(t *testing.T) string {
 }
 
 // GetRootComparmentIDE gets an OCID of the root compartment (a.k.a. tenancy OCID).
-func GetRootCompartmentIDE(t *testing.T) (string, error) {
+func GetRootCompartmentIDE(t TestingT (string, error) {
 	configProvider := common.DefaultConfigProvider()
 	tenancyID, err := configProvider.TenancyOCID()
 	if err != nil {

--- a/modules/oci/provider.go
+++ b/modules/oci/provider.go
@@ -3,8 +3,8 @@ package oci
 import (
 	"os"
 
+	"github.com/gruntwork-io/terratest/modules/testing"
 	"github.com/oracle/oci-go-sdk/common"
-	_ "github.com/gruntwork-io/terratest/modules/testing"
 )
 
 // You can set this environment variable to force Terratest to use a specific compartment.
@@ -21,7 +21,7 @@ const subnetIDEnvVar = "TF_VAR_subnet_ocid"
 const passPhraseEnvVar = "TF_VAR_pass_phrase"
 
 // GetRootComparmentID gets an OCID of the root compartment (a.k.a. tenancy OCID).
-func GetRootCompartmentID(t TestingT) string {
+func GetRootCompartmentID(t testing.TestingT) string {
 	tenancyID, err := GetRootCompartmentIDE(t)
 	if err != nil {
 		t.Fatal(err)
@@ -30,7 +30,7 @@ func GetRootCompartmentID(t TestingT) string {
 }
 
 // GetRootComparmentIDE gets an OCID of the root compartment (a.k.a. tenancy OCID).
-func GetRootCompartmentIDE(t TestingT (string, error) {
+func GetRootCompartmentIDE(t testing.TestingT) (string, error) {
 	configProvider := common.DefaultConfigProvider()
 	tenancyID, err := configProvider.TenancyOCID()
 	if err != nil {

--- a/modules/packer/packer.go
+++ b/modules/packer/packer.go
@@ -13,7 +13,7 @@ import (
 	"github.com/gruntwork-io/terratest/modules/customerrors"
 	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/shell"
-	_ "github.com/gruntwork-io/terratest/modules/testing"
+	"github.com/gruntwork-io/terratest/modules/testing"
 )
 
 // Options are the options for Packer.
@@ -34,7 +34,7 @@ type Options struct {
 // the packer builds. Once all the packer builds have completed a map of identifierName <-> generated identifier
 // is returned. The identifierName can be anything you want, it is only used so that you can
 // know which generated artifact is which.
-func BuildArtifacts(t TestingT, artifactNameToOptions map[string]*Options) map[string]string {
+func BuildArtifacts(t testing.TestingT, artifactNameToOptions map[string]*Options) map[string]string {
 	result, err := BuildArtifactsE(t, artifactNameToOptions)
 
 	if err != nil {
@@ -49,7 +49,7 @@ func BuildArtifacts(t TestingT, artifactNameToOptions map[string]*Options) map[s
 // is returned. If any artifact fails to build, the errors are accumulated and returned
 // as a MultiError. The identifierName can be anything you want, it is only used so that you can
 // know which generated artifact is which.
-func BuildArtifactsE(t TestingT, artifactNameToOptions map[string]*Options) (map[string]string, error) {
+func BuildArtifactsE(t testing.TestingT, artifactNameToOptions map[string]*Options) (map[string]string, error) {
 	var waitForArtifacts sync.WaitGroup
 	waitForArtifacts.Add(len(artifactNameToOptions))
 
@@ -79,7 +79,7 @@ func BuildArtifactsE(t TestingT, artifactNameToOptions map[string]*Options) (map
 }
 
 // BuildArtifact builds the given Packer template and return the generated Artifact ID.
-func BuildArtifact(t TestingT, options *Options) string {
+func BuildArtifact(t testing.TestingT, options *Options) string {
 	artifactID, err := BuildArtifactE(t, options)
 	if err != nil {
 		t.Fatal(err)
@@ -88,7 +88,7 @@ func BuildArtifact(t TestingT, options *Options) string {
 }
 
 // BuildArtifactE builds the given Packer template and return the generated Artifact ID.
-func BuildArtifactE(t TestingT, options *Options) (string, error) {
+func BuildArtifactE(t testing.TestingT, options *Options) (string, error) {
 	logger.Logf(t, "Running Packer to generate a custom artifact for template %s", options.Template)
 
 	cmd := shell.Command{
@@ -114,14 +114,14 @@ func BuildArtifactE(t TestingT, options *Options) (string, error) {
 // BuildAmi builds the given Packer template and return the generated AMI ID.
 //
 // Deprecated: Use BuildArtifact instead.
-func BuildAmi(t TestingT, options *Options) string {
+func BuildAmi(t testing.TestingT, options *Options) string {
 	return BuildArtifact(t, options)
 }
 
 // BuildAmiE builds the given Packer template and return the generated AMI ID.
 //
 // Deprecated: Use BuildArtifactE instead.
-func BuildAmiE(t TestingT, options *Options) (string, error) {
+func BuildAmiE(t testing.TestingT, options *Options) (string, error) {
 	return BuildArtifactE(t, options)
 }
 

--- a/modules/packer/packer.go
+++ b/modules/packer/packer.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"regexp"
 	"sync"
-	"testing"
 	"time"
 
 	"github.com/gruntwork-io/terratest/modules/retry"
@@ -14,6 +13,7 @@ import (
 	"github.com/gruntwork-io/terratest/modules/customerrors"
 	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/shell"
+	_ "github.com/gruntwork-io/terratest/modules/testing"
 )
 
 // Options are the options for Packer.
@@ -34,7 +34,7 @@ type Options struct {
 // the packer builds. Once all the packer builds have completed a map of identifierName <-> generated identifier
 // is returned. The identifierName can be anything you want, it is only used so that you can
 // know which generated artifact is which.
-func BuildArtifacts(t *testing.T, artifactNameToOptions map[string]*Options) map[string]string {
+func BuildArtifacts(t TestingT, artifactNameToOptions map[string]*Options) map[string]string {
 	result, err := BuildArtifactsE(t, artifactNameToOptions)
 
 	if err != nil {
@@ -49,7 +49,7 @@ func BuildArtifacts(t *testing.T, artifactNameToOptions map[string]*Options) map
 // is returned. If any artifact fails to build, the errors are accumulated and returned
 // as a MultiError. The identifierName can be anything you want, it is only used so that you can
 // know which generated artifact is which.
-func BuildArtifactsE(t *testing.T, artifactNameToOptions map[string]*Options) (map[string]string, error) {
+func BuildArtifactsE(t TestingT, artifactNameToOptions map[string]*Options) (map[string]string, error) {
 	var waitForArtifacts sync.WaitGroup
 	waitForArtifacts.Add(len(artifactNameToOptions))
 
@@ -79,7 +79,7 @@ func BuildArtifactsE(t *testing.T, artifactNameToOptions map[string]*Options) (m
 }
 
 // BuildArtifact builds the given Packer template and return the generated Artifact ID.
-func BuildArtifact(t *testing.T, options *Options) string {
+func BuildArtifact(t TestingT, options *Options) string {
 	artifactID, err := BuildArtifactE(t, options)
 	if err != nil {
 		t.Fatal(err)
@@ -88,7 +88,7 @@ func BuildArtifact(t *testing.T, options *Options) string {
 }
 
 // BuildArtifactE builds the given Packer template and return the generated Artifact ID.
-func BuildArtifactE(t *testing.T, options *Options) (string, error) {
+func BuildArtifactE(t TestingT, options *Options) (string, error) {
 	logger.Logf(t, "Running Packer to generate a custom artifact for template %s", options.Template)
 
 	cmd := shell.Command{
@@ -114,14 +114,14 @@ func BuildArtifactE(t *testing.T, options *Options) (string, error) {
 // BuildAmi builds the given Packer template and return the generated AMI ID.
 //
 // Deprecated: Use BuildArtifact instead.
-func BuildAmi(t *testing.T, options *Options) string {
+func BuildAmi(t TestingT, options *Options) string {
 	return BuildArtifact(t, options)
 }
 
 // BuildAmiE builds the given Packer template and return the generated AMI ID.
 //
 // Deprecated: Use BuildArtifactE instead.
-func BuildAmiE(t *testing.T, options *Options) (string, error) {
+func BuildAmiE(t TestingT, options *Options) (string, error) {
 	return BuildArtifactE(t, options)
 }
 

--- a/modules/retry/retry.go
+++ b/modules/retry/retry.go
@@ -4,12 +4,12 @@ package retry
 import (
 	"fmt"
 	"regexp"
-	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/gruntwork-io/terratest/modules/logger"
+	_ "github.com/gruntwork-io/terratest/modules/testing"
 	"golang.org/x/net/context"
 )
 
@@ -21,7 +21,7 @@ type Either struct {
 
 // DoWithTimeout runs the specified action and waits up to the specified timeout for it to complete. Return the output of the action if
 // it completes on time or fail the test otherwise.
-func DoWithTimeout(t *testing.T, actionDescription string, timeout time.Duration, action func() (string, error)) string {
+func DoWithTimeout(t TestingT, actionDescription string, timeout time.Duration, action func() (string, error)) string {
 	out, err := DoWithTimeoutE(t, actionDescription, timeout, action)
 	if err != nil {
 		t.Fatal(err)
@@ -31,7 +31,7 @@ func DoWithTimeout(t *testing.T, actionDescription string, timeout time.Duration
 
 // DoWithTimeoutE runs the specified action and waits up to the specified timeout for it to complete. Return the output of the action if
 // it completes on time or an error otherwise.
-func DoWithTimeoutE(t *testing.T, actionDescription string, timeout time.Duration, action func() (string, error)) (string, error) {
+func DoWithTimeoutE(t TestingT, actionDescription string, timeout time.Duration, action func() (string, error)) (string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
@@ -53,7 +53,7 @@ func DoWithTimeoutE(t *testing.T, actionDescription string, timeout time.Duratio
 // DoWithRetry runs the specified action. If it returns a value, return that value. If it returns a FatalError, return that error
 // immediately. If it returns any other type of error, sleep for sleepBetweenRetries and try again, up to a maximum of
 // maxRetries retries. If maxRetries is exceeded, fail the test.
-func DoWithRetry(t *testing.T, actionDescription string, maxRetries int, sleepBetweenRetries time.Duration, action func() (string, error)) string {
+func DoWithRetry(t TestingT, actionDescription string, maxRetries int, sleepBetweenRetries time.Duration, action func() (string, error)) string {
 	out, err := DoWithRetryE(t, actionDescription, maxRetries, sleepBetweenRetries, action)
 	if err != nil {
 		t.Fatal(err)
@@ -64,7 +64,7 @@ func DoWithRetry(t *testing.T, actionDescription string, maxRetries int, sleepBe
 // DoWithRetryE runs the specified action. If it returns a value, return that value. If it returns a FatalError, return that error
 // immediately. If it returns any other type of error, sleep for sleepBetweenRetries and try again, up to a maximum of
 // maxRetries retries. If maxRetries is exceeded, return a MaxRetriesExceeded error.
-func DoWithRetryE(t *testing.T, actionDescription string, maxRetries int, sleepBetweenRetries time.Duration, action func() (string, error)) (string, error) {
+func DoWithRetryE(t TestingT, actionDescription string, maxRetries int, sleepBetweenRetries time.Duration, action func() (string, error)) (string, error) {
 	var output string
 	var err error
 
@@ -93,7 +93,7 @@ func DoWithRetryE(t *testing.T, actionDescription string, maxRetries int, sleepB
 // matches any of the regular expressions in the specified retryableErrors map. If there is a match, sleep for
 // sleepBetweenRetries, and retry the specified action, up to a maximum of maxRetries retries. If there is no match,
 // return that error immediately, wrapped in a FatalError. If maxRetries is exceeded, return a MaxRetriesExceeded error.
-func DoWithRetryableErrors(t *testing.T, actionDescription string, retryableErrors map[string]string, maxRetries int, sleepBetweenRetries time.Duration, action func() (string, error)) string {
+func DoWithRetryableErrors(t TestingT, actionDescription string, retryableErrors map[string]string, maxRetries int, sleepBetweenRetries time.Duration, action func() (string, error)) string {
 	out, err := DoWithRetryableErrorsE(t, actionDescription, retryableErrors, maxRetries, sleepBetweenRetries, action)
 	require.NoError(t, err)
 	return out
@@ -104,7 +104,7 @@ func DoWithRetryableErrors(t *testing.T, actionDescription string, retryableErro
 // matches any of the regular expressions in the specified retryableErrors map. If there is a match, sleep for
 // sleepBetweenRetries, and retry the specified action, up to a maximum of maxRetries retries. If there is no match,
 // return that error immediately, wrapped in a FatalError. If maxRetries is exceeded, return a MaxRetriesExceeded error.
-func DoWithRetryableErrorsE(t *testing.T, actionDescription string, retryableErrors map[string]string, maxRetries int, sleepBetweenRetries time.Duration, action func() (string, error)) (string, error) {
+func DoWithRetryableErrorsE(t TestingT, actionDescription string, retryableErrors map[string]string, maxRetries int, sleepBetweenRetries time.Duration, action func() (string, error)) (string, error) {
 	retryableErrorsRegexp := map[*regexp.Regexp]string{}
 	for errorStr, errorMessage := range retryableErrors {
 		errorRegex, err := regexp.Compile(errorStr)
@@ -143,7 +143,7 @@ func (done Done) Done() {
 
 // DoInBackgroundUntilStopped runs the specified action in the background (in a goroutine) repeatedly, waiting the specified amount of time between
 // repetitions. To stop this action, call the Done() function on the returned value.
-func DoInBackgroundUntilStopped(t *testing.T, actionDescription string, sleepBetweenRepeats time.Duration, action func()) Done {
+func DoInBackgroundUntilStopped(t TestingT, actionDescription string, sleepBetweenRepeats time.Duration, action func()) Done {
 	stop := make(chan bool)
 
 	go func() {

--- a/modules/retry/retry.go
+++ b/modules/retry/retry.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/gruntwork-io/terratest/modules/logger"
-	_ "github.com/gruntwork-io/terratest/modules/testing"
+	"github.com/gruntwork-io/terratest/modules/testing"
 	"golang.org/x/net/context"
 )
 
@@ -21,7 +21,7 @@ type Either struct {
 
 // DoWithTimeout runs the specified action and waits up to the specified timeout for it to complete. Return the output of the action if
 // it completes on time or fail the test otherwise.
-func DoWithTimeout(t TestingT, actionDescription string, timeout time.Duration, action func() (string, error)) string {
+func DoWithTimeout(t testing.TestingT, actionDescription string, timeout time.Duration, action func() (string, error)) string {
 	out, err := DoWithTimeoutE(t, actionDescription, timeout, action)
 	if err != nil {
 		t.Fatal(err)
@@ -31,7 +31,7 @@ func DoWithTimeout(t TestingT, actionDescription string, timeout time.Duration, 
 
 // DoWithTimeoutE runs the specified action and waits up to the specified timeout for it to complete. Return the output of the action if
 // it completes on time or an error otherwise.
-func DoWithTimeoutE(t TestingT, actionDescription string, timeout time.Duration, action func() (string, error)) (string, error) {
+func DoWithTimeoutE(t testing.TestingT, actionDescription string, timeout time.Duration, action func() (string, error)) (string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
@@ -53,7 +53,7 @@ func DoWithTimeoutE(t TestingT, actionDescription string, timeout time.Duration,
 // DoWithRetry runs the specified action. If it returns a value, return that value. If it returns a FatalError, return that error
 // immediately. If it returns any other type of error, sleep for sleepBetweenRetries and try again, up to a maximum of
 // maxRetries retries. If maxRetries is exceeded, fail the test.
-func DoWithRetry(t TestingT, actionDescription string, maxRetries int, sleepBetweenRetries time.Duration, action func() (string, error)) string {
+func DoWithRetry(t testing.TestingT, actionDescription string, maxRetries int, sleepBetweenRetries time.Duration, action func() (string, error)) string {
 	out, err := DoWithRetryE(t, actionDescription, maxRetries, sleepBetweenRetries, action)
 	if err != nil {
 		t.Fatal(err)
@@ -64,7 +64,7 @@ func DoWithRetry(t TestingT, actionDescription string, maxRetries int, sleepBetw
 // DoWithRetryE runs the specified action. If it returns a value, return that value. If it returns a FatalError, return that error
 // immediately. If it returns any other type of error, sleep for sleepBetweenRetries and try again, up to a maximum of
 // maxRetries retries. If maxRetries is exceeded, return a MaxRetriesExceeded error.
-func DoWithRetryE(t TestingT, actionDescription string, maxRetries int, sleepBetweenRetries time.Duration, action func() (string, error)) (string, error) {
+func DoWithRetryE(t testing.TestingT, actionDescription string, maxRetries int, sleepBetweenRetries time.Duration, action func() (string, error)) (string, error) {
 	var output string
 	var err error
 
@@ -93,7 +93,7 @@ func DoWithRetryE(t TestingT, actionDescription string, maxRetries int, sleepBet
 // matches any of the regular expressions in the specified retryableErrors map. If there is a match, sleep for
 // sleepBetweenRetries, and retry the specified action, up to a maximum of maxRetries retries. If there is no match,
 // return that error immediately, wrapped in a FatalError. If maxRetries is exceeded, return a MaxRetriesExceeded error.
-func DoWithRetryableErrors(t TestingT, actionDescription string, retryableErrors map[string]string, maxRetries int, sleepBetweenRetries time.Duration, action func() (string, error)) string {
+func DoWithRetryableErrors(t testing.TestingT, actionDescription string, retryableErrors map[string]string, maxRetries int, sleepBetweenRetries time.Duration, action func() (string, error)) string {
 	out, err := DoWithRetryableErrorsE(t, actionDescription, retryableErrors, maxRetries, sleepBetweenRetries, action)
 	require.NoError(t, err)
 	return out
@@ -104,7 +104,7 @@ func DoWithRetryableErrors(t TestingT, actionDescription string, retryableErrors
 // matches any of the regular expressions in the specified retryableErrors map. If there is a match, sleep for
 // sleepBetweenRetries, and retry the specified action, up to a maximum of maxRetries retries. If there is no match,
 // return that error immediately, wrapped in a FatalError. If maxRetries is exceeded, return a MaxRetriesExceeded error.
-func DoWithRetryableErrorsE(t TestingT, actionDescription string, retryableErrors map[string]string, maxRetries int, sleepBetweenRetries time.Duration, action func() (string, error)) (string, error) {
+func DoWithRetryableErrorsE(t testing.TestingT, actionDescription string, retryableErrors map[string]string, maxRetries int, sleepBetweenRetries time.Duration, action func() (string, error)) (string, error) {
 	retryableErrorsRegexp := map[*regexp.Regexp]string{}
 	for errorStr, errorMessage := range retryableErrors {
 		errorRegex, err := regexp.Compile(errorStr)
@@ -143,7 +143,7 @@ func (done Done) Done() {
 
 // DoInBackgroundUntilStopped runs the specified action in the background (in a goroutine) repeatedly, waiting the specified amount of time between
 // repetitions. To stop this action, call the Done() function on the returned value.
-func DoInBackgroundUntilStopped(t TestingT, actionDescription string, sleepBetweenRepeats time.Duration, action func()) Done {
+func DoInBackgroundUntilStopped(t testing.TestingT, actionDescription string, sleepBetweenRepeats time.Duration, action func()) Done {
 	stop := make(chan bool)
 
 	go func() {

--- a/modules/shell/command.go
+++ b/modules/shell/command.go
@@ -10,11 +10,11 @@ import (
 	"strings"
 	"sync"
 	"syscall"
-	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/gruntwork-io/terratest/modules/logger"
+	_ "github.com/gruntwork-io/terratest/modules/testing"
 )
 
 // Command is a simpler struct for defining commands than Go's built-in Cmd.
@@ -27,7 +27,7 @@ type Command struct {
 }
 
 // RunCommand runs a shell command and redirects its stdout and stderr to the stdout of the atomic script itself.
-func RunCommand(t *testing.T, command Command) {
+func RunCommand(t TestingT, command Command) {
 	err := RunCommandE(t, command)
 	if err != nil {
 		t.Fatal(err)
@@ -35,14 +35,14 @@ func RunCommand(t *testing.T, command Command) {
 }
 
 // RunCommandE runs a shell command and redirects its stdout and stderr to the stdout of the atomic script itself.
-func RunCommandE(t *testing.T, command Command) error {
+func RunCommandE(t TestingT, command Command) error {
 	_, err := RunCommandAndGetOutputE(t, command)
 	return err
 }
 
 // RunCommandAndGetOutput runs a shell command and returns its stdout and stderr as a string. The stdout and stderr of that command will also
 // be printed to the stdout and stderr of this Go program to make debugging easier.
-func RunCommandAndGetOutput(t *testing.T, command Command) string {
+func RunCommandAndGetOutput(t TestingT, command Command) string {
 	out, err := RunCommandAndGetOutputE(t, command)
 	if err != nil {
 		t.Fatal(err)
@@ -52,7 +52,7 @@ func RunCommandAndGetOutput(t *testing.T, command Command) string {
 
 // RunCommandAndGetOutputE runs a shell command and returns its stdout and stderr as a string. The stdout and stderr of that command will also
 // be printed to the stdout and stderr of this Go program to make debugging easier.
-func RunCommandAndGetOutputE(t *testing.T, command Command) (string, error) {
+func RunCommandAndGetOutputE(t TestingT, command Command) (string, error) {
 	allOutput := []string{}
 	err := runCommandAndStoreOutputE(t, command, &allOutput, &allOutput)
 
@@ -63,7 +63,7 @@ func RunCommandAndGetOutputE(t *testing.T, command Command) (string, error) {
 // RunCommandAndGetStdOut runs a shell command and returns solely its stdout (but not stderr) as a string. The stdout
 // and stderr of that command will also be printed to the stdout and stderr of this Go program to make debugging easier.
 // If there are any errors, fail the test.
-func RunCommandAndGetStdOut(t *testing.T, command Command) string {
+func RunCommandAndGetStdOut(t TestingT, command Command) string {
 	output, err := RunCommandAndGetStdOutE(t, command)
 	require.NoError(t, err)
 	return output
@@ -71,7 +71,7 @@ func RunCommandAndGetStdOut(t *testing.T, command Command) string {
 
 // RunCommandAndGetStdOutE runs a shell command and returns solely its stdout (but not stderr) as a string. The stdout
 // and stderr of that command will also be printed to the stdout and stderr of this Go program to make debugging easier.
-func RunCommandAndGetStdOutE(t *testing.T, command Command) (string, error) {
+func RunCommandAndGetStdOutE(t TestingT, command Command) (string, error) {
 	stdout := []string{}
 	stderr := []string{}
 	err := runCommandAndStoreOutputE(t, command, &stdout, &stderr)
@@ -83,7 +83,7 @@ func RunCommandAndGetStdOutE(t *testing.T, command Command) (string, error) {
 // runCommandAndStoreOutputE runs a shell command and stores each line from stdout and stderr in the given
 // storedStdout and storedStderr variables, respectively. The stdout and stderr of that command will also
 // be printed to the stdout and stderr of this Go program to make debugging easier.
-func runCommandAndStoreOutputE(t *testing.T, command Command, storedStdout *[]string, storedStderr *[]string) error {
+func runCommandAndStoreOutputE(t TestingT, command Command, storedStdout *[]string, storedStderr *[]string) error {
 	logger.Logf(t, "Running command %s with args %s", command.Command, command.Args)
 
 	cmd := exec.Command(command.Command, command.Args...)
@@ -119,7 +119,7 @@ func runCommandAndStoreOutputE(t *testing.T, command Command, storedStdout *[]st
 
 // This function captures stdout and stderr into the given variables while still printing it to the stdout and stderr
 // of this Go program
-func readStdoutAndStderr(t *testing.T, stdout io.ReadCloser, stderr io.ReadCloser, storedStdout *[]string, storedStderr *[]string, maxLineSize int) error {
+func readStdoutAndStderr(t TestingT, stdout io.ReadCloser, stderr io.ReadCloser, storedStdout *[]string, storedStderr *[]string, maxLineSize int) error {
 	stdoutScanner := bufio.NewScanner(stdout)
 	stderrScanner := bufio.NewScanner(stderr)
 
@@ -146,14 +146,14 @@ func readStdoutAndStderr(t *testing.T, stdout io.ReadCloser, stderr io.ReadClose
 	return nil
 }
 
-func readData(t *testing.T, scanner *bufio.Scanner, wg *sync.WaitGroup, mutex *sync.Mutex, allOutput *[]string) {
+func readData(t TestingT, scanner *bufio.Scanner, wg *sync.WaitGroup, mutex *sync.Mutex, allOutput *[]string) {
 	defer wg.Done()
 	for scanner.Scan() {
 		logTextAndAppendToOutput(t, mutex, scanner.Text(), allOutput)
 	}
 }
 
-func logTextAndAppendToOutput(t *testing.T, mutex *sync.Mutex, text string, allOutput *[]string) {
+func logTextAndAppendToOutput(t TestingT, mutex *sync.Mutex, text string, allOutput *[]string) {
 	defer mutex.Unlock()
 	logger.Log(t, text)
 	mutex.Lock()

--- a/modules/shell/command.go
+++ b/modules/shell/command.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/gruntwork-io/terratest/modules/logger"
-	_ "github.com/gruntwork-io/terratest/modules/testing"
+	"github.com/gruntwork-io/terratest/modules/testing"
 )
 
 // Command is a simpler struct for defining commands than Go's built-in Cmd.
@@ -27,7 +27,7 @@ type Command struct {
 }
 
 // RunCommand runs a shell command and redirects its stdout and stderr to the stdout of the atomic script itself.
-func RunCommand(t TestingT, command Command) {
+func RunCommand(t testing.TestingT, command Command) {
 	err := RunCommandE(t, command)
 	if err != nil {
 		t.Fatal(err)
@@ -35,14 +35,14 @@ func RunCommand(t TestingT, command Command) {
 }
 
 // RunCommandE runs a shell command and redirects its stdout and stderr to the stdout of the atomic script itself.
-func RunCommandE(t TestingT, command Command) error {
+func RunCommandE(t testing.TestingT, command Command) error {
 	_, err := RunCommandAndGetOutputE(t, command)
 	return err
 }
 
 // RunCommandAndGetOutput runs a shell command and returns its stdout and stderr as a string. The stdout and stderr of that command will also
 // be printed to the stdout and stderr of this Go program to make debugging easier.
-func RunCommandAndGetOutput(t TestingT, command Command) string {
+func RunCommandAndGetOutput(t testing.TestingT, command Command) string {
 	out, err := RunCommandAndGetOutputE(t, command)
 	if err != nil {
 		t.Fatal(err)
@@ -52,7 +52,7 @@ func RunCommandAndGetOutput(t TestingT, command Command) string {
 
 // RunCommandAndGetOutputE runs a shell command and returns its stdout and stderr as a string. The stdout and stderr of that command will also
 // be printed to the stdout and stderr of this Go program to make debugging easier.
-func RunCommandAndGetOutputE(t TestingT, command Command) (string, error) {
+func RunCommandAndGetOutputE(t testing.TestingT, command Command) (string, error) {
 	allOutput := []string{}
 	err := runCommandAndStoreOutputE(t, command, &allOutput, &allOutput)
 
@@ -63,7 +63,7 @@ func RunCommandAndGetOutputE(t TestingT, command Command) (string, error) {
 // RunCommandAndGetStdOut runs a shell command and returns solely its stdout (but not stderr) as a string. The stdout
 // and stderr of that command will also be printed to the stdout and stderr of this Go program to make debugging easier.
 // If there are any errors, fail the test.
-func RunCommandAndGetStdOut(t TestingT, command Command) string {
+func RunCommandAndGetStdOut(t testing.TestingT, command Command) string {
 	output, err := RunCommandAndGetStdOutE(t, command)
 	require.NoError(t, err)
 	return output
@@ -71,7 +71,7 @@ func RunCommandAndGetStdOut(t TestingT, command Command) string {
 
 // RunCommandAndGetStdOutE runs a shell command and returns solely its stdout (but not stderr) as a string. The stdout
 // and stderr of that command will also be printed to the stdout and stderr of this Go program to make debugging easier.
-func RunCommandAndGetStdOutE(t TestingT, command Command) (string, error) {
+func RunCommandAndGetStdOutE(t testing.TestingT, command Command) (string, error) {
 	stdout := []string{}
 	stderr := []string{}
 	err := runCommandAndStoreOutputE(t, command, &stdout, &stderr)
@@ -83,7 +83,7 @@ func RunCommandAndGetStdOutE(t TestingT, command Command) (string, error) {
 // runCommandAndStoreOutputE runs a shell command and stores each line from stdout and stderr in the given
 // storedStdout and storedStderr variables, respectively. The stdout and stderr of that command will also
 // be printed to the stdout and stderr of this Go program to make debugging easier.
-func runCommandAndStoreOutputE(t TestingT, command Command, storedStdout *[]string, storedStderr *[]string) error {
+func runCommandAndStoreOutputE(t testing.TestingT, command Command, storedStdout *[]string, storedStderr *[]string) error {
 	logger.Logf(t, "Running command %s with args %s", command.Command, command.Args)
 
 	cmd := exec.Command(command.Command, command.Args...)
@@ -119,7 +119,7 @@ func runCommandAndStoreOutputE(t TestingT, command Command, storedStdout *[]stri
 
 // This function captures stdout and stderr into the given variables while still printing it to the stdout and stderr
 // of this Go program
-func readStdoutAndStderr(t TestingT, stdout io.ReadCloser, stderr io.ReadCloser, storedStdout *[]string, storedStderr *[]string, maxLineSize int) error {
+func readStdoutAndStderr(t testing.TestingT, stdout io.ReadCloser, stderr io.ReadCloser, storedStdout *[]string, storedStderr *[]string, maxLineSize int) error {
 	stdoutScanner := bufio.NewScanner(stdout)
 	stderrScanner := bufio.NewScanner(stderr)
 
@@ -146,14 +146,14 @@ func readStdoutAndStderr(t TestingT, stdout io.ReadCloser, stderr io.ReadCloser,
 	return nil
 }
 
-func readData(t TestingT, scanner *bufio.Scanner, wg *sync.WaitGroup, mutex *sync.Mutex, allOutput *[]string) {
+func readData(t testing.TestingT, scanner *bufio.Scanner, wg *sync.WaitGroup, mutex *sync.Mutex, allOutput *[]string) {
 	defer wg.Done()
 	for scanner.Scan() {
 		logTextAndAppendToOutput(t, mutex, scanner.Text(), allOutput)
 	}
 }
 
-func logTextAndAppendToOutput(t TestingT, mutex *sync.Mutex, text string, allOutput *[]string) {
+func logTextAndAppendToOutput(t testing.TestingT, mutex *sync.Mutex, text string, allOutput *[]string) {
 	defer mutex.Unlock()
 	logger.Log(t, text)
 	mutex.Lock()

--- a/modules/ssh/agent.go
+++ b/modules/ssh/agent.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 
 	"github.com/gruntwork-io/terratest/modules/testing"
+	"github.com/gruntwork-io/terratest/modules/logger"
 	"golang.org/x/crypto/ssh/agent"
 )
 
@@ -57,7 +58,7 @@ func (s *SshAgent) run(t testing.TestingT) {
 					return
 					// When s.ln.Accept() returns a legit error, we print it and continue accepting further requests
 				default:
-					t.Logf("could not accept connection to agent %v", err)
+					logger.Logf(t, "could not accept connection to agent %v", err)
 					continue
 				}
 			} else {
@@ -65,7 +66,7 @@ func (s *SshAgent) run(t testing.TestingT) {
 				go func(c io.ReadWriter) {
 					err := agent.ServeAgent(s.agent, c)
 					if err != nil {
-						t.Logf("could not serve ssh agent %v", err)
+						logger.Logf(t, "could not serve ssh agent %v", err)
 					}
 				}(c)
 			}
@@ -111,7 +112,7 @@ func SshAgentWithKeyPairs(t testing.TestingT, keyPairs []*KeyPair) *SshAgent {
 // Instantiates and returns an in-memory ssh agent with the given KeyPair(s) already added
 // You should stop the agent to cleanup files afterwards by calling `defer sshAgent.Stop()`
 func SshAgentWithKeyPairsE(t testing.TestingT, keyPairs []*KeyPair) (*SshAgent, error) {
-	t.Log("Generating SSH Agent with given KeyPair(s)")
+	logger.Logf(t, "Generating SSH Agent with given KeyPair(s)")
 
 	// Instantiate a temporary SSH agent
 	socketDir, err := ioutil.TempDir("", "ssh-agent-")

--- a/modules/ssh/agent.go
+++ b/modules/ssh/agent.go
@@ -9,8 +9,8 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/gruntwork-io/terratest/modules/testing"
 	"github.com/gruntwork-io/terratest/modules/logger"
+	"github.com/gruntwork-io/terratest/modules/testing"
 	"golang.org/x/crypto/ssh/agent"
 )
 

--- a/modules/ssh/agent.go
+++ b/modules/ssh/agent.go
@@ -9,7 +9,7 @@ import (
 	"os"
 	"path/filepath"
 
-	_ "github.com/gruntwork-io/terratest/modules/testing"
+	"github.com/gruntwork-io/terratest/modules/testing"
 	"golang.org/x/crypto/ssh/agent"
 )
 
@@ -24,7 +24,7 @@ type SshAgent struct {
 
 // Create SSH agent, start it in background and returns control back to the main thread
 // You should stop the agent to cleanup files afterwards by calling `defer s.Stop()`
-func NewSshAgent(t TestingT, socketDir string, socketFile string) (*SshAgent, error) {
+func NewSshAgent(t testing.TestingT, socketDir string, socketFile string) (*SshAgent, error) {
 	var err error
 	s := &SshAgent{make(chan bool), make(chan bool), socketDir, socketFile, agent.NewKeyring(), nil}
 	s.ln, err = net.Listen("unix", s.socketFile)
@@ -41,7 +41,7 @@ func (s *SshAgent) SocketFile() string {
 }
 
 // SSH Agent listener and handler
-func (s *SshAgent) run(t TestingT) {
+func (s *SshAgent) run(t testing.TestingT) {
 	defer close(s.stopped)
 	for {
 		select {
@@ -83,7 +83,7 @@ func (s *SshAgent) Stop() {
 
 // Instantiates and returns an in-memory ssh agent with the given KeyPair already added
 // You should stop the agent to cleanup files afterwards by calling `defer sshAgent.Stop()`
-func SshAgentWithKeyPair(t TestingT, keyPair *KeyPair) *SshAgent {
+func SshAgentWithKeyPair(t testing.TestingT, keyPair *KeyPair) *SshAgent {
 	sshAgent, err := SshAgentWithKeyPairE(t, keyPair)
 
 	if err != nil {
@@ -93,12 +93,12 @@ func SshAgentWithKeyPair(t TestingT, keyPair *KeyPair) *SshAgent {
 	return sshAgent
 }
 
-func SshAgentWithKeyPairE(t TestingT, keyPair *KeyPair) (*SshAgent, error) {
+func SshAgentWithKeyPairE(t testing.TestingT, keyPair *KeyPair) (*SshAgent, error) {
 	sshAgent, err := SshAgentWithKeyPairsE(t, []*KeyPair{keyPair})
 	return sshAgent, err
 }
 
-func SshAgentWithKeyPairs(t TestingT, keyPairs []*KeyPair) *SshAgent {
+func SshAgentWithKeyPairs(t testing.TestingT, keyPairs []*KeyPair) *SshAgent {
 	sshAgent, err := SshAgentWithKeyPairsE(t, keyPairs)
 
 	if err != nil {
@@ -110,7 +110,7 @@ func SshAgentWithKeyPairs(t TestingT, keyPairs []*KeyPair) *SshAgent {
 
 // Instantiates and returns an in-memory ssh agent with the given KeyPair(s) already added
 // You should stop the agent to cleanup files afterwards by calling `defer sshAgent.Stop()`
-func SshAgentWithKeyPairsE(t TestingT, keyPairs []*KeyPair) (*SshAgent, error) {
+func SshAgentWithKeyPairsE(t testing.TestingT, keyPairs []*KeyPair) (*SshAgent, error) {
 	t.Log("Generating SSH Agent with given KeyPair(s)")
 
 	// Instantiate a temporary SSH agent

--- a/modules/ssh/agent.go
+++ b/modules/ssh/agent.go
@@ -8,8 +8,8 @@ import (
 	"net"
 	"os"
 	"path/filepath"
-	"testing"
 
+	_ "github.com/gruntwork-io/terratest/modules/testing"
 	"golang.org/x/crypto/ssh/agent"
 )
 
@@ -24,7 +24,7 @@ type SshAgent struct {
 
 // Create SSH agent, start it in background and returns control back to the main thread
 // You should stop the agent to cleanup files afterwards by calling `defer s.Stop()`
-func NewSshAgent(t *testing.T, socketDir string, socketFile string) (*SshAgent, error) {
+func NewSshAgent(t TestingT, socketDir string, socketFile string) (*SshAgent, error) {
 	var err error
 	s := &SshAgent{make(chan bool), make(chan bool), socketDir, socketFile, agent.NewKeyring(), nil}
 	s.ln, err = net.Listen("unix", s.socketFile)
@@ -41,7 +41,7 @@ func (s *SshAgent) SocketFile() string {
 }
 
 // SSH Agent listener and handler
-func (s *SshAgent) run(t *testing.T) {
+func (s *SshAgent) run(t TestingT) {
 	defer close(s.stopped)
 	for {
 		select {
@@ -83,7 +83,7 @@ func (s *SshAgent) Stop() {
 
 // Instantiates and returns an in-memory ssh agent with the given KeyPair already added
 // You should stop the agent to cleanup files afterwards by calling `defer sshAgent.Stop()`
-func SshAgentWithKeyPair(t *testing.T, keyPair *KeyPair) *SshAgent {
+func SshAgentWithKeyPair(t TestingT, keyPair *KeyPair) *SshAgent {
 	sshAgent, err := SshAgentWithKeyPairE(t, keyPair)
 
 	if err != nil {
@@ -93,12 +93,12 @@ func SshAgentWithKeyPair(t *testing.T, keyPair *KeyPair) *SshAgent {
 	return sshAgent
 }
 
-func SshAgentWithKeyPairE(t *testing.T, keyPair *KeyPair) (*SshAgent, error) {
+func SshAgentWithKeyPairE(t TestingT, keyPair *KeyPair) (*SshAgent, error) {
 	sshAgent, err := SshAgentWithKeyPairsE(t, []*KeyPair{keyPair})
 	return sshAgent, err
 }
 
-func SshAgentWithKeyPairs(t *testing.T, keyPairs []*KeyPair) *SshAgent {
+func SshAgentWithKeyPairs(t TestingT, keyPairs []*KeyPair) *SshAgent {
 	sshAgent, err := SshAgentWithKeyPairsE(t, keyPairs)
 
 	if err != nil {
@@ -110,7 +110,7 @@ func SshAgentWithKeyPairs(t *testing.T, keyPairs []*KeyPair) *SshAgent {
 
 // Instantiates and returns an in-memory ssh agent with the given KeyPair(s) already added
 // You should stop the agent to cleanup files afterwards by calling `defer sshAgent.Stop()`
-func SshAgentWithKeyPairsE(t *testing.T, keyPairs []*KeyPair) (*SshAgent, error) {
+func SshAgentWithKeyPairsE(t TestingT, keyPairs []*KeyPair) (*SshAgent, error) {
 	t.Log("Generating SSH Agent with given KeyPair(s)")
 
 	// Instantiate a temporary SSH agent

--- a/modules/ssh/key_pair.go
+++ b/modules/ssh/key_pair.go
@@ -5,10 +5,9 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
-	"testing"
 
 	"github.com/gruntwork-io/terratest/modules/logger"
-	_ "github.com/gruntwork-io/terratest/modules/testing"
+	"github.com/gruntwork-io/terratest/modules/testing"
 	"golang.org/x/crypto/ssh"
 )
 
@@ -19,7 +18,7 @@ type KeyPair struct {
 }
 
 // GenerateRSAKeyPair generates an RSA Keypair and return the public and private keys.
-func GenerateRSAKeyPair(t TestingT, keySize int) *KeyPair {
+func GenerateRSAKeyPair(t testing.TestingT, keySize int) *KeyPair {
 	keyPair, err := GenerateRSAKeyPairE(t, keySize)
 	if err != nil {
 		t.Fatal(err)
@@ -28,7 +27,7 @@ func GenerateRSAKeyPair(t TestingT, keySize int) *KeyPair {
 }
 
 // GenerateRSAKeyPairE generates an RSA Keypair and return the public and private keys.
-func GenerateRSAKeyPairE(t TestingT, keySize int) (*KeyPair, error) {
+func GenerateRSAKeyPairE(t testing.TestingT, keySize int) (*KeyPair, error) {
 	logger.Logf(t, "Generating new public/private key of size %d", keySize)
 
 	rsaKeyPair, err := rsa.GenerateKey(rand.Reader, keySize)

--- a/modules/ssh/key_pair.go
+++ b/modules/ssh/key_pair.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/gruntwork-io/terratest/modules/logger"
+	_ "github.com/gruntwork-io/terratest/modules/testing"
 	"golang.org/x/crypto/ssh"
 )
 
@@ -18,7 +19,7 @@ type KeyPair struct {
 }
 
 // GenerateRSAKeyPair generates an RSA Keypair and return the public and private keys.
-func GenerateRSAKeyPair(t *testing.T, keySize int) *KeyPair {
+func GenerateRSAKeyPair(t TestingT, keySize int) *KeyPair {
 	keyPair, err := GenerateRSAKeyPairE(t, keySize)
 	if err != nil {
 		t.Fatal(err)
@@ -27,7 +28,7 @@ func GenerateRSAKeyPair(t *testing.T, keySize int) *KeyPair {
 }
 
 // GenerateRSAKeyPairE generates an RSA Keypair and return the public and private keys.
-func GenerateRSAKeyPairE(t *testing.T, keySize int) (*KeyPair, error) {
+func GenerateRSAKeyPairE(t TestingT, keySize int) (*KeyPair, error) {
 	logger.Logf(t, "Generating new public/private key of size %d", keySize)
 
 	rsaKeyPair, err := rsa.GenerateKey(rand.Reader, keySize)

--- a/modules/ssh/session.go
+++ b/modules/ssh/session.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/gruntwork-io/terratest/modules/collections"
 	"github.com/gruntwork-io/terratest/modules/logger"
+	_ "github.com/gruntwork-io/terratest/modules/testing"
 	"golang.org/x/crypto/ssh"
 )
 
@@ -39,7 +40,7 @@ type SshSession struct {
 }
 
 // Cleanup cleans up an existing SSH session.
-func (sshSession *SshSession) Cleanup(t *testing.T) {
+func (sshSession *SshSession) Cleanup(t TestingT) {
 	if sshSession == nil {
 		return
 	}
@@ -59,7 +60,7 @@ type JumpHostSession struct {
 }
 
 // Cleanup cleans the jump host session up.
-func (jumpHost *JumpHostSession) Cleanup(t *testing.T) {
+func (jumpHost *JumpHostSession) Cleanup(t TestingT) {
 	if jumpHost == nil {
 		return
 	}
@@ -77,7 +78,7 @@ type Closeable interface {
 }
 
 // Close closes a Closeable.
-func Close(t *testing.T, closeable Closeable, ignoreErrors ...string) {
+func Close(t TestingT, closeable Closeable, ignoreErrors ...string) {
 	if interfaceIsNil(closeable) {
 		return
 	}

--- a/modules/ssh/session.go
+++ b/modules/ssh/session.go
@@ -5,11 +5,10 @@ import (
 	"io"
 	"net"
 	"reflect"
-	"testing"
 
 	"github.com/gruntwork-io/terratest/modules/collections"
 	"github.com/gruntwork-io/terratest/modules/logger"
-	_ "github.com/gruntwork-io/terratest/modules/testing"
+	"github.com/gruntwork-io/terratest/modules/testing"
 	"golang.org/x/crypto/ssh"
 )
 
@@ -40,7 +39,7 @@ type SshSession struct {
 }
 
 // Cleanup cleans up an existing SSH session.
-func (sshSession *SshSession) Cleanup(t TestingT) {
+func (sshSession *SshSession) Cleanup(t testing.TestingT) {
 	if sshSession == nil {
 		return
 	}
@@ -60,7 +59,7 @@ type JumpHostSession struct {
 }
 
 // Cleanup cleans the jump host session up.
-func (jumpHost *JumpHostSession) Cleanup(t TestingT) {
+func (jumpHost *JumpHostSession) Cleanup(t testing.TestingT) {
 	if jumpHost == nil {
 		return
 	}
@@ -78,7 +77,7 @@ type Closeable interface {
 }
 
 // Close closes a Closeable.
-func Close(t TestingT, closeable Closeable, ignoreErrors ...string) {
+func Close(t testing.TestingT, closeable Closeable, ignoreErrors ...string) {
 	if interfaceIsNil(closeable) {
 		return
 	}

--- a/modules/ssh/ssh.go
+++ b/modules/ssh/ssh.go
@@ -15,7 +15,7 @@ import (
 	"github.com/gruntwork-io/terratest/modules/customerrors"
 	"github.com/gruntwork-io/terratest/modules/files"
 	"github.com/gruntwork-io/terratest/modules/logger"
-	_ "github.com/gruntwork-io/terratest/modules/testing"
+	"github.com/gruntwork-io/terratest/modules/testing"
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/agent"
 )
@@ -42,7 +42,7 @@ type ScpDownloadOptions struct {
 }
 
 // ScpFileToE uploads the contents using SCP to the given host and fails the test if the connection fails.
-func ScpFileTo(t TestingT, host Host, mode os.FileMode, remotePath, contents string) {
+func ScpFileTo(t testing.TestingT, host Host, mode os.FileMode, remotePath, contents string) {
 	err := ScpFileToE(t, host, mode, remotePath, contents)
 	if err != nil {
 		t.Fatal(err)
@@ -50,7 +50,7 @@ func ScpFileTo(t TestingT, host Host, mode os.FileMode, remotePath, contents str
 }
 
 // ScpFileToE uploads the contents using SCP to the given host and return an error if the process fails.
-func ScpFileToE(t TestingT, host Host, mode os.FileMode, remotePath, contents string) error {
+func ScpFileToE(t testing.TestingT, host Host, mode os.FileMode, remotePath, contents string) error {
 	authMethods, err := createAuthMethodsForHost(host)
 	if err != nil {
 		return err
@@ -80,7 +80,7 @@ func ScpFileToE(t TestingT, host Host, mode os.FileMode, remotePath, contents st
 }
 
 // ScpFileFrom downloads the file from remotePath on the given host using SCP.
-func ScpFileFrom(t TestingT, host Host, remotePath string, localDestination *os.File, useSudo bool) {
+func ScpFileFrom(t testing.TestingT, host Host, remotePath string, localDestination *os.File, useSudo bool) {
 	err := ScpFileFromE(t, host, remotePath, localDestination, useSudo)
 
 	if err != nil {
@@ -89,7 +89,7 @@ func ScpFileFrom(t TestingT, host Host, remotePath string, localDestination *os.
 }
 
 // ScpFileFromE downloads the file from remotePath on the given host using SCP and returns an error if the process fails.
-func ScpFileFromE(t TestingT, host Host, remotePath string, localDestination *os.File, useSudo bool) error {
+func ScpFileFromE(t testing.TestingT, host Host, remotePath string, localDestination *os.File, useSudo bool) error {
 	authMethods, err := createAuthMethodsForHost(host)
 
 	if err != nil {
@@ -117,7 +117,7 @@ func ScpFileFromE(t TestingT, host Host, remotePath string, localDestination *os
 }
 
 // ScpDirFrom downloads all the files from remotePath on the given host using SCP.
-func ScpDirFrom(t TestingT, options ScpDownloadOptions, useSudo bool) {
+func ScpDirFrom(t testing.TestingT, options ScpDownloadOptions, useSudo bool) {
 	err := ScpDirFromE(t, options, useSudo)
 
 	if err != nil {
@@ -129,7 +129,7 @@ func ScpDirFrom(t TestingT, options ScpDownloadOptions, useSudo bool) {
 // and returns an error if the process fails. NOTE: only files within remotePath will
 // be downloaded. This function will not recursively download subdirectories or follow
 // symlinks.
-func ScpDirFromE(t TestingT, options ScpDownloadOptions, useSudo bool) error {
+func ScpDirFromE(t testing.TestingT, options ScpDownloadOptions, useSudo bool) error {
 	authMethods, err := createAuthMethodsForHost(options.RemoteHost)
 	if err != nil {
 		return err
@@ -186,7 +186,7 @@ func ScpDirFromE(t TestingT, options ScpDownloadOptions, useSudo bool) error {
 }
 
 // CheckSshConnection checks that you can connect via SSH to the given host and fail the test if the connection fails.
-func CheckSshConnection(t TestingT, host Host) {
+func CheckSshConnection(t testing.TestingT, host Host) {
 	err := CheckSshConnectionE(t, host)
 	if err != nil {
 		t.Fatal(err)
@@ -194,13 +194,13 @@ func CheckSshConnection(t TestingT, host Host) {
 }
 
 // CheckSshConnectionE checks that you can connect via SSH to the given host and return an error if the connection fails.
-func CheckSshConnectionE(t TestingT, host Host) error {
+func CheckSshConnectionE(t testing.TestingT, host Host) error {
 	_, err := CheckSshCommandE(t, host, "'exit'")
 	return err
 }
 
 // CheckSshCommand checks that you can connect via SSH to the given host and run the given command. Returns the stdout/stderr.
-func CheckSshCommand(t TestingT, host Host, command string) string {
+func CheckSshCommand(t testing.TestingT, host Host, command string) string {
 	out, err := CheckSshCommandE(t, host, command)
 	if err != nil {
 		t.Fatal(err)
@@ -209,7 +209,7 @@ func CheckSshCommand(t TestingT, host Host, command string) string {
 }
 
 // CheckSshCommandE checks that you can connect via SSH to the given host and run the given command. Returns the stdout/stderr.
-func CheckSshCommandE(t TestingT, host Host, command string) (string, error) {
+func CheckSshCommandE(t testing.TestingT, host Host, command string) (string, error) {
 	authMethods, err := createAuthMethodsForHost(host)
 	if err != nil {
 		return "", err
@@ -236,7 +236,7 @@ func CheckSshCommandE(t TestingT, host Host, command string) (string, error) {
 // CheckPrivateSshConnection attempts to connect to privateHost (which is not addressable from the Internet) via a
 // separate publicHost (which is addressable from the Internet) and then executes "command" on privateHost and returns
 // its output. It is useful for checking that it's possible to SSH from a Bastion Host to a private instance.
-func CheckPrivateSshConnection(t TestingT, publicHost Host, privateHost Host, command string) string {
+func CheckPrivateSshConnection(t testing.TestingT, publicHost Host, privateHost Host, command string) string {
 	out, err := CheckPrivateSshConnectionE(t, publicHost, privateHost, command)
 	if err != nil {
 		t.Fatal(err)
@@ -247,7 +247,7 @@ func CheckPrivateSshConnection(t TestingT, publicHost Host, privateHost Host, co
 // CheckPrivateSshConnectionE attempts to connect to privateHost (which is not addressable from the Internet) via a
 // separate publicHost (which is addressable from the Internet) and then executes "command" on privateHost and returns
 // its output. It is useful for checking that it's possible to SSH from a Bastion Host to a private instance.
-func CheckPrivateSshConnectionE(t TestingT, publicHost Host, privateHost Host, command string) (string, error) {
+func CheckPrivateSshConnectionE(t testing.TestingT, publicHost Host, privateHost Host, command string) (string, error) {
 	jumpHostAuthMethods, err := createAuthMethodsForHost(publicHost)
 	if err != nil {
 		return "", err
@@ -287,7 +287,7 @@ func CheckPrivateSshConnectionE(t TestingT, publicHost Host, privateHost Host, c
 // FetchContentsOfFiles connects to the given host via SSH and fetches the contents of the files at the given filePaths.
 // If useSudo is true, then the contents will be retrieved using sudo. This method returns a map from file path to
 // contents.
-func FetchContentsOfFiles(t TestingT, host Host, useSudo bool, filePaths ...string) map[string]string {
+func FetchContentsOfFiles(t testing.TestingT, host Host, useSudo bool, filePaths ...string) map[string]string {
 	out, err := FetchContentsOfFilesE(t, host, useSudo, filePaths...)
 	if err != nil {
 		t.Fatal(err)
@@ -298,7 +298,7 @@ func FetchContentsOfFiles(t TestingT, host Host, useSudo bool, filePaths ...stri
 // FetchContentsOfFilesE connects to the given host via SSH and fetches the contents of the files at the given filePaths.
 // If useSudo is true, then the contents will be retrieved using sudo. This method returns a map from file path to
 // contents.
-func FetchContentsOfFilesE(t TestingT, host Host, useSudo bool, filePaths ...string) (map[string]string, error) {
+func FetchContentsOfFilesE(t testing.TestingT, host Host, useSudo bool, filePaths ...string) (map[string]string, error) {
 	filePathToContents := map[string]string{}
 
 	for _, filePath := range filePaths {
@@ -315,7 +315,7 @@ func FetchContentsOfFilesE(t TestingT, host Host, useSudo bool, filePaths ...str
 
 // FetchContentsOfFile connects to the given host via SSH and fetches the contents of the file at the given filePath.
 // If useSudo is true, then the contents will be retrieved using sudo. This method returns the contents of that file.
-func FetchContentsOfFile(t TestingT, host Host, useSudo bool, filePath string) string {
+func FetchContentsOfFile(t testing.TestingT, host Host, useSudo bool, filePath string) string {
 	out, err := FetchContentsOfFileE(t, host, useSudo, filePath)
 	if err != nil {
 		t.Fatal(err)
@@ -325,7 +325,7 @@ func FetchContentsOfFile(t TestingT, host Host, useSudo bool, filePath string) s
 
 // FetchContentsOfFileE connects to the given host via SSH and fetches the contents of the file at the given filePath.
 // If useSudo is true, then the contents will be retrieved using sudo. This method returns the contents of that file.
-func FetchContentsOfFileE(t TestingT, host Host, useSudo bool, filePath string) (string, error) {
+func FetchContentsOfFileE(t testing.TestingT, host Host, useSudo bool, filePath string) (string, error) {
 	command := fmt.Sprintf("cat %s", filePath)
 	if useSudo {
 		command = fmt.Sprintf("sudo %s", command)
@@ -334,7 +334,7 @@ func FetchContentsOfFileE(t TestingT, host Host, useSudo bool, filePath string) 
 	return CheckSshCommandE(t, host, command)
 }
 
-func listFileInRemoteDir(t TestingT, sshSession *SshSession, options ScpDownloadOptions, useSudo bool) ([]string, error) {
+func listFileInRemoteDir(t testing.TestingT, sshSession *SshSession, options ScpDownloadOptions, useSudo bool) ([]string, error) {
 	logger.Logf(t, "Running command %s on %s@%s", sshSession.Options.Command, sshSession.Options.Username, sshSession.Options.Address)
 
 	var result []string
@@ -386,7 +386,7 @@ func listFileInRemoteDir(t TestingT, sshSession *SshSession, options ScpDownload
 }
 
 // Added based on code: https://github.com/bramvdbogaerde/go-scp/pull/6/files
-func copyFileFromRemote(t TestingT, sshSession *SshSession, file *os.File, remotePath string, useSudo bool) error {
+func copyFileFromRemote(t testing.TestingT, sshSession *SshSession, file *os.File, remotePath string, useSudo bool) error {
 	logger.Logf(t, "Running command %s on %s@%s", sshSession.Options.Command, sshSession.Options.Username, sshSession.Options.Address)
 	if err := setUpSSHClient(sshSession); err != nil {
 		return err
@@ -412,7 +412,7 @@ func copyFileFromRemote(t TestingT, sshSession *SshSession, file *os.File, remot
 	return err
 }
 
-func runSSHCommand(t TestingT, sshSession *SshSession) (string, error) {
+func runSSHCommand(t testing.TestingT, sshSession *SshSession) (string, error) {
 	logger.Logf(t, "Running command %s on %s@%s", sshSession.Options.Command, sshSession.Options.Username, sshSession.Options.Address)
 	if err := setUpSSHClient(sshSession); err != nil {
 		return "", err

--- a/modules/ssh/ssh.go
+++ b/modules/ssh/ssh.go
@@ -10,12 +10,12 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
-	"testing"
 	"time"
 
 	"github.com/gruntwork-io/terratest/modules/customerrors"
 	"github.com/gruntwork-io/terratest/modules/files"
 	"github.com/gruntwork-io/terratest/modules/logger"
+	_ "github.com/gruntwork-io/terratest/modules/testing"
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/agent"
 )
@@ -42,7 +42,7 @@ type ScpDownloadOptions struct {
 }
 
 // ScpFileToE uploads the contents using SCP to the given host and fails the test if the connection fails.
-func ScpFileTo(t *testing.T, host Host, mode os.FileMode, remotePath, contents string) {
+func ScpFileTo(t TestingT, host Host, mode os.FileMode, remotePath, contents string) {
 	err := ScpFileToE(t, host, mode, remotePath, contents)
 	if err != nil {
 		t.Fatal(err)
@@ -50,7 +50,7 @@ func ScpFileTo(t *testing.T, host Host, mode os.FileMode, remotePath, contents s
 }
 
 // ScpFileToE uploads the contents using SCP to the given host and return an error if the process fails.
-func ScpFileToE(t *testing.T, host Host, mode os.FileMode, remotePath, contents string) error {
+func ScpFileToE(t TestingT, host Host, mode os.FileMode, remotePath, contents string) error {
 	authMethods, err := createAuthMethodsForHost(host)
 	if err != nil {
 		return err
@@ -80,7 +80,7 @@ func ScpFileToE(t *testing.T, host Host, mode os.FileMode, remotePath, contents 
 }
 
 // ScpFileFrom downloads the file from remotePath on the given host using SCP.
-func ScpFileFrom(t *testing.T, host Host, remotePath string, localDestination *os.File, useSudo bool) {
+func ScpFileFrom(t TestingT, host Host, remotePath string, localDestination *os.File, useSudo bool) {
 	err := ScpFileFromE(t, host, remotePath, localDestination, useSudo)
 
 	if err != nil {
@@ -89,7 +89,7 @@ func ScpFileFrom(t *testing.T, host Host, remotePath string, localDestination *o
 }
 
 // ScpFileFromE downloads the file from remotePath on the given host using SCP and returns an error if the process fails.
-func ScpFileFromE(t *testing.T, host Host, remotePath string, localDestination *os.File, useSudo bool) error {
+func ScpFileFromE(t TestingT, host Host, remotePath string, localDestination *os.File, useSudo bool) error {
 	authMethods, err := createAuthMethodsForHost(host)
 
 	if err != nil {
@@ -117,7 +117,7 @@ func ScpFileFromE(t *testing.T, host Host, remotePath string, localDestination *
 }
 
 // ScpDirFrom downloads all the files from remotePath on the given host using SCP.
-func ScpDirFrom(t *testing.T, options ScpDownloadOptions, useSudo bool) {
+func ScpDirFrom(t TestingT, options ScpDownloadOptions, useSudo bool) {
 	err := ScpDirFromE(t, options, useSudo)
 
 	if err != nil {
@@ -129,7 +129,7 @@ func ScpDirFrom(t *testing.T, options ScpDownloadOptions, useSudo bool) {
 // and returns an error if the process fails. NOTE: only files within remotePath will
 // be downloaded. This function will not recursively download subdirectories or follow
 // symlinks.
-func ScpDirFromE(t *testing.T, options ScpDownloadOptions, useSudo bool) error {
+func ScpDirFromE(t TestingT, options ScpDownloadOptions, useSudo bool) error {
 	authMethods, err := createAuthMethodsForHost(options.RemoteHost)
 	if err != nil {
 		return err
@@ -186,7 +186,7 @@ func ScpDirFromE(t *testing.T, options ScpDownloadOptions, useSudo bool) error {
 }
 
 // CheckSshConnection checks that you can connect via SSH to the given host and fail the test if the connection fails.
-func CheckSshConnection(t *testing.T, host Host) {
+func CheckSshConnection(t TestingT, host Host) {
 	err := CheckSshConnectionE(t, host)
 	if err != nil {
 		t.Fatal(err)
@@ -194,13 +194,13 @@ func CheckSshConnection(t *testing.T, host Host) {
 }
 
 // CheckSshConnectionE checks that you can connect via SSH to the given host and return an error if the connection fails.
-func CheckSshConnectionE(t *testing.T, host Host) error {
+func CheckSshConnectionE(t TestingT, host Host) error {
 	_, err := CheckSshCommandE(t, host, "'exit'")
 	return err
 }
 
 // CheckSshCommand checks that you can connect via SSH to the given host and run the given command. Returns the stdout/stderr.
-func CheckSshCommand(t *testing.T, host Host, command string) string {
+func CheckSshCommand(t TestingT, host Host, command string) string {
 	out, err := CheckSshCommandE(t, host, command)
 	if err != nil {
 		t.Fatal(err)
@@ -209,7 +209,7 @@ func CheckSshCommand(t *testing.T, host Host, command string) string {
 }
 
 // CheckSshCommandE checks that you can connect via SSH to the given host and run the given command. Returns the stdout/stderr.
-func CheckSshCommandE(t *testing.T, host Host, command string) (string, error) {
+func CheckSshCommandE(t TestingT, host Host, command string) (string, error) {
 	authMethods, err := createAuthMethodsForHost(host)
 	if err != nil {
 		return "", err
@@ -236,7 +236,7 @@ func CheckSshCommandE(t *testing.T, host Host, command string) (string, error) {
 // CheckPrivateSshConnection attempts to connect to privateHost (which is not addressable from the Internet) via a
 // separate publicHost (which is addressable from the Internet) and then executes "command" on privateHost and returns
 // its output. It is useful for checking that it's possible to SSH from a Bastion Host to a private instance.
-func CheckPrivateSshConnection(t *testing.T, publicHost Host, privateHost Host, command string) string {
+func CheckPrivateSshConnection(t TestingT, publicHost Host, privateHost Host, command string) string {
 	out, err := CheckPrivateSshConnectionE(t, publicHost, privateHost, command)
 	if err != nil {
 		t.Fatal(err)
@@ -247,7 +247,7 @@ func CheckPrivateSshConnection(t *testing.T, publicHost Host, privateHost Host, 
 // CheckPrivateSshConnectionE attempts to connect to privateHost (which is not addressable from the Internet) via a
 // separate publicHost (which is addressable from the Internet) and then executes "command" on privateHost and returns
 // its output. It is useful for checking that it's possible to SSH from a Bastion Host to a private instance.
-func CheckPrivateSshConnectionE(t *testing.T, publicHost Host, privateHost Host, command string) (string, error) {
+func CheckPrivateSshConnectionE(t TestingT, publicHost Host, privateHost Host, command string) (string, error) {
 	jumpHostAuthMethods, err := createAuthMethodsForHost(publicHost)
 	if err != nil {
 		return "", err
@@ -287,7 +287,7 @@ func CheckPrivateSshConnectionE(t *testing.T, publicHost Host, privateHost Host,
 // FetchContentsOfFiles connects to the given host via SSH and fetches the contents of the files at the given filePaths.
 // If useSudo is true, then the contents will be retrieved using sudo. This method returns a map from file path to
 // contents.
-func FetchContentsOfFiles(t *testing.T, host Host, useSudo bool, filePaths ...string) map[string]string {
+func FetchContentsOfFiles(t TestingT, host Host, useSudo bool, filePaths ...string) map[string]string {
 	out, err := FetchContentsOfFilesE(t, host, useSudo, filePaths...)
 	if err != nil {
 		t.Fatal(err)
@@ -298,7 +298,7 @@ func FetchContentsOfFiles(t *testing.T, host Host, useSudo bool, filePaths ...st
 // FetchContentsOfFilesE connects to the given host via SSH and fetches the contents of the files at the given filePaths.
 // If useSudo is true, then the contents will be retrieved using sudo. This method returns a map from file path to
 // contents.
-func FetchContentsOfFilesE(t *testing.T, host Host, useSudo bool, filePaths ...string) (map[string]string, error) {
+func FetchContentsOfFilesE(t TestingT, host Host, useSudo bool, filePaths ...string) (map[string]string, error) {
 	filePathToContents := map[string]string{}
 
 	for _, filePath := range filePaths {
@@ -315,7 +315,7 @@ func FetchContentsOfFilesE(t *testing.T, host Host, useSudo bool, filePaths ...s
 
 // FetchContentsOfFile connects to the given host via SSH and fetches the contents of the file at the given filePath.
 // If useSudo is true, then the contents will be retrieved using sudo. This method returns the contents of that file.
-func FetchContentsOfFile(t *testing.T, host Host, useSudo bool, filePath string) string {
+func FetchContentsOfFile(t TestingT, host Host, useSudo bool, filePath string) string {
 	out, err := FetchContentsOfFileE(t, host, useSudo, filePath)
 	if err != nil {
 		t.Fatal(err)
@@ -325,7 +325,7 @@ func FetchContentsOfFile(t *testing.T, host Host, useSudo bool, filePath string)
 
 // FetchContentsOfFileE connects to the given host via SSH and fetches the contents of the file at the given filePath.
 // If useSudo is true, then the contents will be retrieved using sudo. This method returns the contents of that file.
-func FetchContentsOfFileE(t *testing.T, host Host, useSudo bool, filePath string) (string, error) {
+func FetchContentsOfFileE(t TestingT, host Host, useSudo bool, filePath string) (string, error) {
 	command := fmt.Sprintf("cat %s", filePath)
 	if useSudo {
 		command = fmt.Sprintf("sudo %s", command)
@@ -334,7 +334,7 @@ func FetchContentsOfFileE(t *testing.T, host Host, useSudo bool, filePath string
 	return CheckSshCommandE(t, host, command)
 }
 
-func listFileInRemoteDir(t *testing.T, sshSession *SshSession, options ScpDownloadOptions, useSudo bool) ([]string, error) {
+func listFileInRemoteDir(t TestingT, sshSession *SshSession, options ScpDownloadOptions, useSudo bool) ([]string, error) {
 	logger.Logf(t, "Running command %s on %s@%s", sshSession.Options.Command, sshSession.Options.Username, sshSession.Options.Address)
 
 	var result []string
@@ -386,7 +386,7 @@ func listFileInRemoteDir(t *testing.T, sshSession *SshSession, options ScpDownlo
 }
 
 // Added based on code: https://github.com/bramvdbogaerde/go-scp/pull/6/files
-func copyFileFromRemote(t *testing.T, sshSession *SshSession, file *os.File, remotePath string, useSudo bool) error {
+func copyFileFromRemote(t TestingT, sshSession *SshSession, file *os.File, remotePath string, useSudo bool) error {
 	logger.Logf(t, "Running command %s on %s@%s", sshSession.Options.Command, sshSession.Options.Username, sshSession.Options.Address)
 	if err := setUpSSHClient(sshSession); err != nil {
 		return err
@@ -412,7 +412,7 @@ func copyFileFromRemote(t *testing.T, sshSession *SshSession, file *os.File, rem
 	return err
 }
 
-func runSSHCommand(t *testing.T, sshSession *SshSession) (string, error) {
+func runSSHCommand(t TestingT, sshSession *SshSession) (string, error) {
 	logger.Logf(t, "Running command %s on %s@%s", sshSession.Options.Command, sshSession.Options.Username, sshSession.Options.Address)
 	if err := setUpSSHClient(sshSession); err != nil {
 		return "", err

--- a/modules/terraform/apply.go
+++ b/modules/terraform/apply.go
@@ -1,14 +1,14 @@
 package terraform
 
 import (
-	_ "github.com/gruntwork-io/terratest/modules/testing"
+	"github.com/gruntwork-io/terratest/modules/testing"
 	"github.com/stretchr/testify/require"
 )
 
 // InitAndApply runs terraform init and apply with the given options and return stdout/stderr from the apply command. Note that this
 // method does NOT call destroy and assumes the caller is responsible for cleaning up any resources created by running
 // apply.
-func InitAndApply(t TestingT, options *Options) string {
+func InitAndApply(t testing.TestingT, options *Options) string {
 	out, err := InitAndApplyE(t, options)
 	require.NoError(t, err)
 	return out
@@ -17,7 +17,7 @@ func InitAndApply(t TestingT, options *Options) string {
 // InitAndApplyE runs terraform init and apply with the given options and return stdout/stderr from the apply command. Note that this
 // method does NOT call destroy and assumes the caller is responsible for cleaning up any resources created by running
 // apply.
-func InitAndApplyE(t TestingT, options *Options) (string, error) {
+func InitAndApplyE(t testing.TestingT, options *Options) (string, error) {
 	if _, err := InitE(t, options); err != nil {
 		return "", err
 	}
@@ -31,7 +31,7 @@ func InitAndApplyE(t TestingT, options *Options) (string, error) {
 
 // Apply runs terraform apply with the given options and return stdout/stderr. Note that this method does NOT call destroy and
 // assumes the caller is responsible for cleaning up any resources created by running apply.
-func Apply(t TestingT, options *Options) string {
+func Apply(t testing.TestingT, options *Options) string {
 	out, err := ApplyE(t, options)
 	require.NoError(t, err)
 	return out
@@ -39,7 +39,7 @@ func Apply(t TestingT, options *Options) string {
 
 // TgApplyAll runs terragrunt apply with the given options and return stdout/stderr. Note that this method does NOT call destroy and
 // assumes the caller is responsible for cleaning up any resources created by running apply.
-func TgApplyAll(t TestingT, options *Options) string {
+func TgApplyAll(t testing.TestingT, options *Options) string {
 	out, err := TgApplyAllE(t, options)
 	require.NoError(t, err)
 	return out
@@ -47,13 +47,13 @@ func TgApplyAll(t TestingT, options *Options) string {
 
 // ApplyE runs terraform apply with the given options and return stdout/stderr. Note that this method does NOT call destroy and
 // assumes the caller is responsible for cleaning up any resources created by running apply.
-func ApplyE(t TestingT, options *Options) (string, error) {
+func ApplyE(t testing.TestingT, options *Options) (string, error) {
 	return RunTerraformCommandE(t, options, FormatArgs(options, "apply", "-input=false", "-auto-approve")...)
 }
 
 // TgApplyAllE runs terragrunt apply-all with the given options and return stdout/stderr. Note that this method does NOT call destroy and
 // assumes the caller is responsible for cleaning up any resources created by running apply.
-func TgApplyAllE(t TestingT, options *Options) (string, error) {
+func TgApplyAllE(t testing.TestingT, options *Options) (string, error) {
 	if options.TerraformBinary != "terragrunt" {
 		return "", TgInvalidBinary(options.TerraformBinary)
 	}

--- a/modules/terraform/apply.go
+++ b/modules/terraform/apply.go
@@ -1,15 +1,14 @@
 package terraform
 
 import (
-	"testing"
-
+	_ "github.com/gruntwork-io/terratest/modules/testing"
 	"github.com/stretchr/testify/require"
 )
 
 // InitAndApply runs terraform init and apply with the given options and return stdout/stderr from the apply command. Note that this
 // method does NOT call destroy and assumes the caller is responsible for cleaning up any resources created by running
 // apply.
-func InitAndApply(t *testing.T, options *Options) string {
+func InitAndApply(t TestingT, options *Options) string {
 	out, err := InitAndApplyE(t, options)
 	require.NoError(t, err)
 	return out
@@ -18,7 +17,7 @@ func InitAndApply(t *testing.T, options *Options) string {
 // InitAndApplyE runs terraform init and apply with the given options and return stdout/stderr from the apply command. Note that this
 // method does NOT call destroy and assumes the caller is responsible for cleaning up any resources created by running
 // apply.
-func InitAndApplyE(t *testing.T, options *Options) (string, error) {
+func InitAndApplyE(t TestingT, options *Options) (string, error) {
 	if _, err := InitE(t, options); err != nil {
 		return "", err
 	}
@@ -32,7 +31,7 @@ func InitAndApplyE(t *testing.T, options *Options) (string, error) {
 
 // Apply runs terraform apply with the given options and return stdout/stderr. Note that this method does NOT call destroy and
 // assumes the caller is responsible for cleaning up any resources created by running apply.
-func Apply(t *testing.T, options *Options) string {
+func Apply(t TestingT, options *Options) string {
 	out, err := ApplyE(t, options)
 	require.NoError(t, err)
 	return out
@@ -40,7 +39,7 @@ func Apply(t *testing.T, options *Options) string {
 
 // TgApplyAll runs terragrunt apply with the given options and return stdout/stderr. Note that this method does NOT call destroy and
 // assumes the caller is responsible for cleaning up any resources created by running apply.
-func TgApplyAll(t *testing.T, options *Options) string {
+func TgApplyAll(t TestingT, options *Options) string {
 	out, err := TgApplyAllE(t, options)
 	require.NoError(t, err)
 	return out
@@ -48,13 +47,13 @@ func TgApplyAll(t *testing.T, options *Options) string {
 
 // ApplyE runs terraform apply with the given options and return stdout/stderr. Note that this method does NOT call destroy and
 // assumes the caller is responsible for cleaning up any resources created by running apply.
-func ApplyE(t *testing.T, options *Options) (string, error) {
+func ApplyE(t TestingT, options *Options) (string, error) {
 	return RunTerraformCommandE(t, options, FormatArgs(options, "apply", "-input=false", "-auto-approve")...)
 }
 
 // TgApplyAllE runs terragrunt apply-all with the given options and return stdout/stderr. Note that this method does NOT call destroy and
 // assumes the caller is responsible for cleaning up any resources created by running apply.
-func TgApplyAllE(t *testing.T, options *Options) (string, error) {
+func TgApplyAllE(t TestingT, options *Options) (string, error) {
 	if options.TerraformBinary != "terragrunt" {
 		return "", TgInvalidBinary(options.TerraformBinary)
 	}

--- a/modules/terraform/cmd.go
+++ b/modules/terraform/cmd.go
@@ -2,12 +2,12 @@ package terraform
 
 import (
 	"fmt"
-	"testing"
 
 	"github.com/gruntwork-io/terratest/modules/collections"
 	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/retry"
 	"github.com/gruntwork-io/terratest/modules/shell"
+	_ "github.com/gruntwork-io/terratest/modules/testing"
 )
 
 // GetCommonOptions extracts commons terraform options
@@ -36,7 +36,7 @@ func GetCommonOptions(options *Options, args ...string) (*Options, []string) {
 }
 
 // RunTerraformCommand runs terraform with the given arguments and options and return stdout/stderr.
-func RunTerraformCommand(t *testing.T, additionalOptions *Options, args ...string) string {
+func RunTerraformCommand(t TestingT, additionalOptions *Options, args ...string) string {
 	out, err := RunTerraformCommandE(t, additionalOptions, args...)
 	if err != nil {
 		t.Fatal(err)
@@ -45,7 +45,7 @@ func RunTerraformCommand(t *testing.T, additionalOptions *Options, args ...strin
 }
 
 // RunTerraformCommandE runs terraform with the given arguments and options and return stdout/stderr.
-func RunTerraformCommandE(t *testing.T, additionalOptions *Options, additionalArgs ...string) (string, error) {
+func RunTerraformCommandE(t TestingT, additionalOptions *Options, additionalArgs ...string) (string, error) {
 	options, args := GetCommonOptions(additionalOptions, additionalArgs...)
 
 	cmd := shell.Command{
@@ -64,7 +64,7 @@ func RunTerraformCommandE(t *testing.T, additionalOptions *Options, additionalAr
 
 // RunTerraformCommandAndGetStdoutE runs terraform with the given arguments and options and returns solely its stdout
 // (but not stderr).
-func RunTerraformCommandAndGetStdoutE(t *testing.T, additionalOptions *Options, additionalArgs ...string) (string, error) {
+func RunTerraformCommandAndGetStdoutE(t TestingT, additionalOptions *Options, additionalArgs ...string) (string, error) {
 	options, args := GetCommonOptions(additionalOptions, additionalArgs...)
 
 	cmd := shell.Command{
@@ -81,7 +81,7 @@ func RunTerraformCommandAndGetStdoutE(t *testing.T, additionalOptions *Options, 
 }
 
 // GetExitCodeForTerraformCommand runs terraform with the given arguments and options and returns exit code
-func GetExitCodeForTerraformCommand(t *testing.T, additionalOptions *Options, args ...string) int {
+func GetExitCodeForTerraformCommand(t TestingT, additionalOptions *Options, args ...string) int {
 	exitCode, err := GetExitCodeForTerraformCommandE(t, additionalOptions, args...)
 	if err != nil {
 		t.Fatal(err)
@@ -90,7 +90,7 @@ func GetExitCodeForTerraformCommand(t *testing.T, additionalOptions *Options, ar
 }
 
 // GetExitCodeForTerraformCommandE runs terraform with the given arguments and options and returns exit code
-func GetExitCodeForTerraformCommandE(t *testing.T, additionalOptions *Options, additionalArgs ...string) (int, error) {
+func GetExitCodeForTerraformCommandE(t TestingT, additionalOptions *Options, additionalArgs ...string) (int, error) {
 	options, args := GetCommonOptions(additionalOptions, additionalArgs...)
 
 	logger.Logf(t, "Running %s with args %v", options.TerraformBinary, args)

--- a/modules/terraform/cmd.go
+++ b/modules/terraform/cmd.go
@@ -7,7 +7,7 @@ import (
 	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/retry"
 	"github.com/gruntwork-io/terratest/modules/shell"
-	_ "github.com/gruntwork-io/terratest/modules/testing"
+	"github.com/gruntwork-io/terratest/modules/testing"
 )
 
 // GetCommonOptions extracts commons terraform options
@@ -36,7 +36,7 @@ func GetCommonOptions(options *Options, args ...string) (*Options, []string) {
 }
 
 // RunTerraformCommand runs terraform with the given arguments and options and return stdout/stderr.
-func RunTerraformCommand(t TestingT, additionalOptions *Options, args ...string) string {
+func RunTerraformCommand(t testing.TestingT, additionalOptions *Options, args ...string) string {
 	out, err := RunTerraformCommandE(t, additionalOptions, args...)
 	if err != nil {
 		t.Fatal(err)
@@ -45,7 +45,7 @@ func RunTerraformCommand(t TestingT, additionalOptions *Options, args ...string)
 }
 
 // RunTerraformCommandE runs terraform with the given arguments and options and return stdout/stderr.
-func RunTerraformCommandE(t TestingT, additionalOptions *Options, additionalArgs ...string) (string, error) {
+func RunTerraformCommandE(t testing.TestingT, additionalOptions *Options, additionalArgs ...string) (string, error) {
 	options, args := GetCommonOptions(additionalOptions, additionalArgs...)
 
 	cmd := shell.Command{
@@ -64,7 +64,7 @@ func RunTerraformCommandE(t TestingT, additionalOptions *Options, additionalArgs
 
 // RunTerraformCommandAndGetStdoutE runs terraform with the given arguments and options and returns solely its stdout
 // (but not stderr).
-func RunTerraformCommandAndGetStdoutE(t TestingT, additionalOptions *Options, additionalArgs ...string) (string, error) {
+func RunTerraformCommandAndGetStdoutE(t testing.TestingT, additionalOptions *Options, additionalArgs ...string) (string, error) {
 	options, args := GetCommonOptions(additionalOptions, additionalArgs...)
 
 	cmd := shell.Command{
@@ -81,7 +81,7 @@ func RunTerraformCommandAndGetStdoutE(t TestingT, additionalOptions *Options, ad
 }
 
 // GetExitCodeForTerraformCommand runs terraform with the given arguments and options and returns exit code
-func GetExitCodeForTerraformCommand(t TestingT, additionalOptions *Options, args ...string) int {
+func GetExitCodeForTerraformCommand(t testing.TestingT, additionalOptions *Options, args ...string) int {
 	exitCode, err := GetExitCodeForTerraformCommandE(t, additionalOptions, args...)
 	if err != nil {
 		t.Fatal(err)
@@ -90,7 +90,7 @@ func GetExitCodeForTerraformCommand(t TestingT, additionalOptions *Options, args
 }
 
 // GetExitCodeForTerraformCommandE runs terraform with the given arguments and options and returns exit code
-func GetExitCodeForTerraformCommandE(t TestingT, additionalOptions *Options, additionalArgs ...string) (int, error) {
+func GetExitCodeForTerraformCommandE(t testing.TestingT, additionalOptions *Options, additionalArgs ...string) (int, error) {
 	options, args := GetCommonOptions(additionalOptions, additionalArgs...)
 
 	logger.Logf(t, "Running %s with args %v", options.TerraformBinary, args)

--- a/modules/terraform/count.go
+++ b/modules/terraform/count.go
@@ -5,7 +5,7 @@ import (
 	"regexp"
 	"strconv"
 
-	_ "github.com/gruntwork-io/terratest/modules/testing"
+	"github.com/gruntwork-io/terratest/modules/testing"
 	"github.com/stretchr/testify/require"
 )
 
@@ -28,14 +28,14 @@ const getResourceCountErrMessage = "Can't parse Terraform output"
 
 // GetResourceCount parses stdout/stderr of apply/plan/destroy commands and returns number of affected resources.
 // This will fail the test if given stdout/stderr isn't a valid output of apply/plan/destroy.
-func GetResourceCount(t TestingT, cmdout string) *ResourceCount {
+func GetResourceCount(t testing.TestingT, cmdout string) *ResourceCount {
 	cnt, err := GetResourceCountE(t, cmdout)
 	require.NoError(t, err)
 	return cnt
 }
 
 // GetResourceCountE parses stdout/stderr of apply/plan/destroy commands and returns number of affected resources.
-func GetResourceCountE(t TestingT, cmdout string) (*ResourceCount, error) {
+func GetResourceCountE(t testing.TestingT, cmdout string) (*ResourceCount, error) {
 	cnt := ResourceCount{}
 
 	terraformCommandPatterns := []struct {

--- a/modules/terraform/count.go
+++ b/modules/terraform/count.go
@@ -4,8 +4,8 @@ import (
 	"errors"
 	"regexp"
 	"strconv"
-	"testing"
 
+	_ "github.com/gruntwork-io/terratest/modules/testing"
 	"github.com/stretchr/testify/require"
 )
 
@@ -28,14 +28,14 @@ const getResourceCountErrMessage = "Can't parse Terraform output"
 
 // GetResourceCount parses stdout/stderr of apply/plan/destroy commands and returns number of affected resources.
 // This will fail the test if given stdout/stderr isn't a valid output of apply/plan/destroy.
-func GetResourceCount(t *testing.T, cmdout string) *ResourceCount {
+func GetResourceCount(t TestingT, cmdout string) *ResourceCount {
 	cnt, err := GetResourceCountE(t, cmdout)
 	require.NoError(t, err)
 	return cnt
 }
 
 // GetResourceCountE parses stdout/stderr of apply/plan/destroy commands and returns number of affected resources.
-func GetResourceCountE(t *testing.T, cmdout string) (*ResourceCount, error) {
+func GetResourceCountE(t TestingT, cmdout string) (*ResourceCount, error) {
 	cnt := ResourceCount{}
 
 	terraformCommandPatterns := []struct {

--- a/modules/terraform/count_test.go
+++ b/modules/terraform/count_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/gruntwork-io/terratest/modules/files"
+	ttesting "github.com/gruntwork-io/terratest/modules/testing"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -39,7 +40,7 @@ func TestGetResourceCountENoColor(t *testing.T) {
 func runTestGetResourceCountE(t *testing.T, noColor bool) {
 	testCases := []struct {
 		Name                                         string
-		tfFuncToRun                                  func(t *testing.T, options *Options) string
+		tfFuncToRun                                  func(t ttesting.TestingT, options *Options) string
 		cntValue                                     int
 		expectedAdd, expectedChange, expectedDestroy int
 	}{

--- a/modules/terraform/destroy.go
+++ b/modules/terraform/destroy.go
@@ -1,32 +1,31 @@
 package terraform
 
 import (
-	"testing"
-
+	_ "github.com/gruntwork-io/terratest/modules/testing"
 	"github.com/stretchr/testify/require"
 )
 
 // Destroy runs terraform destroy with the given options and return stdout/stderr.
-func Destroy(t *testing.T, options *Options) string {
+func Destroy(t TestingT, options *Options) string {
 	out, err := DestroyE(t, options)
 	require.NoError(t, err)
 	return out
 }
 
 // TgDestroyAll runs terragrunt destroy with the given options and return stdout.
-func TgDestroyAll(t *testing.T, options *Options) string {
+func TgDestroyAll(t TestingT, options *Options) string {
 	out, err := TgDestroyAllE(t, options)
 	require.NoError(t, err)
 	return out
 }
 
 // DestroyE runs terraform destroy with the given options and return stdout/stderr.
-func DestroyE(t *testing.T, options *Options) (string, error) {
+func DestroyE(t TestingT, options *Options) (string, error) {
 	return RunTerraformCommandE(t, options, FormatArgs(options, "destroy", "-auto-approve", "-input=false")...)
 }
 
 // TgDestroyAllE runs terragrunt destroy with the given options and return stdout.
-func TgDestroyAllE(t *testing.T, options *Options) (string, error) {
+func TgDestroyAllE(t TestingT, options *Options) (string, error) {
 	if options.TerraformBinary != "terragrunt" {
 		return "", TgInvalidBinary(options.TerraformBinary)
 	}

--- a/modules/terraform/destroy.go
+++ b/modules/terraform/destroy.go
@@ -1,31 +1,31 @@
 package terraform
 
 import (
-	_ "github.com/gruntwork-io/terratest/modules/testing"
+	"github.com/gruntwork-io/terratest/modules/testing"
 	"github.com/stretchr/testify/require"
 )
 
 // Destroy runs terraform destroy with the given options and return stdout/stderr.
-func Destroy(t TestingT, options *Options) string {
+func Destroy(t testing.TestingT, options *Options) string {
 	out, err := DestroyE(t, options)
 	require.NoError(t, err)
 	return out
 }
 
 // TgDestroyAll runs terragrunt destroy with the given options and return stdout.
-func TgDestroyAll(t TestingT, options *Options) string {
+func TgDestroyAll(t testing.TestingT, options *Options) string {
 	out, err := TgDestroyAllE(t, options)
 	require.NoError(t, err)
 	return out
 }
 
 // DestroyE runs terraform destroy with the given options and return stdout/stderr.
-func DestroyE(t TestingT, options *Options) (string, error) {
+func DestroyE(t testing.TestingT, options *Options) (string, error) {
 	return RunTerraformCommandE(t, options, FormatArgs(options, "destroy", "-auto-approve", "-input=false")...)
 }
 
 // TgDestroyAllE runs terragrunt destroy with the given options and return stdout.
-func TgDestroyAllE(t TestingT, options *Options) (string, error) {
+func TgDestroyAllE(t testing.TestingT, options *Options) (string, error) {
 	if options.TerraformBinary != "terragrunt" {
 		return "", TgInvalidBinary(options.TerraformBinary)
 	}

--- a/modules/terraform/get.go
+++ b/modules/terraform/get.go
@@ -1,11 +1,11 @@
 package terraform
 
 import (
-	_ "github.com/gruntwork-io/terratest/modules/testing"
+	"github.com/gruntwork-io/terratest/modules/testing"
 )
 
 // Get calls terraform get and return stdout/stderr.
-func Get(t TestingT, options *Options) string {
+func Get(t testing.TestingT, options *Options) string {
 	out, err := GetE(t, options)
 	if err != nil {
 		t.Fatal(err)
@@ -14,6 +14,6 @@ func Get(t TestingT, options *Options) string {
 }
 
 // GetE calls terraform get and return stdout/stderr.
-func GetE(t TestingT, options *Options) (string, error) {
+func GetE(t testing.TestingT, options *Options) (string, error) {
 	return RunTerraformCommandE(t, options, "get", "-update")
 }

--- a/modules/terraform/get.go
+++ b/modules/terraform/get.go
@@ -1,11 +1,11 @@
 package terraform
 
 import (
-	"testing"
+	_ "github.com/gruntwork-io/terratest/modules/testing"
 )
 
 // Get calls terraform get and return stdout/stderr.
-func Get(t *testing.T, options *Options) string {
+func Get(t TestingT, options *Options) string {
 	out, err := GetE(t, options)
 	if err != nil {
 		t.Fatal(err)
@@ -14,6 +14,6 @@ func Get(t *testing.T, options *Options) string {
 }
 
 // GetE calls terraform get and return stdout/stderr.
-func GetE(t *testing.T, options *Options) (string, error) {
+func GetE(t TestingT, options *Options) (string, error) {
 	return RunTerraformCommandE(t, options, "get", "-update")
 }

--- a/modules/terraform/init.go
+++ b/modules/terraform/init.go
@@ -2,6 +2,7 @@ package terraform
 
 import (
 	"fmt"
+
 	"github.com/gruntwork-io/terratest/modules/testing"
 )
 

--- a/modules/terraform/init.go
+++ b/modules/terraform/init.go
@@ -2,11 +2,11 @@ package terraform
 
 import (
 	"fmt"
-	"testing"
+	_ "github.com/gruntwork-io/terratest/modules/testing"
 )
 
 // Init calls terraform init and return stdout/stderr.
-func Init(t *testing.T, options *Options) string {
+func Init(t TestingT, options *Options) string {
 	out, err := InitE(t, options)
 	if err != nil {
 		t.Fatal(err)
@@ -15,7 +15,7 @@ func Init(t *testing.T, options *Options) string {
 }
 
 // InitE calls terraform init and return stdout/stderr.
-func InitE(t *testing.T, options *Options) (string, error) {
+func InitE(t TestingT, options *Options) (string, error) {
 	args := []string{"init", fmt.Sprintf("-upgrade=%t", options.Upgrade)}
 	args = append(args, FormatTerraformBackendConfigAsArgs(options.BackendConfig)...)
 	return RunTerraformCommandE(t, options, args...)

--- a/modules/terraform/init.go
+++ b/modules/terraform/init.go
@@ -2,11 +2,11 @@ package terraform
 
 import (
 	"fmt"
-	_ "github.com/gruntwork-io/terratest/modules/testing"
+	"github.com/gruntwork-io/terratest/modules/testing"
 )
 
 // Init calls terraform init and return stdout/stderr.
-func Init(t TestingT, options *Options) string {
+func Init(t testing.TestingT, options *Options) string {
 	out, err := InitE(t, options)
 	if err != nil {
 		t.Fatal(err)
@@ -15,7 +15,7 @@ func Init(t TestingT, options *Options) string {
 }
 
 // InitE calls terraform init and return stdout/stderr.
-func InitE(t TestingT, options *Options) (string, error) {
+func InitE(t testing.TestingT, options *Options) (string, error) {
 	args := []string{"init", fmt.Sprintf("-upgrade=%t", options.Upgrade)}
 	args = append(args, FormatTerraformBackendConfigAsArgs(options.BackendConfig)...)
 	return RunTerraformCommandE(t, options, args...)

--- a/modules/terraform/output.go
+++ b/modules/terraform/output.go
@@ -6,19 +6,19 @@ import (
 	"reflect"
 	"strings"
 
-	_ "github.com/gruntwork-io/terratest/modules/testing"
+	"github.com/gruntwork-io/terratest/modules/testing"
 	"github.com/stretchr/testify/require"
 )
 
 // Output calls terraform output for the given variable and return its value.
-func Output(t TestingT, options *Options, key string) string {
+func Output(t testing.TestingT, options *Options, key string) string {
 	out, err := OutputE(t, options, key)
 	require.NoError(t, err)
 	return out
 }
 
 // OutputE calls terraform output for the given variable and return its value.
-func OutputE(t TestingT, options *Options, key string) (string, error) {
+func OutputE(t testing.TestingT, options *Options, key string) (string, error) {
 	output, err := RunTerraformCommandAndGetStdoutE(t, options, "output", "-no-color", key)
 
 	if err != nil {
@@ -29,14 +29,14 @@ func OutputE(t TestingT, options *Options, key string) (string, error) {
 }
 
 // OutputRequired calls terraform output for the given variable and return its value. If the value is empty, fail the test.
-func OutputRequired(t TestingT, options *Options, key string) string {
+func OutputRequired(t testing.TestingT, options *Options, key string) string {
 	out, err := OutputRequiredE(t, options, key)
 	require.NoError(t, err)
 	return out
 }
 
 // OutputRequiredE calls terraform output for the given variable and return its value. If the value is empty, return an error.
-func OutputRequiredE(t TestingT, options *Options, key string) (string, error) {
+func OutputRequiredE(t testing.TestingT, options *Options, key string) (string, error) {
 	out, err := OutputE(t, options, key)
 
 	if err != nil {
@@ -51,7 +51,7 @@ func OutputRequiredE(t TestingT, options *Options, key string) (string, error) {
 
 // OutputList calls terraform output for the given variable and returns its value as a list.
 // If the output value is not a list type, then it fails the test.
-func OutputList(t TestingT, options *Options, key string) []string {
+func OutputList(t testing.TestingT, options *Options, key string) []string {
 	out, err := OutputListE(t, options, key)
 	require.NoError(t, err)
 	return out
@@ -59,7 +59,7 @@ func OutputList(t TestingT, options *Options, key string) []string {
 
 // OutputListE calls terraform output for the given variable and returns its value as a list.
 // If the output value is not a list type, then it returns an error.
-func OutputListE(t TestingT, options *Options, key string) ([]string, error) {
+func OutputListE(t testing.TestingT, options *Options, key string) ([]string, error) {
 	out, err := RunTerraformCommandAndGetStdoutE(t, options, "output", "-no-color", "-json", key)
 	if err != nil {
 		return nil, err
@@ -90,7 +90,7 @@ func parseListOutputTerraform(outputList []interface{}, key string) ([]string, e
 
 // OutputMap calls terraform output for the given variable and returns its value as a map.
 // If the output value is not a map type, then it fails the test.
-func OutputMap(t TestingT, options *Options, key string) map[string]string {
+func OutputMap(t testing.TestingT, options *Options, key string) map[string]string {
 	out, err := OutputMapE(t, options, key)
 	require.NoError(t, err)
 	return out
@@ -98,7 +98,7 @@ func OutputMap(t TestingT, options *Options, key string) map[string]string {
 
 // OutputMapE calls terraform output for the given variable and returns its value as a map.
 // If the output value is not a map type, then it returns an error.
-func OutputMapE(t TestingT, options *Options, key string) (map[string]string, error) {
+func OutputMapE(t testing.TestingT, options *Options, key string) (map[string]string, error) {
 	out, err := RunTerraformCommandAndGetStdoutE(t, options, "output", "-no-color", "-json", key)
 	if err != nil {
 		return nil, err
@@ -118,7 +118,7 @@ func OutputMapE(t TestingT, options *Options, key string) (map[string]string, er
 
 // OutputForKeys calls terraform output for the given key list and returns values as a map.
 // If keys not found in the output, fails the test
-func OutputForKeys(t TestingT, options *Options, keys []string) map[string]interface{} {
+func OutputForKeys(t testing.TestingT, options *Options, keys []string) map[string]interface{} {
 	out, err := OutputForKeysE(t, options, keys)
 	require.NoError(t, err)
 	return out
@@ -126,7 +126,7 @@ func OutputForKeys(t TestingT, options *Options, keys []string) map[string]inter
 
 // OutputForKeysE calls terraform output for the given key list and returns values as a map.
 // The returned values are of type interface{} and need to be type casted as necessary. Refer to output_test.go
-func OutputForKeysE(t TestingT, options *Options, keys []string) (map[string]interface{}, error) {
+func OutputForKeysE(t testing.TestingT, options *Options, keys []string) (map[string]interface{}, error) {
 	out, err := RunTerraformCommandAndGetStdoutE(t, options, "output", "-no-color", "-json")
 	if err != nil {
 		return nil, err
@@ -158,13 +158,13 @@ func OutputForKeysE(t TestingT, options *Options, keys []string) (map[string]int
 
 // OutputAll calls terraform output returns all values as a map.
 // If there is error fetching the output, fails the test
-func OutputAll(t TestingT, options *Options) map[string]interface{} {
+func OutputAll(t testing.TestingT, options *Options) map[string]interface{} {
 	out, err := OutputAllE(t, options)
 	require.NoError(t, err)
 	return out
 }
 
 // OutputAllE calls terraform and returns all the outputs as a map
-func OutputAllE(t TestingT, options *Options) (map[string]interface{}, error) {
+func OutputAllE(t testing.TestingT, options *Options) (map[string]interface{}, error) {
 	return OutputForKeysE(t, options, nil)
 }

--- a/modules/terraform/output.go
+++ b/modules/terraform/output.go
@@ -5,20 +5,20 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
-	"testing"
 
+	_ "github.com/gruntwork-io/terratest/modules/testing"
 	"github.com/stretchr/testify/require"
 )
 
 // Output calls terraform output for the given variable and return its value.
-func Output(t *testing.T, options *Options, key string) string {
+func Output(t TestingT, options *Options, key string) string {
 	out, err := OutputE(t, options, key)
 	require.NoError(t, err)
 	return out
 }
 
 // OutputE calls terraform output for the given variable and return its value.
-func OutputE(t *testing.T, options *Options, key string) (string, error) {
+func OutputE(t TestingT, options *Options, key string) (string, error) {
 	output, err := RunTerraformCommandAndGetStdoutE(t, options, "output", "-no-color", key)
 
 	if err != nil {
@@ -29,14 +29,14 @@ func OutputE(t *testing.T, options *Options, key string) (string, error) {
 }
 
 // OutputRequired calls terraform output for the given variable and return its value. If the value is empty, fail the test.
-func OutputRequired(t *testing.T, options *Options, key string) string {
+func OutputRequired(t TestingT, options *Options, key string) string {
 	out, err := OutputRequiredE(t, options, key)
 	require.NoError(t, err)
 	return out
 }
 
 // OutputRequiredE calls terraform output for the given variable and return its value. If the value is empty, return an error.
-func OutputRequiredE(t *testing.T, options *Options, key string) (string, error) {
+func OutputRequiredE(t TestingT, options *Options, key string) (string, error) {
 	out, err := OutputE(t, options, key)
 
 	if err != nil {
@@ -51,7 +51,7 @@ func OutputRequiredE(t *testing.T, options *Options, key string) (string, error)
 
 // OutputList calls terraform output for the given variable and returns its value as a list.
 // If the output value is not a list type, then it fails the test.
-func OutputList(t *testing.T, options *Options, key string) []string {
+func OutputList(t TestingT, options *Options, key string) []string {
 	out, err := OutputListE(t, options, key)
 	require.NoError(t, err)
 	return out
@@ -59,7 +59,7 @@ func OutputList(t *testing.T, options *Options, key string) []string {
 
 // OutputListE calls terraform output for the given variable and returns its value as a list.
 // If the output value is not a list type, then it returns an error.
-func OutputListE(t *testing.T, options *Options, key string) ([]string, error) {
+func OutputListE(t TestingT, options *Options, key string) ([]string, error) {
 	out, err := RunTerraformCommandAndGetStdoutE(t, options, "output", "-no-color", "-json", key)
 	if err != nil {
 		return nil, err
@@ -90,7 +90,7 @@ func parseListOutputTerraform(outputList []interface{}, key string) ([]string, e
 
 // OutputMap calls terraform output for the given variable and returns its value as a map.
 // If the output value is not a map type, then it fails the test.
-func OutputMap(t *testing.T, options *Options, key string) map[string]string {
+func OutputMap(t TestingT, options *Options, key string) map[string]string {
 	out, err := OutputMapE(t, options, key)
 	require.NoError(t, err)
 	return out
@@ -98,7 +98,7 @@ func OutputMap(t *testing.T, options *Options, key string) map[string]string {
 
 // OutputMapE calls terraform output for the given variable and returns its value as a map.
 // If the output value is not a map type, then it returns an error.
-func OutputMapE(t *testing.T, options *Options, key string) (map[string]string, error) {
+func OutputMapE(t TestingT, options *Options, key string) (map[string]string, error) {
 	out, err := RunTerraformCommandAndGetStdoutE(t, options, "output", "-no-color", "-json", key)
 	if err != nil {
 		return nil, err
@@ -118,7 +118,7 @@ func OutputMapE(t *testing.T, options *Options, key string) (map[string]string, 
 
 // OutputForKeys calls terraform output for the given key list and returns values as a map.
 // If keys not found in the output, fails the test
-func OutputForKeys(t *testing.T, options *Options, keys []string) map[string]interface{} {
+func OutputForKeys(t TestingT, options *Options, keys []string) map[string]interface{} {
 	out, err := OutputForKeysE(t, options, keys)
 	require.NoError(t, err)
 	return out
@@ -126,7 +126,7 @@ func OutputForKeys(t *testing.T, options *Options, keys []string) map[string]int
 
 // OutputForKeysE calls terraform output for the given key list and returns values as a map.
 // The returned values are of type interface{} and need to be type casted as necessary. Refer to output_test.go
-func OutputForKeysE(t *testing.T, options *Options, keys []string) (map[string]interface{}, error) {
+func OutputForKeysE(t TestingT, options *Options, keys []string) (map[string]interface{}, error) {
 	out, err := RunTerraformCommandAndGetStdoutE(t, options, "output", "-no-color", "-json")
 	if err != nil {
 		return nil, err
@@ -158,13 +158,13 @@ func OutputForKeysE(t *testing.T, options *Options, keys []string) (map[string]i
 
 // OutputAll calls terraform output returns all values as a map.
 // If there is error fetching the output, fails the test
-func OutputAll(t *testing.T, options *Options) map[string]interface{} {
+func OutputAll(t TestingT, options *Options) map[string]interface{} {
 	out, err := OutputAllE(t, options)
 	require.NoError(t, err)
 	return out
 }
 
 // OutputAllE calls terraform and returns all the outputs as a map
-func OutputAllE(t *testing.T, options *Options) (map[string]interface{}, error) {
+func OutputAllE(t TestingT, options *Options) (map[string]interface{}, error) {
 	return OutputForKeysE(t, options, nil)
 }

--- a/modules/terraform/plan.go
+++ b/modules/terraform/plan.go
@@ -3,20 +3,20 @@ package terraform
 import (
 	"fmt"
 
-	_ "github.com/gruntwork-io/terratest/modules/testing"
+	"github.com/gruntwork-io/terratest/modules/testing"
 	"github.com/stretchr/testify/require"
 )
 
 // InitAndPlan runs terraform init and plan with the given options and returns stdout/stderr from the plan command.
 // This will fail the test if there is an error in the command.
-func InitAndPlan(t TestingT, options *Options) string {
+func InitAndPlan(t testing.TestingT, options *Options) string {
 	out, err := InitAndPlanE(t, options)
 	require.NoError(t, err)
 	return out
 }
 
 // InitAndPlanE runs terraform init and plan with the given options and returns stdout/stderr from the plan command.
-func InitAndPlanE(t TestingT, options *Options) (string, error) {
+func InitAndPlanE(t testing.TestingT, options *Options) (string, error) {
 	if _, err := InitE(t, options); err != nil {
 		return "", err
 	}
@@ -30,27 +30,27 @@ func InitAndPlanE(t TestingT, options *Options) (string, error) {
 
 // Plan runs terraform plan with the given options and returns stdout/stderr.
 // This will fail the test if there is an error in the command.
-func Plan(t TestingT, options *Options) string {
+func Plan(t testing.TestingT, options *Options) string {
 	out, err := PlanE(t, options)
 	require.NoError(t, err)
 	return out
 }
 
 // PlanE runs terraform plan with the given options and returns stdout/stderr.
-func PlanE(t TestingT, options *Options) (string, error) {
+func PlanE(t testing.TestingT, options *Options) (string, error) {
 	return RunTerraformCommandE(t, options, FormatArgs(options, "plan", "-input=false", "-lock=false")...)
 }
 
 // InitAndPlanWithExitCode runs terraform init and plan with the given options and returns exitcode for the plan command.
 // This will fail the test if there is an error in the command.
-func InitAndPlanWithExitCode(t TestingT, options *Options) int {
+func InitAndPlanWithExitCode(t testing.TestingT, options *Options) int {
 	exitCode, err := InitAndPlanWithExitCodeE(t, options)
 	require.NoError(t, err)
 	return exitCode
 }
 
 // InitAndPlanWithExitCodeE runs terraform init and plan with the given options and returns exitcode for the plan command.
-func InitAndPlanWithExitCodeE(t TestingT, options *Options) (int, error) {
+func InitAndPlanWithExitCodeE(t testing.TestingT, options *Options) (int, error) {
 	if _, err := InitE(t, options); err != nil {
 		return DefaultErrorExitCode, err
 	}
@@ -60,27 +60,27 @@ func InitAndPlanWithExitCodeE(t TestingT, options *Options) (int, error) {
 
 // PlanExitCode runs terraform plan with the given options and returns the detailed exitcode.
 // This will fail the test if there is an error in the command.
-func PlanExitCode(t TestingT, options *Options) int {
+func PlanExitCode(t testing.TestingT, options *Options) int {
 	exitCode, err := PlanExitCodeE(t, options)
 	require.NoError(t, err)
 	return exitCode
 }
 
 // PlanExitCodeE runs terraform plan with the given options and returns the detailed exitcode.
-func PlanExitCodeE(t TestingT, options *Options) (int, error) {
+func PlanExitCodeE(t testing.TestingT, options *Options) (int, error) {
 	return GetExitCodeForTerraformCommandE(t, options, FormatArgs(options, "plan", "-input=false", "-detailed-exitcode")...)
 }
 
 // TgPlanAllExitCode runs terragrunt plan-all with the given options and returns the detailed exitcode.
 // This will fail the test if there is an error in the command.
-func TgPlanAllExitCode(t TestingT, options *Options) int {
+func TgPlanAllExitCode(t testing.TestingT, options *Options) int {
 	exitCode, err := TgPlanAllExitCodeE(t, options)
 	require.NoError(t, err)
 	return exitCode
 }
 
 // TgPlanAllExitCodeE runs terragrunt plan-all with the given options and returns the detailed exitcode.
-func TgPlanAllExitCodeE(t TestingT, options *Options) (int, error) {
+func TgPlanAllExitCodeE(t testing.TestingT, options *Options) (int, error) {
 	if options.TerraformBinary != "terragrunt" {
 		return 1, fmt.Errorf("terragrunt must be set as TerraformBinary to use this method")
 	}

--- a/modules/terraform/plan.go
+++ b/modules/terraform/plan.go
@@ -2,21 +2,21 @@ package terraform
 
 import (
 	"fmt"
-	"testing"
 
+	_ "github.com/gruntwork-io/terratest/modules/testing"
 	"github.com/stretchr/testify/require"
 )
 
 // InitAndPlan runs terraform init and plan with the given options and returns stdout/stderr from the plan command.
 // This will fail the test if there is an error in the command.
-func InitAndPlan(t *testing.T, options *Options) string {
+func InitAndPlan(t TestingT, options *Options) string {
 	out, err := InitAndPlanE(t, options)
 	require.NoError(t, err)
 	return out
 }
 
 // InitAndPlanE runs terraform init and plan with the given options and returns stdout/stderr from the plan command.
-func InitAndPlanE(t *testing.T, options *Options) (string, error) {
+func InitAndPlanE(t TestingT, options *Options) (string, error) {
 	if _, err := InitE(t, options); err != nil {
 		return "", err
 	}
@@ -30,27 +30,27 @@ func InitAndPlanE(t *testing.T, options *Options) (string, error) {
 
 // Plan runs terraform plan with the given options and returns stdout/stderr.
 // This will fail the test if there is an error in the command.
-func Plan(t *testing.T, options *Options) string {
+func Plan(t TestingT, options *Options) string {
 	out, err := PlanE(t, options)
 	require.NoError(t, err)
 	return out
 }
 
 // PlanE runs terraform plan with the given options and returns stdout/stderr.
-func PlanE(t *testing.T, options *Options) (string, error) {
+func PlanE(t TestingT, options *Options) (string, error) {
 	return RunTerraformCommandE(t, options, FormatArgs(options, "plan", "-input=false", "-lock=false")...)
 }
 
 // InitAndPlanWithExitCode runs terraform init and plan with the given options and returns exitcode for the plan command.
 // This will fail the test if there is an error in the command.
-func InitAndPlanWithExitCode(t *testing.T, options *Options) int {
+func InitAndPlanWithExitCode(t TestingT, options *Options) int {
 	exitCode, err := InitAndPlanWithExitCodeE(t, options)
 	require.NoError(t, err)
 	return exitCode
 }
 
 // InitAndPlanWithExitCodeE runs terraform init and plan with the given options and returns exitcode for the plan command.
-func InitAndPlanWithExitCodeE(t *testing.T, options *Options) (int, error) {
+func InitAndPlanWithExitCodeE(t TestingT, options *Options) (int, error) {
 	if _, err := InitE(t, options); err != nil {
 		return DefaultErrorExitCode, err
 	}
@@ -60,27 +60,27 @@ func InitAndPlanWithExitCodeE(t *testing.T, options *Options) (int, error) {
 
 // PlanExitCode runs terraform plan with the given options and returns the detailed exitcode.
 // This will fail the test if there is an error in the command.
-func PlanExitCode(t *testing.T, options *Options) int {
+func PlanExitCode(t TestingT, options *Options) int {
 	exitCode, err := PlanExitCodeE(t, options)
 	require.NoError(t, err)
 	return exitCode
 }
 
 // PlanExitCodeE runs terraform plan with the given options and returns the detailed exitcode.
-func PlanExitCodeE(t *testing.T, options *Options) (int, error) {
+func PlanExitCodeE(t TestingT, options *Options) (int, error) {
 	return GetExitCodeForTerraformCommandE(t, options, FormatArgs(options, "plan", "-input=false", "-detailed-exitcode")...)
 }
 
 // TgPlanAllExitCode runs terragrunt plan-all with the given options and returns the detailed exitcode.
 // This will fail the test if there is an error in the command.
-func TgPlanAllExitCode(t *testing.T, options *Options) int {
+func TgPlanAllExitCode(t TestingT, options *Options) int {
 	exitCode, err := TgPlanAllExitCodeE(t, options)
 	require.NoError(t, err)
 	return exitCode
 }
 
 // TgPlanAllExitCodeE runs terragrunt plan-all with the given options and returns the detailed exitcode.
-func TgPlanAllExitCodeE(t *testing.T, options *Options) (int, error) {
+func TgPlanAllExitCodeE(t TestingT, options *Options) (int, error) {
 	if options.TerraformBinary != "terragrunt" {
 		return 1, fmt.Errorf("terragrunt must be set as TerraformBinary to use this method")
 	}

--- a/modules/terraform/workspace.go
+++ b/modules/terraform/workspace.go
@@ -5,13 +5,13 @@ import (
 	"regexp"
 	"strings"
 
-	_ "github.com/gruntwork-io/terratest/modules/testing"
+	"github.com/gruntwork-io/terratest/modules/testing"
 )
 
 // WorkspaceSelectOrNew runs terraform workspace with the given options and the workspace name
 // and returns a name of the current workspace. It tries to select a workspace with the given
 // name, or it creates a new one if it doesn't exist.
-func WorkspaceSelectOrNew(t TestingT, options *Options, name string) string {
+func WorkspaceSelectOrNew(t testing.TestingT, options *Options, name string) string {
 	out, err := WorkspaceSelectOrNewE(t, options, name)
 	if err != nil {
 		t.Fatal(err)
@@ -22,7 +22,7 @@ func WorkspaceSelectOrNew(t TestingT, options *Options, name string) string {
 // WorkspaceSelectOrNewE runs terraform workspace with the given options and the workspace name
 // and returns a name of the current workspace. It tries to select a workspace with the given
 // name, or it creates a new one if it doesn't exist.
-func WorkspaceSelectOrNewE(t TestingT, options *Options, name string) (string, error) {
+func WorkspaceSelectOrNewE(t testing.TestingT, options *Options, name string) (string, error) {
 	out, err := RunTerraformCommandE(t, options, "workspace", "list")
 	if err != nil {
 		return "", err

--- a/modules/terraform/workspace.go
+++ b/modules/terraform/workspace.go
@@ -4,13 +4,14 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
-	"testing"
+
+	_ "github.com/gruntwork-io/terratest/modules/testing"
 )
 
 // WorkspaceSelectOrNew runs terraform workspace with the given options and the workspace name
 // and returns a name of the current workspace. It tries to select a workspace with the given
 // name, or it creates a new one if it doesn't exist.
-func WorkspaceSelectOrNew(t *testing.T, options *Options, name string) string {
+func WorkspaceSelectOrNew(t TestingT, options *Options, name string) string {
 	out, err := WorkspaceSelectOrNewE(t, options, name)
 	if err != nil {
 		t.Fatal(err)
@@ -21,7 +22,7 @@ func WorkspaceSelectOrNew(t *testing.T, options *Options, name string) string {
 // WorkspaceSelectOrNewE runs terraform workspace with the given options and the workspace name
 // and returns a name of the current workspace. It tries to select a workspace with the given
 // name, or it creates a new one if it doesn't exist.
-func WorkspaceSelectOrNewE(t *testing.T, options *Options, name string) (string, error) {
+func WorkspaceSelectOrNewE(t TestingT, options *Options, name string) (string, error) {
 	out, err := RunTerraformCommandE(t, options, "workspace", "list")
 	if err != nil {
 		return "", err

--- a/modules/test-structure/save_test_data.go
+++ b/modules/test-structure/save_test_data.go
@@ -176,7 +176,7 @@ func SaveTestData(t testing.TestingT, path string, value interface{}) {
 		t.Fatalf("Failed to convert value %s to JSON: %v", path, err)
 	}
 
-	logger.Logf("Marshalled JSON: %s", string(bytes))
+	logger.Logf(t, "Marshalled JSON: %s", string(bytes))
 
 	parentDir := filepath.Dir(path)
 	if err := os.MkdirAll(parentDir, 0777); err != nil {

--- a/modules/test-structure/save_test_data.go
+++ b/modules/test-structure/save_test_data.go
@@ -6,7 +6,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"testing"
 
 	"github.com/gruntwork-io/terratest/modules/aws"
 	"github.com/gruntwork-io/terratest/modules/files"
@@ -14,18 +13,19 @@ import (
 	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/packer"
 	"github.com/gruntwork-io/terratest/modules/terraform"
+	"github.com/gruntwork-io/terratest/modules/testing"
 	"github.com/stretchr/testify/require"
 )
 
 // SaveTerraformOptions serializes and saves TerraformOptions into the given folder. This allows you to create TerraformOptions during setup
 // and to reuse that TerraformOptions later during validation and teardown.
-func SaveTerraformOptions(t *testing.T, testFolder string, terraformOptions *terraform.Options) {
+func SaveTerraformOptions(t testing.TestingT, testFolder string, terraformOptions *terraform.Options) {
 	SaveTestData(t, formatTerraformOptionsPath(testFolder), terraformOptions)
 }
 
 // LoadTerraformOptions loads and unserializes TerraformOptions from the given folder. This allows you to reuse a TerraformOptions that was
 // created during an earlier setup step in later validation and teardown steps.
-func LoadTerraformOptions(t *testing.T, testFolder string) *terraform.Options {
+func LoadTerraformOptions(t testing.TestingT, testFolder string) *terraform.Options {
 	var terraformOptions terraform.Options
 	LoadTestData(t, formatTerraformOptionsPath(testFolder), &terraformOptions)
 	return &terraformOptions
@@ -38,13 +38,13 @@ func formatTerraformOptionsPath(testFolder string) string {
 
 // SavePackerOptions serializes and saves PackerOptions into the given folder. This allows you to create PackerOptions during setup
 // and to reuse that PackerOptions later during validation and teardown.
-func SavePackerOptions(t *testing.T, testFolder string, packerOptions *packer.Options) {
+func SavePackerOptions(t testing.TestingT, testFolder string, packerOptions *packer.Options) {
 	SaveTestData(t, formatPackerOptionsPath(testFolder), packerOptions)
 }
 
 // LoadPackerOptions loads and unserializes PackerOptions from the given folder. This allows you to reuse a PackerOptions that was
 // created during an earlier setup step in later validation and teardown steps.
-func LoadPackerOptions(t *testing.T, testFolder string) *packer.Options {
+func LoadPackerOptions(t testing.TestingT, testFolder string) *packer.Options {
 	var packerOptions packer.Options
 	LoadTestData(t, formatPackerOptionsPath(testFolder), &packerOptions)
 	return &packerOptions
@@ -57,13 +57,13 @@ func formatPackerOptionsPath(testFolder string) string {
 
 // SaveEc2KeyPair serializes and saves an Ec2KeyPair into the given folder. This allows you to create an Ec2KeyPair during setup
 // and to reuse that Ec2KeyPair later during validation and teardown.
-func SaveEc2KeyPair(t *testing.T, testFolder string, keyPair *aws.Ec2Keypair) {
+func SaveEc2KeyPair(t testing.TestingT, testFolder string, keyPair *aws.Ec2Keypair) {
 	SaveTestData(t, formatEc2KeyPairPath(testFolder), keyPair)
 }
 
 // LoadEc2KeyPair loads and unserializes an Ec2KeyPair from the given folder. This allows you to reuse an Ec2KeyPair that was
 // created during an earlier setup step in later validation and teardown steps.
-func LoadEc2KeyPair(t *testing.T, testFolder string) *aws.Ec2Keypair {
+func LoadEc2KeyPair(t testing.TestingT, testFolder string) *aws.Ec2Keypair {
 	var keyPair aws.Ec2Keypair
 	LoadTestData(t, formatEc2KeyPairPath(testFolder), &keyPair)
 	return &keyPair
@@ -76,13 +76,13 @@ func formatEc2KeyPairPath(testFolder string) string {
 
 // SaveKubectlOptions serializes and saves KubectlOptions into the given folder. This allows you to create a KubectlOptions during setup
 // and reuse that KubectlOptions later during validation and teardown.
-func SaveKubectlOptions(t *testing.T, testFolder string, kubectlOptions *k8s.KubectlOptions) {
+func SaveKubectlOptions(t testing.TestingT, testFolder string, kubectlOptions *k8s.KubectlOptions) {
 	SaveTestData(t, formatKubectlOptionsPath(testFolder), kubectlOptions)
 }
 
 // LoadKubectlOptions loads and unserializes a KubectlOptions from the given folder. This allows you to reuse a KubectlOptions that was
 // created during an earlier setup step in later validation and teardown steps.
-func LoadKubectlOptions(t *testing.T, testFolder string) *k8s.KubectlOptions {
+func LoadKubectlOptions(t testing.TestingT, testFolder string) *k8s.KubectlOptions {
 	var kubectlOptions k8s.KubectlOptions
 	LoadTestData(t, formatKubectlOptionsPath(testFolder), &kubectlOptions)
 	return &kubectlOptions
@@ -95,14 +95,14 @@ func formatKubectlOptionsPath(testFolder string) string {
 
 // SaveString serializes and saves a uniquely named string value into the given folder. This allows you to create one or more string
 // values during one stage -- each with a unique name -- and to reuse those values during later stages.
-func SaveString(t *testing.T, testFolder string, name string, val string) {
+func SaveString(t testing.TestingT, testFolder string, name string, val string) {
 	path := formatNamedTestDataPath(testFolder, name)
 	SaveTestData(t, path, val)
 }
 
 // LoadString loads and unserializes a uniquely named string value from the given folder. This allows you to reuse one or more string
 // values that were created during an earlier setup step in later steps.
-func LoadString(t *testing.T, testFolder string, name string) string {
+func LoadString(t testing.TestingT, testFolder string, name string) string {
 	var val string
 	LoadTestData(t, formatNamedTestDataPath(testFolder, name), &val)
 	return val
@@ -110,14 +110,14 @@ func LoadString(t *testing.T, testFolder string, name string) string {
 
 // SaveInt saves a uniquely named int value into the given folder. This allows you to create one or more int
 // values during one stage -- each with a unique name -- and to reuse those values during later stages.
-func SaveInt(t *testing.T, testFolder string, name string, val int) {
+func SaveInt(t testing.TestingT, testFolder string, name string, val int) {
 	path := formatNamedTestDataPath(testFolder, name)
 	SaveTestData(t, path, val)
 }
 
 // LoadInt loads a uniquely named int value from the given folder. This allows you to reuse one or more int
 // values that were created during an earlier setup step in later steps.
-func LoadInt(t *testing.T, testFolder string, name string) int {
+func LoadInt(t testing.TestingT, testFolder string, name string) int {
 	var val int
 	LoadTestData(t, formatNamedTestDataPath(testFolder, name), &val)
 	return val
@@ -125,13 +125,13 @@ func LoadInt(t *testing.T, testFolder string, name string) int {
 
 // SaveArtifactID serializes and saves an Artifact ID into the given folder. This allows you to build an Artifact during setup and to reuse that
 // Artifact later during validation and teardown.
-func SaveArtifactID(t *testing.T, testFolder string, artifactID string) {
+func SaveArtifactID(t testing.TestingT, testFolder string, artifactID string) {
 	SaveString(t, testFolder, "Artifact", artifactID)
 }
 
 // LoadArtifactID loads and unserializes an Artifact ID from the given folder. This allows you to reuse an Artifact that was created during an
 // earlier setup step in later validation and teardown steps.
-func LoadArtifactID(t *testing.T, testFolder string) string {
+func LoadArtifactID(t testing.TestingT, testFolder string) string {
 	return LoadString(t, testFolder, "Artifact")
 }
 
@@ -139,7 +139,7 @@ func LoadArtifactID(t *testing.T, testFolder string) string {
 // AMI later during validation and teardown.
 //
 // Deprecated: Use SaveArtifactID instead.
-func SaveAmiId(t *testing.T, testFolder string, amiId string) {
+func SaveAmiId(t testing.TestingT, testFolder string, amiId string) {
 	SaveString(t, testFolder, "AMI", amiId)
 }
 
@@ -147,7 +147,7 @@ func SaveAmiId(t *testing.T, testFolder string, amiId string) {
 // earlier setup step in later validation and teardown steps.
 //
 // Deprecated: Use LoadArtifactID instead.
-func LoadAmiId(t *testing.T, testFolder string) string {
+func LoadAmiId(t testing.TestingT, testFolder string) string {
 	return LoadString(t, testFolder, "AMI")
 }
 
@@ -164,7 +164,7 @@ func FormatTestDataPath(testFolder string, filename string) string {
 
 // SaveTestData serializes and saves a value used at test time to the given path. This allows you to create some sort of test data
 // (e.g., TerraformOptions) during setup and to reuse this data later during validation and teardown.
-func SaveTestData(t *testing.T, path string, value interface{}) {
+func SaveTestData(t testing.TestingT, path string, value interface{}) {
 	logger.Logf(t, "Storing test data in %s so it can be reused later", path)
 
 	if IsTestDataPresent(t, path) {
@@ -176,7 +176,7 @@ func SaveTestData(t *testing.T, path string, value interface{}) {
 		t.Fatalf("Failed to convert value %s to JSON: %v", path, err)
 	}
 
-	t.Logf("Marshalled JSON: %s", string(bytes))
+	logger.Logf("Marshalled JSON: %s", string(bytes))
 
 	parentDir := filepath.Dir(path)
 	if err := os.MkdirAll(parentDir, 0777); err != nil {
@@ -191,7 +191,7 @@ func SaveTestData(t *testing.T, path string, value interface{}) {
 // LoadTestData loads and unserializes a value stored at the given path. The value should be a pointer to a struct into which the
 // value will be deserialized. This allows you to reuse some sort of test data (e.g., TerraformOptions) from earlier
 // setup steps in later validation and teardown steps.
-func LoadTestData(t *testing.T, path string, value interface{}) {
+func LoadTestData(t testing.TestingT, path string, value interface{}) {
 	logger.Logf(t, "Loading test data from %s", path)
 
 	bytes, err := ioutil.ReadFile(path)
@@ -205,7 +205,7 @@ func LoadTestData(t *testing.T, path string, value interface{}) {
 }
 
 // IsTestDataPresent returns true if a file exists at $path and the test data there is non-empty.
-func IsTestDataPresent(t *testing.T, path string) bool {
+func IsTestDataPresent(t testing.TestingT, path string) bool {
 	exists, err := files.FileExistsE(path)
 	if err != nil {
 		t.Fatalf("Failed to load test data from %s due to unexpected error: %v", path, err)
@@ -229,7 +229,7 @@ func IsTestDataPresent(t *testing.T, path string) bool {
 
 // isEmptyJSON returns true if the given bytes are empty, or in a valid JSON format that can reasonably be considered empty.
 // The types used are based on the type possibilities listed at https://golang.org/src/encoding/json/decode.go?s=4062:4110#L51
-func isEmptyJSON(t *testing.T, bytes []byte) bool {
+func isEmptyJSON(t testing.TestingT, bytes []byte) bool {
 	var value interface{}
 
 	if len(bytes) == 0 {
@@ -273,7 +273,7 @@ func isEmptyJSON(t *testing.T, bytes []byte) bool {
 }
 
 // CleanupTestData cleans up the test data at the given path.
-func CleanupTestData(t *testing.T, path string) {
+func CleanupTestData(t testing.TestingT, path string) {
 	if files.FileExists(path) {
 		logger.Logf(t, "Cleaning up test data from %s", path)
 		if err := os.Remove(path); err != nil {
@@ -286,13 +286,13 @@ func CleanupTestData(t *testing.T, path string) {
 
 // CleanupTestDataFolder cleans up the .test-data folder inside the given folder.
 // If there are any errors, fail the test.
-func CleanupTestDataFolder(t *testing.T, path string) {
+func CleanupTestDataFolder(t testing.TestingT, path string) {
 	err := CleanupTestDataFolderE(t, path)
 	require.NoError(t, err)
 }
 
 // CleanupTestDataFolderE cleans up the .test-data folder inside the given folder.
-func CleanupTestDataFolderE(t *testing.T, path string) error {
+func CleanupTestDataFolderE(t testing.TestingT, path string) error {
 	path = filepath.Join(path, ".test-data")
 	exists, err := files.FileExistsE(path)
 	if err != nil {

--- a/modules/test-structure/test_structure.go
+++ b/modules/test-structure/test_structure.go
@@ -6,10 +6,10 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"testing"
 
 	"github.com/gruntwork-io/terratest/modules/files"
 	"github.com/gruntwork-io/terratest/modules/logger"
+	"github.com/gruntwork-io/terratest/modules/testing"
 )
 
 // SKIP_STAGE_ENV_VAR_PREFIX is the prefix used for skipping stage environment variables.
@@ -17,7 +17,7 @@ const SKIP_STAGE_ENV_VAR_PREFIX = "SKIP_"
 
 // RunTestStage executes the given test stage (e.g., setup, teardown, validation) if an environment variable of the name
 // `SKIP_<stageName>` (e.g., SKIP_teardown) is not set.
-func RunTestStage(t *testing.T, stageName string, stage func()) {
+func RunTestStage(t testing.TestingT, stageName string, stage func()) {
 	envVarName := fmt.Sprintf("%s%s", SKIP_STAGE_ENV_VAR_PREFIX, stageName)
 	if os.Getenv(envVarName) == "" {
 		logger.Logf(t, "The '%s' environment variable is not set, so executing stage '%s'.", envVarName, stageName)
@@ -66,7 +66,7 @@ func SkipStageEnvVarSet() bool {
 // Note that if any of the SKIP_<stage> environment variables is set, we assume this is a test in the local dev where
 // there are no other concurrent tests running and we want to be able to cache test data between test stages, so in that
 // case, we do NOT copy anything to a temp folder, and return the path to the original terraform module folder instead.
-func CopyTerraformFolderToTemp(t *testing.T, rootFolder string, terraformModuleFolder string) string {
+func CopyTerraformFolderToTemp(t testing.TestingT, rootFolder string, terraformModuleFolder string) string {
 	if SkipStageEnvVarSet() {
 		logger.Logf(t, "A SKIP_XXX environment variable is set. Using original examples folder rather than a temp folder so we can cache data between stages for faster local testing.")
 		return filepath.Join(rootFolder, terraformModuleFolder)

--- a/modules/testing/types.go
+++ b/modules/testing/types.go
@@ -1,0 +1,18 @@
+package testing
+
+type TestingT interface {
+	Fail()
+	Error(args ...interface{})
+	Errorf(format string, args ...interface{})
+	FailNow()
+	Fatal(args ...interface{})
+	Fatalf(format string, args ...interface{})
+	Log(args ...interface{})
+	Logf(format string, args ...interface{})
+	Failed() bool
+	Parallel()
+	Skip(args ...interface{})
+	Skipf(format string, args ...interface{})
+	SkipNow()
+	Skipped() bool
+}

--- a/modules/testing/types.go
+++ b/modules/testing/types.go
@@ -16,17 +16,13 @@ type TestingT interface {
 	// created during the test. Calling FailNow does not stop
 	// those other goroutines.
 	FailNow()
+	Fatal(args ...interface{})
 	// Fatalf is equivalent to Logf followed by FailNow.
 	Fatalf(format string, args ...interface{})
 	// Error is equivalent to Log followed by Fail.
 	Error(args ...interface{})
 	// Errorf is equivalent to Logf followed by Fail.
 	Errorf(format string, args ...interface{})
-	// Log formats its arguments using default formatting, analogous to Println,
-	// and records the text in the error log. For tests, the text will be printed only if
-	// the test fails or the -test.v flag is set. For benchmarks, the text is always
-	// printed to avoid having performance depend on the value of the -test.v flag.
-	Log(args ...interface{})
 	// Logf formats its arguments according to the format, analogous to Printf, and
 	// records the text in the error log. A final newline is added if not provided. For
 	// tests, the text will be printed only if the test fails or the -test.v flag is

--- a/modules/testing/types.go
+++ b/modules/testing/types.go
@@ -6,17 +6,9 @@ package testing
 // makes terratest usable in a wider variety of contexts (e.g. use with ginkgo : https://godoc.org/github.com/onsi/ginkgo#GinkgoT)
 type TestingT interface {
 	Fail()
+	Fatalf(format string, args ...interface{})
 	Error(args ...interface{})
 	Errorf(format string, args ...interface{})
-	FailNow()
-	Fatal(args ...interface{})
-	Fatalf(format string, args ...interface{})
-	Log(args ...interface{})
+	Name() string
 	Logf(format string, args ...interface{})
-	Failed() bool
-	Parallel()
-	Skip(args ...interface{})
-	Skipf(format string, args ...interface{})
-	SkipNow()
-	Skipped() bool
 }

--- a/modules/testing/types.go
+++ b/modules/testing/types.go
@@ -23,12 +23,6 @@ type TestingT interface {
 	Error(args ...interface{})
 	// Errorf is equivalent to Logf followed by Fail.
 	Errorf(format string, args ...interface{})
-	// Logf formats its arguments according to the format, analogous to Printf, and
-	// records the text in the error log. A final newline is added if not provided. For
-	// tests, the text will be printed only if the test fails or the -test.v flag is
-	// set. For benchmarks, the text is always printed to avoid having performance
-	// depend on the value of the -test.v flag.
-	Logf(format string, args ...interface{})
 	// Name returns the name of the running test or benchmark.
 	Name() string
 }

--- a/modules/testing/types.go
+++ b/modules/testing/types.go
@@ -2,7 +2,7 @@ package testing
 
 // TestingT is an interface that describes the implementation of the testing object
 // that the majority of Terratest functions accept as first argument.
-// Using an interface that describes *testing.T instead of the actual implementation
+// Using an interface that describes testing.T instead of the actual implementation
 // makes terratest usable in a wider variety of contexts (e.g. use with ginkgo : https://godoc.org/github.com/onsi/ginkgo#GinkgoT)
 type TestingT interface {
 	//Fail marks the function as having failed but continues execution.

--- a/modules/testing/types.go
+++ b/modules/testing/types.go
@@ -1,5 +1,9 @@
 package testing
 
+// TestingT is an interface that describes the implementation of the testing object
+// that the majority of Terratest functions accept as first argument.
+// Using an interface that describes *testing.T instead of the actual implementation
+// makes terratest usable in a wider variety of contexts (e.g. use with ginkgo : https://godoc.org/github.com/onsi/ginkgo#GinkgoT)
 type TestingT interface {
 	Fail()
 	Error(args ...interface{})

--- a/modules/testing/types.go
+++ b/modules/testing/types.go
@@ -5,10 +5,34 @@ package testing
 // Using an interface that describes *testing.T instead of the actual implementation
 // makes terratest usable in a wider variety of contexts (e.g. use with ginkgo : https://godoc.org/github.com/onsi/ginkgo#GinkgoT)
 type TestingT interface {
+	//Fail marks the function as having failed but continues execution.
 	Fail()
+	// FailNow marks the function as having failed and stops its execution
+	// by calling runtime.Goexit (which then runs all deferred calls in the
+	// current goroutine).
+	// Execution will continue at the next test or benchmark.
+	// FailNow must be called from the goroutine running the
+	// test or benchmark function, not from other goroutines
+	// created during the test. Calling FailNow does not stop
+	// those other goroutines.
+	FailNow()
+	// Fatalf is equivalent to Logf followed by FailNow.
 	Fatalf(format string, args ...interface{})
+	// Error is equivalent to Log followed by Fail.
 	Error(args ...interface{})
+	// Errorf is equivalent to Logf followed by Fail.
 	Errorf(format string, args ...interface{})
-	Name() string
+	// Log formats its arguments using default formatting, analogous to Println,
+	// and records the text in the error log. For tests, the text will be printed only if
+	// the test fails or the -test.v flag is set. For benchmarks, the text is always
+	// printed to avoid having performance depend on the value of the -test.v flag.
+	Log(args ...interface{})
+	// Logf formats its arguments according to the format, analogous to Printf, and
+	// records the text in the error log. A final newline is added if not provided. For
+	// tests, the text will be printed only if the test fails or the -test.v flag is
+	// set. For benchmarks, the text is always printed to avoid having performance
+	// depend on the value of the -test.v flag.
 	Logf(format string, args ...interface{})
+	// Name returns the name of the running test or benchmark.
+	Name() string
 }


### PR DESCRIPTION
I would like to use `terratest` with [ginkgo](https://github.com/onsi/ginkgo).
Because most of the terratest functions expect a `*testing.T` object, I thought I could use `GinkgoT()` however this doesn't work because terratest doesn't use an interface but uses the concrete impl.

This PR attempts to fix that by creating a `testing.TestingT` template that is then used throughout the project instead of `*testing.T` object.