### PR TITLE
Added helper function to extract tags from an AWS TagSet

### DIFF
--- a/modules/aws/ec2.go
+++ b/modules/aws/ec2.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"fmt"
+	"reflect"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -305,6 +306,26 @@ func AddTagsToResourceE(t *testing.T, region string, resource string, tags map[s
 	})
 
 	return err
+}
+
+// ExtractTagsFromResource extracts the tags out of an AWS TagSet for any resource such as EC2, AMI, or VPC.
+func ExtractTagsFromResource(tagSet interface{}) map[string]string {
+	tags := make(map[string]string)
+
+	switch reflect.TypeOf(tagSet).Kind() {
+	case reflect.Slice:
+		slice := reflect.ValueOf(tagSet)
+
+		for i := 0; i < slice.Len(); i++ {
+			s := slice.Index(i)
+
+			key := s.FieldByName("Key").Elem().String()
+			value := s.FieldByName("Value").Elem().String()
+
+			tags[key] = value
+		}
+	}
+	return tags
 }
 
 // TerminateInstance terminates the EC2 instance with the given ID in the given region.

--- a/modules/aws/ec2_test.go
+++ b/modules/aws/ec2_test.go
@@ -2,8 +2,11 @@ package aws
 
 import (
 	"fmt"
+	"reflect"
 	"testing"
 
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -30,4 +33,65 @@ func TestGetEc2InstanceIdsByFilters(t *testing.T) {
 	ids, err := GetEc2InstanceIdsByFiltersE(t, region, filters)
 	require.NoError(t, err)
 	assert.Equal(t, 0, len(ids))
+}
+
+func TestExtractTagsFromResource(t *testing.T) {
+	t.Parallel()
+
+	env := "test"
+	createdBy := "terratest"
+
+	t.Run("verify ExtractTagsFromResource works with EC2 Instance TagSet", func(t *testing.T) {
+		instanceName := "web-server"
+
+		ec2InstanceTagSet := []ec2.Tag{
+			{
+				Key:   aws.String("Name"),
+				Value: aws.String(instanceName),
+			},
+			{
+				Key:   aws.String("Env"),
+				Value: aws.String(env),
+			},
+			{
+				Key:   aws.String("CreatedBy"),
+				Value: aws.String(createdBy),
+			},
+		}
+
+		expected := map[string]string{
+			"Name":      instanceName,
+			"Env":       env,
+			"CreatedBy": createdBy,
+		}
+		actual := ExtractTagsFromResource(ec2InstanceTagSet)
+		assert.True(t, reflect.DeepEqual(expected, actual))
+	})
+
+	t.Run("verify ExtractTagsFromResource works with S3 Bucket TagSet", func(t *testing.T) {
+		bucketName := "terratest-s3-bucket"
+
+		s3BucketTagSet := []ec2.Tag{
+			{
+				Key:   aws.String("Name"),
+				Value: aws.String(bucketName),
+			},
+			{
+				Key:   aws.String("Env"),
+				Value: aws.String(env),
+			},
+			{
+				Key:   aws.String("CreatedBy"),
+				Value: aws.String(createdBy),
+			},
+		}
+
+		expected := map[string]string{
+			"Name":      bucketName,
+			"Env":       env,
+			"CreatedBy": createdBy,
+		}
+		actual := ExtractTagsFromResource(s3BucketTagSet)
+		assert.True(t, reflect.DeepEqual(expected, actual))
+	})
 }


### PR DESCRIPTION
This PR adds a generic helper function to extract the tags from an AWS TagSet into a map.

A [TagSet](https://docs.aws.amazon.com/AmazonS3/latest/API/API_Tagging.html) is of the following form:

```
"TagSet": [
    {
      "Key": "Name",
      "Value": "my-vpc"
    },
    {
      "Key": "CreatedBy",
      "Value": "Terraform"
    },
    {
      "Key": "Env",
      "Value": "test"
    },
]
```

An example of using this to extract the tags set on a VPC:

```go
vpcID := "vpc-a5b9c5e7"

req := client.DescribeVpcsRequest(&ec2.DescribeVpcsInput{
	VpcIds: []string{
		vpcID,
	},
})

resp, err := req.Send(context.Background())
if err != nil {
	logger.Logf(t, "Failed to lookup the VPC %q. Error: %s", vpcID, err.Error())
}
assert.Nil(t, err)

tags := aws.ExtractResourceTags(resp.Vpcs[0].Tags)
```