### PR TITLE
Add GetRecommendedInstanceType function and pick-instance-type CLI tool

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,13 +76,20 @@ jobs:
             pre-commit run --all-files
 
       # Build any binaries that need to be built
-      # We always want to build the binaries, because we will use the terratest_log_parser to parse out the test output
-      # during a failure.
+      # We always want to build the binaries to test that there are no compile failures. Also, we will use the
+      # terratest_log_parser to parse out the test output during a failure. Finally, on releases, we'll push these
+      # binaries to GitHub as release assets.
       - run:
           command: |
             GO_ENABLED=0 build-go-binaries \
               --app-name terratest_log_parser \
               --src-path ./cmd/terratest_log_parser \
+              --dest-path ./cmd/bin \
+              --ld-flags "-X main.VERSION=$CIRCLE_TAG -extldflags '-static'"
+
+            GO_ENABLED=0 build-go-binaries \
+              --app-name pick-instance-type \
+              --src-path ./cmd/pick-instance-type \
               --dest-path ./cmd/bin \
               --ld-flags "-X main.VERSION=$CIRCLE_TAG -extldflags '-static'"
           when: always

--- a/cmd/pick-instance-type/main.go
+++ b/cmd/pick-instance-type/main.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"fmt"
+	"github.com/gruntwork-io/gruntwork-cli/entrypoint"
+	"github.com/gruntwork-io/terratest/modules/aws"
+	"github.com/urfave/cli"
+)
+
+const CUSTOM_USAGE_TEXT = `Usage: pick-instance-type [OPTIONS] <REGION> <INSTANCE_TYPE> <INSTANCE_TYPE...> 
+
+This tool takes in an AWS region and a list of EC2 instance types and returns the first instance type in the list that is available in all Availability Zones (AZs) in the given region, or exits with an error if no instance type is available in all AZs. This is useful because certain instance types, such as t2.micro, are not available in some of the newer AZs, while t3.micro is not available in some of the older AZs, and if you have code that needs to run on a "small" instance across all AZs in many different regions, you can use this CLI tool to automatically figure out which instance type you should use.
+
+Arguments:
+   
+  REGION           The AWS region in which to look up instance availability. E.g.: us-east-1. 
+  INSTANCE_TYPE    One more more EC2 instance types. E.g.: t2.micro.
+
+
+Options:
+
+  --help            Show this help text and exit.
+
+Example:
+
+  pick-instance-type ap-northeast-2 t2.micro t3.micro 
+`
+
+func run(cliContext *cli.Context) error {
+	region := cliContext.Args().First()
+	if region == "" {
+		return fmt.Errorf("You must specify an AWS region as the first argument")
+	}
+
+	instanceTypes := cliContext.Args().Tail()
+	if len(instanceTypes) == 0 {
+		return fmt.Errorf("You must specify at least one instance type")
+	}
+
+	// Create mock testing.T implementation so we can re-use Terratest methods
+	t := MockTestingT{MockName: "pick-instance-type"}
+
+	recommendedInstanceType, err := aws.GetRecommendedInstanceTypeE(t, region, instanceTypes)
+	if err != nil {
+		return err
+	}
+
+	// Print the recommended instnace type to stdout
+	fmt.Println(recommendedInstanceType)
+
+	return nil
+}
+
+func main() {
+	app := entrypoint.NewApp()
+	cli.AppHelpTemplate = CUSTOM_USAGE_TEXT
+	entrypoint.HelpTextLineWidth = 120
+
+	app.Name = "pick-instance-type"
+	app.Author = "Gruntwork <www.gruntwork.io>"
+	app.Description = `This tool takes in a list of EC2 instance types (e.g., "t2.micro", "t3.micro") and returns the first instance type in the list that is available in all Availability Zones (AZs) in the given AWS region, or exits with an error if no instance type is available in all AZs.`
+	app.Action = run
+
+	entrypoint.RunApp(app)
+}
+
+// MockTestingT is a mock implementation of testing.TestingT. All the functions are essentially no-ops. This allows us
+// to use Terratest methods outside of a testing context (e.g., in a CLI tool).
+type MockTestingT struct {
+	MockName string
+}
+
+func (t MockTestingT) Fail()                                     {}
+func (t MockTestingT) FailNow()                                  {}
+func (t MockTestingT) Fatal(args ...interface{})                 {}
+func (t MockTestingT) Fatalf(format string, args ...interface{}) {}
+func (t MockTestingT) Error(args ...interface{})                 {}
+func (t MockTestingT) Errorf(format string, args ...interface{}) {}
+func (t MockTestingT) Name() string {
+	return t.MockName
+}

--- a/cmd/pick-instance-type/main.go
+++ b/cmd/pick-instance-type/main.go
@@ -45,8 +45,8 @@ func run(cliContext *cli.Context) error {
 		return err
 	}
 
-	// Print the recommended instnace type to stdout
-	fmt.Println(recommendedInstanceType)
+	// Print the recommended instance type to stdout
+	fmt.Print(recommendedInstanceType)
 
 	return nil
 }

--- a/cmd/pick-instance-type/main.go
+++ b/cmd/pick-instance-type/main.go
@@ -8,7 +8,7 @@ import (
 	"github.com/urfave/cli"
 )
 
-const CUSTOM_USAGE_TEXT = `Usage: pick-instance-type [OPTIONS] <REGION> <INSTANCE_TYPE> <INSTANCE_TYPE...> 
+const CustomUsageText = `Usage: pick-instance-type [OPTIONS] <REGION> <INSTANCE_TYPE> <INSTANCE_TYPE...> 
 
 This tool takes in an AWS region and a list of EC2 instance types and returns the first instance type in the list that is available in all Availability Zones (AZs) in the given region, or exits with an error if no instance type is available in all AZs. This is useful because certain instance types, such as t2.micro, are not available in some of the newer AZs, while t3.micro is not available in some of the older AZs, and if you have code that needs to run on a "small" instance across all AZs in many different regions, you can use this CLI tool to automatically figure out which instance type you should use.
 
@@ -54,7 +54,7 @@ func run(cliContext *cli.Context) error {
 
 func main() {
 	app := entrypoint.NewApp()
-	cli.AppHelpTemplate = CUSTOM_USAGE_TEXT
+	cli.AppHelpTemplate = CustomUsageText
 	entrypoint.HelpTextLineWidth = 120
 
 	app.Name = "pick-instance-type"

--- a/cmd/pick-instance-type/main.go
+++ b/cmd/pick-instance-type/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+
 	"github.com/gruntwork-io/gruntwork-cli/entrypoint"
 	"github.com/gruntwork-io/terratest/modules/aws"
 	"github.com/urfave/cli"

--- a/cmd/pick-instance-type/main.go
+++ b/cmd/pick-instance-type/main.go
@@ -10,7 +10,7 @@ import (
 
 const CustomUsageText = `Usage: pick-instance-type [OPTIONS] <REGION> <INSTANCE_TYPE> <INSTANCE_TYPE...> 
 
-This tool takes in an AWS region and a list of EC2 instance types and returns the first instance type in the list that is available in all Availability Zones (AZs) in the given region, or exits with an error if no instance type is available in all AZs. This is useful because certain instance types, such as t2.micro, are not available in some of the newer AZs, while t3.micro is not available in some of the older AZs, and if you have code that needs to run on a "small" instance across all AZs in many different regions, you can use this CLI tool to automatically figure out which instance type you should use.
+This tool takes in an AWS region and a list of EC2 instance types and returns the first instance type in the list that is available in all Availability Zones (AZs) in the given region, or exits with an error if no instance type is available in all AZs. This is useful because certain instance types, such as t2.micro, are not available in some of the newer AZs, while t3.micro is not available in some of the older AZs. If you have code that needs to run on a "small" instance across all AZs in many different regions, you can use this CLI tool to automatically figure out which instance type you should use.
 
 Arguments:
    

--- a/docs/_docs/02_testing-best-practices/picking-instance-types.md
+++ b/docs/_docs/02_testing-best-practices/picking-instance-types.md
@@ -1,0 +1,65 @@
+---
+layout: collection-browser-doc
+title: Picking EC2 instance types
+category: testing-best-practices
+excerpt: >-
+  Pick EC2 instance types that are available in the current AWS region.
+tags: ["testing-best-practices", "aws", "ec2"]
+order: 213
+nav_title: Documentation
+nav_title_link: /docs/
+---
+
+It's common to want to test infrastructure code that deploys [EC2 instances](https://aws.amazon.com/ec2/) into AWS. 
+There are many different [instance types](https://aws.amazon.com/ec2/instance-types/), but not all instance types
+are available in all [regions or availability zones 
+(AZs)](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html). For example, 
+`t3.micro` is sometimes available only in newer AZs, while `t2.micro` is sometimes only available in older AZs. If you
+are testing code that needs to deploy a "small" instance across many regions, this can make it tricky to know which
+region to pick.
+
+To help work around this problem, Terratest includes:
+
+1. [`GetRecommendedInstanceType`](#getrecommendedinstancetype): A Go function that helps you pick a recommended instance type.
+1. [`pick-instance-type`](#pick-instance-type): A CLI tool that helps you pick a recommended instance type.
+
+
+
+
+## `GetRecommendedInstanceType`
+
+`GetRecommendedInstanceType` takes in an AWS region and a list of EC2 instance types and returns the first instance 
+type in the list that is available in all Availability Zones (AZs) in the given region. If there's no
+instance available in all AZs, this function exits with an error. 
+
+Example usage:
+
+```go
+aws.GetRecommendedInstanceType(t, "eu-west-1", []string{"t2.micro", "t3.micro"})
+// As of July, 2020, returns "t2.micro"
+
+aws.GetRecommendedInstanceType(t, "ap-northeast-2", []string{"t2.micro", "t3.micro"})
+// As of July, 2020, returns "t3.micro"
+```   
+
+
+
+## `pick-instance-type`
+
+`pick-instance-type` is a CLI tool that you can download from the [Terratest releases 
+page](https://github.com/gruntwork-io/terratest/releases) (click "Assets" under any release). It takes in an AWS 
+region and a list of EC2 instance types and prints to `stdout` the first instance type in the list that is available in 
+all Availability Zones (AZs) in the given region. If there's no instance available in all AZs, `pick-instance-type`
+exits with an error.
+
+Example usage:
+
+```bash
+# Data below is from July, 2020
+
+$ pick-instance-type eu-west-1 t2.micro t3.micro
+t2.micro
+
+$ pick-instance-type ap-northeast-2 t2.micro t3.micro
+t3.micro
+```   

--- a/modules/aws/ec2.go
+++ b/modules/aws/ec2.go
@@ -445,7 +445,7 @@ func instanceTypeExistsInAllAzs(instanceType string, availabilityZones []string,
 	if len(availabilityZones) == 0 || len(instanceTypeOfferings) == 0 {
 		return false
 	}
-	
+
 	for _, az := range availabilityZones {
 		if !hasOffering(instanceTypeOfferings, az, instanceType) {
 			return false
@@ -459,7 +459,7 @@ func instanceTypeExistsInAllAzs(instanceType string, availabilityZones []string,
 // instanceTypeOfferings
 func hasOffering(instanceTypeOfferings []*ec2.InstanceTypeOffering, availabilityZone string, instanceType string) bool {
 	for _, offering := range instanceTypeOfferings {
-		if (aws.StringValue(offering.InstanceType) == instanceType && aws.StringValue(offering.Location) == availabilityZone) {
+		if aws.StringValue(offering.InstanceType) == instanceType && aws.StringValue(offering.Location) == availabilityZone {
 			return true
 		}
 	}

--- a/modules/aws/ec2.go
+++ b/modules/aws/ec2.go
@@ -404,7 +404,7 @@ func GetRecommendedInstanceType(t testing.TestingT, region string, instanceTypeO
 // first instance type in the list that is available in all Availability Zones (AZs) in the given region. If there's no
 // instance available in all AZs, this function exits with an error. This is useful because certain instance types,
 // such as t2.micro, are not available in some of the newer AZs, while t3.micro is not available in some of the older
-// AZs, and if you have code that needs to run on a "small" instance across all AZs in many different regions, you can
+// AZs. If you have code that needs to run on a "small" instance across all AZs in many different regions, you can
 // use this function to automatically figure out which instance type you should use.
 func GetRecommendedInstanceTypeE(t testing.TestingT, region string, instanceTypeOptions []string) (string, error) {
 	client, err := NewEc2ClientE(t, region)

--- a/modules/aws/ec2_test.go
+++ b/modules/aws/ec2_test.go
@@ -2,10 +2,11 @@ package aws
 
 import (
 	"fmt"
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/ec2"
 	"strings"
 	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
 
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/stretchr/testify/assert"

--- a/modules/aws/ec2_test.go
+++ b/modules/aws/ec2_test.go
@@ -49,12 +49,17 @@ func TestGetRecommendedInstanceType(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		// The following is necessary to make sure testCase's values don't
-		// get updated due to concurrency within the scope of t.Run(..) below
+		// The following is necessary to make sure testCase's values don't get updated due to concurrency within the
+		// scope of t.Run(..) below. https://golang.org/doc/faq#closures_and_goroutines
 		testCase := testCase
+
 		t.Run(fmt.Sprintf("%s-%s", testCase.region, strings.Join(testCase.instanceTypeOptions, "-")), func(t *testing.T) {
 			t.Parallel()
 			instanceType := GetRecommendedInstanceType(t, testCase.region, testCase.instanceTypeOptions)
+			// We could hard-code the expected result (e.g., as of July, 2020, we expect eu-west-1 to return t2.micro
+			// and ap-northeast-2 to return t3.micro), but the result will likely change over time, so to avoid a
+			// brittle test, we simply check that we get _one_ result. Combined with the unit test below, this hopefully
+			// is enough to be confident this function works correctly.
 			assert.Contains(t, testCase.instanceTypeOptions, instanceType)
 		})
 	}
@@ -113,9 +118,10 @@ func TestPickRecommendedInstanceTypeHappyPath(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		// The following is necessary to make sure testCase's values don't
-		// get updated due to concurrency within the scope of t.Run(..) below
+		// The following is necessary to make sure testCase's values don't get updated due to concurrency within the
+		// scope of t.Run(..) below. https://golang.org/doc/faq#closures_and_goroutines
 		testCase := testCase
+
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/modules/aws/ec2_test.go
+++ b/modules/aws/ec2_test.go
@@ -2,6 +2,9 @@ package aws
 
 import (
 	"fmt"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"strings"
 	"testing"
 
 	"github.com/gruntwork-io/terratest/modules/random"
@@ -30,4 +33,163 @@ func TestGetEc2InstanceIdsByFilters(t *testing.T) {
 	ids, err := GetEc2InstanceIdsByFiltersE(t, region, filters)
 	require.NoError(t, err)
 	assert.Equal(t, 0, len(ids))
+}
+
+func TestGetRecommendedInstanceType(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		region              string
+		instanceTypeOptions []string
+	}{
+		{"eu-west-1", []string{"t2.micro", "t3.micro"}},
+		{"ap-northeast-2", []string{"t2.micro", "t3.micro"}},
+		{"us-east-1", []string{"t2.large", "t3.large"}},
+	}
+
+	for _, testCase := range testCases {
+		// The following is necessary to make sure testCase's values don't
+		// get updated due to concurrency within the scope of t.Run(..) below
+		testCase := testCase
+		t.Run(fmt.Sprintf("%s-%s", testCase.region, strings.Join(testCase.instanceTypeOptions, "-")), func(t *testing.T) {
+			t.Parallel()
+			instanceType := GetRecommendedInstanceType(t, testCase.region, testCase.instanceTypeOptions)
+			assert.Contains(t, testCase.instanceTypeOptions, instanceType)
+		})
+	}
+}
+
+func TestPickRecommendedInstanceTypeHappyPath(t *testing.T) {
+	testCases := []struct {
+		name                  string
+		availabilityZones     []string
+		instanceTypeOfferings []*ec2.InstanceTypeOffering
+		instanceTypeOptions   []string
+		expected              string
+	}{
+		{
+			"One AZ, one instance type, available in one offering",
+			[]string{"us-east-1a"},
+			offerings(map[string][]string{"us-east-1a": {"t2.micro"}}),
+			[]string{"t2.micro"},
+			"t2.micro",
+		},
+		{
+			"Three AZs, one instance type, available in all three offerings",
+			[]string{"us-east-1a", "us-east-1b", "us-east-1c"},
+			offerings(map[string][]string{"us-east-1a": {"t2.micro"}, "us-east-1b": {"t2.micro"}, "us-east-1c": {"t2.micro"}}),
+			[]string{"t2.micro"},
+			"t2.micro",
+		},
+		{
+			"Three AZs, two instance types, first one available in all three offerings, the other not available at all",
+			[]string{"us-east-1a", "us-east-1b", "us-east-1c"},
+			offerings(map[string][]string{"us-east-1a": {"t2.micro"}, "us-east-1b": {"t2.micro"}, "us-east-1c": {"t2.micro"}}),
+			[]string{"t2.micro", "t3.micro"},
+			"t2.micro",
+		},
+		{
+			"Three AZs, two instance types, first one available in all three offerings, the other only available in one offering in an unrequested AZ",
+			[]string{"us-east-1a", "us-east-1b", "us-east-1c"},
+			offerings(map[string][]string{"us-east-1a": {"t2.micro"}, "us-east-1b": {"t2.micro"}, "us-east-1c": {"t2.micro"}, "us-east-1d": {"t3.micro"}}),
+			[]string{"t2.micro", "t3.micro"},
+			"t2.micro",
+		},
+		{
+			"Three AZs, two instance types, first one available in all three offerings, the other one available in only two offerings",
+			[]string{"us-east-1a", "us-east-1b", "us-east-1c"},
+			offerings(map[string][]string{"us-east-1a": {"t2.micro", "t3.micro"}, "us-east-1b": {"t2.micro"}, "us-east-1c": {"t2.micro"}}),
+			[]string{"t2.micro", "t3.micro"},
+			"t2.micro",
+		},
+		{
+			"Three AZs, three instance types, first one available in two offerings, second in all three offerings, third in two offerings",
+			[]string{"us-east-1a", "us-east-1b", "us-east-1c"},
+			offerings(map[string][]string{"us-east-1a": {"t2.micro", "t3.micro", "t3.small"}, "us-east-1b": {"t3.micro"}, "us-east-1c": {"t2.micro", "t3.micro", "t3.small"}}),
+			[]string{"t2.micro", "t3.micro", "t3.small"},
+			"t3.micro",
+		},
+	}
+
+	for _, testCase := range testCases {
+		// The following is necessary to make sure testCase's values don't
+		// get updated due to concurrency within the scope of t.Run(..) below
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			actual, err := pickRecommendedInstanceTypeE(testCase.availabilityZones, testCase.instanceTypeOfferings, testCase.instanceTypeOptions)
+			assert.NoError(t, err)
+			assert.Equal(t, testCase.expected, actual)
+		})
+	}
+}
+
+func TestPickRecommendedInstanceTypeErrors(t *testing.T) {
+	testCases := []struct {
+		name                  string
+		availabilityZones     []string
+		instanceTypeOfferings []*ec2.InstanceTypeOffering
+		instanceTypeOptions   []string
+	}{
+		{
+			"All params nil",
+			nil,
+			nil,
+			nil,
+		},
+		{
+			"No AZs, one instance type, no offerings",
+			nil,
+			nil,
+			[]string{"t2.micro"},
+		},
+		{
+			"One AZ, one instance type, no offerings",
+			[]string{"us-east-1a"},
+			nil,
+			[]string{"t2.micro"},
+		},
+		{
+			"Two AZs, one instance type, available in only one offering",
+			[]string{"us-east-1a", "us-east-1b"},
+			offerings(map[string][]string{"us-east-1a": {"t2.micro"}}),
+			[]string{"t2.micro"},
+		},
+		{
+			"Three AZs, two instance types, each available in only two of the three offerings",
+			[]string{"us-east-1a", "us-east-1b", "us-east-1c"},
+			offerings(map[string][]string{"us-east-1a": {"t2.micro"}, "us-east-1b": {"t2.micro", "t3.micro"}, "us-east-1c": {"t3.micro"}}),
+			[]string{"t2.micro", "t3.micro"},
+		},
+	}
+
+	for _, testCase := range testCases {
+		// The following is necessary to make sure testCase's values don't
+		// get updated due to concurrency within the scope of t.Run(..) below
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := pickRecommendedInstanceTypeE(testCase.availabilityZones, testCase.instanceTypeOfferings, testCase.instanceTypeOptions)
+			assert.EqualError(t, err, NoInstanceTypeError{Azs: testCase.availabilityZones, InstanceTypeOptions: testCase.instanceTypeOptions}.Error())
+		})
+	}
+}
+
+func offerings(offerings map[string][]string) []*ec2.InstanceTypeOffering {
+	var out []*ec2.InstanceTypeOffering
+
+	for az, instanceTypes := range offerings {
+		for _, instanceType := range instanceTypes {
+			offering := &ec2.InstanceTypeOffering{
+				InstanceType: aws.String(instanceType),
+				Location:     aws.String(az),
+				LocationType: aws.String(ec2.LocationTypeAvailabilityZone),
+			}
+			out = append(out, offering)
+		}
+	}
+
+	return out
 }

--- a/modules/aws/errors.go
+++ b/modules/aws/errors.go
@@ -99,3 +99,17 @@ func (err NoBucketPolicyError) Error() string {
 func NewNoBucketPolicyError(s3BucketName string, awsRegion string, bucketPolicy string) NoBucketPolicyError {
 	return NoBucketPolicyError{s3BucketName: s3BucketName, awsRegion: awsRegion, bucketPolicy: bucketPolicy}
 }
+
+// NoInstanceTypeError is returned when none of the given instance type options are available in all AZs in a region
+type NoInstanceTypeError struct {
+	InstanceTypeOptions []string
+	Azs                 []string
+}
+
+func (err NoInstanceTypeError) Error() string {
+	return fmt.Sprintf(
+		"None of the given instance types (%v) is available in all the AZs in this region (%v).",
+		err.InstanceTypeOptions,
+		err.Azs,
+	)
+}


### PR DESCRIPTION
This PR adds: 

1. A new `GetRecommendedInstanceType` function to help us solve the issue where t2.micro and t3.micro instances are each available in some AZs, but not available in others. This module takes in a list of instance types to pick from and returns the recommended one to use, which is one that's available in all AZs in the current region.

1. A new `pick-instance-type` CLI that can be used to execute the same function from the CLI and get a recommended instance type printed to `stdout`. This can be used to figure out the instance type to use outside of an automated testing context: e.g., as part of Gruntwork Reference Architecture deployments.