### PR TITLE
Enable the parallelism flag for Terragrunt commands

### DIFF
--- a/modules/terraform/cmd.go
+++ b/modules/terraform/cmd.go
@@ -24,6 +24,9 @@ var commandsWithParallelism = []string{
 	"plan",
 	"apply",
 	"destroy",
+	"plan-all",
+	"apply-all",
+	"destroy-all",
 }
 
 // GetCommonOptions extracts commons terraform options


### PR DESCRIPTION
This is a follow up to https://github.com/gruntwork-io/terratest/pull/571. It ensures that the `-parallelism` flag works with Terragrunt `xxx-all` commands. Thx for catching this @yorinasub17!