### PR TITLE
Check in config for no-response experiment

### DIFF
--- a/.github/no-response.yml
+++ b/.github/no-response.yml
@@ -1,0 +1,13 @@
+# Configuration for probot-no-response - https://github.com/probot/no-response
+
+# Number of days of inactivity before an Issue is closed for lack of response
+daysUntilClose: 30
+# Label requiring a response
+responseRequiredLabel: more-information-needed
+# Comment to post when closing an Issue for lack of response. Set to `false` to disable
+closeComment: >
+  This issue has been automatically closed because there has been no response
+  to our request for more information from the original author. With only the
+  information that is currently in the issue, we don't have enough information
+  to take action. Please feel free to reach out if you have or find the answers we need so
+  that we can investigate further. Thank you!


### PR DESCRIPTION
This config will be read by our installed [No Response bot](https://github.com/probot/no-response) so that we can evaluate its effectiveness for our workflow. 

Once merged, any issue that: 
1. has been given the label: `more-information-needed` 
2. hasn't received an update within 30 days 

will be automatically closed out with an explanation as configured in this PR. 

Note that, should the **original issue author** later respond with additional info, the issue will be re-opened automatically.