### PR TITLE
Also delete the delete markers whem emptying a bucket

### DIFF
--- a/modules/aws/s3.go
+++ b/modules/aws/s3.go
@@ -227,6 +227,14 @@ func EmptyS3BucketE(t testing.TestingT, region string, name string) error {
 			objectsToDelete = append(objectsToDelete, &obj)
 		}
 
+		for _, object := range (*bucketObjects).DeleteMarkers {
+			obj := s3.ObjectIdentifier{
+				Key:       object.Key,
+				VersionId: object.VersionId,
+			}
+			objectsToDelete = append(objectsToDelete, &obj)
+		}
+
 		//Creating JSON payload for bulk delete
 		deleteArray := s3.Delete{Objects: objectsToDelete}
 		deleteParams := &s3.DeleteObjectsInput{

--- a/modules/aws/s3_test.go
+++ b/modules/aws/s3_test.go
@@ -148,8 +148,9 @@ func TestAssertS3BucketPolicyExists(t *testing.T) {
 
 func testEmptyBucket(t *testing.T, s3Client *s3.S3, region string, s3BucketName string) {
 	expectedFileCount := rand.Intn(10000)
-
 	logger.Logf(t, "Uploading %s files to bucket %s", strconv.Itoa(expectedFileCount), s3BucketName)
+
+	deleted := 0
 
 	// Upload expectedFileCount files
 	for i := 1; i <= expectedFileCount; i++ {
@@ -167,6 +168,17 @@ func testEmptyBucket(t *testing.T, s3Client *s3.S3, region string, s3BucketName 
 		_, err := uploader.Upload(params)
 		if err != nil {
 			t.Fatal(err)
+		}
+
+		if i < 10 {
+			_, err := s3Client.DeleteObject(&s3.DeleteObjectInput{
+				Bucket: aws.String(s3BucketName),
+				Key:    aws.String(key),
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			deleted++
 		}
 
 		if i != 0 && i%100 == 0 {
@@ -199,7 +211,7 @@ func testEmptyBucket(t *testing.T, s3Client *s3.S3, region string, s3BucketName 
 		listObjectsParams.ContinuationToken = bucketObjects.NextContinuationToken
 	}
 
-	require.Equal(t, expectedFileCount, actualCount)
+	require.Equal(t, expectedFileCount-deleted, actualCount)
 
 	//empty bucket
 	logger.Logf(t, "Emptying bucket %s", s3BucketName)

--- a/modules/aws/s3_test.go
+++ b/modules/aws/s3_test.go
@@ -170,6 +170,7 @@ func testEmptyBucket(t *testing.T, s3Client *s3.S3, region string, s3BucketName 
 			t.Fatal(err)
 		}
 
+		// Delete the first 10 files to be able to test if all files, including delete markers are deleted
 		if i < 10 {
 			_, err := s3Client.DeleteObject(&s3.DeleteObjectInput{
 				Bucket: aws.String(s3BucketName),


### PR DESCRIPTION
EmptyS3BucketE isn't deleting everything if you have some delete markers in your bucket.

Those delete markers also need to be removed in order to be able to delete the bucket.
