### PR TITLE
Do not convert booleans to int

### DIFF
--- a/modules/terraform/format.go
+++ b/modules/terraform/format.go
@@ -3,6 +3,7 @@ package terraform
 import (
 	"fmt"
 	"reflect"
+	"strconv"
 	"strings"
 
 	"github.com/gruntwork-io/terratest/modules/collections"
@@ -184,10 +185,7 @@ func primitiveToHclString(value interface{}, isNested bool) string {
 	switch v := value.(type) {
 
 	case bool:
-		if v {
-			return "1"
-		}
-		return "0"
+		return strconv.FormatBool(v)
 
 	case string:
 		// If string is nested in a larger data structure (e.g. list of string, map of string), ensure value is quoted

--- a/modules/terraform/format_test.go
+++ b/modules/terraform/format_test.go
@@ -17,12 +17,12 @@ func TestFormatTerraformVarsAsArgs(t *testing.T) {
 		{map[string]interface{}{}, nil},
 		{map[string]interface{}{"foo": "bar"}, []string{"-var", "foo=bar"}},
 		{map[string]interface{}{"foo": 123}, []string{"-var", "foo=123"}},
-		{map[string]interface{}{"foo": true}, []string{"-var", "foo=1"}},
+		{map[string]interface{}{"foo": true}, []string{"-var", "foo=true"}},
 		{map[string]interface{}{"foo": []int{1, 2, 3}}, []string{"-var", "foo=[1, 2, 3]"}},
 		{map[string]interface{}{"foo": map[string]string{"baz": "blah"}}, []string{"-var", "foo={\"baz\" = \"blah\"}"}},
 		{
 			map[string]interface{}{"str": "bar", "int": -1, "bool": false, "list": []string{"foo", "bar", "baz"}, "map": map[string]int{"foo": 0}},
-			[]string{"-var", "str=bar", "-var", "int=-1", "-var", "bool=0", "-var", "list=[\"foo\", \"bar\", \"baz\"]", "-var", "map={\"foo\" = 0}"},
+			[]string{"-var", "str=bar", "-var", "int=-1", "-var", "bool=false", "-var", "list=[\"foo\", \"bar\", \"baz\"]", "-var", "map={\"foo\" = 0}"},
 		},
 	}
 
@@ -43,7 +43,7 @@ func TestPrimitiveToHclString(t *testing.T) {
 		{"", ""},
 		{"foo", "foo"},
 		{"true", "true"},
-		{true, "1"},
+		{true, "true"},
 		{3, "3"},
 		{[]int{1, 2, 3}, "[1 2 3]"}, // Anything that isn't a primitive is forced into a string
 	}
@@ -64,9 +64,9 @@ func TestMapToHclString(t *testing.T) {
 		{map[string]interface{}{}, "{}"},
 		{map[string]interface{}{"key1": "value1"}, "{\"key1\" = \"value1\"}"},
 		{map[string]interface{}{"key1": 123}, "{\"key1\" = 123}"},
-		{map[string]interface{}{"key1": true}, "{\"key1\" = 1}"},
+		{map[string]interface{}{"key1": true}, "{\"key1\" = true}"},
 		{map[string]interface{}{"key1": []int{1, 2, 3}}, "{\"key1\" = [1, 2, 3]}"}, // Any value that isn't a primitive is forced into a string
-		{map[string]interface{}{"key1": "value1", "key2": 0, "key3": false}, "{\"key1\" = \"value1\", \"key2\" = 0, \"key3\" = 0}"},
+		{map[string]interface{}{"key1": "value1", "key2": 0, "key3": false}, "{\"key1\" = \"value1\", \"key2\" = 0, \"key3\" = false}"},
 		{map[string]interface{}{"key1.a.b.c": "value1"}, "{\"key1.a.b.c\" = \"value1\"}"},
 	}
 
@@ -119,9 +119,9 @@ func TestSliceToHclString(t *testing.T) {
 		{[]interface{}{}, "[]"},
 		{[]interface{}{"foo"}, "[\"foo\"]"},
 		{[]interface{}{123}, "[123]"},
-		{[]interface{}{true}, "[1]"},
+		{[]interface{}{true}, "[true]"},
 		{[]interface{}{[]int{1, 2, 3}}, "[[1, 2, 3]]"}, // Any value that isn't a primitive is forced into a string
-		{[]interface{}{"foo", 0, false}, "[\"foo\", 0, 0]"},
+		{[]interface{}{"foo", 0, false}, "[\"foo\", 0, false]"},
 		{[]interface{}{map[string]interface{}{"foo": "bar"}}, "[{\"foo\" = \"bar\"}]"},
 		{[]interface{}{map[string]interface{}{"foo": "bar"}, map[string]interface{}{"foo": "bar"}}, "[{\"foo\" = \"bar\"}, {\"foo\" = \"bar\"}]"},
 	}
@@ -142,7 +142,7 @@ func TestToHclString(t *testing.T) {
 		{"", ""},
 		{"foo", "foo"},
 		{123, "123"},
-		{true, "1"},
+		{true, "true"},
 		{[]int{1, 2, 3}, "[1, 2, 3]"},
 		{[]string{"foo", "bar", "baz"}, "[\"foo\", \"bar\", \"baz\"]"},
 		{map[string]string{"key1": "value1"}, "{\"key1\" = \"value1\"}"},


### PR DESCRIPTION
Fixes #468
This commit partly reverts the PR [#113](https://github.com/gruntwork-io/terratest/pull/113). Terraform
seems to not allow integers as booleans when these boolean types are
nested within other types. Top-Level variables as booleans are not
affected.
In order to fix this, we should not tranlate the booleans to integers
anymore, but pass them through directly.
