### PR TITLE
Update quick start examples to use tested example code

### DIFF
--- a/docs/_data/examples.yml
+++ b/docs/_data/examples.yml
@@ -3,7 +3,9 @@
   image: /assets/img/logos/terraform-logo.png
   files:
     - url: /examples/terraform-hello-world-example/main.tf
+      id: terraform_code
     - url: /test/terraform_hello_world_example_test.go
+      id: test_code
       default: true
   learn_more:
     - name: Terraform Hello, World
@@ -14,7 +16,9 @@
   image: /assets/img/logos/packer-logo.png
   files:
     - url: /examples/packer-hello-world-example/build.json
+      id: packer_code
     - url: /test/packer_hello_world_example_test.go
+      id: test_code
       default: true
   learn_more:
     - name: Packer Hello, World
@@ -25,8 +29,10 @@
   image: /assets/img/logos/docker-logo.png
   files:
     - url: /examples/docker-hello-world-example/Dockerfile
+      id: docker_code
       prism_lang: docker
     - url: /test/docker_hello_world_example_test.go
+      id: test_code
       default: true
   learn_more:
     - name: Docker Hello, World
@@ -37,7 +43,9 @@
   image: /assets/img/logos/kubernetes-logo.png
   files:
     - url: /examples/kubernetes-hello-world-example/hello-world-deployment.yml
+      id: k8s_code
     - url: /test/kubernetes_hello_world_example_test.go
+      id: test_code
       default: true
   learn_more:
     - name: Kubernetes Hello, World
@@ -48,7 +56,9 @@
   image: /assets/img/logos/aws-logo.png
   files:
     - url: /examples/terraform-aws-hello-world-example/main.tf
+      id: terraform_code
     - url: /test/terraform_aws_hello_world_example_test.go
+      id: test_code
       default: true
   learn_more:
     - name: AWS Hello, World
@@ -59,7 +69,9 @@
   image: /assets/img/logos/gcp-logo.png
   files:
     - url: /examples/terraform-gcp-hello-world-example/main.tf
+      id: terraform_code
     - url: /test/terraform_gcp_hello_world_example_test.go
+      id: test_code
       default: true
   learn_more:
     - name: GCP Hello, World
@@ -70,9 +82,13 @@
   image: /assets/img/logos/azure-logo.png
   files:
     - url: /examples/terraform-azure-example/main.tf
+      id: terraform_main_code
     - url: /examples/terraform-azure-example/outputs.tf
+      id: terraform_output_code
     - url: /examples/terraform-azure-example/variables.tf
+      id: terraform_var_code
     - url: /test/terraform_azure_example_test.go
+      id: test_code
       default: true
   learn_more:
     - name: Terraform Azure Example

--- a/docs/_includes/examples/example.html
+++ b/docs/_includes/examples/example.html
@@ -2,8 +2,29 @@
 
   <div class="examples__tabs" data-target="{{ include.example.id }}">
     {% for file in include.example.files %}
+      {% if include.file_id == nil or include.file_id == file.id %}
+        {% assign assign_class = '' %}
+        {% if file.default or include.file_id == file.id %}
+          {% assign assign_class = 'active' %}
+        {% endif %}
+
+        {% assign url_split = file.url | split: '/' %}
+        {% assign file_name = url_split.last %}
+        {% if file.name %}
+          {% assign file_name = file.name %}
+        {% endif %}
+
+        <div class="tab {{ assign_class }}" data-target="#example__code-{{ include.example.id }}-{{ file_name | replace: '.', '-' | replace: ' ', '-' }}">
+          <label>{{ file_name }}</label>
+        </div>
+      {% endif %}
+    {% endfor %}
+  </div>
+
+  {% for file in include.example.files %}
+    {% if include.file_id == nil or include.file_id == file.id %}
       {% assign assign_class = '' %}
-      {% if file.default %}
+      {% if file.default or include.file_id == file.id %}
         {% assign assign_class = 'active' %}
       {% endif %}
 
@@ -13,51 +34,37 @@
         {% assign file_name = file.name %}
       {% endif %}
 
-      <div class="tab {{ assign_class }}" data-target="#example__code-{{ include.example.id }}-{{ file_name | replace: '.', '-' | replace: ' ', '-' }}">
-        <label>{{ file_name }}</label>
+      {% assign prism_lang = '' %}
+      {% assign file_name_splitted = file.url | split: '.' %}
+      {% if site.data.prism_extends[file_name_splitted.last] %}
+        {% assign prism_lang = site.data.prism_extends[file_name_splitted.last] %}
+      {% elsif file_name_splitted.last %}
+        {% assign prism_lang = file_name_splitted.last %}
+      {% endif %}
+      {% if file.prism_lang %}
+        {% assign prism_lang = file.prism_lang %}
+      {% endif %}
+
+      <div
+        id="example__code-{{ include.example.id }}-{{ file_name | replace: '.', '-' | replace: ' ', '-' }}"
+        class="examples__code examples__code--example {{ assign_class }}"
+        data-example="{{ include.example.id }}"
+        data-target="{{ file_name | replace: '.', '-' | replace: ' ', '-' }}"
+        data-url="{{ site.github_api_url }}{{ file.url }}"
+        data-skip-tags="{{include.skip_tags}}"
+        >
+        <pre><code class="language-{{ prism_lang }}">Loading...</code></pre>
+        {% unless include.skip_view_on_github %}
+          <div class="example__file-link">
+            <p>View on GitHub:</p>
+            <a href="https://{{ site.repository }}/tree/master{{ file.url }}">{{ site.repository }}{{ file.url }}</a>
+          </div>
+        {% endunless %}
       </div>
-    {% endfor %}
-  </div>
-
-  {% for file in include.example.files %}
-    {% assign assign_class = '' %}
-    {% if file.default %}
-      {% assign assign_class = 'active' %}
     {% endif %}
-
-    {% assign url_split = file.url | split: '/' %}
-    {% assign file_name = url_split.last %}
-    {% if file.name %}
-      {% assign file_name = file.name %}
-    {% endif %}
-
-    {% assign prism_lang = '' %}
-    {% assign file_name_splitted = file.url | split: '.' %}
-    {% if site.data.prism_extends[file_name_splitted.last] %}
-      {% assign prism_lang = site.data.prism_extends[file_name_splitted.last] %}
-    {% elsif file_name_splitted.last %}
-      {% assign prism_lang = file_name_splitted.last %}
-    {% endif %}
-    {% if file.prism_lang %}
-      {% assign prism_lang = file.prism_lang %}
-    {% endif %}
-
-    <div
-      id="example__code-{{ include.example.id }}-{{ file_name | replace: '.', '-' | replace: ' ', '-' }}"
-      class="examples__code examples__code--example {{ assign_class }}"
-      data-example="{{ include.example.id }}"
-      data-target="{{ file_name | replace: '.', '-' | replace: ' ', '-' }}"
-      data-url="{{ site.github_api_url }}{{ file.url }}"
-      >
-      <pre><code class="language-{{ prism_lang }}">Loading...</code></pre>
-      <div class="example__file-link">
-        <p>View on GitHub:</p>
-        <a href="https://{{ site.repository }}/tree/master{{ file.url }}">{{ site.repository }}{{ file.url }}</a>
-      </div>
-    </div>
   {% endfor %}
 
-  {% if include.example.learn_more %}
+  {% if include.example.learn_more and include.skip_learn_more != true %}
   <div class="examples__learn-more">
     <span class="title">Learn more:</span>
     <ul>

--- a/docs/_includes/examples/explorer.html
+++ b/docs/_includes/examples/explorer.html
@@ -2,39 +2,45 @@
   <nav class="examples__nav">
     <div class="hidden-navs">
       {% for example in site.data.examples %}
-        <div
-          class="examples__nav-item nav-{{ example.id }}"
-          data-id="{{ example.id }}"
-          data-name="{{ example.name }}"
-          data-url="{{ site.github_api_url }}{{ example.url }}"
-          >
-          <img src="{{ site.baseurl }}{{ example.image }}" alt="{{ example.name }}" />
-        </div>
+        {% if include.example_id == nil or include.example_id == example.id %}
+          <div
+            class="examples__nav-item nav-{{ example.id }}"
+            data-id="{{ example.id }}"
+            data-name="{{ example.name }}"
+            data-url="{{ site.github_api_url }}{{ example.url }}"
+            >
+            <img src="{{ site.baseurl }}{{ example.image }}" alt="{{ example.name }}" />
+          </div>
+        {% endif %}
       {% endfor %}
     </div>
 
-    <div class="hidden-navs__static-links">
-      <a
-        href="https://github.com/gruntwork-io/terratest/tree/master/examples"
-        class="examples__nav-item static-link nav-{{ example.id }}"
-        target="_blank"
-        >
-        See more examples
-      </a>
-    </div>
-
-    <div class="navs">
-      <div class="navs__visible-bar"></div>
-      <div class="navs__dropdown-input"></div>
-      <div class="navs__dropdown-arrow">
-        <span class="glyphicon glyphicon-menu-down"></span>
+    {% if include.example_id == nil %}
+      <div class="hidden-navs__static-links">
+        <a
+          href="https://github.com/gruntwork-io/terratest/tree/master/examples"
+          class="examples__nav-item static-link nav-{{ example.id }}"
+          target="_blank"
+          >
+          See more examples
+        </a>
       </div>
-      <div class="navs__dropdown-menu"></div>
-    </div>
+
+      <div class="navs">
+        <div class="navs__visible-bar"></div>
+        <div class="navs__dropdown-input"></div>
+        <div class="navs__dropdown-arrow">
+          <span class="glyphicon glyphicon-menu-down"></span>
+        </div>
+        <div class="navs__dropdown-menu"></div>
+      </div>
+    {% endif %}
   </nav>
 
   {% for example in site.data.examples %}
-    {% include examples/example.html example=example %}
+    {% if include.example_id == nil or include.example_id == example.id %}
+      {% include examples/example.html example=example file_id=include.file_id skip_learn_more=include.skip_learn_more skip_view_on_github=include.skip_view_on_github skip_tags=include.skip_tags %}
+    {% endif %}
   {% endfor %}
 
 </div>

--- a/docs/assets/css/examples.scss
+++ b/docs/assets/css/examples.scss
@@ -450,6 +450,18 @@
   }
 }
 
+.examples__container.quick-start-examples {
+  padding: 0;
+
+  .examples__nav {
+    display: none;
+  }
+
+  .examples__code {
+    margin-bottom: 30px;
+  }
+}
+
 .examples__container.wide {
   .examples__block {
     .examples__code {


### PR DESCRIPTION
This PR updates the Terratest quick start guide to use our tested example code (that is, the code from the `examples` folder that we run through automated tests) instead of code copy/pasted into the Markdown files. The copy/pasted code is _already_ broken (e.g., bad AMI ID, not enough retries), and this will only get worse over time, so switching to example code that's actually tested makes our documentation more up to date and maintainable. We were already using real examples on the home page and examples page of Terratest, so this update is mainly about:

1. Refactoring the example code so that it's possible to embed single files rather than a list of examples.
1. Updating the UI for the example code so that certain aspects can be hidden, such as the nav, "learn more" links, etc.
1. Using these new super powers in the quick start guide to replace the hard-coded, out-of-date examples with the tested examples from the home page.