### PR TITLE
Add support for parallelism flag

### DIFF
--- a/modules/terraform/apply_test.go
+++ b/modules/terraform/apply_test.go
@@ -2,6 +2,7 @@ package terraform
 
 import (
 	"testing"
+	"time"
 
 	"github.com/gruntwork-io/terratest/modules/files"
 	"github.com/stretchr/testify/assert"
@@ -150,4 +151,34 @@ func TestIdempotentWithChanges(t *testing.T) {
 	require.NotEmpty(t, out)
 	require.Error(t, err)
 	require.EqualError(t, err, "terraform configuration not idempotent")
+}
+
+func TestParallelism(t *testing.T) {
+	t.Parallel()
+
+	testFolder, err := files.CopyTerraformFolderToTemp("../../test/fixtures/terraform-parallelism", t.Name())
+	require.NoError(t, err)
+
+	options := &Options{
+		TerraformDir: testFolder,
+		NoColor:      true,
+	}
+
+	Init(t, options)
+
+	// Run the first time with parallelism set to 5 and it should take about 5 seconds (plus or minus 10 seconds to
+	// account for other CPU hogging stuff)
+	options.Parallelism = 5
+	start := time.Now()
+	Apply(t, options)
+	end := time.Now()
+	require.WithinDuration(t, end, start, 15 * time.Second)
+
+	// Run the second time with parallelism set to 1 and it should take at least 25 seconds
+	options.Parallelism = 1
+	start = time.Now()
+	Apply(t, options)
+	end = time.Now()
+	duration := end.Sub(start)
+	require.Greater(t, int64(duration.Seconds()), int64(25))
 }

--- a/modules/terraform/apply_test.go
+++ b/modules/terraform/apply_test.go
@@ -172,7 +172,7 @@ func TestParallelism(t *testing.T) {
 	start := time.Now()
 	Apply(t, options)
 	end := time.Now()
-	require.WithinDuration(t, end, start, 15 * time.Second)
+	require.WithinDuration(t, end, start, 15*time.Second)
 
 	// Run the second time with parallelism set to 1 and it should take at least 25 seconds
 	options.Parallelism = 1

--- a/modules/terraform/cmd.go
+++ b/modules/terraform/cmd.go
@@ -20,6 +20,12 @@ func generateCommand(options *Options, args ...string) shell.Command {
 	return cmd
 }
 
+var commandsWithParallelism = []string{
+	"plan",
+	"apply",
+	"destroy",
+}
+
 // GetCommonOptions extracts commons terraform options
 func GetCommonOptions(options *Options, args ...string) (*Options, []string) {
 	if options.NoColor && !collections.ListContains(args, "-no-color") {
@@ -32,6 +38,10 @@ func GetCommonOptions(options *Options, args ...string) (*Options, []string) {
 
 	if options.TerraformBinary == "terragrunt" {
 		args = append(args, "--terragrunt-non-interactive")
+	}
+
+	if options.Parallelism > 0 && len(args) > 0 && collections.ListContains(commandsWithParallelism, args[0]) {
+		args = append(args, fmt.Sprintf("--parallelism=%d", options.Parallelism))
 	}
 
 	// if SshAgent is provided, override the local SSH agent with the socket of our in-process agent

--- a/modules/terraform/options.go
+++ b/modules/terraform/options.go
@@ -35,4 +35,5 @@ type Options struct {
 	SshAgent                 *ssh.SshAgent          // Overrides local SSH agent with the given in-process agent
 	NoStderr                 bool                   // Disable stderr redirection
 	Logger                   *logger.Logger         // Set a non-default logger that should be used. See the logger package for more info.
+	Parallelism              int                    // Set the parallelism setting for Terraform
 }

--- a/test/fixtures/terraform-parallelism/main.tf
+++ b/test/fixtures/terraform-parallelism/main.tf
@@ -1,0 +1,13 @@
+# This resource just waits for 5 seconds. If we run it with enough parallelism, the whole module should apply in about
+# 5 seconds. If we set parallelism to 1, it should take at least 25 seconds.
+resource "null_resource" "wait" {
+  count = 5
+
+  triggers = {
+    run_always = timestamp()
+  }
+
+  provisioner "local-exec" {
+    command = "sleep 5"
+  }
+}


### PR DESCRIPTION
This allows setting the `-parallelism` flag in `terraform.Options`. Includes a handy test.