### PR TITLE
Use new released version of module-ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ defaults: &defaults
     image: "ubuntu-1604:201903-01"
   environment:
     GRUNTWORK_INSTALLER_VERSION: v0.0.21
-    MODULE_CI_VERSION: v0.16.0-alpha.1
+    MODULE_CI_VERSION: v0.16.0
     TERRAFORM_VERSION: 0.11.11
     TERRAGRUNT_VERSION: v0.18.3
     PACKER_VERSION: 1.3.3

--- a/README.md
+++ b/README.md
@@ -69,16 +69,11 @@ validateServerIsWorking(t, terraformOptions)
 
 Terratest uses the Go testing framework. To use terratest, you need to install:
 
-- [Go](https://golang.org/) (requires version >=1.10)
-- [dep](https://github.com/golang/dep) (requires version >=0.5.1)
+- [Go](https://golang.org/) (requires version >=1.13)
 
 
 ### Setting up your project
 
-1. Golang requires go source files to be available in the `GOPATH`. By default this is typically `$HOME/go/src`. Create
-   a new blank folder in the `GOPATH` to hold your terraform module and terratest code. For example, if you were
-   developing a VPC module named `terraform-aws-vpc`, create the folder `$HOME/go/src/terraform-aws-vpc` to hold your
-   module code.
 1. In the project folder, create three subfolders:
     1. `modules`: This folder should contain your terraform modules that will be tested.
     1. `examples`: This folder should contain examples of how to use the modules. These should be self-contained
@@ -91,26 +86,12 @@ Terratest uses the Go testing framework. To use terratest, you need to install:
 1. Copy the [basic terraform example
    test](https://github.com/gruntwork-io/terratest/blob/master/test/terraform_basic_example_test.go) into the `test`
    folder.
-1. In the `test` folder, create a `Gopkg.toml` file with the following content:
-
-```
-[[constraint]]
-  name = "github.com/gruntwork-io/terratest"
-  version = "0.17.4"
-```
+1. In the `test` folder, run `go mod init MODULE_NAME` to get a new `go.mod` file. Then run `go mod tidy` to download
+   terratest.
 
 Now you should be able to run the example test. To run the test:
 
 1. Change your working directory to the `test` folder.
-1. Run `dep ensure`
-    - This will download all the dependencies to the current directory (in this case, the `test` folder) under the
-      folder `vendor`. You should only need to run this when you update the `Gopkg.toml` file, or if you have not run it
-      previously on the machine (e.g in a CI environment).
-    - This will create a new file `Gopkg.lock`. This file acts as an index of all the versions of every dependency you
-      need.
-    - You should check in the `Gopkg.lock` file that is generated so that all future calls to `dep ensure` will be
-      consistent, but you should NOT check in the `vendor` folder, as that can be recreated using `dep ensure` from the
-      `Gopkg.lock` file.
 1. Each time you want to run the tests, use `go test -v -timeout 90m .`
     - Note that `go` has a default test timeout of 10 minutes. With infrastructure testing, your tests will surpass the
       10 minutes very easily. To extend the timeout, you can pass in the `-timeout` option, which takes a `go` duration
@@ -196,7 +177,7 @@ Next, head over to the [test folder](/test) to see how you can use Terratest to 
     the web server to check that it is working correctly, and run `terraform destroy` to undeploy the web server.
 1.  [terraform_gcp_example_test.go](/test/terraform_gcp_example_test.go): Use Terratest to run `terraform apply` on
     the Terraform GCP Example and verify you get the expected outputs.
-1.  [terraform_remote_exec_example_test.go](/test/terraform_remote_exec_example_test.go): Use Terratest to run 
+1.  [terraform_remote_exec_example_test.go](/test/terraform_remote_exec_example_test.go): Use Terratest to run
     `terraform apply` and then remotely provision the instance while using a custom SSH agent managed by Terratest
 1.  [terraform_scp_example_test.go](/test/terraform_scp_example_test.go): Use Terratest to simplify copying resources
     like config files and logs from deployed EC2 Instances. This is especially useful for getting a snapshot of the


### PR DESCRIPTION
As part of the release plan for `go modules`, update the README and use a proper release tag for module-ci. The build is expected to fail because the tag for module-ci does not exist yet.