### PR TITLE
Fix bug where fallback to aws node fails

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/gruntwork-io/gruntwork-cli v0.5.1
 	github.com/imdario/mergo v0.3.7 // indirect
 	github.com/jstemmer/go-junit-report v0.9.1
+	github.com/magiconair/properties v1.8.0
 	github.com/mattn/go-zglob v0.0.2-0.20190814121620-e3c945676326 // indirect
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/oracle/oci-go-sdk v7.1.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -263,6 +263,7 @@ github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.5/go.mod h1:9r2w37qlBe7rQ6e1fg1S/9xpWHSnaqNdHD3WcMdbPDA=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/magiconair/properties v1.8.0 h1:LLgXmsheXeRoUOBOjtwPQCWIYqM/LU1ayDtDePerRcY=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mailru/easyjson v0.0.0-20160728113105-d5b7844b561a/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=

--- a/modules/k8s/service.go
+++ b/modules/k8s/service.go
@@ -227,7 +227,7 @@ func findAwsNodeHostnameE(t testing.TestingT, node corev1.Node, awsIDUri *url.UR
 	}
 
 	publicIP, containsIP := ipMap[instanceID]
-	if !containsIP {
+	if !containsIP || publicIP == "" {
 		// return default hostname
 		return findDefaultNodeHostnameE(node)
 	}


### PR DESCRIPTION
Fixes #559 

The fallback was failing because the public IP map did contain an entry for the instance, but it was the blank string. This fixes the bug by explicitly checking for empty string.