### PR TITLE
Idempotent apply

### DIFF
--- a/docs/_docs/02_testing-best-practices/idempotent.md
+++ b/docs/_docs/02_testing-best-practices/idempotent.md
@@ -1,0 +1,25 @@
+---
+layout: collection-browser-doc
+title: Idempotent
+category: testing-best-practices
+excerpt: >-
+  Test that your Terraform configuration results in consistent deployments.
+tags: ["testing-best-practices", "idempotent", "terraform"]
+order: 212
+nav_title: Documentation
+nav_title_link: /docs/
+---
+
+A Terraform configuration is idempotent when a second apply results in 0 changes. A idempotent configuration ensures that:
+
+1.  What you define in Terraform is exactly what is being deployed. 
+1.  Detection of bugs in Terraform resources and providers that might affect your configuration.
+
+You can use Terratest's `terraform.ApplyAndIdempotent()` function to both apply your Terraform configuration and test its
+idempotency.
+
+```go
+terraform.ApplyAndIdempotent(t, terraformOptions)
+```
+
+If a second apply of your Terraform configuration results in changes then your test will fail.

--- a/docs/_docs/04_community/contributing.md
+++ b/docs/_docs/04_community/contributing.md
@@ -115,8 +115,8 @@ We also recommend updating the automated tests *before* updating any code (see [
 Development](https://en.wikipedia.org/wiki/Test-driven_development)). That means you add or update a test case,
 verify that it's failing with a clear error message, and *then* make the code changes to get that test to pass. This
 ensures the tests stay up to date and verify all the functionality in this Module, including whatever new
-functionality you're adding in your contribution. Check out the [test](https://github.com/gruntwork-io/terratest/tree/master/test) folder for instructions on running the
-automated tests.
+functionality you're adding in your contribution. The instructions for running the automated tests can be
+found [here](https://terratest.gruntwork.io/docs/community/contributing/#developing-terratest).
 
 ### Update the code
 

--- a/modules/terraform/apply.go
+++ b/modules/terraform/apply.go
@@ -63,7 +63,7 @@ func TgApplyAllE(t testing.TestingT, options *Options) (string, error) {
 	return RunTerraformCommandE(t, options, FormatArgs(options, "apply-all", "-input=false", "-lock=false", "-auto-approve")...)
 }
 
-// ApplyAndIdempotent runs terraform init and apply with the given options and return stdout/stderr from the apply command. It then runs
+// ApplyAndIdempotent runs terraform apply with the given options and return stdout/stderr from the apply command. It then runs
 // plan again and will fail the test if plan requires additional changes. Note that this method does NOT call destroy and assumes
 // the caller is responsible for cleaning up any resources created by running apply.
 func ApplyAndIdempotent(t testing.TestingT, options *Options) string {
@@ -74,11 +74,11 @@ func ApplyAndIdempotent(t testing.TestingT, options *Options) string {
 	return out
 }
 
-// ApplyAndIdempotentE runs terraform init and apply with the given options and return stdout/stderr from the apply command. It then runs
+// ApplyAndIdempotentE runs terraform apply with the given options and return stdout/stderr from the apply command. It then runs
 // plan again and will fail the test if plan requires additional changes. Note that this method does NOT call destroy and assumes
 // the caller is responsible for cleaning up any resources created by running apply.
 func ApplyAndIdempotentE(t testing.TestingT, options *Options) (string, error) {
-	out, err := InitAndApplyE(t, options)
+	out, err := ApplyE(t, options)
 
 	if err != nil {
 		return "", err

--- a/modules/terraform/apply.go
+++ b/modules/terraform/apply.go
@@ -80,17 +80,17 @@ func ApplyAndIdempotentE(t testing.TestingT, options *Options) (string, error) {
 	out, err := ApplyE(t, options)
 
 	if err != nil {
-		return "", err
+		return out, err
 	}
 
 	exitCode, err := PlanExitCodeE(t, options)
 
 	if err != nil {
-		return "", err
+		return out, err
 	}
 
 	if exitCode != 0 {
-		return "", errors.New("terraform configuration not idempotent")
+		return out, errors.New("terraform configuration not idempotent")
 	}
 
 	return out, nil

--- a/modules/terraform/apply.go
+++ b/modules/terraform/apply.go
@@ -84,11 +84,39 @@ func ApplyAndIdempotentE(t testing.TestingT, options *Options) (string, error) {
 		return "", err
 	}
 
-	exitCode := PlanExitCode(t, options)
+	exitCode, err := PlanExitCodeE(t, options)
+
+	if err != nil {
+		return "", err
+	}
 
 	if exitCode != 0 {
 		return "", errors.New("terraform configuration not idempotent")
 	}
 
 	return out, nil
+}
+
+// InitAndApplyAndIdempotent runs terraform init and apply with the given options and return stdout/stderr from the apply command. It then runs
+// plan again and will fail the test if plan requires additional changes. Note that this method does NOT call destroy and assumes
+// the caller is responsible for cleaning up any resources created by running apply.
+func InitAndApplyAndIdempotent(t testing.TestingT, options *Options) string {
+
+	out, err := InitAndApplyAndIdempotentE(t, options)
+	require.NoError(t, err)
+
+	return out
+}
+
+// InitAndApplyAndIdempotentE runs terraform init and apply with the given options and return stdout/stderr from the apply command. It then runs
+// plan again and will fail the test if plan requires additional changes. Note that this method does NOT call destroy and assumes
+// the caller is responsible for cleaning up any resources created by running apply.
+func InitAndApplyAndIdempotentE(t testing.TestingT, options *Options) (string, error) {
+
+	if _, err := InitE(t, options); err != nil {
+		return "", err
+	}
+
+	return ApplyAndIdempotentE(t, options)
+
 }

--- a/modules/terraform/apply.go
+++ b/modules/terraform/apply.go
@@ -60,3 +60,17 @@ func TgApplyAllE(t testing.TestingT, options *Options) (string, error) {
 
 	return RunTerraformCommandE(t, options, FormatArgs(options, "apply-all", "-input=false", "-lock=false", "-auto-approve")...)
 }
+
+// ApplyAndIdempotent runs terraform init and apply with the given options and return stdout/stderr from the apply command. It then runs
+// plan again and will fail the test if plan requires additional changes. Note that this method does NOT call destroy and assumes
+// the caller is responsible for cleaning up any resources created by running apply.
+func ApplyAndIdempotent(t testing.TestingT, options *Options) string {
+
+	out, err := InitAndApplyE(t, options)
+	require.NoError(t, err)
+
+	exitCode := Plan(t, options)
+	require.Equal(t, DefaultSuccessExitCode, exitCode)
+
+	return out
+}

--- a/modules/terraform/apply.go
+++ b/modules/terraform/apply.go
@@ -67,7 +67,6 @@ func TgApplyAllE(t testing.TestingT, options *Options) (string, error) {
 // plan again and will fail the test if plan requires additional changes. Note that this method does NOT call destroy and assumes
 // the caller is responsible for cleaning up any resources created by running apply.
 func ApplyAndIdempotent(t testing.TestingT, options *Options) string {
-
 	out, err := ApplyAndIdempotentE(t, options)
 	require.NoError(t, err)
 
@@ -101,7 +100,6 @@ func ApplyAndIdempotentE(t testing.TestingT, options *Options) (string, error) {
 // plan again and will fail the test if plan requires additional changes. Note that this method does NOT call destroy and assumes
 // the caller is responsible for cleaning up any resources created by running apply.
 func InitAndApplyAndIdempotent(t testing.TestingT, options *Options) string {
-
 	out, err := InitAndApplyAndIdempotentE(t, options)
 	require.NoError(t, err)
 
@@ -112,11 +110,9 @@ func InitAndApplyAndIdempotent(t testing.TestingT, options *Options) string {
 // plan again and will fail the test if plan requires additional changes. Note that this method does NOT call destroy and assumes
 // the caller is responsible for cleaning up any resources created by running apply.
 func InitAndApplyAndIdempotentE(t testing.TestingT, options *Options) (string, error) {
-
 	if _, err := InitE(t, options); err != nil {
 		return "", err
 	}
 
 	return ApplyAndIdempotentE(t, options)
-
 }

--- a/modules/terraform/apply_test.go
+++ b/modules/terraform/apply_test.go
@@ -120,7 +120,7 @@ func TestTgApplyOutput(t *testing.T) {
 	assert.Equal(t, allOutputs, map[string]interface{}{"str": "str", "list": []interface{}{"a", "b", "c"}, "map": map[string]interface{}{"foo": "bar"}})
 }
 
-func TestIdempotentNochanges(t *testing.T) {
+func TestIdempotentNoChanges(t *testing.T) {
 	t.Parallel()
 
 	testFolder, err := files.CopyTerraformFolderToTemp("../../test/fixtures/terraform-no-error", t.Name())
@@ -131,10 +131,10 @@ func TestIdempotentNochanges(t *testing.T) {
 		NoColor:      true,
 	}
 
-	ApplyAndIdempotent(t, options)
+	InitAndApplyAndIdempotentE(t, options)
 }
 
-func TestIdempotentWithchanges(t *testing.T) {
+func TestIdempotentWithChanges(t *testing.T) {
 	t.Parallel()
 
 	testFolder, err := files.CopyTerraformFolderToTemp("../../test/fixtures/terraform-not-idempotent", t.Name())
@@ -145,10 +145,10 @@ func TestIdempotentWithchanges(t *testing.T) {
 		NoColor:      true,
 	}
 
-	out, err := ApplyAndIdempotentE(t, options)
+	out, err := InitAndApplyAndIdempotentE(t, options)
 
-	_ = out
-
+	require.Equal(t, out, "")
 	require.Error(t, err)
+	require.EqualError(t, err, "terraform configuration not idempotent")
 
 }

--- a/modules/terraform/apply_test.go
+++ b/modules/terraform/apply_test.go
@@ -147,7 +147,7 @@ func TestIdempotentWithChanges(t *testing.T) {
 
 	out, err := InitAndApplyAndIdempotentE(t, options)
 
-	require.Equal(t, out, "")
+	require.NotEmpty(t, out)
 	require.Error(t, err)
 	require.EqualError(t, err, "terraform configuration not idempotent")
 }

--- a/modules/terraform/apply_test.go
+++ b/modules/terraform/apply_test.go
@@ -119,3 +119,32 @@ func TestTgApplyOutput(t *testing.T) {
 	allOutputs := OutputForKeys(t, options, []string{"str", "list", "map"})
 	assert.Equal(t, allOutputs, map[string]interface{}{"str": "str", "list": []interface{}{"a", "b", "c"}, "map": map[string]interface{}{"foo": "bar"}})
 }
+
+func TestIdempotentNochanges(t *testing.T) {
+	t.Parallel()
+
+	testFolder, err := files.CopyTerraformFolderToTemp("../../test/fixtures/terraform-no-error", t.Name())
+	require.NoError(t, err)
+
+	options := &Options{
+		TerraformDir: testFolder,
+		NoColor:      true,
+	}
+
+	ApplyAndIdempotent(t, options)
+}
+
+func TestIdempotentWithchanges(t *testing.T) {
+	t.Parallel()
+
+	testFolder, err := files.CopyTerraformFolderToTemp("../../test/fixtures/terraform-not-idempotent", t.Name())
+	require.NoError(t, err)
+
+	options := &Options{
+		TerraformDir: testFolder,
+		NoColor:      true,
+	}
+
+	require.Panicsf(t, func() { ApplyAndIdempotent(t, options) }, "Should Fail")
+
+}

--- a/modules/terraform/apply_test.go
+++ b/modules/terraform/apply_test.go
@@ -150,5 +150,4 @@ func TestIdempotentWithChanges(t *testing.T) {
 	require.Equal(t, out, "")
 	require.Error(t, err)
 	require.EqualError(t, err, "terraform configuration not idempotent")
-
 }

--- a/modules/terraform/apply_test.go
+++ b/modules/terraform/apply_test.go
@@ -145,6 +145,10 @@ func TestIdempotentWithchanges(t *testing.T) {
 		NoColor:      true,
 	}
 
-	require.Panicsf(t, func() { ApplyAndIdempotent(t, options) }, "Should Fail")
+	out, err := ApplyAndIdempotentE(t, options)
+
+	_ = out
+
+	require.Error(t, err)
 
 }

--- a/test/fixtures/terraform-not-idempotent/main.tf
+++ b/test/fixtures/terraform-not-idempotent/main.tf
@@ -1,0 +1,5 @@
+resource "null_resource" test {
+  triggers = {
+    time = timestamp()
+  }
+}


### PR DESCRIPTION
Closes #551 

This PR adds a "Apply" function to `apply.go`. This function will apply the terraform config and then immediately afterward run the plan function to verify that the configuration doesn't produce any plan changes. 

I have updated the Docs with an example. I have added two tests in `apply_test.go`. One test works as expected but the other I can't get to work correctly. 

In `ApplyAndIdempotent()` function I use this to error if there is changes on the second plan. 

```
exitCode := Plan(t, options)
require.Equal(t, DefaultSuccessExitCode, exitCode)
```

I don't know how to "catch" the test failure caused by `require.Equal`. I can't seem to find a way to mark my test as "FailureExpected". I tried catching like this:

```
require.Panicsf(t, func() { ApplyAndIdempotent(t, options) }, "Should Fail")
```

But that doesn't work. I decided it's best to get some guidance. I don't write in Golang often.

Edit: It looks like maybe I should create a "wrapper" function that returns an error and test that for failures. That seems to be the pattern like, `Plan()` and `PlanE()`