### PR TITLE
Fix pre-commit call

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,6 +65,9 @@ jobs:
           name: run precommit
           command: |
             go get golang.org/x/tools/cmd/goimports
+            # Oct 26, 2019: Install the last known working version of pre-commit. Also, we have to pin the version of a
+            # transitive dependency that is being pulled in (cfgv) which released a new version that is no longer compatible
+            # with any python < 3.6.
             pip install pre-commit==1.11.2 cfgv==2.0.1
             pre-commit install
             pre-commit run --all-files

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,10 +61,13 @@ jobs:
           - $HOME/go/src/
 
       # Run pre-commit hooks and fail the build if any hook finds required changes.
-      - run: go get golang.org/x/tools/cmd/goimports
-      - run: pip install pre-commit==1.11.2
-      - run: pre-commit install
-      - run: pre-commit run --all-files
+      - run:
+          name: run precommit
+          command: |
+            go get golang.org/x/tools/cmd/goimports
+            pip install pre-commit==1.11.2 cfgv==2.0.1
+            pre-commit install
+            pre-commit run --all-files
 
       # Build any binaries that need to be built
       # We always want to build the binaries, because we will use the terratest_log_parser to parse out the test output


### PR DESCRIPTION
The build broke because `pre-commit` can no longer be called due to issues with `cfgv`. This fixes that.