### PR TITLE
add --install flag to helm upgrade command

### DIFF
--- a/modules/helm/upgrade.go
+++ b/modules/helm/upgrade.go
@@ -35,7 +35,7 @@ func UpgradeE(t testing.TestingT, options *Options, chart string, releaseName st
 		return err
 	}
 
-	args = append(args, releaseName, chart)
+	args = append(args, "--install", releaseName, chart)
 	_, err = RunHelmCommandAndGetOutputE(t, options, "upgrade", args...)
 	return err
 }


### PR DESCRIPTION
This PR adds the `--install` flag to the helm upgrade commands, as discussed in #549.

Package tests ran successfully. Let me know if you need anything else.
Thanks a lot!



