### PR TITLE
Add CleanupTestDataFolder for deleting .test-data

### DIFF
--- a/modules/test-structure/save_test_data.go
+++ b/modules/test-structure/save_test_data.go
@@ -282,3 +282,30 @@ func CleanupTestData(t *testing.T, path string) {
 		logger.Logf(t, "%s does not exist. Nothing to cleanup.", path)
 	}
 }
+
+// CleanupTestData cleans up the .test-data folder inside the given folder.
+// If deleteParent is true, CleanupTestDataFolder will also delete the given folder.
+func CleanupTestDataFolder(t *testing.T, path string, deleteParent bool) {
+	if deleteParent {
+		deleteFolder(t, path)
+	} else {
+		testDataPath := filepath.Join(path, ".test-data")
+		deleteFolder(t, testDataPath)
+	}
+}
+
+// cleanupTestDataFolder deletes the given folder.
+func deleteFolder(t *testing.T, path string) {
+	exists, err := files.FileExistsE(path)
+	if err != nil {
+		t.Fatalf("Failed to clean up test data folder at %s: %v", path, err)
+	}
+
+	if exists {
+		if err := os.RemoveAll(path); err != nil {
+			t.Fatalf("Failed to clean up test data folder at %s: %v", path, err)
+		}
+	} else {
+		logger.Logf(t, "%s does not exist. Nothing to cleanup", path)
+	}
+}

--- a/modules/test-structure/save_test_data.go
+++ b/modules/test-structure/save_test_data.go
@@ -311,7 +311,7 @@ func cleanupTestDataFolder(t *testing.T, path string) error {
 	}
 
 	if !exists {
-		logger.Logf(t, "%s does not exist. Nothing to cleanup", path)
+		logger.Logf(t, "%s does not exist. Nothing to cleanup.", path)
 		return nil
 	}
 	if err := os.RemoveAll(path); err != nil {

--- a/modules/test-structure/save_test_data.go
+++ b/modules/test-structure/save_test_data.go
@@ -283,29 +283,27 @@ func CleanupTestData(t *testing.T, path string) {
 	}
 }
 
-// CleanupTestData cleans up the .test-data folder inside the given folder.
+// CleanupTestDataFolder cleans up the .test-data folder inside the given folder.
 // If deleteParent is true, CleanupTestDataFolder will also delete the given folder.
 func CleanupTestDataFolder(t *testing.T, path string, deleteParent bool) {
-	if deleteParent {
-		deleteFolder(t, path)
-	} else {
-		testDataPath := filepath.Join(path, ".test-data")
-		deleteFolder(t, testDataPath)
+	if !deleteParent {
+		path = filepath.Join(path, ".test-data")
 	}
+	cleanupTestDataFolder(t, path)
 }
 
 // cleanupTestDataFolder deletes the given folder.
-func deleteFolder(t *testing.T, path string) {
+func cleanupTestDataFolder(t *testing.T, path string) {
 	exists, err := files.FileExistsE(path)
 	if err != nil {
 		t.Fatalf("Failed to clean up test data folder at %s: %v", path, err)
 	}
 
-	if exists {
-		if err := os.RemoveAll(path); err != nil {
-			t.Fatalf("Failed to clean up test data folder at %s: %v", path, err)
-		}
-	} else {
+	if !exists {
 		logger.Logf(t, "%s does not exist. Nothing to cleanup", path)
+		return
+	}
+	if err := os.RemoveAll(path); err != nil {
+		t.Fatalf("Failed to clean up test data folder at %s: %v", path, err)
 	}
 }

--- a/modules/test-structure/save_test_data.go
+++ b/modules/test-structure/save_test_data.go
@@ -285,25 +285,15 @@ func CleanupTestData(t *testing.T, path string) {
 }
 
 // CleanupTestDataFolder cleans up the .test-data folder inside the given folder.
-// If deleteParent is true, CleanupTestDataFolder will also delete the given folder.
 // If there are any errors, fail the test.
-func CleanupTestDataFolder(t *testing.T, path string, deleteParent bool) {
-	err := CleanupTestDataFolderE(t, path, deleteParent)
+func CleanupTestDataFolder(t *testing.T, path string) {
+	err := CleanupTestDataFolderE(t, path)
 	require.NoError(t, err)
 }
 
 // CleanupTestDataFolderE cleans up the .test-data folder inside the given folder.
-// If deleteParent is true, CleanupTestDataFolder will also delete the given folder.
-func CleanupTestDataFolderE(t *testing.T, path string, deleteParent bool) error {
-	if !deleteParent {
-		path = filepath.Join(path, ".test-data")
-	}
-
-	return cleanupTestDataFolder(t, path)
-}
-
-// cleanupTestDataFolder deletes the given folder.
-func cleanupTestDataFolder(t *testing.T, path string) error {
+func CleanupTestDataFolderE(t *testing.T, path string) error {
+	path = filepath.Join(path, ".test-data")
 	exists, err := files.FileExistsE(path)
 	if err != nil {
 		logger.Logf(t, "Failed to clean up test data folder at %s: %v", path, err)


### PR DESCRIPTION
This function allows the user to easily cleanup the `.test-data` directory created by the `Save` functions. It optionally allows the user to delete the `workingDir` folder itself. I am still very new to Go, so let me know if there are any improvements required. Thanks!

Closes #383 