### PR TITLE
Default logger needs to mark itself as helper to avoid the line numbers

### DIFF
--- a/modules/logger/logger.go
+++ b/modules/logger/logger.go
@@ -99,6 +99,10 @@ func (_ testingT) Logf(t testing.TestingT, format string, args ...interface{}) {
 type terratestLogger struct{}
 
 func (_ terratestLogger) Logf(t testing.TestingT, format string, args ...interface{}) {
+	if tt, ok := t.(helper); ok {
+		tt.Helper()
+	}
+
 	DoLog(t, 3, os.Stdout, fmt.Sprintf(format, args...))
 }
 


### PR DESCRIPTION
Right now, the default logger does not call the helper function, so it ends up logging an extraneous line number `logger.go:66:`.