### PR TITLE
Implement PutObject functionality for AWS S3

### DIFF
--- a/modules/aws/s3.go
+++ b/modules/aws/s3.go
@@ -163,6 +163,29 @@ func PutS3BucketVersioningE(t *testing.T, region string, bucketName string) erro
 	return err
 }
 
+func PutS3Object(t *testing.T, region string, bucket string, key string, body string) {
+	err := PutS3ObjectE(t, region, bucket, key, body)
+	require.NoError(t, err)
+}
+
+func PutS3ObjectE(t *testing.T, region string, bucket string, key string, body string) error {
+	logger.Logf(t, "Inserting key %s in bucket %s with body '%s'", key, bucket, body)
+
+	s3Client, err := NewS3ClientE(t, region)
+	if err != nil {
+		return err
+	}
+
+	params := &s3.PutObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(key),
+		Body:   aws.ReadSeekCloser(strings.NewReader(body)),
+	}
+
+	_, err = s3Client.PutObject(params)
+	return err
+}
+
 // DeleteS3Bucket destroys the S3 bucket in the given region with the given name.
 func DeleteS3Bucket(t *testing.T, region string, name string) {
 	err := DeleteS3BucketE(t, region, name)

--- a/modules/aws/s3.go
+++ b/modules/aws/s3.go
@@ -163,11 +163,13 @@ func PutS3BucketVersioningE(t *testing.T, region string, bucketName string) erro
 	return err
 }
 
+// PutS3Object creates a key in a existing S3 bucket with the provided body.
 func PutS3Object(t *testing.T, region string, bucket string, key string, body string) {
 	err := PutS3ObjectE(t, region, bucket, key, body)
 	require.NoError(t, err)
 }
 
+// PutS3ObjectE creates a key in a existing S3 bucket with the provided body.
 func PutS3ObjectE(t *testing.T, region string, bucket string, key string, body string) error {
 	logger.Logf(t, "Inserting key %s in bucket %s with body '%s'", key, bucket, body)
 

--- a/modules/aws/s3_test.go
+++ b/modules/aws/s3_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
 	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/random"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -48,9 +49,7 @@ func TestPutS3Object(t *testing.T) {
 
 	actualBody := GetS3ObjectContents(t, region, s3BucketName, key)
 
-	if actualBody != body {
-		t.Fatalf("Expected to have body '%s', but got '%s'.", body, actualBody)
-	}
+	assert.Equal(t, body, actualBody)
 }
 
 func TestAssertS3BucketExistsNoFalseNegative(t *testing.T) {

--- a/modules/aws/s3_test.go
+++ b/modules/aws/s3_test.go
@@ -29,6 +29,30 @@ func TestCreateAndDestroyS3Bucket(t *testing.T) {
 	DeleteS3Bucket(t, region, s3BucketName)
 }
 
+func TestPutS3Object(t *testing.T) {
+	t.Parallel()
+
+	region := GetRandomStableRegion(t, nil, nil)
+	id := random.UniqueId()
+	logger.Logf(t, "Random values selected. Region = %s, Id = %s\n", region, id)
+
+	s3BucketName := "gruntwork-terratest-" + strings.ToLower(id)
+	key := fmt.Sprintf("test-%s", id)
+	body := "This is the body"
+
+	CreateS3Bucket(t, region, s3BucketName)
+	defer DeleteS3Bucket(t, region, s3BucketName)
+
+	PutS3Object(t, region, s3BucketName, key, body)
+	defer EmptyS3Bucket(t, region, s3BucketName)
+
+	actualBody := GetS3ObjectContents(t, region, s3BucketName, key)
+
+	if actualBody != body {
+		t.Fatalf("Expected to have body '%s', but got '%s'.", body, actualBody)
+	}
+}
+
 func TestAssertS3BucketExistsNoFalseNegative(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
This PR implements the function `PutS3Object`, which inserts into an existing S3 bucket a given key and body.

Related issue: #187 