### PR TITLE
Fix for error [flag used but not declared -auto-approve]

### DIFF
--- a/modules/terraform/destroy.go
+++ b/modules/terraform/destroy.go
@@ -1,7 +1,6 @@
 package terraform
 
 import (
-	"flag"
 	"github.com/gruntwork-io/terratest/modules/testing"
 	"github.com/stretchr/testify/require"
 )
@@ -22,8 +21,7 @@ func TgDestroyAll(t testing.TestingT, options *Options) string {
 
 // DestroyE runs terraform destroy with the given options and return stdout/stderr.
 func DestroyE(t testing.TestingT, options *Options) (string, error) {
-	flag.Args()
-	return RunTerraformCommandE(t, options, FormatArgs(options, "destroy", "-input=false", "-auto-approve")...)
+	return RunTerraformCommandE(t, options, FormatArgs(options, "destroy","-force", "-input=false", "-auto-approve")...)
 }
 
 // TgDestroyAllE runs terragrunt destroy with the given options and return stdout.

--- a/modules/terraform/destroy.go
+++ b/modules/terraform/destroy.go
@@ -21,7 +21,7 @@ func TgDestroyAll(t testing.TestingT, options *Options) string {
 
 // DestroyE runs terraform destroy with the given options and return stdout/stderr.
 func DestroyE(t testing.TestingT, options *Options) (string, error) {
-	return RunTerraformCommandE(t, options, FormatArgs(options, "destroy","-force", "-input=false", "-auto-approve")...)
+	return RunTerraformCommandE(t, options, FormatArgs(options, "destroy","-force", "-input=false")...)
 }
 
 // TgDestroyAllE runs terragrunt destroy with the given options and return stdout.

--- a/modules/terraform/destroy.go
+++ b/modules/terraform/destroy.go
@@ -23,7 +23,7 @@ func TgDestroyAll(t testing.TestingT, options *Options) string {
 // DestroyE runs terraform destroy with the given options and return stdout/stderr.
 func DestroyE(t testing.TestingT, options *Options) (string, error) {
 	flag.Args()
-	return RunTerraformCommandE(t, options, FormatArgs(options, "destroy", "-input=false", "-auto-approve", "-input=false")...)
+	return RunTerraformCommandE(t, options, FormatArgs(options, "destroy", "-input=false", "-auto-approve")...)
 }
 
 // TgDestroyAllE runs terragrunt destroy with the given options and return stdout.

--- a/modules/terraform/destroy.go
+++ b/modules/terraform/destroy.go
@@ -1,6 +1,7 @@
 package terraform
 
 import (
+	"flag"
 	"github.com/gruntwork-io/terratest/modules/testing"
 	"github.com/stretchr/testify/require"
 )
@@ -21,7 +22,8 @@ func TgDestroyAll(t testing.TestingT, options *Options) string {
 
 // DestroyE runs terraform destroy with the given options and return stdout/stderr.
 func DestroyE(t testing.TestingT, options *Options) (string, error) {
-	return RunTerraformCommandE(t, options, FormatArgs(options, "destroy", "-auto-approve", "-input=false")...)
+	flag.Args()
+	return RunTerraformCommandE(t, options, FormatArgs(options, "destroy", "-input=false", "-auto-approve", "-input=false")...)
 }
 
 // TgDestroyAllE runs terragrunt destroy with the given options and return stdout.


### PR DESCRIPTION
Instead of using -auto-approve using -force to destroy, as I was facing an issue while running the tests in a Docker with go1.13.4 and terraform0.11.3