### PR TITLE
tunnel: Break dependency on k8s.io/kubernetes

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -918,14 +918,6 @@
   pruneopts = "UT"
   revision = "386e588352a49a5c8dc7632348278569d4f57419"
 
-[[projects]]
-  digest = "1:0eb0e54e287f561fa804eba0640e99c857606aa47c04c0a41ce6e395e0ea3b7a"
-  name = "k8s.io/kubernetes"
-  packages = ["pkg/kubectl/generate"]
-  pruneopts = "UT"
-  revision = "2d3c76f9091b6bec110a5e63777c332469e0cba2"
-  version = "v1.15.3"
-
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -104,10 +104,6 @@ required = [
   branch = "release-9.0"
 
 [[constraint]]
-  name = "k8s.io/kubernetes"
-  version = "1.15.1"
-
-[[constraint]]
   name = "github.com/json-iterator/go"
   version = "1.1.5"
 

--- a/modules/k8s/tunnel.go
+++ b/modules/k8s/tunnel.go
@@ -12,6 +12,7 @@ import (
 	"net"
 	"net/http"
 	"strconv"
+	"strings"
 	"sync"
 	"testing"
 
@@ -19,7 +20,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/portforward"
 	"k8s.io/client-go/transport/spdy"
-	"k8s.io/kubernetes/pkg/kubectl/generate"
 
 	"github.com/gruntwork-io/terratest/modules/logger"
 )
@@ -45,6 +45,14 @@ func (resourceType KubeResourceType) String() string {
 		// This should not happen
 		return "UNKNOWN_RESOURCE_TYPE"
 	}
+}
+
+func makeLabels(labels map[string]string) string {
+	out := []string{}
+	for key, value := range labels {
+		out = append(out, fmt.Sprintf("%s=%s", key, value))
+	}
+	return strings.Join(out, ",")
 }
 
 // Tunnel is the main struct that configures and manages port forwading tunnels to Kubernetes resources.
@@ -103,7 +111,7 @@ func (tunnel *Tunnel) getAttachablePodForServiceE(t *testing.T) (string, error) 
 	if err != nil {
 		return "", err
 	}
-	selectorLabelsOfPods := generate.MakeLabels(service.Spec.Selector)
+	selectorLabelsOfPods := makeLabels(service.Spec.Selector)
 	servicePods, err := ListPodsE(t, tunnel.kubectlOptions, metav1.ListOptions{LabelSelector: selectorLabelsOfPods})
 	if err != nil {
 		return "", err

--- a/modules/k8s/tunnel.go
+++ b/modules/k8s/tunnel.go
@@ -47,6 +47,7 @@ func (resourceType KubeResourceType) String() string {
 	}
 }
 
+// makeLabels is a helper to format a map of label key and value pairs into a single string for use as a selector.
 func makeLabels(labels map[string]string) string {
 	out := []string{}
 	for key, value := range labels {


### PR DESCRIPTION
This removes the dependency on k8s.io/kubernetes by pulling the label helper code in.