### PR TITLE
Fix links to basic terraform example

### DIFF
--- a/docs/_docs/01_getting-started/quick-start.md
+++ b/docs/_docs/01_getting-started/quick-start.md
@@ -23,9 +23,9 @@ types of infrastructure code you can test (e.g., Packer, Kubernetes, etc).
 
 1. Create an `examples` and `test` folder.
 
-1. Copy all the files from the [basic terraform example]({{site.baseurl}}/examples/code-examples/terraform-basic-example/) into the `examples` folder.
+1. Copy all the files from the [basic terraform example](https://github.com/gruntwork-io/terratest/tree/master/examples/terraform-basic-example/) into the `examples` folder.
 
-1. Copy the [basic terraform example test]({{site.baseurl}}/examples/tests/terraform-basic-example-test/) into the `test` folder.
+1. Copy the [basic terraform example test](https://github.com/gruntwork-io/terratest/blob/master/test/terraform_basic_example_test.go) into the `test` folder.
 
 1. To configure dependencies, run:
 


### PR DESCRIPTION
Links to the terraform basic example were dead.