### PR TITLE
Add ability for parseMap() to parse non-map list values

### DIFF
--- a/modules/terraform/output.go
+++ b/modules/terraform/output.go
@@ -100,6 +100,52 @@ func parseMap(m map[string]interface{}) (map[string]interface{}, error) {
 			}
 			result[k] = nestedMap
 		case []interface{}:
+			if len(vt) == 0 {
+				result[k] = []interface{}{}
+			} else {
+				switch vt[0].(type) {
+				case map[string]interface{}:
+					nestedList, err := parseListOfMaps(vt)
+					if err != nil {
+						return nil, err
+					}
+					result[k] = nestedList
+				default:
+					nestedList, err := parseListOutputTerraform(vt, k)
+					if err != nil {
+						return nil, err
+					}
+					result[k] = nestedList
+				}
+			}
+		case float64:
+			testInt, err := strconv.ParseInt((fmt.Sprintf("%v", vt)), 10, 0)
+			if err == nil {
+				result[k] = int(testInt)
+			} else {
+				result[k] = vt
+			}
+		default:
+			result[k] = vt
+		}
+	}
+
+	return result, nil
+}
+
+func parseMapOriginal(m map[string]interface{}) (map[string]interface{}, error) {
+
+	result := make(map[string]interface{})
+
+	for k, v := range m {
+		switch vt := v.(type) {
+		case map[string]interface{}:
+			nestedMap, err := parseMap(vt)
+			if err != nil {
+				return nil, err
+			}
+			result[k] = nestedMap
+		case []interface{}:
 			nestedList, err := parseListOfMaps(vt)
 			if err != nil {
 				return nil, err

--- a/modules/terraform/output.go
+++ b/modules/terraform/output.go
@@ -133,40 +133,6 @@ func parseMap(m map[string]interface{}) (map[string]interface{}, error) {
 	return result, nil
 }
 
-func parseMapOriginal(m map[string]interface{}) (map[string]interface{}, error) {
-
-	result := make(map[string]interface{})
-
-	for k, v := range m {
-		switch vt := v.(type) {
-		case map[string]interface{}:
-			nestedMap, err := parseMap(vt)
-			if err != nil {
-				return nil, err
-			}
-			result[k] = nestedMap
-		case []interface{}:
-			nestedList, err := parseListOfMaps(vt)
-			if err != nil {
-				return nil, err
-			}
-			result[k] = nestedList
-		case float64:
-			testInt, err := strconv.ParseInt((fmt.Sprintf("%v", vt)), 10, 0)
-			if err == nil {
-				result[k] = int(testInt)
-			} else {
-				result[k] = vt
-			}
-		default:
-			result[k] = vt
-		}
-
-	}
-
-	return result, nil
-}
-
 // OutputMapOfObjects calls terraform output for the given variable and returns its value as a map of lists/maps.
 // If the output value is not a map of lists/maps, then it fails the test.
 func OutputMapOfObjects(t testing.TestingT, options *Options, key string) map[string]interface{} {

--- a/modules/terraform/output_test.go
+++ b/modules/terraform/output_test.go
@@ -160,33 +160,43 @@ func TestOutputListOfObjects(t *testing.T) {
 	out := OutputListOfObjects(t, options, "list_of_maps")
 
 	expectedLen := 2
+
 	nestedMap1 := map[string]interface{}{
 		"four": 4,
 		"five": "five",
 	}
-	nestedList1 := []map[string]interface{}{
+	nestedList1 := []string{"six"}
+
+	nestedMap2 := []map[string]interface{}{
 		map[string]interface{}{
 			"four": 4,
 			"five": "five",
 		},
 	}
-	expectedMap1 := map[string]interface{}{
-		"one":   1,
-		"two":   "two",
-		"three": "three",
-		"more":  nestedMap1,
-	}
 
+	// This feels like it should be consistent with other functions and return
+	// a []float64 or at least a []interface{}, but parseListOutputTerraform()
+	// returns a []string, so that's what we'll use for now.
+	nestedList2 := []string{"6"}
+
+	expectedMap1 := map[string]interface{}{
+		"one":       1,
+		"two":       "two",
+		"three":     "three",
+		"more":      nestedMap1,
+		"even_more": nestedList1,
+	}
 	expectedMap2 := map[string]interface{}{
-		"one":   "one",
-		"two":   2,
-		"three": 3,
-		"more":  nestedList1,
+		"one":       "one",
+		"two":       2,
+		"three":     3,
+		"more":      nestedMap2,
+		"even_more": nestedList2,
 	}
 
 	require.Len(t, out, expectedLen, "Output should contain %d items", expectedLen)
 	require.Equal(t, out[0], expectedMap1, "First map should be %q, got %q", expectedMap1, out[0])
-	require.Equal(t, out[1], expectedMap2, "First map should be %q, got %q", expectedMap2, out[1])
+	require.Equal(t, out[1], expectedMap2, "Second map should be %q, got %q", expectedMap2, out[1])
 }
 
 func TestOutputNotListOfObjectsError(t *testing.T) {

--- a/test/fixtures/terraform-output-listofobjects/output.tf
+++ b/test/fixtures/terraform-output-listofobjects/output.tf
@@ -8,6 +8,9 @@ output "list_of_maps" {
         four = 4
         five = "five"
       }
+      even_more = [
+        "six"
+      ]
     },
     {
       one   = "one"
@@ -17,6 +20,9 @@ output "list_of_maps" {
         four = 4
         five = "five"
       }]
+      even_more = [
+        6
+      ]
     }
   ]
 }


### PR DESCRIPTION
When working with outputs from Terraform `aws_security_group` resources I found that the `OutputListOfObjectsE` function couldn't handle lists nested inside the maps elements (such as the `cidr_blocks` values in the `aws_security_group.foo.ingress` list). I tracked the issue to the inability of `parseMap` to parse maps that contained values of a list type other than `[]map[string]interface{}`. 

To test, I extended the maps `test/fixtures/terraform-output-listofobjects/output.tf` to include lists, as seen in the diff. 

Running `go test -run TestOutputListOfObjects` against the test condition returned the same error:

```
$ go test -run TestOutputListOfObjects
...
--- FAIL: TestOutputListOfObjects (0.27s)
    output.go:155: 
        	Error Trace:	output.go:155
        	            				output_test.go:160
        	Error:      	Received unexpected error:
        	            	Type switching to map[string]interface{} failed.
        	Test:       	TestOutputListOfObjects
FAIL
```

I'll admit that this diff isn't pretty, but it adds the desired functionality.

Test results, post change:

```
$ go test -run TestOutputListOfObjects
...
TestOutputListOfObjects 2020-06-28T17:26:52-04:00 logger.go:66: Running command terraform with args [output -no-color -json list_of_maps]
TestOutputListOfObjects 2020-06-28T17:26:52-04:00 logger.go:66: [{"even_more":["six"],"more":{"five":"five","four":4},"one":1,"three":"three","two":"two"},{"even_more":[6],"more":[{"five":"five","four":4}],"one":"one","three":3,"two":2}]
PASS
```