### PR TITLE
Use large machine class

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,5 @@
 defaults: &defaults
+  resource_class: large
   machine:
     enabled: true
     image: "ubuntu-1604:201903-01"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,4 @@
 defaults: &defaults
-  resource_class: large
   machine:
     enabled: true
     image: "ubuntu-1604:201903-01"
@@ -92,6 +91,7 @@ jobs:
 
   test:
     <<: *defaults
+    resource_class: large
     steps:
       - attach_workspace:
           at: /home/circleci


### PR DESCRIPTION
This enables the large machine class for our circleci builds, but only on the main test suite. The helm and kubernetes test suites did not benefit from using the larger instance classes, running at roughly the same speed.

Speed wise, the large instance class didn't help with the main test suite either, but it looks like it helps make the tests stable as I got two tests to pass in a row: something that we struggled to do with this repo.