### PR TITLE
Fix typo for 'southafricawest' region

### DIFF
--- a/modules/azure/region.go
+++ b/modules/azure/region.go
@@ -55,7 +55,7 @@ var stableRegions = []string{
 
 	// Middle East and Africa
 	"southafricanorth",
-	"southfricawest",
+	"southafricawest",
 	"uaecentral",
 	"uaenorth",
 }


### PR DESCRIPTION
Hi,

This is a tiny PR to fix the following issue :  
https://github.com/gruntwork-io/terratest/issues/375