### PR TITLE
Implement OutputStructE and OutputStruct

### DIFF
--- a/modules/terraform/output.go
+++ b/modules/terraform/output.go
@@ -281,11 +281,7 @@ func OutputStructE(t testing.TestingT, options *Options, key string, v interface
 		return err
 	}
 
-	if err := json.Unmarshal([]byte(out), &v); err != nil {
-		return err
-	}
-
-	return nil
+	return json.Unmarshal([]byte(out), &v)
 }
 
 // OutputForKeysE calls terraform output for the given key list and returns values as a map.

--- a/modules/terraform/output.go
+++ b/modules/terraform/output.go
@@ -262,6 +262,32 @@ func OutputForKeys(t testing.TestingT, options *Options, keys []string) map[stri
 	return out
 }
 
+// OutputStruct calls terraform output for the given variable and stores the
+// result in the value pointed to by out. If out is nil or not a pointer, or if
+// the value returned by Terraform is not appropriate for a given target type,
+// it fails the test.
+func OutputStruct(t testing.TestingT, options *Options, key string, out interface{}) {
+	err := OutputStructE(t, options, key, out)
+	require.NoError(t, err)
+}
+
+// OutputStructE calls terraform output for the given variable and stores the
+// result in the value pointed to by v. If v is nil or not a pointer, or if
+// the value returned by Terraform is not appropriate for a given target type,
+// it returns an error.
+func OutputStructE(t testing.TestingT, options *Options, key string, v interface{}) error {
+	out, err := RunTerraformCommandAndGetStdoutE(t, options, "output", "-no-color", "-json", key)
+	if err != nil {
+		return err
+	}
+
+	if err := json.Unmarshal([]byte(out), &v); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // OutputForKeysE calls terraform output for the given key list and returns values as a map.
 // The returned values are of type interface{} and need to be type casted as necessary. Refer to output_test.go
 func OutputForKeysE(t testing.TestingT, options *Options, keys []string) (map[string]interface{}, error) {

--- a/modules/terraform/output.go
+++ b/modules/terraform/output.go
@@ -263,11 +263,11 @@ func OutputForKeys(t testing.TestingT, options *Options, keys []string) map[stri
 }
 
 // OutputStruct calls terraform output for the given variable and stores the
-// result in the value pointed to by out. If out is nil or not a pointer, or if
+// result in the value pointed to by v. If v is nil or not a pointer, or if
 // the value returned by Terraform is not appropriate for a given target type,
 // it fails the test.
-func OutputStruct(t testing.TestingT, options *Options, key string, out interface{}) {
-	err := OutputStructE(t, options, key, out)
+func OutputStruct(t testing.TestingT, options *Options, key string, v interface{}) {
+	err := OutputStructE(t, options, key, v)
 	require.NoError(t, err)
 }
 

--- a/modules/terraform/output_test.go
+++ b/modules/terraform/output_test.go
@@ -253,6 +253,63 @@ func TestOutputsForKeys(t *testing.T) {
 	require.Nil(t, outputNotPresentMap)
 }
 
+func TestOutputStruct(t *testing.T) {
+	type TestStruct struct {
+		Somebool    bool
+		Somefloat   float64
+		Someint     int
+		Somestring  string
+		Somemap     map[string]interface{}
+		Listmaps    []map[string]interface{}
+		Liststrings []string
+	}
+
+	t.Parallel()
+
+	testFolder, err := files.CopyTerraformFolderToTemp("../../test/fixtures/terraform-output-struct", t.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	options := &Options{
+		TerraformDir: testFolder,
+	}
+
+	InitAndApply(t, options)
+
+	expectedObject := TestStruct{
+		Somebool:    true,
+		Somefloat:   0.1,
+		Someint:     1,
+		Somestring:  "two",
+		Somemap:     map[string]interface{}{"three": 3.0, "four": "four"},
+		Listmaps:    []map[string]interface{}{{"five": 5.0, "six": "six"}},
+		Liststrings: []string{"seven", "eight", "nine"},
+	}
+	v1 := TestStruct{}
+	OutputStruct(t, options, "object", &v1)
+
+	expectedList := []TestStruct{
+		{
+			Somebool:   true,
+			Somefloat:  0.1,
+			Someint:    1,
+			Somestring: "two",
+		},
+		{
+			Somebool:   false,
+			Somefloat:  0.3,
+			Someint:    4,
+			Somestring: "five",
+		},
+	}
+	v2 := []TestStruct{}
+	OutputStruct(t, options, "list_of_objects", &v2)
+
+	require.Equal(t, expectedObject, v1, "Object should be %q, got %q", expectedObject, v1)
+	require.Equal(t, expectedList, v2, "List should be %q, got %q", expectedList, v2)
+}
+
 func TestOutputsAll(t *testing.T) {
 	t.Parallel()
 

--- a/modules/terraform/output_test.go
+++ b/modules/terraform/output_test.go
@@ -254,6 +254,8 @@ func TestOutputsForKeys(t *testing.T) {
 }
 
 func TestOutputStruct(t *testing.T) {
+	t.Parallel()
+
 	type TestStruct struct {
 		Somebool    bool
 		Somefloat   float64
@@ -263,8 +265,6 @@ func TestOutputStruct(t *testing.T) {
 		Listmaps    []map[string]interface{}
 		Liststrings []string
 	}
-
-	t.Parallel()
 
 	testFolder, err := files.CopyTerraformFolderToTemp("../../test/fixtures/terraform-output-struct", t.Name())
 	if err != nil {
@@ -286,8 +286,8 @@ func TestOutputStruct(t *testing.T) {
 		Listmaps:    []map[string]interface{}{{"five": 5.0, "six": "six"}},
 		Liststrings: []string{"seven", "eight", "nine"},
 	}
-	v1 := TestStruct{}
-	OutputStruct(t, options, "object", &v1)
+	actualObject := TestStruct{}
+	OutputStruct(t, options, "object", &actualObject)
 
 	expectedList := []TestStruct{
 		{
@@ -303,11 +303,11 @@ func TestOutputStruct(t *testing.T) {
 			Somestring: "five",
 		},
 	}
-	v2 := []TestStruct{}
-	OutputStruct(t, options, "list_of_objects", &v2)
+	actualList := []TestStruct{}
+	OutputStruct(t, options, "list_of_objects", &actualList)
 
-	require.Equal(t, expectedObject, v1, "Object should be %q, got %q", expectedObject, v1)
-	require.Equal(t, expectedList, v2, "List should be %q, got %q", expectedList, v2)
+	require.Equal(t, expectedObject, actualObject, "Object should be %q, got %q", expectedObject, actualObject)
+	require.Equal(t, expectedList, actualList, "List should be %q, got %q", expectedList, actualList)
 }
 
 func TestOutputsAll(t *testing.T) {

--- a/test/fixtures/terraform-output-struct/output.tf
+++ b/test/fixtures/terraform-output-struct/output.tf
@@ -1,0 +1,40 @@
+output "object" {
+  value = {
+    somebool   = true
+    somefloat  = 0.1
+    someint    = 1
+    somestring = "two"
+    somemap = {
+      three = 3
+      four  = "four"
+    },
+    listmaps = [
+      {
+        five = 5
+        six  = "six"
+      },
+    ]
+    liststrings = [
+      "seven",
+      "eight",
+      "nine",
+    ]
+  }
+}
+
+output "list_of_objects" {
+  value = [
+    {
+      somebool   = true
+      somefloat  = 0.1
+      someint    = 1
+      somestring = "two"
+    },
+    {
+      somebool   = false
+      somefloat  = 0.3
+      someint    = 4
+      somestring = "five"
+    }
+  ]
+}


### PR DESCRIPTION
Implemented `OutputStructE` and `OutputStruct` [as per the this comment on PR 513](https://github.com/gruntwork-io/terratest/pull/513#issuecomment-627833280).

Includes passing tests for both a single struct and a list of structs.

```$ go test -run TestOutputStruct
TestOutputStruct 2020-07-06T11:06:41-04:00 retry.go:72: terraform [init -upgrade=false]
TestOutputStruct 2020-07-06T11:06:41-04:00 logger.go:66: Running command terraform with args [init -upgrade=false]
TestOutputStruct 2020-07-06T11:06:41-04:00 logger.go:66: 
TestOutputStruct 2020-07-06T11:06:41-04:00 logger.go:66: Initializing the backend...
TestOutputStruct 2020-07-06T11:06:41-04:00 logger.go:66: 
TestOutputStruct 2020-07-06T11:06:41-04:00 logger.go:66: Terraform has been successfully initialized!
TestOutputStruct 2020-07-06T11:06:41-04:00 logger.go:66: 
TestOutputStruct 2020-07-06T11:06:41-04:00 logger.go:66: You may now begin working with Terraform. Try running "terraform plan" to see
TestOutputStruct 2020-07-06T11:06:41-04:00 logger.go:66: any changes that are required for your infrastructure. All Terraform commands
TestOutputStruct 2020-07-06T11:06:41-04:00 logger.go:66: should now work.
TestOutputStruct 2020-07-06T11:06:41-04:00 logger.go:66: 
TestOutputStruct 2020-07-06T11:06:41-04:00 logger.go:66: If you ever set or change modules or backend configuration for Terraform,
TestOutputStruct 2020-07-06T11:06:41-04:00 logger.go:66: rerun this command to reinitialize your working directory. If you forget, other
TestOutputStruct 2020-07-06T11:06:41-04:00 logger.go:66: commands will detect it and remind you to do so if necessary.
TestOutputStruct 2020-07-06T11:06:41-04:00 retry.go:72: terraform [get -update]
TestOutputStruct 2020-07-06T11:06:41-04:00 logger.go:66: Running command terraform with args [get -update]
TestOutputStruct 2020-07-06T11:06:41-04:00 retry.go:72: terraform [apply -input=false -auto-approve -lock=false]
TestOutputStruct 2020-07-06T11:06:41-04:00 logger.go:66: Running command terraform with args [apply -input=false -auto-approve -lock=false]
TestOutputStruct 2020-07-06T11:06:41-04:00 logger.go:66: 
TestOutputStruct 2020-07-06T11:06:41-04:00 logger.go:66: Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
TestOutputStruct 2020-07-06T11:06:41-04:00 logger.go:66: 
TestOutputStruct 2020-07-06T11:06:41-04:00 logger.go:66: Outputs:
TestOutputStruct 2020-07-06T11:06:41-04:00 logger.go:66: 
TestOutputStruct 2020-07-06T11:06:41-04:00 logger.go:66: list_of_objects = [
TestOutputStruct 2020-07-06T11:06:41-04:00 logger.go:66:   {
TestOutputStruct 2020-07-06T11:06:41-04:00 logger.go:66:     "somebool" = true
TestOutputStruct 2020-07-06T11:06:41-04:00 logger.go:66:     "somefloat" = 0.1
TestOutputStruct 2020-07-06T11:06:41-04:00 logger.go:66:     "someint" = 1
TestOutputStruct 2020-07-06T11:06:41-04:00 logger.go:66:     "somestring" = "two"
TestOutputStruct 2020-07-06T11:06:41-04:00 logger.go:66:   },
TestOutputStruct 2020-07-06T11:06:41-04:00 logger.go:66:   {
TestOutputStruct 2020-07-06T11:06:41-04:00 logger.go:66:     "somebool" = false
TestOutputStruct 2020-07-06T11:06:41-04:00 logger.go:66:     "somefloat" = 0.3
TestOutputStruct 2020-07-06T11:06:41-04:00 logger.go:66:     "someint" = 4
TestOutputStruct 2020-07-06T11:06:41-04:00 logger.go:66:     "somestring" = "five"
TestOutputStruct 2020-07-06T11:06:41-04:00 logger.go:66:   },
TestOutputStruct 2020-07-06T11:06:41-04:00 logger.go:66: ]
TestOutputStruct 2020-07-06T11:06:41-04:00 logger.go:66: object = {
TestOutputStruct 2020-07-06T11:06:41-04:00 logger.go:66:   "listmaps" = [
TestOutputStruct 2020-07-06T11:06:41-04:00 logger.go:66:     {
TestOutputStruct 2020-07-06T11:06:41-04:00 logger.go:66:       "five" = 5
TestOutputStruct 2020-07-06T11:06:41-04:00 logger.go:66:       "six" = "six"
TestOutputStruct 2020-07-06T11:06:41-04:00 logger.go:66:     },
TestOutputStruct 2020-07-06T11:06:41-04:00 logger.go:66:   ]
TestOutputStruct 2020-07-06T11:06:41-04:00 logger.go:66:   "liststrings" = [
TestOutputStruct 2020-07-06T11:06:41-04:00 logger.go:66:     "seven",
TestOutputStruct 2020-07-06T11:06:41-04:00 logger.go:66:     "eight",
TestOutputStruct 2020-07-06T11:06:41-04:00 logger.go:66:     "nine",
TestOutputStruct 2020-07-06T11:06:41-04:00 logger.go:66:   ]
TestOutputStruct 2020-07-06T11:06:41-04:00 logger.go:66:   "somebool" = true
TestOutputStruct 2020-07-06T11:06:41-04:00 logger.go:66:   "somefloat" = 0.1
TestOutputStruct 2020-07-06T11:06:41-04:00 logger.go:66:   "someint" = 1
TestOutputStruct 2020-07-06T11:06:41-04:00 logger.go:66:   "somemap" = {
TestOutputStruct 2020-07-06T11:06:41-04:00 logger.go:66:     "four" = "four"
TestOutputStruct 2020-07-06T11:06:41-04:00 logger.go:66:     "three" = 3
TestOutputStruct 2020-07-06T11:06:41-04:00 logger.go:66:   }
TestOutputStruct 2020-07-06T11:06:41-04:00 logger.go:66:   "somestring" = "two"
TestOutputStruct 2020-07-06T11:06:41-04:00 logger.go:66: }
TestOutputStruct 2020-07-06T11:06:41-04:00 retry.go:72: terraform [output -no-color -json object]
TestOutputStruct 2020-07-06T11:06:41-04:00 logger.go:66: Running command terraform with args [output -no-color -json object]
TestOutputStruct 2020-07-06T11:06:41-04:00 logger.go:66: {"listmaps":[{"five":5,"six":"six"}],"liststrings":["seven","eight","nine"],"somebool":true,"somefloat":0.1,"someint":1,"somemap":{"four":"four","three":3},"somestring":"two"}
TestOutputStruct 2020-07-06T11:06:41-04:00 retry.go:72: terraform [output -no-color -json list_of_objects]
TestOutputStruct 2020-07-06T11:06:41-04:00 logger.go:66: Running command terraform with args [output -no-color -json list_of_objects]
TestOutputStruct 2020-07-06T11:06:41-04:00 logger.go:66: [{"somebool":true,"somefloat":0.1,"someint":1,"somestring":"two"},{"somebool":false,"somefloat":0.3,"someint":4,"somestring":"five"}]
PASS
ok      github.com/gruntwork-io/terratest/modules/terraform     0.475s
```