### PR TITLE
Use badge from pkg.go.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Maintained by Gruntwork.io](https://img.shields.io/badge/maintained%20by-gruntwork.io-%235849a6.svg)](https://gruntwork.io/?ref=repo_terratest)
 [![CircleCI](https://circleci.com/gh/gruntwork-io/terratest.svg?style=svg&circle-token=e48019e09fc3b8bf6e0315a84048501c87c4157c)](https://circleci.com/gh/gruntwork-io/terratest)
 [![Go Report Card](https://goreportcard.com/badge/github.com/gruntwork-io/terratest)](https://goreportcard.com/report/github.com/gruntwork-io/terratest)
-[![GoDoc](https://godoc.org/github.com/gruntwork-io/terratest?status.svg)](https://godoc.org/github.com/gruntwork-io/terratest)
+[![go.dev reference](https://img.shields.io/badge/go.dev-reference-007d9c?logo=go&logoColor=white&style=flat-square)](https://pkg.go.dev/mod/github.com/gruntwork-io/terratest?tab=overview)
 
 
 Terratest is a Go library that makes it easier to write automated tests for your infrastructure code. It provides a


### PR DESCRIPTION
This updates the godoc ref to go.dev, using a temporary badge from shields.io. See https://github.com/golang/go/issues/36982 for more info on the issue around the badging.

Fixes https://github.com/gruntwork-io/terratest/issues/533 , where the suggested URL in godoc is actually wrong because it points to a non-go-modules version of terratest, before dep was introduced. The URL on the badge uses `mod` in the first path, which is the correct URL.