### PR TITLE
Allow custom ssh ports

### DIFF
--- a/modules/ssh/ssh_test.go
+++ b/modules/ssh/ssh_test.go
@@ -1,0 +1,24 @@
+package ssh
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHostWithDefaultPort(t *testing.T) {
+	t.Parallel()
+
+	host := Host{}
+
+	assert.Equal(t, 22, host.getPort(), "host.getPort() did not return the default ssh port of 22")
+}
+
+func TestHostWithCustomPort(t *testing.T) {
+	t.Parallel()
+
+	customPort := 2222
+	host := Host{CustomPort: customPort}
+
+	assert.Equal(t, customPort, host.getPort(), "host.getPort() did not return the custom port number")
+}


### PR DESCRIPTION
Add a new CustomPort field to the Host struct so that we can test ssh using ports other than 22

#433 

Test run logs: https://gist.github.com/malmanzor/af9ab1f1392791c791923d89d7dad545