### PR TITLE
Fix hello world example for k8s on minikube

### DIFF
--- a/modules/k8s/minikube.go
+++ b/modules/k8s/minikube.go
@@ -1,0 +1,15 @@
+package k8s
+
+import "testing"
+
+// IsMinikubeE returns true if the underlying kubernetes cluster is Minikube. This is determined by getting the
+// associated nodes and checking if:
+// - there is only one node
+// - the node is named "minikube"
+func IsMinikubeE(t *testing.T, options *KubectlOptions) (bool, error) {
+	nodes, err := GetNodesE(t, options)
+	if err != nil {
+		return false, err
+	}
+	return len(nodes) == 1 && nodes[0].GetName() == "minikube", nil
+}

--- a/modules/k8s/service.go
+++ b/modules/k8s/service.go
@@ -68,7 +68,15 @@ func WaitUntilServiceAvailable(t *testing.T, options *KubectlOptions, serviceNam
 			if err != nil {
 				return "", err
 			}
-			if !IsServiceAvailable(service) {
+
+			isMinikube, err := IsMinikubeE(t, options)
+			if err != nil {
+				return "", err
+			}
+
+			// For minikube, all services will be available immediately so we only do the check if we are not on
+			// minikube.
+			if !isMinikube && !IsServiceAvailable(service) {
 				return "", NewServiceNotAvailableError(service)
 			}
 			return "Service is now available", nil
@@ -77,7 +85,8 @@ func WaitUntilServiceAvailable(t *testing.T, options *KubectlOptions, serviceNam
 	logger.Logf(t, message)
 }
 
-// IsServiceAvailable returns true if the service endpoint is ready to accept traffic.
+// IsServiceAvailable returns true if the service endpoint is ready to accept traffic. Note that for Minikube, this
+// function is moot as all services, even LoadBalancer, is available immediately.
 func IsServiceAvailable(service *corev1.Service) bool {
 	// Only the LoadBalancer type has a delay. All other service types are available if the resource exists.
 	switch service.Spec.Type {
@@ -112,6 +121,15 @@ func GetServiceEndpointE(t *testing.T, options *KubectlOptions, service *corev1.
 	case corev1.ServiceTypeNodePort:
 		return findEndpointForNodePortService(t, options, service, int32(servicePort))
 	case corev1.ServiceTypeLoadBalancer:
+		// For minikube, LoadBalancer service is exactly the same as NodePort service
+		isMinikube, err := IsMinikubeE(t, options)
+		if err != nil {
+			return "", err
+		}
+		if isMinikube {
+			return findEndpointForNodePortService(t, options, service, int32(servicePort))
+		}
+
 		ingress := service.Status.LoadBalancer.Ingress
 		if len(ingress) == 0 {
 			return "", NewServiceNotAvailableError(service)

--- a/test/kubernetes_hello_world_example_test.go
+++ b/test/kubernetes_hello_world_example_test.go
@@ -33,5 +33,5 @@ func TestKubernetesHelloWorldExample(t *testing.T) {
 	url := fmt.Sprintf("http://%s", k8s.GetServiceEndpoint(t, options, service, 5000))
 
 	// website::tag::5:: Make an HTTP request to the URL and make sure it returns a 200 OK with the body "Hello, World".
-	http_helper.HttpGetWithRetry(t, url, nil, 200, "Hello world!", 10, 3*time.Second)
+	http_helper.HttpGetWithRetry(t, url, nil, 200, "Hello world!", 30, 3*time.Second)
 }


### PR DESCRIPTION
The hello world example for k8s is broken because `LoadBalancer` services on `minikube` does not behave like any other k8s flavor. `LoadBalancer` services are automatically converted to `NodePort` under the hood in `minikube`, so it doesn't get the `ingress` property. Unfortunately, a lot of our functions assume the `ingress` property and use that to determine service endpoints and availability for that. Note that this is also happening in CI and our CI builds have been broken.

This fixes the behavior by having special handling of minikube in the various service functions.