### PR TITLE
Helm3 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ install_helm: &install_helm
   name: install helm
   command: |
     # install helm
-    curl -Lo helm.tar.gz https://storage.googleapis.com/kubernetes-helm/helm-${HELM_VERSION}-linux-amd64.tar.gz
+    curl -Lo helm.tar.gz https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz
     tar -xvf helm.tar.gz
     chmod +x linux-amd64/helm
     sudo mv linux-amd64/helm /usr/local/bin/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,9 @@ install_helm: &install_helm
     chmod +x linux-amd64/helm
     sudo mv linux-amd64/helm /usr/local/bin/
 
+    # Initialize stable repository
+    helm repo add stable https://kubernetes-charts.storage.googleapis.com/
+
 
 install_gruntwork_utils: &install_gruntwork_utils
   name: install gruntwork utils

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ defaults: &defaults
     PACKER_VERSION: 1.5.1
     GOLANG_VERSION: 1.13
     K8S_VERSION: v1.10.0  # Same as EKS
-    HELM_VERSION: v2.12.2
+    HELM_VERSION: v3.1.1
     KUBECONFIG: /home/circleci/.kube/config
 
 
@@ -22,9 +22,6 @@ install_helm: &install_helm
     tar -xvf helm.tar.gz
     chmod +x linux-amd64/helm
     sudo mv linux-amd64/helm /usr/local/bin/
-
-    # Deploy Tiller
-    helm init --wait
 
 
 install_gruntwork_utils: &install_gruntwork_utils

--- a/modules/helm/cmd.go
+++ b/modules/helm/cmd.go
@@ -24,6 +24,14 @@ func getCommonArgs(options *Options, args ...string) []string {
 	return args
 }
 
+// getNamespaceArgs returns the args to append for the namespace, if set in the helm Options struct.
+func getNamespaceArgs(options *Options) []string {
+	if options.KubectlOptions != nil && options.KubectlOptions.Namespace != "" {
+		return []string{"--namespace", options.KubectlOptions.Namespace}
+	}
+	return []string{}
+}
+
 // getValuesArgsE computes the args to pass in for setting values
 func getValuesArgsE(t *testing.T, options *Options, args ...string) ([]string, error) {
 	args = append(args, formatSetValuesAsArgs(options.SetValues, "--set")...)

--- a/modules/helm/delete.go
+++ b/modules/helm/delete.go
@@ -19,9 +19,7 @@ func DeleteE(t *testing.T, options *Options, releaseName string, purge bool) err
 	if !purge {
 		args = append(args, "--keep-history")
 	}
-	if options.KubectlOptions != nil && options.KubectlOptions.Namespace != "" {
-		args = append(args, "--namespace", options.KubectlOptions.Namespace)
-	}
+	args = append(args, getNamespaceArgs(options)...)
 	args = append(args, releaseName)
 	_, err := RunHelmCommandAndGetOutputE(t, options, "delete", args...)
 	return err

--- a/modules/helm/delete.go
+++ b/modules/helm/delete.go
@@ -16,8 +16,11 @@ func Delete(t *testing.T, options *Options, releaseName string, purge bool) {
 // as well so that the release name can be reused.
 func DeleteE(t *testing.T, options *Options, releaseName string, purge bool) error {
 	args := []string{}
-	if purge {
-		args = append(args, "--purge")
+	if !purge {
+		args = append(args, "--keep-history")
+	}
+	if options.KubectlOptions != nil && options.KubectlOptions.Namespace != "" {
+		args = append(args, "--namespace", options.KubectlOptions.Namespace)
 	}
 	args = append(args, releaseName)
 	_, err := RunHelmCommandAndGetOutputE(t, options, "delete", args...)

--- a/modules/helm/install.go
+++ b/modules/helm/install.go
@@ -32,9 +32,7 @@ func InstallE(t *testing.T, options *Options, chart string, releaseName string) 
 	// Declare err here so that we can update args later
 	var err error
 	args := []string{}
-	if options.KubectlOptions != nil && options.KubectlOptions.Namespace != "" {
-		args = append(args, "--namespace", options.KubectlOptions.Namespace)
-	}
+	args = append(args, getNamespaceArgs(options)...)
 	if options.Version != "" {
 		args = append(args, "--version", options.Version)
 	}

--- a/modules/helm/install.go
+++ b/modules/helm/install.go
@@ -42,7 +42,7 @@ func InstallE(t *testing.T, options *Options, chart string, releaseName string) 
 	if err != nil {
 		return err
 	}
-	args = append(args, "-n", releaseName, chart)
+	args = append(args, releaseName, chart)
 	_, err = RunHelmCommandAndGetOutputE(t, options, "install", args...)
 	return err
 }

--- a/modules/helm/template.go
+++ b/modules/helm/template.go
@@ -36,7 +36,6 @@ func RenderTemplateE(t *testing.T, options *Options, chartDir string, releaseNam
 	// Now construct the args
 	// We first construct the template args
 	args := []string{}
-	args = append(args, "--name", releaseName)
 	if options.KubectlOptions != nil && options.KubectlOptions.Namespace != "" {
 		args = append(args, "--namespace", options.KubectlOptions.Namespace)
 	}
@@ -53,10 +52,10 @@ func RenderTemplateE(t *testing.T, options *Options, chartDir string, releaseNam
 
 		// Note: we only get the abs template file path to check it actually exists, but the `helm template` command
 		// expects the relative path from the chart.
-		args = append(args, "-x", templateFile)
+		args = append(args, "--show-only", templateFile)
 	}
-	// ... and add the chart at the end as the command expects
-	args = append(args, chartDir)
+	// ... and add the name and chart at the end as the command expects
+	args = append(args, releaseName, chartDir)
 
 	// Finally, call out to helm template command
 	return RunHelmCommandAndGetOutputE(t, options, "template", args...)

--- a/modules/helm/upgrade.go
+++ b/modules/helm/upgrade.go
@@ -29,6 +29,7 @@ func UpgradeE(t *testing.T, options *Options, chart string, releaseName string) 
 
 	var err error
 	args := []string{}
+	args = append(args, getNamespaceArgs(options)...)
 	args, err = getValuesArgsE(t, options, args...)
 	if err != nil {
 		return err


### PR DESCRIPTION
This updates terratest to be compatible with helm3. Here are the relevant changes:

- `helm.DeleteE`: `--purge` has been removed and is now the default. Instead, there is `--keep-history` for the negative of that.
- `helm.DeleteE`: Releases are now tied to the namespace they were deployed in, so we need to pass in the corresponding namespace.
- `helm.UpgradeE`: Releases are now tied to the namespace they were deployed in, so we need to pass in the corresponding namespace.
- `helm.InstallE`: Namespace argument is now required and is a positional argument.
- `helm.RenderTemplateE`: Release name is now required and is a positional argument.
- `helm.RenderTemplateE`: `-x` no longer exists, but is replaced with `--show-only`.