### PR TITLE
Implement GetBucketTagging functionality for AWS S3

### DIFF
--- a/modules/aws/s3.go
+++ b/modules/aws/s3.go
@@ -326,7 +326,10 @@ func GetS3BucketTaggingE(t *testing.T, awsRegion string, bucket string) (map[str
 	)
 
 	for _, tag := range result.TagSet {
-		tags[*(tag.Key)] = *(tag.Value)
+		key := aws.StringValue(tag.Key)
+		value := aws.StringValue(tag.Value)
+
+		tags[key] = value
 	}
 
 	return tags, nil

--- a/modules/aws/s3.go
+++ b/modules/aws/s3.go
@@ -302,6 +302,36 @@ func GetS3BucketPolicyE(t *testing.T, awsRegion string, bucket string) (string, 
 	return aws.StringValue(res.Policy), nil
 }
 
+// GetS3BucketTagging returns the tags associated to a given S3 bucket
+func GetS3BucketTagging(t *testing.T, awsRegion string, bucket string) map[string]string {
+	tags, err := GetS3BucketTaggingE(t, awsRegion, bucket)
+	require.NoError(t, err)
+
+	return tags
+}
+
+// GetS3BucketTaggingE returns the tags associated to a given S3 bucket
+func GetS3BucketTaggingE(t *testing.T, awsRegion string, bucket string) (map[string]string, error) {
+	tags := make(map[string]string)
+
+	s3Client, err := NewS3ClientE(t, awsRegion)
+	if err != nil {
+		return tags, err
+	}
+
+	result, err := s3Client.GetBucketTagging(
+		&s3.GetBucketTaggingInput{
+			Bucket: aws.String(bucket),
+		},
+	)
+
+	for _, tag := range result.TagSet {
+		tags[*(tag.Key)] = *(tag.Value)
+	}
+
+	return tags, nil
+}
+
 // AssertS3BucketExists checks if the given S3 bucket exists in the given region and fail the test if it does not.
 func AssertS3BucketExists(t *testing.T, region string, name string) {
 	err := AssertS3BucketExistsE(t, region, name)

--- a/modules/aws/s3_test.go
+++ b/modules/aws/s3_test.go
@@ -4,7 +4,6 @@ package aws
 import (
 	"fmt"
 	"math/rand"
-	"reflect"
 	"strconv"
 	"strings"
 	"testing"
@@ -14,6 +13,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
 	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/random"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -56,9 +56,7 @@ func TestS3BucketTagging(t *testing.T) {
 
 	bucketTags := GetS3BucketTagging(t, region, s3BucketName)
 
-	if !reflect.DeepEqual(tags, bucketTags) {
-		t.Fatalf("Expect bucket to have tags '%+v', but got '%+v'", tags, bucketTags)
-	}
+	assert.Equal(t, tags, bucketTags)
 }
 
 func TestAssertS3BucketExistsNoFalseNegative(t *testing.T) {


### PR DESCRIPTION
This PR adds support for `S3::GetBucketTagging`, returning all the tags attached to a given S3 bucket.

Related issue: #125 