### PR TITLE
Add Docker build and run commands

### DIFF
--- a/modules/docker/build.go
+++ b/modules/docker/build.go
@@ -1,0 +1,60 @@
+package docker
+
+import (
+	"github.com/gruntwork-io/terratest/modules/logger"
+	"github.com/gruntwork-io/terratest/modules/shell"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+// BuildOptions defines options that can be passed to the 'docker build' command.
+type BuildOptions struct {
+	File      string
+	Tags      []string
+	BuildArgs []string
+}
+
+// Build runs the 'docker build' command at the given path with the given options and fails the test if there are any
+// errors.
+func Build(t *testing.T, path string, options *BuildOptions) {
+	require.NoError(t, BuildE(t, path, options))
+}
+
+// BuildE runs the 'docker build' command at the given path with the given options and returns any errors.
+func BuildE(t *testing.T, path string, options *BuildOptions) error {
+	logger.Logf(t, "Running Docker build on Dockerfile %s", options.File)
+
+	args, err := formatDockerBuildArgs(path, options)
+	if err != nil {
+		return err
+	}
+
+	cmd := shell.Command{
+		Command: "docker",
+		Args:    args,
+	}
+
+	_, buildErr := shell.RunCommandAndGetOutputE(t, cmd)
+	return buildErr
+}
+
+// formatDockerBuildArgs formats the arguments for the 'docker build' command.
+func formatDockerBuildArgs(path string, options *BuildOptions) ([]string, error) {
+	args := []string{"build"}
+
+	if options.File != "" {
+		args = append(args, "--file", options.File)
+	}
+
+	for _, tag := range options.Tags {
+		args = append(args, "--tag", tag)
+	}
+
+	for _, arg := range options.BuildArgs {
+		args = append(args, "--build-arg", arg)
+	}
+
+	args = append(args, path)
+
+	return args, nil
+}

--- a/modules/docker/build.go
+++ b/modules/docker/build.go
@@ -1,10 +1,11 @@
 package docker
 
 import (
+	"testing"
+
 	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/shell"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 // BuildOptions defines options that can be passed to the 'docker build' command.

--- a/modules/docker/build_test.go
+++ b/modules/docker/build_test.go
@@ -21,5 +21,5 @@ func TestBuild(t *testing.T) {
 	Build(t, "../../test/fixtures/docker", options)
 
 	out := Run(t, tag, &RunOptions{Remove: true})
-	require.Contains(t, text, out)
+	require.Contains(t, out, text)
 }

--- a/modules/docker/build_test.go
+++ b/modules/docker/build_test.go
@@ -21,5 +21,5 @@ func TestBuild(t *testing.T) {
 	Build(t, "../../test/fixtures/docker", options)
 
 	out := Run(t, tag, &RunOptions{Remove: true})
-	require.Equal(t, text, out)
+	require.Contains(t, text, out)
 }

--- a/modules/docker/build_test.go
+++ b/modules/docker/build_test.go
@@ -1,0 +1,20 @@
+package docker
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestBuild(t *testing.T) {
+	t.Parallel()
+
+	tag := "gruntwork-io/test-image:v1"
+	text := "Hello, World!"
+
+	options := &BuildOptions{
+		Tags:      []string{tag},
+		BuildArgs: []string{fmt.Sprintf("text=%s", text)},
+	}
+
+	Build(t, "../../test/fixtures/docker", options)
+}

--- a/modules/docker/build_test.go
+++ b/modules/docker/build_test.go
@@ -2,8 +2,9 @@ package docker
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestBuild(t *testing.T) {

--- a/modules/docker/build_test.go
+++ b/modules/docker/build_test.go
@@ -2,6 +2,7 @@ package docker
 
 import (
 	"fmt"
+	"github.com/stretchr/testify/require"
 	"testing"
 )
 
@@ -17,4 +18,7 @@ func TestBuild(t *testing.T) {
 	}
 
 	Build(t, "../../test/fixtures/docker", options)
+
+	out := Run(t, tag, &RunOptions{Remove: true})
+	require.Equal(t, text, out)
 }

--- a/modules/docker/run.go
+++ b/modules/docker/run.go
@@ -1,10 +1,11 @@
 package docker
 
 import (
+	"testing"
+
 	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/shell"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 // RunOptions defines options that can be passed to the 'docker run' command.

--- a/modules/docker/run.go
+++ b/modules/docker/run.go
@@ -1,0 +1,132 @@
+package docker
+
+import (
+	"github.com/gruntwork-io/terratest/modules/logger"
+	"github.com/gruntwork-io/terratest/modules/shell"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+// RunOptions defines options that can be passed to the 'docker run' command.
+type RunOptions struct {
+	// Override the default COMMAND of the Docker image
+	Command []string
+
+	// If set to true, pass the --detach flag to 'docker run' to run the container in the background
+	Detach bool
+
+	// Override the default ENTRYPOINT of the Docker image
+	Entrypoint string
+
+	// Set environment variables
+	EnvironmentVariables []string
+
+	// If set to true, pass the --init flag to 'docker run' to run an init inside the container that forwards signals
+	// and reaps processes
+	Init bool
+
+	// Assign a name to the container
+	Name string
+
+	// If set to true, pass the --privileged flag to 'docker run' to give extended privileges to the container
+	Privileged bool
+
+	// If set to true, pass the --rm flag to 'docker run' to automatically remove the container when it exits
+	Remove bool
+
+	// If set to true, pass the -tty flag to 'docker run' to allocate a pseudo-TTY
+	Tty bool
+
+	// Username or UID
+	User string
+
+	// Bind mount these volume(s) when running the container
+	Volumes []string
+
+	// Custom CLI options that will be passed as-is to the 'docker run' command. This is an "escape hatch" that allows
+	// Terratest to not have to support every single command-line option offered by the 'docker run' command, and
+	// solely focus on the most important ones.
+	OtherOptions []string
+}
+
+// Run runs the 'docker run' command on the given image with the given options and return stdout/stderr. This method
+// fails the test if there are any errors.
+func Run(t *testing.T, image string, options *RunOptions) string {
+	out, err := RunE(t, image, options)
+	require.NoError(t, err)
+	return out
+}
+
+// Run runs the 'docker run' command on the given image with the given options and return stdout/stderr, or any error.
+func RunE(t *testing.T, image string, options *RunOptions) (string, error) {
+	logger.Logf(t, "Running 'docker run' on image '%s'", image)
+
+	args, err := formatDockerRunArgs(image, options)
+	if err != nil {
+		return "", err
+	}
+
+	cmd := shell.Command{
+		Command: "docker",
+		Args:    args,
+	}
+
+	return shell.RunCommandAndGetOutputE(t, cmd)
+}
+
+// formatDockerRunArgs formats the arguments for the 'docker run' command.
+func formatDockerRunArgs(image string, options *RunOptions) ([]string, error) {
+	args := []string{"run"}
+
+	if options.Detach {
+		args = append(args, "--detach")
+	}
+
+	if options.Entrypoint != "" {
+		args = append(args, "--entrypoint", options.Entrypoint)
+	}
+
+	for _, envVar := range options.EnvironmentVariables {
+		args = append(args, "--env", envVar)
+	}
+
+	if options.Init {
+		args = append(args, "--init")
+	}
+
+	if options.Name != "" {
+		args = append(args, "--name", options.Name)
+	}
+
+	if options.Privileged {
+		args = append(args, "--privileged")
+	}
+
+	if options.Remove {
+		args = append(args, "--rm")
+	}
+
+	if options.Tty {
+		args = append(args, "--tty")
+	}
+
+	if options.User != "" {
+		args = append(args, "--user", options.User)
+	}
+
+	for _, volume := range options.Volumes {
+		args = append(args, "--volume", volume)
+	}
+
+	for _, opt := range options.OtherOptions {
+		args = append(args, opt)
+	}
+
+	args = append(args, image)
+
+	for _, arg := range options.Command {
+		args = append(args, arg)
+	}
+
+	return args, nil
+}

--- a/modules/docker/run_test.go
+++ b/modules/docker/run_test.go
@@ -17,5 +17,5 @@ func TestRun(t *testing.T) {
 	}
 
 	out := Run(t, "alpine:3.7", options)
-	require.Contains(t, "Hello, World!", out)
+	require.Contains(t, out, "Hello, World!")
 }

--- a/modules/docker/run_test.go
+++ b/modules/docker/run_test.go
@@ -17,5 +17,5 @@ func TestRun(t *testing.T) {
 	}
 
 	out := Run(t, "alpine:3.7", options)
-	require.Equal(t, "Hello, World!", out)
+	require.Contains(t, "Hello, World!", out)
 }

--- a/modules/docker/run_test.go
+++ b/modules/docker/run_test.go
@@ -1,0 +1,20 @@
+package docker
+
+import (
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestRun(t *testing.T) {
+	t.Parallel()
+
+	options := &RunOptions{
+		Command:              []string{"-c", `echo "Hello, $NAME!"`},
+		Entrypoint:           "sh",
+		EnvironmentVariables: []string{"NAME=World"},
+		Remove:               true,
+	}
+
+	out := Run(t, "alpine:3.7", options)
+	require.Equal(t, "Hello, World!", out)
+}

--- a/modules/docker/run_test.go
+++ b/modules/docker/run_test.go
@@ -1,8 +1,9 @@
 package docker
 
 import (
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestRun(t *testing.T) {

--- a/test/fixtures/docker/Dockerfile
+++ b/test/fixtures/docker/Dockerfile
@@ -1,0 +1,4 @@
+# A "Hello, World" Docker image used in automated tests for the docker.Build command.
+FROM alpine:3.7
+ARG text
+CMD ["echo", "$text"]

--- a/test/fixtures/docker/Dockerfile
+++ b/test/fixtures/docker/Dockerfile
@@ -1,4 +1,5 @@
 # A "Hello, World" Docker image used in automated tests for the docker.Build command.
 FROM alpine:3.7
 ARG text
-CMD ["echo", "$text"]
+RUN echo $text > text.txt
+CMD ["cat", "text.txt"]


### PR DESCRIPTION
This PR adds `docker.Build` and `docker.Run` commands to Terratest. These are quite handy when you need to build and run a Docker image at test time. I've written a few local versions of these in various tests, so I figured it was time to finally centralize the implementation in Terratest.