### PR TITLE
Specify chart version

### DIFF
--- a/modules/helm/install.go
+++ b/modules/helm/install.go
@@ -35,6 +35,9 @@ func InstallE(t *testing.T, options *Options, chart string, releaseName string) 
 	if options.KubectlOptions != nil && options.KubectlOptions.Namespace != "" {
 		args = append(args, "--namespace", options.KubectlOptions.Namespace)
 	}
+	if options.Version != "" {
+		args = append(args, "--version", options.Version)
+	}
 	args, err = getValuesArgsE(t, options, args...)
 	if err != nil {
 		return err

--- a/modules/helm/options.go
+++ b/modules/helm/options.go
@@ -12,4 +12,5 @@ type Options struct {
 	KubectlOptions *k8s.KubectlOptions // KubectlOptions to control how to authenticate to kubernetes cluster. `nil` => use defaults.
 	HomePath       string              // The path to the helm home to use when calling out to helm. Empty string means use default ($HOME/.helm).
 	EnvVars        map[string]string   // Environment variables to set when running helm
+	Version        string              // Version of chart
 }


### PR DESCRIPTION
The only way to pass chart version is --version directive:

helm install --name elastic kiwigrid / fluentd-elasticsearch --version 1.21.1

I added Version to helm.Options then I use it in helml.install