### PR TITLE
Address different flavors of minikube

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,10 +9,13 @@ defaults: &defaults
     TERRAGRUNT_VERSION: v0.21.11
     PACKER_VERSION: 1.5.1
     GOLANG_VERSION: 1.13
-    K8S_VERSION: v1.10.0  # Same as EKS
+    K8S_VERSION: v1.15.0  # Same as EKS
+    MINIKUBE_VERSION: v1.9.2
     HELM_VERSION: v3.1.1
     KUBECONFIG: /home/circleci/.kube/config
 
+setup_minikube: &setup_minikube
+  command: setup-minikube --k8s-version "$K8S_VERSION" --minikube-version "$MINIKUBE_VERSION"
 
 install_helm: &install_helm
   name: install helm
@@ -141,7 +144,7 @@ jobs:
       - run: echo 'export PATH=$HOME/.local/bin:$HOME/terraform:$HOME/packer:$PATH' >> $BASH_ENV
 
       - run:
-          command: setup-minikube
+          <<: *setup_minikube
 
       # Run the Kubernetes tests. These tests are run because the kubernetes build tag is included, and we explicitly
       # select the kubernetes tests
@@ -177,7 +180,7 @@ jobs:
       - run: echo 'export PATH=$HOME/.local/bin:$HOME/terraform:$HOME/packer:$PATH' >> $BASH_ENV
 
       - run:
-          command: setup-minikube
+          <<: *setup_minikube
 
       - run:
           <<: *install_helm

--- a/modules/k8s/minikube.go
+++ b/modules/k8s/minikube.go
@@ -4,33 +4,35 @@ import (
 	"strings"
 
 	"github.com/gruntwork-io/terratest/modules/testing"
+	corev1 "k8s.io/api/core/v1"
 )
 
 // IsMinikubeE returns true if the underlying kubernetes cluster is Minikube. This is determined by getting the
-// associated nodes and checking if:
-// - there is only one node
-// - the node has at least one label namespaced with "minikube.k8s.io"
+// associated nodes and checking if all nodes has at least one label namespaced with "minikube.k8s.io".
 func IsMinikubeE(t testing.TestingT, options *KubectlOptions) (bool, error) {
 	nodes, err := GetNodesE(t, options)
 	if err != nil {
 		return false, err
 	}
 
-	// ASSUMPTION: Minikube always only has one node.
-	if len(nodes) != 1 {
-		return false, nil
-	}
-
-	// ASSUMPTION: All minikube setups will have a node with labels that are namespaced with minikube.k8s.io
-	node := nodes[0]
-	labels := node.GetLabels()
-	for key, _ := range labels {
-		if strings.HasPrefix(key, "minikube.k8s.io") {
-			return true, nil
+	// ASSUMPTION: All minikube setups will have nodes with labels that are namespaced with minikube.k8s.io
+	for _, node := range nodes {
+		if !nodeHasMinikubeLabel(node) {
+			return false, nil
 		}
 	}
 
-	// At this point we know that the cluster has 1 node without the expected minikube label, so we assume it is not
-	// minikube.
-	return false, nil
+	// At this point we know that all the nodes in the cluster has the minikube label, so we return true.
+	return true, nil
+}
+
+// nodeHasMinikubeLabel returns true if any of the labels on the node is namespaced with minikube.k8s.io
+func nodeHasMinikubeLabel(node corev1.Node) bool {
+	labels := node.GetLabels()
+	for key, _ := range labels {
+		if strings.HasPrefix(key, "minikube.k8s.io") {
+			return true
+		}
+	}
+	return false
 }

--- a/modules/k8s/minikube.go
+++ b/modules/k8s/minikube.go
@@ -1,15 +1,36 @@
 package k8s
 
-import "github.com/gruntwork-io/terratest/modules/testing"
+import (
+	"strings"
+
+	"github.com/gruntwork-io/terratest/modules/testing"
+)
 
 // IsMinikubeE returns true if the underlying kubernetes cluster is Minikube. This is determined by getting the
 // associated nodes and checking if:
 // - there is only one node
-// - the node is named "minikube"
+// - the node has at least one label namespaced with "minikube.k8s.io"
 func IsMinikubeE(t testing.TestingT, options *KubectlOptions) (bool, error) {
 	nodes, err := GetNodesE(t, options)
 	if err != nil {
 		return false, err
 	}
-	return len(nodes) == 1 && nodes[0].GetName() == "minikube", nil
+
+	// ASSUMPTION: Minikube always only has one node.
+	if len(nodes) != 1 {
+		return false, nil
+	}
+
+	// ASSUMPTION: All minikube setups will have a node with labels that are namespaced with minikube.k8s.io
+	node := nodes[0]
+	labels := node.GetLabels()
+	for key, _ := range labels {
+		if strings.HasPrefix(key, "minikube.k8s.io") {
+			return true, nil
+		}
+	}
+
+	// At this point we know that the cluster has 1 node without the expected minikube label, so we assume it is not
+	// minikube.
+	return false, nil
 }

--- a/modules/k8s/minikube_test.go
+++ b/modules/k8s/minikube_test.go
@@ -1,0 +1,25 @@
+// +build kubeall kubernetes
+
+// NOTE: we have build tags to differentiate kubernetes tests from non-kubernetes tests. This is done because minikube
+// is heavy and can interfere with docker related tests in terratest. Specifically, many of the tests start to fail with
+// `connection refused` errors from `minikube`. To avoid overloading the system, we run the kubernetes tests and helm
+// tests separately from the others. This may not be necessary if you have a sufficiently powerful machine.  We
+// recommend at least 4 cores and 16GB of RAM if you want to run all the tests together.
+
+package k8s
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Since we always run unit tests against minikube, we can only test if IsMinikubeE returns true.
+func TestIsMinikube(t *testing.T) {
+	t.Parallel()
+
+	options := NewKubectlOptions("", "", "")
+	isMinikube, err := IsMinikubeE(t, options)
+	assert.NoError(t, err)
+	assert.True(t, isMinikube)
+}


### PR DESCRIPTION
This attempts to address https://github.com/gruntwork-io/terratest/issues/487 by switching the `IsMinikubeE` check to be based on the node labels, which is more likely to be consistent than the nodename.