### PR TITLE
Azure Kubernetes Service sample and helper methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ vendor
 
 # OS X
 .DS_Store
+# Intermediate file for testing
+kubeconfig

--- a/examples/terraform-azure-aks-example/README.md
+++ b/examples/terraform-azure-aks-example/README.md
@@ -1,0 +1,59 @@
+# Terraform Azure AKS Example
+
+This folder contains a Terraform module that deploys a basic AKS cluster in [Azure](https://azure.microsoft.com/) to demonstrate how you can use Terratest to write automated tests for your Azure Terraform code. 
+
+This module deploys [Azure Kubenetes Service](https://azure.microsoft.com/en-us/services/kubernetes-service/), then deploys nginx by a kubernetes yaml file with a Public IP Address using the `Service` resource.
+
+Check out [test/terraform_azure_aks_example_test.go](/test/terraform/azure_aks_example_test.go) to see how you can write automated tests for this module and validate the configuration of the parameters and options. 
+
+**WARNING**: This module and the automated tests for it deploy real resources into your Azure account which can cost you money. 
+
+## Prerequisite: Setup Azure CLI access
+1. Sign up for [Azure](https://azure.microsoft.com/).
+1. Install [Azure CLI](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli?view=azure-cli-latest)
+1. Install [Terraform](https://www.terraform.io/) and make sure it's on your `PATH`.
+1. Install [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) and make sure it's on your `PATH`.
+1. Login to Azure on the CLI with `az login` or `az login --use-device`, and then configure the CLI.
+
+## Running this module manually
+1. Create [Service Principal](https://docs.microsoft.com/en-us/cli/azure/create-an-azure-service-principal-azure-cli?view=azure-cli-latest) then set the value to the environment variables. 
+1. Run `terraform init`
+1. Run `terraform apply`
+1. Apply `nginx-deployment.yml`
+1. Watch the service until Public IPAddress is assigned.
+1. Send http request to the Public IPAddress, make sure it returns 200.
+1. When you're done, run `terraform destroy`.
+
+### Example
+
+```bash
+$ az login 
+$ export ARM_SUBSCRIPTION_ID={YOUR_SUBSCRIPTION_ID} 
+$ az ad sp create-for-rbac
+$ export TF_VAR_client_id={YOUR_SERVICE_PRINCIPAL_APP_ID}
+$ export TF_VAR_client_secret={YOUR_SERVICE_PRINCIPAL_PASSWORD}
+$ terraform init
+$ terraform apply
+$ kubectl --kubeconfig ./kubeconfig -f ./nginx-deployment.yml
+$ kubectl --kubeconfig ./kubeconfig get svc -w
+// Open browser and access the Nginx Service IPAddress
+$ terraform destroy
+```
+
+## Running automated tests against this module
+1. Create [Service Principal](https://docs.microsoft.com/en-us/cli/azure/create-an-azure-service-principal-azure-cli?view=azure-cli-latest) then set the value to the environment variables. 
+1. Install [Golang](https://golang.org/) version `1.13+` required. 
+1. `cd test`
+1. `go test -v -timeout 60m -tags azure -run TestTerraformAzureAKS`
+
+
+### Example
+
+```bash
+$ az login 
+$ export ARM_SUBSCRIPTION_ID={YOUR_SUBSCRIPTION_ID} 
+$ export TF_VAR_client_id={YOUR_SERVICE_PRINCIPAL_APP_ID}
+$ export TF_VAR_client_secret={YOUR_SERVICE_PRINCIPAL_PASSWORD}
+$ cd test
+$ go test -v -timeout 60m -tags azure -run TestTerraformAzureAKS
+```

--- a/examples/terraform-azure-aks-example/main.tf
+++ b/examples/terraform-azure-aks-example/main.tf
@@ -1,0 +1,69 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# DEPLOY AN AZURE AKS CLUSTER
+# This is an example of how to deploy an Azure AKS cluster with load balancer in front of the service 
+# to handle providing the public interface into the cluster.
+# ---------------------------------------------------------------------------------------------------------------------
+
+# ------------------------------------------------------------------------------
+# CONFIGURE OUR AZURE CONNECTION
+# ------------------------------------------------------------------------------
+
+provider "azurerm" {
+  version = "1.40.0"
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# DEPLOY A RESOURCE GROUP
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "azurerm_resource_group" "k8s" {
+  name     = var.resource_group_name
+  location = var.location
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# DEPLOY AN AZURE KUBERNETES CLUSTER
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "azurerm_kubernetes_cluster" "k8s" {
+  name                = var.cluster_name
+  location            = azurerm_resource_group.k8s.location
+  resource_group_name = azurerm_resource_group.k8s.name
+  dns_prefix          = var.dns_prefix
+
+  linux_profile {
+    admin_username = "ubuntu"
+
+    ssh_key {
+      key_data = file(var.ssh_public_key)
+    }
+  }
+
+  default_node_pool {
+    name       = "agentpool"
+    node_count = var.agent_count
+    vm_size    = "Standard_DS1_v2"
+  }
+
+  service_principal {
+    client_id     = var.client_id
+    client_secret = var.client_secret
+  }
+
+  tags = {
+    Environment = "Development"
+  }
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# CREATE KUBECONFIG FILE
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "local_file" "kubeconfig" {
+  content  = azurerm_kubernetes_cluster.k8s.kube_config_raw
+  filename = "kubeconfig"
+
+  depends_on = [
+    azurerm_kubernetes_cluster.k8s
+  ]
+}

--- a/examples/terraform-azure-aks-example/nginx-deployment.yml
+++ b/examples/terraform-azure-aks-example/nginx-deployment.yml
@@ -1,0 +1,33 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+spec:
+  selector:
+    matchLabels:
+      app: nginx
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.15.7
+        ports:
+        - containerPort: 80
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: nginx-service
+spec:
+  selector:
+    app: nginx
+  ports:
+  - protocol: TCP
+    targetPort: 80
+    port: 80
+  type: LoadBalancer

--- a/examples/terraform-azure-aks-example/output.tf
+++ b/examples/terraform-azure-aks-example/output.tf
@@ -1,0 +1,27 @@
+output "client_key" {
+  value = azurerm_kubernetes_cluster.k8s.kube_config.0.client_key
+}
+
+output "client_certificate" {
+  value = azurerm_kubernetes_cluster.k8s.kube_config.0.client_certificate
+}
+
+output "cluster_ca_certificate" {
+  value = azurerm_kubernetes_cluster.k8s.kube_config.0.cluster_ca_certificate
+}
+
+output "cluster_username" {
+  value = azurerm_kubernetes_cluster.k8s.kube_config.0.username
+}
+
+output "cluster_password" {
+  value = azurerm_kubernetes_cluster.k8s.kube_config.0.password
+}
+
+output "kube_config" {
+  value = azurerm_kubernetes_cluster.k8s.kube_config_raw
+}
+
+output "host" {
+  value = azurerm_kubernetes_cluster.k8s.kube_config.0.host
+}

--- a/examples/terraform-azure-aks-example/variables.tf
+++ b/examples/terraform-azure-aks-example/variables.tf
@@ -1,0 +1,46 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# REQUIRED PARAMETERS
+# You must provide a value for each of these parameters.
+# ---------------------------------------------------------------------------------------------------------------------
+
+variable "client_id" {
+  description = "The Service Principal Client Id for AKS to modify Azure resources."
+}
+variable "client_secret" {
+  description = "The Service Principal Client Password for AKS to modify Azure resources."
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# OPTIONAL PARAMETERS
+# These parameters have reasonable defaults.
+# ---------------------------------------------------------------------------------------------------------------------
+
+variable "agent_count" {
+  description = "The number of the nodes of the AKS cluster."
+  default     = 3
+}
+
+variable "ssh_public_key" {
+  description = "The public key for the ssh connection to the nodes."
+  default     = "~/.ssh/id_rsa.pub"
+}
+
+variable "dns_prefix" {
+  description = "The prefix to set for the AKS cluster resoureces names."
+  default     = "k8stest"
+}
+
+variable cluster_name {
+  description = "The name to set for the AKS cluster."
+  default     = "k8stest"
+}
+
+variable resource_group_name {
+  description = "The name to set for the resource group."
+  default     = "azure-k8stest"
+}
+
+variable location {
+  description = "The location to set for the AKS cluster."
+  default     = "Central US"
+}

--- a/modules/azure/aks.go
+++ b/modules/azure/aks.go
@@ -1,0 +1,45 @@
+package azure
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2019-11-01/containerservice"
+)
+
+// GetManagedClustersClientE is a helper function that will setup an Azure ManagedClusters client on your behalf
+func GetManagedClustersClientE(subscriptionID string) (*containerservice.ManagedClustersClient, error) {
+	// Validate Azure subscription ID
+	subscriptionID, err := getTargetAzureSubscription(subscriptionID)
+	if err != nil {
+		return nil, err
+	}
+
+	managedServicesClient := containerservice.NewManagedClustersClient(subscriptionID)
+	authorizer, err := NewAuthorizer()
+
+	if err != nil {
+		return nil, err
+	}
+
+	managedServicesClient.Authorizer = *authorizer
+
+	return &managedServicesClient, nil
+}
+
+// GetManagedClusterE will return ManagedCluster
+func GetManagedClusterE(t *testing.T, resourceGroupName, clusterName, subscriptionID string) (*containerservice.ManagedCluster, error) {
+	subscriptionID, err := getTargetAzureSubscription(subscriptionID)
+	if err != nil {
+		return nil, err
+	}
+	client, err := GetManagedClustersClientE(subscriptionID)
+	if err != nil {
+		return nil, err
+	}
+	managedCluster, err := client.Get(context.Background(), resourceGroupName, clusterName)
+	if err != nil {
+		return nil, err
+	}
+	return &managedCluster, nil
+}

--- a/test/terraform_azure_aks_example_test.go
+++ b/test/terraform_azure_aks_example_test.go
@@ -1,0 +1,101 @@
+// +build azure
+
+// NOTE: We use build tags to differentiate azure testing because we currently do not have azure access setup for
+// CircleCI.
+
+package test
+
+import (
+	"crypto/tls"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gruntwork-io/terratest/modules/azure"
+	http_helper "github.com/gruntwork-io/terratest/modules/http-helper"
+	"github.com/gruntwork-io/terratest/modules/k8s"
+	"github.com/gruntwork-io/terratest/modules/random"
+	"github.com/gruntwork-io/terratest/modules/terraform"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTerraformAzureAKSExample(t *testing.T) {
+	t.Parallel()
+	// MC_+ResourceGroupName_ClusterName_AzureRegion must be no greater than 80 chars.
+	// https://docs.microsoft.com/en-us/azure/aks/troubleshooting#what-naming-restrictions-are-enforced-for-aks-resources-and-parameters
+	expectedClusterName := fmt.Sprintf("terratest-aks-cluster-%s", random.UniqueId())
+	expectedResourceGroupName := fmt.Sprintf("terratest-aks-rg-%s", random.UniqueId())
+	expectedAagentCount := 3
+
+	terraformOptions := &terraform.Options{
+		TerraformDir: "../examples/terraform-azure-aks-example",
+		Vars: map[string]interface{}{
+			"cluster_name":        expectedClusterName,
+			"resource_group_name": expectedResourceGroupName,
+			"agent_count":         expectedAagentCount,
+		},
+	}
+	// At the end of the test, run `terraform destroy` to clean up any resources that were created
+	defer terraform.Destroy(t, terraformOptions)
+
+	// This will run `terraform init` and `terraform apply` and fail the test if there are any errors
+	terraform.InitAndApply(t, terraformOptions)
+
+	// Look up the cluster node count
+	cluster, err := azure.GetManagedClusterE(t, expectedResourceGroupName, expectedClusterName, "")
+	require.NoError(t, err)
+	actualCount := *(*cluster.ManagedClusterProperties.AgentPoolProfiles)[0].Count
+
+	// Test that the Node count matches the Terraform specification
+	assert.Equal(t, int32(expectedAagentCount), actualCount)
+
+	// Path to the Kubernetes resource config we will test
+	kubeResourcePath, err := filepath.Abs("../examples/terraform-azure-aks-example/nginx-deployment.yml")
+	require.NoError(t, err)
+
+	// To ensure we can reuse the resource config on the same cluster to test different scenarios, we setup a unique
+	// namespace for the resources for this test.
+	// Note that namespaces must be lowercase.
+	namespaceName := strings.ToLower(random.UniqueId())
+
+	// Setup the kubectl config and context. Here we choose to use the defaults, which is:
+	// - HOME/.kube/config for the kubectl config file
+	// - Current context of the kubectl config file
+	options := k8s.NewKubectlOptions("", "../examples/terraform-azure-aks-example/kubeconfig", namespaceName)
+
+	k8s.CreateNamespace(t, options, namespaceName)
+	// ... and make sure to delete the namespace at the end of the test
+	defer k8s.DeleteNamespace(t, options, namespaceName)
+
+	// At the end of the test, run `kubectl delete -f RESOURCE_CONFIG` to clean up any resources that were created.
+	defer k8s.KubectlDelete(t, options, kubeResourcePath)
+
+	// This will run `kubectl apply -f RESOURCE_CONFIG` and fail the test if there are any errors
+	k8s.KubectlApply(t, options, kubeResourcePath)
+
+	// This will wait up to 10 seconds for the service to become available, to ensure that we can access it.
+	k8s.WaitUntilServiceAvailable(t, options, "nginx-service", 10, 20*time.Second)
+	// Now we verify that the service will successfully boot and start serving requests
+	service := k8s.GetService(t, options, "nginx-service")
+	endpoint := k8s.GetServiceEndpoint(t, options, service, 80)
+
+	// Setup a TLS configuration to submit with the helper, a blank struct is acceptable
+	tlsConfig := tls.Config{}
+
+	// Test the endpoint for up to 5 minutes. This will only fail if we timeout waiting for the service to return a 200
+	// response.
+	http_helper.HttpGetWithRetryWithCustomValidation(
+		t,
+		fmt.Sprintf("http://%s", endpoint),
+		&tlsConfig,
+		30,
+		10*time.Second,
+		func(statusCode int, body string) bool {
+			return statusCode == 200
+		},
+	)
+
+}


### PR DESCRIPTION
Based on the conversation of the issue. https://github.com/gruntwork-io/terratest/issues/89
I create a sample and helper method for supporting Azure Kubernetes Service usage. 

This PR provide two helper methods. 

1. Fetch the Kubernetes Service metadata
1. Wait for the allocation of Public IP Address on Kubernetes Service

In case of Azure, Node Port is not good option for external access outside of the kubernetes cluster, we use ingress or LoadBalancer type. For both case, we need to wait until Public IPAddress is assigned to the service. It takes some time. That is why, the sample for kubernetes doesn't work for Azure users. So I'd like to contribute this to unblock it to Azure users. 