### PR TITLE
Allow configuring all command options for packer

### DIFF
--- a/modules/packer/packer.go
+++ b/modules/packer/packer.go
@@ -26,6 +26,8 @@ type Options struct {
 	RetryableErrors    map[string]string // If packer build fails with one of these (transient) errors, retry. The keys are a regexp to match against the error and the message is what to display to a user if that error is matched.
 	MaxRetries         int               // Maximum number of times to retry errors matching RetryableErrors
 	TimeBetweenRetries time.Duration     // The amount of time to wait between retries
+	WorkingDir         string            // The directory to run packer in
+	OutputMaxLineSize  int               // The max line size of stdout and stderr (in bytes)
 }
 
 // BuildArtifacts can take a map of identifierName <-> Options and then parallelize
@@ -90,9 +92,11 @@ func BuildArtifactE(t *testing.T, options *Options) (string, error) {
 	logger.Logf(t, "Running Packer to generate a custom artifact for template %s", options.Template)
 
 	cmd := shell.Command{
-		Command: "packer",
-		Args:    formatPackerArgs(options),
-		Env:     options.Env,
+		Command:           "packer",
+		Args:              formatPackerArgs(options),
+		Env:               options.Env,
+		WorkingDir:        options.WorkingDir,
+		OutputMaxLineSize: options.OutputMaxLineSize,
 	}
 
 	description := fmt.Sprintf("%s %v", cmd.Command, cmd.Args)


### PR DESCRIPTION
:wave:

I have a packer template that includes copying of files from a directory relative to the working dir via a file provisioner; this means I need to be able to tell terratest to run with a specific working dir. `shell.Command` already supported this, but the packer module wasn't taking advantage of that. This change allows passing through WorkingDir down to the `shell.Command` that runs packer.

I also added the OutputMaxLineSize option while I was in there; this means packer can set all possible options that are able to be set on the `shell.Command`.

I didn't see a test that I could add to for this, so I did not add one. I'm happy to add one if I can be pointed to where it should belong, though!

A possible improvement to this would be further changes that make the `Template` option not required as packer does not require it be set if you use the `packer-template.json` name for the template. For now, my usage of terratest specifies both `WorkingDir` and `Template`.