### PR TITLE
LoadOrCreateAndSaveString

### DIFF
--- a/modules/test-structure/save_test_data.go
+++ b/modules/test-structure/save_test_data.go
@@ -108,6 +108,18 @@ func LoadString(t *testing.T, testFolder string, name string) string {
 	return val
 }
 
+// LoadOrSaveString loads and unserializes a uniquely named string value from the given folder. If the string is not found,
+// it will create and save it instead.
+func LoadOrSaveString(t *testing.T, testFolder string, name string, create func() string) string {
+	if IsTestDataPresent(t, formatNamedTestDataPath(testFolder, name)) {
+		return LoadString(t, testFolder, name)
+	}
+
+	val := create()
+	SaveString(t, testFolder, name, val)
+	return val
+}
+
 // SaveInt saves a uniquely named int value into the given folder. This allows you to create one or more int
 // values during one stage -- each with a unique name -- and to reuse those values during later stages.
 func SaveInt(t *testing.T, testFolder string, name string, val int) {

--- a/modules/test-structure/save_test_data_test.go
+++ b/modules/test-structure/save_test_data_test.go
@@ -197,6 +197,29 @@ func TestSaveDuplicateTestData(t *testing.T) {
 	assert.Equal(t, val2, actualVal, "Actual test data should use overwritten values")
 }
 
+func TestLoadOrSaveString(t *testing.T) {
+	t.Parallel()
+
+	tmpFolder, err := ioutil.TempDir("", "load-or-create-and-save-string")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+
+	name := "cluster-name"
+	expectedData := "app"
+
+	LoadOrSaveString(t, tmpFolder, name, func() string { return expectedData })
+
+	assert.Equal(t, expectedData, LoadString(t, tmpFolder, name))
+
+	LoadOrSaveString(t, tmpFolder, name, func() string {
+		t.Fatalf("Create callback should not be called if the value already exists")
+		return "something else"
+	})
+
+	assert.Equal(t, expectedData, LoadString(t, tmpFolder, name))
+}
+
 func TestSaveAndLoadNamedInts(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
I found that I needed a function that either loads a test data string from disk or if it does not exist yet, creates it. I chose a name for the function that contains both "load" and "save".  An alternative to the current name is `LoadOrSaveString()`.