### PR TITLE
Adding support for docker stop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ terraform.tfvars
 .terragrunt-cache
 
 .idea
+.vscode
 *.iml
 vendor
 

--- a/modules/docker/run.go
+++ b/modules/docker/run.go
@@ -58,7 +58,7 @@ func Run(t *testing.T, image string, options *RunOptions) string {
 	return out
 }
 
-// Run runs the 'docker run' command on the given image with the given options and return stdout/stderr, or any error.
+// RunE runs the 'docker run' command on the given image with the given options and return stdout/stderr, or any error.
 func RunE(t *testing.T, image string, options *RunOptions) (string, error) {
 	logger.Logf(t, "Running 'docker run' on image '%s'", image)
 

--- a/modules/docker/stop.go
+++ b/modules/docker/stop.go
@@ -49,9 +49,7 @@ func formatDockerStopArgs(containers []string, options *StopOptions) ([]string, 
 		args = append(args, "--time", strconv.Itoa(options.Time))
 	}
 
-	for _, container := range containers {
-		args = append(args, container)
-	}
+	args = append(args, containers...)
 
 	return args, nil
 }

--- a/modules/docker/stop.go
+++ b/modules/docker/stop.go
@@ -1,0 +1,57 @@
+package docker
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/logger"
+	"github.com/gruntwork-io/terratest/modules/shell"
+	"github.com/stretchr/testify/require"
+)
+
+// StopOptions defines the options that can be passed to the 'docker stop' command
+type StopOptions struct {
+	// Seconds to wait for stop before killing the container (default 10)
+	Time int
+}
+
+// Stop runs the 'docker stop' command for the given containers and return the stdout/stderr. This method fails
+// the test if there are any errors
+func Stop(t *testing.T, containers []string, options *StopOptions) string {
+	out, err := StopE(t, containers, options)
+	require.NoError(t, err)
+	return out
+}
+
+// StopE runs the 'docker stop' command for the given containers and returns any errors.
+func StopE(t *testing.T, containers []string, options *StopOptions) (string, error) {
+	logger.Logf(t, "Running 'docker stop' on containers '%s'", containers)
+
+	args, err := formatDockerStopArgs(containers, options)
+	if err != nil {
+		return "", err
+	}
+
+	cmd := shell.Command{
+		Command: "docker",
+		Args:    args,
+	}
+
+	return shell.RunCommandAndGetOutputE(t, cmd)
+
+}
+
+// formatDockerStopArgs formats the arguments for the 'docker stop' command
+func formatDockerStopArgs(containers []string, options *StopOptions) ([]string, error) {
+	args := []string{"stop"}
+
+	if options.Time != 0 {
+		args = append(args, "--time", strconv.Itoa(options.Time))
+	}
+
+	for _, container := range containers {
+		args = append(args, container)
+	}
+
+	return args, nil
+}

--- a/modules/docker/stop_test.go
+++ b/modules/docker/stop_test.go
@@ -1,10 +1,13 @@
 package docker
 
 import (
+	"crypto/tls"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
+	http_helper "github.com/gruntwork-io/terratest/modules/http-helper"
 	"github.com/stretchr/testify/require"
 )
 
@@ -14,17 +17,32 @@ func TestStop(t *testing.T) {
 	// appending timestamp to container name to run tests in parallel
 	name := "test-nginx" + strconv.FormatInt(time.Now().UnixNano(), 10)
 
+	// choosing a unique port since 80 may not fly well on test machines
+	port := "13030"
+	testURL := strings.Join([]string{"http://localhost", port}, ":")
+
 	// for testing the stopping of a docker container
 	// we got to run a container first and then stop it
 	runOpts := &RunOptions{
-		Detach: true,
-		Name:   name,
-		Remove: true,
+		Detach:       true,
+		Name:         name,
+		Remove:       true,
+		OtherOptions: []string{"-p", strings.Join([]string{port, "80"}, ":")},
 	}
 	Run(t, "nginx:1.17-alpine", runOpts)
+
+	// verify nginx is running
+	tlsConfig := &tls.Config{}
+	statusCode, _ := http_helper.HttpGet(t, testURL, tlsConfig)
+	require.Equal(t, 200, statusCode)
 
 	// try to stop it now
 	stopOpts := &StopOptions{}
 	out := Stop(t, []string{name}, stopOpts)
 	require.Contains(t, out, name)
+
+	// verify nginx is down
+	statusCode, _, err := http_helper.HttpGetE(t, testURL, tlsConfig)
+	require.NotEmpty(t, err)
+
 }

--- a/modules/docker/stop_test.go
+++ b/modules/docker/stop_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	http_helper "github.com/gruntwork-io/terratest/modules/http-helper"
+	"github.com/gruntwork-io/terratest/modules/shell"
 	"github.com/stretchr/testify/require"
 )
 
@@ -19,7 +20,7 @@ func TestStop(t *testing.T) {
 
 	// choosing a unique port since 80 may not fly well on test machines
 	port := "13030"
-	testURL := strings.Join([]string{"http://localhost", port}, ":")
+	testURL := "http://localhost:" + port
 
 	// for testing the stopping of a docker container
 	// we got to run a container first and then stop it
@@ -27,22 +28,27 @@ func TestStop(t *testing.T) {
 		Detach:       true,
 		Name:         name,
 		Remove:       true,
-		OtherOptions: []string{"-p", strings.Join([]string{port, "80"}, ":")},
+		OtherOptions: []string{"-p", port + ":80"},
 	}
 	Run(t, "nginx:1.17-alpine", runOpts)
 
 	// verify nginx is running
-	tlsConfig := &tls.Config{}
-	statusCode, _ := http_helper.HttpGet(t, testURL, tlsConfig)
-	require.Equal(t, 200, statusCode)
+	http_helper.HttpGetWithRetryWithCustomValidation(t, testURL, &tls.Config{}, 60, 2*time.Second, verifyNginxIsUp)
 
 	// try to stop it now
-	stopOpts := &StopOptions{}
-	out := Stop(t, []string{name}, stopOpts)
+	out := Stop(t, []string{name}, &StopOptions{})
 	require.Contains(t, out, name)
 
 	// verify nginx is down
-	statusCode, _, err := http_helper.HttpGetE(t, testURL, tlsConfig)
-	require.NotEmpty(t, err)
+	// run a docker ps with name filter
+	command := shell.Command{
+		Command: "docker",
+		Args:    []string{"ps", "-q", "--filter", "name=" + name},
+	}
+	output := shell.RunCommandAndGetStdOut(t, command)
+	require.Empty(t, output)
+}
 
+func verifyNginxIsUp(statusCode int, body string) bool {
+	return statusCode == 200 && strings.Contains(body, "nginx!")
 }

--- a/modules/docker/stop_test.go
+++ b/modules/docker/stop_test.go
@@ -1,0 +1,30 @@
+package docker
+
+import (
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestStop(t *testing.T) {
+	t.Parallel()
+
+	// appending timestamp to container name to run tests in parallel
+	name := "test-nginx" + strconv.FormatInt(time.Now().UnixNano(), 10)
+
+	// for testing the stopping of a docker container
+	// we got to run a container first and then stop it
+	runOpts := &RunOptions{
+		Detach: true,
+		Name:   name,
+		Remove: true,
+	}
+	Run(t, "nginx:1.17-alpine", runOpts)
+
+	// try to stop it now
+	stopOpts := &StopOptions{}
+	out := Stop(t, []string{name}, stopOpts)
+	require.Contains(t, out, name)
+}


### PR DESCRIPTION
# Description
Adding support for `docker stop` command in the terratest docker API.

# Github Issue
https://github.com/gruntwork-io/terratest/issues/421

# pre-commit hook
```
git commit -m "Adding support for docker stop"
goimports................................................................Passed
[docker-stop-command 1cb9753] Adding support for docker stop
 2 files changed, 87 insertions(+)
 create mode 100644 modules/docker/stop.go
 create mode 100644 modules/docker/stop_test.go
```

# Test Run output
https://gist.github.com/dhwaneetbhatt/018f0775493143b30b7b463deaa45e37