### PR TITLE
Change IsTestDataPresent to use os.Stat to check path

### DIFF
--- a/modules/files/files.go
+++ b/modules/files/files.go
@@ -14,6 +14,16 @@ func FileExists(path string) bool {
 	return err == nil
 }
 
+// FileExistsE returns true if the given file exists
+// It will return an error if os.Stat error is not an ErrNotExist
+func FileExistsE(path string) (bool, error) {
+	_, err := os.Stat(path)
+	if err != nil && !os.IsNotExist(err) {
+		 return false, err
+	}
+	return err == nil, nil
+}
+
 // CopyTerraformFolderToTemp creates a copy of the given folder and all its contents in a temp folder with a unique name and the given prefix.
 // This is useful when running multiple tests in parallel against the same set of Terraform files to ensure the
 // tests don't overwrite each other's .terraform working directory and terraform.tfstate files. This method returns

--- a/modules/files/files.go
+++ b/modules/files/files.go
@@ -19,7 +19,7 @@ func FileExists(path string) bool {
 func FileExistsE(path string) (bool, error) {
 	_, err := os.Stat(path)
 	if err != nil && !os.IsNotExist(err) {
-		 return false, err
+		return false, err
 	}
 	return err == nil, nil
 }

--- a/modules/test-structure/save_test_data.go
+++ b/modules/test-structure/save_test_data.go
@@ -205,13 +205,14 @@ func LoadTestData(t *testing.T, path string, value interface{}) {
 
 // IsTestDataPresent returns true if a file exists at $path and the test data there is non-empty.
 func IsTestDataPresent(t *testing.T, path string) bool {
-	if _, err := os.Stat(path); err != nil {
-		if os.IsNotExist(err) {
-			return false
-		} else {
-			t.Fatalf("Failed to load test data from %s due to unexpected error: %v", path, err)
-		}
+	exists, err := files.FileExistsE(path)
+	if err != nil {
+		t.Fatalf("Failed to load test data from %s due to unexpected error: %v", path, err)
 	}
+	if exists == false {
+		return false
+	}
+
 	bytes, err := ioutil.ReadFile(path)
 
 	if err != nil {

--- a/modules/test-structure/save_test_data.go
+++ b/modules/test-structure/save_test_data.go
@@ -6,7 +6,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/gruntwork-io/terratest/modules/aws"

--- a/modules/test-structure/save_test_data.go
+++ b/modules/test-structure/save_test_data.go
@@ -209,7 +209,7 @@ func IsTestDataPresent(t *testing.T, path string) bool {
 	if err != nil {
 		t.Fatalf("Failed to load test data from %s due to unexpected error: %v", path, err)
 	}
-	if exists == false {
+	if !exists {
 		return false
 	}
 

--- a/modules/test-structure/save_test_data.go
+++ b/modules/test-structure/save_test_data.go
@@ -206,10 +206,16 @@ func LoadTestData(t *testing.T, path string, value interface{}) {
 
 // IsTestDataPresent returns true if a file exists at $path and the test data there is non-empty.
 func IsTestDataPresent(t *testing.T, path string) bool {
+	if _, err := os.Stat(path); err != nil {
+		if os.IsNotExist(err) {
+			return false
+		} else {
+			t.Fatalf("Failed to load test data from %s due to unexpected error: %v", path, err)
+		}
+	}
 	bytes, err := ioutil.ReadFile(path)
-	if err != nil && strings.Contains(err.Error(), "no such file or directory") {
-		return false
-	} else if err != nil {
+
+	if err != nil {
 		t.Fatalf("Failed to load test data from %s due to unexpected error: %v", path, err)
 	}
 


### PR DESCRIPTION
The existing logic relies on error string detection which may not be consistent across systems and OSes. Using os.Stat should be more robust when checking for path existence.

https://github.com/gruntwork-io/terratest/issues/372