### PR TITLE
Logging

### DIFF
--- a/modules/docker/build.go
+++ b/modules/docker/build.go
@@ -20,8 +20,8 @@ type BuildOptions struct {
 	// solely focus on the most important ones.
 	OtherOptions []string
 
-	// Set one or more loggers that should be used. See the logger package for more info.
-	Log *logger.Loggers
+	// Set a logger that should be used. See the logger package for more info.
+	Logger *logger.Logger
 }
 
 // Build runs the 'docker build' command at the given path with the given options and fails the test if there are any
@@ -32,7 +32,7 @@ func Build(t testing.TestingT, path string, options *BuildOptions) {
 
 // BuildE runs the 'docker build' command at the given path with the given options and returns any errors.
 func BuildE(t testing.TestingT, path string, options *BuildOptions) error {
-	options.Log.Logf(t, "Running 'docker build' in %s", path)
+	options.Logger.Logf(t, "Running 'docker build' in %s", path)
 
 	args, err := formatDockerBuildArgs(path, options)
 	if err != nil {
@@ -42,7 +42,7 @@ func BuildE(t testing.TestingT, path string, options *BuildOptions) error {
 	cmd := shell.Command{
 		Command: "docker",
 		Args:    args,
-		Log:     options.Log,
+		Logger:  options.Logger,
 	}
 
 	_, buildErr := shell.RunCommandAndGetOutputE(t, cmd)

--- a/modules/docker/docker_compose.go
+++ b/modules/docker/docker_compose.go
@@ -1,6 +1,7 @@
 package docker
 
 import (
+	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/shell"
 	"github.com/gruntwork-io/terratest/modules/testing"
 )
@@ -9,6 +10,8 @@ import (
 type Options struct {
 	WorkingDir string
 	EnvVars    map[string]string
+	// Set one or more loggers that should be used. See the logger package for more info.
+	Log *logger.Loggers
 }
 
 // RunDockerCompose runs docker-compose with the given arguments and options and return stdout/stderr.
@@ -29,6 +32,7 @@ func RunDockerComposeE(t testing.TestingT, options *Options, args ...string) (st
 		Args:       append([]string{"--project-name", t.Name()}, args...),
 		WorkingDir: options.WorkingDir,
 		Env:        options.EnvVars,
+		Log:        options.Log,
 	}
 
 	return shell.RunCommandAndGetOutputE(t, cmd)

--- a/modules/docker/docker_compose.go
+++ b/modules/docker/docker_compose.go
@@ -10,8 +10,8 @@ import (
 type Options struct {
 	WorkingDir string
 	EnvVars    map[string]string
-	// Set one or more loggers that should be used. See the logger package for more info.
-	Log *logger.Loggers
+	// Set a logger that should be used. See the logger package for more info.
+	Logger *logger.Logger
 }
 
 // RunDockerCompose runs docker-compose with the given arguments and options and return stdout/stderr.
@@ -32,7 +32,7 @@ func RunDockerComposeE(t testing.TestingT, options *Options, args ...string) (st
 		Args:       append([]string{"--project-name", t.Name()}, args...),
 		WorkingDir: options.WorkingDir,
 		Env:        options.EnvVars,
-		Log:        options.Log,
+		Logger:     options.Logger,
 	}
 
 	return shell.RunCommandAndGetOutputE(t, cmd)

--- a/modules/docker/inspect.go
+++ b/modules/docker/inspect.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/shell"
 	"github.com/stretchr/testify/require"
 )
@@ -94,6 +95,8 @@ func InspectE(t *testing.T, id string) (*ContainerInspect, error) {
 	cmd := shell.Command{
 		Command: "docker",
 		Args:    []string{"container", "inspect", id},
+		// inspect is a short-running command, don't print the output.
+		Log: logger.With(logger.Discard),
 	}
 
 	out, err := shell.RunCommandAndGetStdOutE(t, cmd)

--- a/modules/docker/inspect.go
+++ b/modules/docker/inspect.go
@@ -96,7 +96,7 @@ func InspectE(t *testing.T, id string) (*ContainerInspect, error) {
 		Command: "docker",
 		Args:    []string{"container", "inspect", id},
 		// inspect is a short-running command, don't print the output.
-		Log: logger.With(logger.Discard),
+		Logger: logger.Discard,
 	}
 
 	out, err := shell.RunCommandAndGetStdOutE(t, cmd)

--- a/modules/docker/run.go
+++ b/modules/docker/run.go
@@ -48,8 +48,8 @@ type RunOptions struct {
 	// solely focus on the most important ones.
 	OtherOptions []string
 
-	// Set one or more loggers that should be used. See the logger package for more info.
-	Log *logger.Loggers
+	// Set a logger that should be used. See the logger package for more info.
+	Logger *logger.Logger
 }
 
 // Run runs the 'docker run' command on the given image with the given options and return stdout/stderr. This method
@@ -62,7 +62,7 @@ func Run(t testing.TestingT, image string, options *RunOptions) string {
 
 // RunE runs the 'docker run' command on the given image with the given options and return stdout/stderr, or any error.
 func RunE(t testing.TestingT, image string, options *RunOptions) (string, error) {
-	options.Log.Logf(t, "Running 'docker run' on image '%s'", image)
+	options.Logger.Logf(t, "Running 'docker run' on image '%s'", image)
 
 	args, err := formatDockerRunArgs(image, options)
 	if err != nil {
@@ -72,7 +72,7 @@ func RunE(t testing.TestingT, image string, options *RunOptions) (string, error)
 	cmd := shell.Command{
 		Command: "docker",
 		Args:    args,
-		Log:     options.Log,
+		Logger:  options.Logger,
 	}
 
 	return shell.RunCommandAndGetOutputE(t, cmd)
@@ -89,7 +89,7 @@ func RunAndGetID(t testing.TestingT, image string, options *RunOptions) string {
 // RunAndGetIDE runs the 'docker run' command on the given image with the given options and returns the container ID
 // that is returned in stdout, or any error.
 func RunAndGetIDE(t testing.TestingT, image string, options *RunOptions) (string, error) {
-	options.Log.Logf(t, "Running 'docker run' on image '%s', returning stdout", image)
+	options.Logger.Logf(t, "Running 'docker run' on image '%s', returning stdout", image)
 
 	args, err := formatDockerRunArgs(image, options)
 	if err != nil {
@@ -99,7 +99,7 @@ func RunAndGetIDE(t testing.TestingT, image string, options *RunOptions) (string
 	cmd := shell.Command{
 		Command: "docker",
 		Args:    args,
-		Log:     options.Log,
+		Logger:  options.Logger,
 	}
 
 	return shell.RunCommandAndGetStdOutE(t, cmd)

--- a/modules/docker/run.go
+++ b/modules/docker/run.go
@@ -47,6 +47,9 @@ type RunOptions struct {
 	// Terratest to not have to support every single command-line option offered by the 'docker run' command, and
 	// solely focus on the most important ones.
 	OtherOptions []string
+
+	// Set one or more loggers that should be used. See the logger package for more info.
+	Log *logger.Loggers
 }
 
 // Run runs the 'docker run' command on the given image with the given options and return stdout/stderr. This method
@@ -59,7 +62,7 @@ func Run(t testing.TestingT, image string, options *RunOptions) string {
 
 // RunE runs the 'docker run' command on the given image with the given options and return stdout/stderr, or any error.
 func RunE(t testing.TestingT, image string, options *RunOptions) (string, error) {
-	logger.Logf(t, "Running 'docker run' on image '%s'", image)
+	options.Log.Logf(t, "Running 'docker run' on image '%s'", image)
 
 	args, err := formatDockerRunArgs(image, options)
 	if err != nil {
@@ -69,6 +72,7 @@ func RunE(t testing.TestingT, image string, options *RunOptions) (string, error)
 	cmd := shell.Command{
 		Command: "docker",
 		Args:    args,
+		Log:     options.Log,
 	}
 
 	return shell.RunCommandAndGetOutputE(t, cmd)
@@ -85,7 +89,7 @@ func RunAndGetID(t testing.TestingT, image string, options *RunOptions) string {
 // RunAndGetIDE runs the 'docker run' command on the given image with the given options and returns the container ID
 // that is returned in stdout, or any error.
 func RunAndGetIDE(t testing.TestingT, image string, options *RunOptions) (string, error) {
-	logger.Logf(t, "Running 'docker run' on image '%s', returning stdout", image)
+	options.Log.Logf(t, "Running 'docker run' on image '%s', returning stdout", image)
 
 	args, err := formatDockerRunArgs(image, options)
 	if err != nil {
@@ -95,6 +99,7 @@ func RunAndGetIDE(t testing.TestingT, image string, options *RunOptions) (string
 	cmd := shell.Command{
 		Command: "docker",
 		Args:    args,
+		Log:     options.Log,
 	}
 
 	return shell.RunCommandAndGetStdOutE(t, cmd)
@@ -144,15 +149,11 @@ func formatDockerRunArgs(image string, options *RunOptions) ([]string, error) {
 		args = append(args, "--volume", volume)
 	}
 
-	for _, opt := range options.OtherOptions {
-		args = append(args, opt)
-	}
+	args = append(args, options.OtherOptions...)
 
 	args = append(args, image)
 
-	for _, arg := range options.Command {
-		args = append(args, arg)
-	}
+	args = append(args, options.Command...)
 
 	return args, nil
 }

--- a/modules/docker/stop.go
+++ b/modules/docker/stop.go
@@ -13,6 +13,9 @@ import (
 type StopOptions struct {
 	// Seconds to wait for stop before killing the container (default 10)
 	Time int
+
+	// Set one or more loggers that should be used. See the logger package for more info.
+	Log *logger.Loggers
 }
 
 // Stop runs the 'docker stop' command for the given containers and return the stdout/stderr. This method fails
@@ -25,7 +28,7 @@ func Stop(t testing.TestingT, containers []string, options *StopOptions) string 
 
 // StopE runs the 'docker stop' command for the given containers and returns any errors.
 func StopE(t testing.TestingT, containers []string, options *StopOptions) (string, error) {
-	logger.Logf(t, "Running 'docker stop' on containers '%s'", containers)
+	options.Log.Logf(t, "Running 'docker stop' on containers '%s'", containers)
 
 	args, err := formatDockerStopArgs(containers, options)
 	if err != nil {
@@ -35,6 +38,7 @@ func StopE(t testing.TestingT, containers []string, options *StopOptions) (strin
 	cmd := shell.Command{
 		Command: "docker",
 		Args:    args,
+		Log:     options.Log,
 	}
 
 	return shell.RunCommandAndGetOutputE(t, cmd)

--- a/modules/docker/stop.go
+++ b/modules/docker/stop.go
@@ -14,8 +14,8 @@ type StopOptions struct {
 	// Seconds to wait for stop before killing the container (default 10)
 	Time int
 
-	// Set one or more loggers that should be used. See the logger package for more info.
-	Log *logger.Loggers
+	// Set a logger that should be used. See the logger package for more info.
+	Logger *logger.Logger
 }
 
 // Stop runs the 'docker stop' command for the given containers and return the stdout/stderr. This method fails
@@ -28,7 +28,7 @@ func Stop(t testing.TestingT, containers []string, options *StopOptions) string 
 
 // StopE runs the 'docker stop' command for the given containers and returns any errors.
 func StopE(t testing.TestingT, containers []string, options *StopOptions) (string, error) {
-	options.Log.Logf(t, "Running 'docker stop' on containers '%s'", containers)
+	options.Logger.Logf(t, "Running 'docker stop' on containers '%s'", containers)
 
 	args, err := formatDockerStopArgs(containers, options)
 	if err != nil {
@@ -38,7 +38,7 @@ func StopE(t testing.TestingT, containers []string, options *StopOptions) (strin
 	cmd := shell.Command{
 		Command: "docker",
 		Args:    args,
-		Log:     options.Log,
+		Logger:  options.Logger,
 	}
 
 	return shell.RunCommandAndGetOutputE(t, cmd)

--- a/modules/helm/cmd.go
+++ b/modules/helm/cmd.go
@@ -61,6 +61,7 @@ func RunHelmCommandAndGetOutputE(t testing.TestingT, options *Options, cmd strin
 		Args:       args,
 		WorkingDir: ".",
 		Env:        options.EnvVars,
+		Log:        options.Log,
 	}
 	return shell.RunCommandAndGetOutputE(t, helmCmd)
 }

--- a/modules/helm/cmd.go
+++ b/modules/helm/cmd.go
@@ -61,7 +61,7 @@ func RunHelmCommandAndGetOutputE(t testing.TestingT, options *Options, cmd strin
 		Args:       args,
 		WorkingDir: ".",
 		Env:        options.EnvVars,
-		Log:        options.Log,
+		Logger:     options.Logger,
 	}
 	return shell.RunCommandAndGetOutputE(t, helmCmd)
 }

--- a/modules/helm/options.go
+++ b/modules/helm/options.go
@@ -14,5 +14,5 @@ type Options struct {
 	HomePath       string              // The path to the helm home to use when calling out to helm. Empty string means use default ($HOME/.helm).
 	EnvVars        map[string]string   // Environment variables to set when running helm
 	Version        string              // Version of chart
-	Log            *logger.Loggers     // Set one or more loggers that should be used. See the logger package for more info.
+	Logger         *logger.Logger      // Set a non-default logger that should be used. See the logger package for more info.
 }

--- a/modules/helm/options.go
+++ b/modules/helm/options.go
@@ -2,6 +2,7 @@ package helm
 
 import (
 	"github.com/gruntwork-io/terratest/modules/k8s"
+	"github.com/gruntwork-io/terratest/modules/logger"
 )
 
 type Options struct {
@@ -13,4 +14,5 @@ type Options struct {
 	HomePath       string              // The path to the helm home to use when calling out to helm. Empty string means use default ($HOME/.helm).
 	EnvVars        map[string]string   // Environment variables to set when running helm
 	Version        string              // Version of chart
+	Log            *logger.Loggers     // Set one or more loggers that should be used. See the logger package for more info.
 }

--- a/modules/logger/logger.go
+++ b/modules/logger/logger.go
@@ -6,31 +6,125 @@ import (
 	"io"
 	"os"
 	"runtime"
+	"strconv"
 	"strings"
+	gotesting "testing"
 	"time"
 
 	"github.com/gruntwork-io/terratest/modules/testing"
 )
 
-// Logf logs the given format and arguments, formatted using fmt.Sprintf, to stdout, along with a timestamp and information
-// about what test and file is doing the logging. This is an alternative to t.Logf that logs to stdout immediately,
-// rather than buffering all log output and only displaying it at the very end of the test. This is useful because:
+// defaultLogf will be used if the caller uses the function
+// Logf, where on the first call to that function, a sane
+// default logging function will be set. We keep that in a
+// global variable so that we don't need to define it on
+// every call to Logf.
+var defaultLogf LogFunc
+
+type Loggers []LogFunc
+type LogFunc func(t testing.TestingT, format string, args ...interface{})
+
+func With(l ...LogFunc) *Loggers {
+	lo := Loggers(l)
+	return &lo
+}
+
+// Logf logs to all given loggers. If no loggers are given (or it is nil), it will
+// use the default logger. This allows for the following usecases:
+//   var l *Loggers
+//   l.Logf(...)
+//   l = With(TestingT)
+//   l.Logf(...)
+func (l *Loggers) Logf(t testing.TestingT, format string, args ...interface{}) {
+	if tt, ok := t.(*gotesting.T); ok {
+		tt.Helper()
+	}
+
+	// if l is not initialised or no loggers
+	// are supplied, use the default logging.
+	if l == nil || len(*l) == 0 {
+		logDefaultLogf(t, format, args...)
+		return
+	}
+
+	for _, logf := range *l {
+		logf(t, format, args...)
+	}
+}
+
+// Discard discards all logging.
+func Discard(_ testing.TestingT, format string, args ...interface{}) {}
+
+// TestingT can be used to explicitly use Go's testing.T to log.
+// It is also used as the default if Go version >= 1.14 (if detected
+// correctly). If this is used, but no testing.T is provided, it will
+// fallback to Logger.
+func TestingT(t testing.TestingT, format string, args ...interface{}) {
+	// this should never fail
+	tt, ok := t.(*gotesting.T)
+	if !ok {
+		// fallback
+		DoLog(t, 2, os.Stdout, fmt.Sprintf(format, args...))
+		return
+	}
+
+	tt.Helper()
+	tt.Logf(format, args...)
+	return
+}
+
+// Logger is the conventional logging utility that terratest uses.
+// Default up until Go 1.14.
+func Logger(t testing.TestingT, format string, args ...interface{}) {
+	DoLog(t, 3, os.Stdout, fmt.Sprintf(format, args...))
+}
+
+// Logf logs the given format and arguments with the default logging utility. If the Go
+// version can be determined and is 1.14 or above, t.Logf will be used (Go 1.14 introduced
+// streaming log output). Else, a default logger will be used that adds a timestamp and
+// information about what test and file is doing the logging.
+// Compared to the Go's builtin testing.T.Logf, this will always print the output instead
+// of buffering it and only display it at the very end of the test.
 //
-// 1. It allows you to iterate faster locally, as you get feedback on whether your code changes are working as expected
-//    right away, rather than at the very end of the test run.
-//
-// 2. If you have a bug in your code that causes a test to never complete or if the test code crashes,, t.Logf would
-//    show you no log output whatsoever, making debugging very hard, where as this method will show you all the log
-//    output available.
-//
-// 3. If you have a test that takes a long time to complete, some CI systems will kill the test suite prematurely
-//    because there is no log output with t.Logf (e.g., CircleCI kills tests after 10 minutes of no log output). With
-//    this log method, you get log output continuously.
-//
-// Note that there is a proposal to improve t.Logf (https://github.com/golang/go/issues/24929), but until that's
-// implemented, this method is our best bet.
+// To have more control over logging, use With(...LogFunc) to get a custom logger.
+// Builtin alternatives are Discard, TestingT and Logger.
 func Logf(t testing.TestingT, format string, args ...interface{}) {
-	DoLog(t, 2, os.Stdout, fmt.Sprintf(format, args...))
+	if tt, ok := t.(*gotesting.T); ok {
+		tt.Helper()
+	}
+
+	logDefaultLogf(t, format, args...)
+}
+
+func logDefaultLogf(t testing.TestingT, format string, args ...interface{}) {
+	if defaultLogf == nil {
+		// if a gotesting.T is given and the go version is 1.14, use
+		// gotesting.T.Logf
+		if tt, ok := t.(*gotesting.T); ok && hasStreamingLogf(runtime.Version()) {
+			tt.Helper()
+			// we should not assign tt.Logf directly as testing.T may change
+			// during the execution of the test (consider subtests, for example).
+			defaultLogf = TestingT
+		} else {
+			defaultLogf = Logger
+			defaultLogf(t, "streaming logf not supported, falling back to legacy logger")
+		}
+	}
+
+	defaultLogf(t, format, args...)
+}
+
+// hasStreamingLogf returns true if the go runtime version
+// is >= Go 1.14, where streaming Logf output has been
+// introduced (https://github.com/golang/go/issues/24929)
+func hasStreamingLogf(goVersion string) bool {
+	noMajor := strings.TrimPrefix(goVersion, "go1.")
+	ver, err := strconv.ParseFloat(noMajor, 32)
+	if err != nil {
+		return false
+	}
+
+	return ver >= 14
 }
 
 // Log logs the given arguments to stdout, along with a timestamp and information about what test and file is doing the

--- a/modules/logger/logger.go
+++ b/modules/logger/logger.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"os"
 	"runtime"
-	"strconv"
 	"strings"
 	gotesting "testing"
 	"time"
@@ -14,52 +13,76 @@ import (
 	"github.com/gruntwork-io/terratest/modules/testing"
 )
 
-// defaultLogf will be used if the caller uses the function
-// Logf, where on the first call to that function, a sane
-// default logging function will be set. We keep that in a
-// global variable so that we don't need to define it on
-// every call to Logf.
-var defaultLogf LogFunc
+var (
+	// Default is the default logger that is used for the Logf function, if no one is provided. It uses the
+	// TerratestLogger to log messages. This can be overwritten to change the logging globally.
+	Default = New(terratestLogger{})
+	// Discard discards all logging.
+	Discard = New(discardLogger{})
+	// Terratest logs the given format and arguments, formatted using fmt.Sprintf, to stdout, along with a timestamp and
+	// information about what test and file is doing the logging. Before Go 1.14, this is an alternative to t.Logf as it
+	// logs to stdout immediately, rather than buffering all log output and only displaying it at the very end of the test.
+	// This is useful because:
+	//
+	// 1. It allows you to iterate faster locally, as you get feedback on whether your code changes are working as expected
+	//    right away, rather than at the very end of the test run.
+	//
+	// 2. If you have a bug in your code that causes a test to never complete or if the test code crashes, t.Logf would
+	//    show you no log output whatsoever, making debugging very hard, where as this method will show you all the log
+	//    output available.
+	//
+	// 3. If you have a test that takes a long time to complete, some CI systems will kill the test suite prematurely
+	//    because there is no log output with t.Logf (e.g., CircleCI kills tests after 10 minutes of no log output). With
+	//    this log method, you get log output continuously.
+	//
+	Terratest = New(terratestLogger{})
+	// TestingT can be used to use Go's testing.T to log. If this is used, but no testing.T is provided, it will fallback
+	// to Default.
+	TestingT = New(testingT{})
+)
 
-type Loggers []LogFunc
-type LogFunc func(t testing.TestingT, format string, args ...interface{})
-
-func With(l ...LogFunc) *Loggers {
-	lo := Loggers(l)
-	return &lo
+type TestLogger interface {
+	Logf(t testing.TestingT, format string, args ...interface{})
 }
 
-// Logf logs to all given loggers. If no loggers are given (or it is nil), it will
-// use the default logger. This allows for the following usecases:
-//   var l *Loggers
-//   l.Logf(...)
-//   l = With(TestingT)
-//   l.Logf(...)
-func (l *Loggers) Logf(t testing.TestingT, format string, args ...interface{}) {
-	if tt, ok := t.(*gotesting.T); ok {
+type Logger struct {
+	l TestLogger
+}
+
+func New(l TestLogger) *Logger {
+	return &Logger{
+		l,
+	}
+}
+
+func (l *Logger) Logf(t testing.TestingT, format string, args ...interface{}) {
+	if tt, ok := t.(helper); ok {
 		tt.Helper()
 	}
 
-	// if l is not initialised or no loggers
-	// are supplied, use the default logging.
-	if l == nil || len(*l) == 0 {
-		logDefaultLogf(t, format, args...)
+	// methods can be called on (typed) nil pointers. In this case, use the Default function to log. This enables the
+	// caller to do `var l *Logger` and then use the logger already.
+	if l == nil || l.l == nil {
+		Default.Logf(t, format, args...)
 		return
 	}
 
-	for _, logf := range *l {
-		logf(t, format, args...)
-	}
+	l.l.Logf(t, format, args...)
 }
 
-// Discard discards all logging.
-func Discard(_ testing.TestingT, format string, args ...interface{}) {}
+// helper is used to mark this library as a "helper", and thus not appearing in the line numbers. testing.T implements
+// this interface, for example.
+type helper interface {
+	Helper()
+}
 
-// TestingT can be used to explicitly use Go's testing.T to log.
-// It is also used as the default if Go version >= 1.14 (if detected
-// correctly). If this is used, but no testing.T is provided, it will
-// fallback to Logger.
-func TestingT(t testing.TestingT, format string, args ...interface{}) {
+type discardLogger struct{}
+
+func (_ discardLogger) Logf(_ testing.TestingT, format string, args ...interface{}) {}
+
+type testingT struct{}
+
+func (_ testingT) Logf(t testing.TestingT, format string, args ...interface{}) {
 	// this should never fail
 	tt, ok := t.(*gotesting.T)
 	if !ok {
@@ -73,64 +96,45 @@ func TestingT(t testing.TestingT, format string, args ...interface{}) {
 	return
 }
 
-// Logger is the conventional logging utility that terratest uses.
-// Default up until Go 1.14.
-func Logger(t testing.TestingT, format string, args ...interface{}) {
+type terratestLogger struct{}
+
+func (_ terratestLogger) Logf(t testing.TestingT, format string, args ...interface{}) {
 	DoLog(t, 3, os.Stdout, fmt.Sprintf(format, args...))
 }
 
-// Logf logs the given format and arguments with the default logging utility. If the Go
-// version can be determined and is 1.14 or above, t.Logf will be used (Go 1.14 introduced
-// streaming log output). Else, a default logger will be used that adds a timestamp and
-// information about what test and file is doing the logging.
-// Compared to the Go's builtin testing.T.Logf, this will always print the output instead
-// of buffering it and only display it at the very end of the test.
+// Deprecated: use Logger instead, as it provides more flexibility on logging.
+// Logf logs the given format and arguments, formatted using fmt.Sprintf, to stdout, along with a timestamp and information
+// about what test and file is doing the logging. Before Go 1.14, this is an alternative to t.Logf as it logs to stdout
+// immediately, rather than buffering all log output and only displaying it at the very end of the test. This is useful
+// because:
 //
-// To have more control over logging, use With(...LogFunc) to get a custom logger.
-// Builtin alternatives are Discard, TestingT and Logger.
+// 1. It allows you to iterate faster locally, as you get feedback on whether your code changes are working as expected
+//    right away, rather than at the very end of the test run.
+//
+// 2. If you have a bug in your code that causes a test to never complete or if the test code crashes, t.Logf would
+//    show you no log output whatsoever, making debugging very hard, where as this method will show you all the log
+//    output available.
+//
+// 3. If you have a test that takes a long time to complete, some CI systems will kill the test suite prematurely
+//    because there is no log output with t.Logf (e.g., CircleCI kills tests after 10 minutes of no log output). With
+//    this log method, you get log output continuously.
+// Although t.Logf now supports streaming output since Go 1.14, this is kept for compatibility purposes.
 func Logf(t testing.TestingT, format string, args ...interface{}) {
-	if tt, ok := t.(*gotesting.T); ok {
+	if tt, ok := t.(helper); ok {
 		tt.Helper()
 	}
 
-	logDefaultLogf(t, format, args...)
-}
-
-func logDefaultLogf(t testing.TestingT, format string, args ...interface{}) {
-	if defaultLogf == nil {
-		// if a gotesting.T is given and the go version is 1.14, use
-		// gotesting.T.Logf
-		if tt, ok := t.(*gotesting.T); ok && hasStreamingLogf(runtime.Version()) {
-			tt.Helper()
-			// we should not assign tt.Logf directly as testing.T may change
-			// during the execution of the test (consider subtests, for example).
-			defaultLogf = TestingT
-		} else {
-			defaultLogf = Logger
-			defaultLogf(t, "streaming logf not supported, falling back to legacy logger")
-		}
-	}
-
-	defaultLogf(t, format, args...)
-}
-
-// hasStreamingLogf returns true if the go runtime version
-// is >= Go 1.14, where streaming Logf output has been
-// introduced (https://github.com/golang/go/issues/24929)
-func hasStreamingLogf(goVersion string) bool {
-	noMajor := strings.TrimPrefix(goVersion, "go1.")
-	ver, err := strconv.ParseFloat(noMajor, 32)
-	if err != nil {
-		return false
-	}
-
-	return ver >= 14
+	DoLog(t, 2, os.Stdout, fmt.Sprintf(format, args...))
 }
 
 // Log logs the given arguments to stdout, along with a timestamp and information about what test and file is doing the
 // logging. This is an alternative to t.Logf that logs to stdout immediately, rather than buffering all log output and
 // only displaying it at the very end of the test. See the Logf method for more info.
 func Log(t testing.TestingT, args ...interface{}) {
+	if tt, ok := t.(helper); ok {
+		tt.Helper()
+	}
+
 	DoLog(t, 2, os.Stdout, args...)
 }
 

--- a/modules/logger/logger_test.go
+++ b/modules/logger/logger_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	tftesting "github.com/gruntwork-io/terratest/modules/testing"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -18,4 +19,52 @@ func TestDoLog(t *testing.T) {
 	DoLog(t, 1, &buffer, text)
 
 	assert.Regexp(t, fmt.Sprintf("^%s .+? [[:word:]]+.go:[0-9]+: %s$", t.Name(), text), strings.TrimSpace(buffer.String()))
+}
+
+func TestVersion(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		version      string
+		hasStreaming bool
+	}{
+		{"go1.14", true},
+		{"go1.14.1", true},
+		{"go1.13.5", false},
+		{"go1.15", true},
+		{"ae0365fab0", false}, // simulate some commit ID
+	}
+
+	for _, test := range cases {
+		assert.Equal(t, test.hasStreaming, hasStreamingLogf(test.version))
+	}
+}
+
+func TestCustomLogger(t *testing.T) {
+	var logs []string
+	customLogf := func(t tftesting.TestingT, format string, args ...interface{}) {
+		logs = append(logs, fmt.Sprintf(format, args...))
+	}
+
+	Logf(t, "this should be logged with legacylogger or testing.T if go >=1.14")
+	var l *Loggers
+
+	l.Logf(t, "this should be logged with legacylogger or testing.T if go >=1.14")
+	l = With()
+	l.Logf(t, "this should be logged with legacylogger or testing.T if go >=1.14")
+
+	// try all loggers, though this may spam the output a bit.
+	l = With(customLogf, Logger, TestingT, Discard)
+
+	l.Logf(t, "log output 1")
+	l.Logf(t, "log output 2")
+
+	t.Run("logger-subtest", func(t *testing.T) {
+		l.Logf(t, "subtest log")
+	})
+
+	assert.Len(t, logs, 3)
+	assert.Equal(t, "log output 1", logs[0])
+	assert.Equal(t, "log output 2", logs[1])
+	assert.Equal(t, "subtest log", logs[2])
 }

--- a/modules/packer/packer.go
+++ b/modules/packer/packer.go
@@ -27,7 +27,7 @@ type Options struct {
 	MaxRetries         int               // Maximum number of times to retry errors matching RetryableErrors
 	TimeBetweenRetries time.Duration     // The amount of time to wait between retries
 	WorkingDir         string            // The directory to run packer in
-	Log                *logger.Loggers
+	Logger             *logger.Logger    // If set, use a non-default logger
 }
 
 // BuildArtifacts can take a map of identifierName <-> Options and then parallelize
@@ -89,7 +89,7 @@ func BuildArtifact(t testing.TestingT, options *Options) string {
 
 // BuildArtifactE builds the given Packer template and return the generated Artifact ID.
 func BuildArtifactE(t testing.TestingT, options *Options) (string, error) {
-	options.Log.Logf(t, "Running Packer to generate a custom artifact for template %s", options.Template)
+	options.Logger.Logf(t, "Running Packer to generate a custom artifact for template %s", options.Template)
 
 	cmd := shell.Command{
 		Command:    "packer",

--- a/modules/packer/packer.go
+++ b/modules/packer/packer.go
@@ -27,6 +27,7 @@ type Options struct {
 	MaxRetries         int               // Maximum number of times to retry errors matching RetryableErrors
 	TimeBetweenRetries time.Duration     // The amount of time to wait between retries
 	WorkingDir         string            // The directory to run packer in
+	Log                *logger.Loggers
 }
 
 // BuildArtifacts can take a map of identifierName <-> Options and then parallelize
@@ -88,7 +89,7 @@ func BuildArtifact(t testing.TestingT, options *Options) string {
 
 // BuildArtifactE builds the given Packer template and return the generated Artifact ID.
 func BuildArtifactE(t testing.TestingT, options *Options) (string, error) {
-	logger.Logf(t, "Running Packer to generate a custom artifact for template %s", options.Template)
+	options.Log.Logf(t, "Running Packer to generate a custom artifact for template %s", options.Template)
 
 	cmd := shell.Command{
 		Command:    "packer",

--- a/modules/shell/command_test.go
+++ b/modules/shell/command_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/random"
 )
 
@@ -89,6 +90,7 @@ wait
 	cmd := Command{
 		Command: "bash",
 		Args:    []string{"-c", bashCode},
+		Log:     logger.With(logger.Discard),
 	}
 
 	out := RunCommandAndGetOutput(t, cmd)
@@ -113,6 +115,7 @@ echo
 	cmd := Command{
 		Command: "bash",
 		Args:    []string{"-c", bashCode},
+		Log:     logger.With(logger.Discard), // don't print that line to stdout
 	}
 
 	out, err := RunCommandAndGetOutputE(t, cmd)

--- a/modules/shell/command_test.go
+++ b/modules/shell/command_test.go
@@ -90,7 +90,7 @@ wait
 	cmd := Command{
 		Command: "bash",
 		Args:    []string{"-c", bashCode},
-		Log:     logger.With(logger.Discard),
+		Logger:  logger.Discard,
 	}
 
 	out := RunCommandAndGetOutput(t, cmd)
@@ -115,7 +115,7 @@ echo
 	cmd := Command{
 		Command: "bash",
 		Args:    []string{"-c", bashCode},
-		Log:     logger.With(logger.Discard), // don't print that line to stdout
+		Logger:  logger.Discard, // don't print that line to stdout
 	}
 
 	out, err := RunCommandAndGetOutputE(t, cmd)

--- a/modules/terraform/cmd.go
+++ b/modules/terraform/cmd.go
@@ -15,7 +15,7 @@ func generateCommand(options *Options, args ...string) shell.Command {
 		Args:       args,
 		WorkingDir: options.TerraformDir,
 		Env:        options.EnvVars,
-		Log:        options.Log,
+		Logger:     options.Logger,
 	}
 	return cmd
 }
@@ -90,7 +90,7 @@ func GetExitCodeForTerraformCommand(t testing.TestingT, additionalOptions *Optio
 func GetExitCodeForTerraformCommandE(t testing.TestingT, additionalOptions *Options, additionalArgs ...string) (int, error) {
 	options, args := GetCommonOptions(additionalOptions, additionalArgs...)
 
-	additionalOptions.Log.Logf(t, "Running %s with args %v", options.TerraformBinary, args)
+	additionalOptions.Logger.Logf(t, "Running %s with args %v", options.TerraformBinary, args)
 	cmd := generateCommand(options, args...)
 	_, err := shell.RunCommandAndGetOutputE(t, cmd)
 	if err == nil {

--- a/modules/terraform/cmd.go
+++ b/modules/terraform/cmd.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/gruntwork-io/terratest/modules/collections"
-	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/retry"
 	"github.com/gruntwork-io/terratest/modules/shell"
 	"github.com/gruntwork-io/terratest/modules/testing"
@@ -16,6 +15,7 @@ func generateCommand(options *Options, args ...string) shell.Command {
 		Args:       args,
 		WorkingDir: options.TerraformDir,
 		Env:        options.EnvVars,
+		Log:        options.Log,
 	}
 	return cmd
 }
@@ -90,7 +90,7 @@ func GetExitCodeForTerraformCommand(t testing.TestingT, additionalOptions *Optio
 func GetExitCodeForTerraformCommandE(t testing.TestingT, additionalOptions *Options, additionalArgs ...string) (int, error) {
 	options, args := GetCommonOptions(additionalOptions, additionalArgs...)
 
-	logger.Logf(t, "Running %s with args %v", options.TerraformBinary, args)
+	additionalOptions.Log.Logf(t, "Running %s with args %v", options.TerraformBinary, args)
 	cmd := generateCommand(options, args...)
 	_, err := shell.RunCommandAndGetOutputE(t, cmd)
 	if err == nil {

--- a/modules/terraform/options.go
+++ b/modules/terraform/options.go
@@ -25,5 +25,5 @@ type Options struct {
 	NoColor                  bool                   // Whether the -no-color flag will be set for any Terraform command or not
 	SshAgent                 *ssh.SshAgent          // Overrides local SSH agent with the given in-process agent
 	NoStderr                 bool                   // Disable stderr redirection
-	Log                      *logger.Loggers        // Set one or more loggers that should be used. See the logger package for more info.
+	Logger                   *logger.Logger         // Set a non-default logger that should be used. See the logger package for more info.
 }

--- a/modules/terraform/options.go
+++ b/modules/terraform/options.go
@@ -3,6 +3,7 @@ package terraform
 import (
 	"time"
 
+	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/ssh"
 )
 
@@ -24,4 +25,5 @@ type Options struct {
 	NoColor                  bool                   // Whether the -no-color flag will be set for any Terraform command or not
 	SshAgent                 *ssh.SshAgent          // Overrides local SSH agent with the given in-process agent
 	NoStderr                 bool                   // Disable stderr redirection
+	Log                      *logger.Loggers
 }

--- a/modules/terraform/options.go
+++ b/modules/terraform/options.go
@@ -25,5 +25,5 @@ type Options struct {
 	NoColor                  bool                   // Whether the -no-color flag will be set for any Terraform command or not
 	SshAgent                 *ssh.SshAgent          // Overrides local SSH agent with the given in-process agent
 	NoStderr                 bool                   // Disable stderr redirection
-	Log                      *logger.Loggers
+	Log                      *logger.Loggers        // Set one or more loggers that should be used. See the logger package for more info.
 }


### PR DESCRIPTION
This commit introduces a better logging facility. It adds some types to
allow the caller to customise logging, while not introducing
API-breaking changes.

It enables the user to disable logging for terraform commands and shell
commands. The user may also supply his own Logf function (or even
multiple Logf functions) to these packages to further customise the
output.

The default Logf function is kept and has changed to use testing.T.Logf
if the Go version is at least 1.14. This is because with Go 1.14,
streaming output for Logf has been introduced. The inability to print
the output during testing was why the logger package was created in the
first place. This is fixed now, so if the logger package can determine
the Go version and that version supports streaming Logf, it will be used
instead.

Furthermore, some default loggers have been created:

- Discard:  discards all logging. Useful for functions where the output
            is too large or or unnecessary.
- TestingT: uses testing.T, if supplied (falls back to the "old" logger
            if not). This means that users with pre-1.14 versions can
            use testing.T.Logf anyway, if they want to.
- Logger:   This is the "old" logger that has been used so far. Can be
            used if, for example, the go version is >=1.14, but the
            "default" testing.T.Logf should not be used for whatvever
            reason.

This is all implemented while maintaining the old API. For users of that
API, nothing changes.

Signed-off-by: Ramon Rüttimann <me@ramonr.ch>