### PR TITLE
Support specifying the chart namespace in RenderTemplate

### DIFF
--- a/examples/helm-basic-example/templates/deployment.yaml
+++ b/examples/helm-basic-example/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "helm-basic-example.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     # These labels are required by helm. You can read more about required labels in the chart best pracices guide:
     # https://docs.helm.sh/chart_best_practices/#standard-labels

--- a/modules/helm/template.go
+++ b/modules/helm/template.go
@@ -36,6 +36,9 @@ func RenderTemplateE(t *testing.T, options *Options, chartDir string, templateFi
 	// Now construct the args
 	// We first construct the template args
 	args := []string{}
+	if options.KubectlOptions != nil && options.KubectlOptions.Namespace != "" {
+		args = append(args, "--namespace", options.KubectlOptions.Namespace)
+	}
 	args, err = getValuesArgsE(t, options, args...)
 	if err != nil {
 		return "", err

--- a/test/helm_basic_example_template_test.go
+++ b/test/helm_basic_example_template_test.go
@@ -10,7 +10,6 @@
 package test
 
 import (
-	"fmt"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -20,6 +19,7 @@ import (
 
 	"github.com/gruntwork-io/terratest/modules/helm"
 	"github.com/gruntwork-io/terratest/modules/k8s"
+	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/random"
 )
 
@@ -43,7 +43,7 @@ func TestHelmBasicExampleTemplateRenderedDeployment(t *testing.T) {
 
 	// Set up the namespace; confirm that the template renders the expected value for the namespace.
 	namespaceName := "medieval-" + strings.ToLower(random.UniqueId())
-	fmt.Printf("Namespace: %s\n", namespaceName)
+	logger.Logf(t, "Namespace: %s\n", namespaceName)
 
 	// Setup the args. For this test, we will set the following input values:
 	// - containerImageRepo=nginx


### PR DESCRIPTION
Currently, the `RenderTemplate` family of functions don't support specifying the release namespace for a chart:

```console
$ helm template --help | grep namespace
      --namespace string         namespace to install the release into
```

For charts that use the [`.Release.Namespace`](https://helm.sh/docs/chart_template_guide/#built-in-objects) object in chart templates, I'd like to be able to confirm the correct behavior via `RenderTemplate`.

`Install`/`InstallE` *do* support overriding the namespace parameter via `options.KubectlOptions`:

https://github.com/gruntwork-io/terratest/blob/3bd1244cbcb33e46f51549f97b028b530f752543/modules/helm/install.go#L35-L37

Permit this behavior for `RenderTemplate`/`RenderTemplateE` as well, using the same source for the namespace name as `Install` / `InstallE`.