### PR TITLE
Add helper functions for AWS Secrets Manager

### DIFF
--- a/modules/aws/secretsmanager.go
+++ b/modules/aws/secretsmanager.go
@@ -1,0 +1,79 @@
+package aws
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/secretsmanager"
+	"github.com/gruntwork-io/terratest/modules/logger"
+	"github.com/gruntwork-io/terratest/modules/testing"
+)
+
+// CreateSecretStringWithDefaultKey creates a new secret in Secrets Manager using the default "aws/secretsmanager" KMS key and returns the secret ARN
+func CreateSecretStringWithDefaultKey(t testing.TestingT, awsRegion, description, name, secretString string) (string, error) {
+	logger.Logf(t, "Creating new secret in secrets manager named %s", name)
+
+	client := NewSecretsManagerClient(t, awsRegion)
+
+	secret, err := client.CreateSecret(&secretsmanager.CreateSecretInput{
+		Description:  aws.String(description),
+		Name:         aws.String(name),
+		SecretString: aws.String(secretString),
+	})
+
+	if err != nil {
+		return "", err
+	}
+
+	return aws.StringValue(secret.ARN), nil
+}
+
+// GetSecretValue takes the friendly name or ARN of a secret and returns the plaintext value
+func GetSecretValue(t testing.TestingT, awsRegion, id string) (string, error) {
+	logger.Logf(t, "Getting value of secret with ID %s", id)
+
+	client := NewSecretsManagerClient(t, awsRegion)
+
+	secret, err := client.GetSecretValue(&secretsmanager.GetSecretValueInput{
+		SecretId: aws.String(id),
+	})
+	if err != nil {
+		return "", err
+	}
+
+	return aws.StringValue(secret.SecretString), nil
+}
+
+// DeleteSecret deletes a secret. If forceDelete is true, the secret will be deleted after a short delay. If forceDelete is false, the secret will be deleted after a 30 day recovery window.
+func DeleteSecret(t testing.TestingT, awsRegion, id string, forceDelete bool) error {
+	logger.Logf(t, "Deleting secret with ID %s", id)
+
+	client := NewSecretsManagerClient(t, awsRegion)
+
+	_, err := client.DeleteSecret(&secretsmanager.DeleteSecretInput{
+		ForceDeleteWithoutRecovery: aws.Bool(forceDelete),
+		SecretId:                   aws.String(id),
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// NewSecretsManagerClient creates a new SecretsManager client.
+func NewSecretsManagerClient(t testing.TestingT, region string) *secretsmanager.SecretsManager {
+	client, err := NewSecretsManagerClientE(t, region)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return client
+}
+
+// NewSecretsManagerClientE creates a new SecretsManager client.
+func NewSecretsManagerClientE(t testing.TestingT, region string) (*secretsmanager.SecretsManager, error) {
+	sess, err := NewAuthenticatedSession(region)
+	if err != nil {
+		return nil, err
+	}
+
+	return secretsmanager.New(sess), nil
+}

--- a/modules/aws/secretsmanager.go
+++ b/modules/aws/secretsmanager.go
@@ -5,10 +5,18 @@ import (
 	"github.com/aws/aws-sdk-go/service/secretsmanager"
 	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/testing"
+	"github.com/stretchr/testify/require"
 )
 
 // CreateSecretStringWithDefaultKey creates a new secret in Secrets Manager using the default "aws/secretsmanager" KMS key and returns the secret ARN
-func CreateSecretStringWithDefaultKey(t testing.TestingT, awsRegion, description, name, secretString string) (string, error) {
+func CreateSecretStringWithDefaultKey(t testing.TestingT, awsRegion, description, name, secretString string) string {
+	arn, err := CreateSecretStringWithDefaultKeyE(t, awsRegion, description, name, secretString)
+	require.NoError(t, err)
+	return arn
+}
+
+// CreateSecretStringWithDefaultKeyE creates a new secret in Secrets Manager using the default "aws/secretsmanager" KMS key and returns the secret ARN
+func CreateSecretStringWithDefaultKeyE(t testing.TestingT, awsRegion, description, name, secretString string) (string, error) {
 	logger.Logf(t, "Creating new secret in secrets manager named %s", name)
 
 	client := NewSecretsManagerClient(t, awsRegion)
@@ -27,7 +35,14 @@ func CreateSecretStringWithDefaultKey(t testing.TestingT, awsRegion, description
 }
 
 // GetSecretValue takes the friendly name or ARN of a secret and returns the plaintext value
-func GetSecretValue(t testing.TestingT, awsRegion, id string) (string, error) {
+func GetSecretValue(t testing.TestingT, awsRegion, id string) string {
+	secret, err := GetSecretValueE(t, awsRegion, id)
+	require.NoError(t, err)
+	return secret
+}
+
+// GetSecretValueE takes the friendly name or ARN of a secret and returns the plaintext value
+func GetSecretValueE(t testing.TestingT, awsRegion, id string) (string, error) {
 	logger.Logf(t, "Getting value of secret with ID %s", id)
 
 	client := NewSecretsManagerClient(t, awsRegion)
@@ -43,7 +58,13 @@ func GetSecretValue(t testing.TestingT, awsRegion, id string) (string, error) {
 }
 
 // DeleteSecret deletes a secret. If forceDelete is true, the secret will be deleted after a short delay. If forceDelete is false, the secret will be deleted after a 30 day recovery window.
-func DeleteSecret(t testing.TestingT, awsRegion, id string, forceDelete bool) error {
+func DeleteSecret(t testing.TestingT, awsRegion, id string, forceDelete bool) {
+	err := DeleteSecretE(t, awsRegion, id, forceDelete)
+	require.NoError(t, err)
+}
+
+// DeleteSecretE deletes a secret. If forceDelete is true, the secret will be deleted after a short delay. If forceDelete is false, the secret will be deleted after a 30 day recovery window.
+func DeleteSecretE(t testing.TestingT, awsRegion, id string, forceDelete bool) error {
 	logger.Logf(t, "Deleting secret with ID %s", id)
 
 	client := NewSecretsManagerClient(t, awsRegion)
@@ -52,19 +73,14 @@ func DeleteSecret(t testing.TestingT, awsRegion, id string, forceDelete bool) er
 		ForceDeleteWithoutRecovery: aws.Bool(forceDelete),
 		SecretId:                   aws.String(id),
 	})
-	if err != nil {
-		return err
-	}
 
-	return nil
+	return err
 }
 
 // NewSecretsManagerClient creates a new SecretsManager client.
 func NewSecretsManagerClient(t testing.TestingT, region string) *secretsmanager.SecretsManager {
 	client, err := NewSecretsManagerClientE(t, region)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	return client
 }
 

--- a/modules/aws/secretsmanager_test.go
+++ b/modules/aws/secretsmanager_test.go
@@ -16,20 +16,16 @@ func TestSecretsManagerMethods(t *testing.T) {
 	description := "This is just a secrets manager test description."
 	secretValue := "This is the secret value."
 
-	secretARN, err := CreateSecretStringWithDefaultKey(t, region, description, name, secretValue)
-	require.NoError(t, err)
-
+	secretARN := CreateSecretStringWithDefaultKey(t, region, description, name, secretValue)
 	defer deleteSecret(t, region, secretARN)
 
-	storedValue, err := GetSecretValue(t, region, secretARN)
-	require.NoError(t, err)
+	storedValue := GetSecretValue(t, region, secretARN)
 	assert.Equal(t, secretValue, storedValue)
 }
 
 func deleteSecret(t *testing.T, region, id string) {
-	err := DeleteSecret(t, region, id, true)
-	require.NoError(t, err)
+	DeleteSecret(t, region, id, true)
 
-	_, err = GetSecretValue(t, region, id)
+	_, err := GetSecretValueE(t, region, id)
 	require.Error(t, err)
 }

--- a/modules/aws/secretsmanager_test.go
+++ b/modules/aws/secretsmanager_test.go
@@ -1,0 +1,35 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/random"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSecretsManagerMethods(t *testing.T) {
+	t.Parallel()
+
+	region := GetRandomStableRegion(t, nil, nil)
+	name := random.UniqueId()
+	description := "This is just a secrets manager test description."
+	secretValue := "This is the secret value."
+
+	secretARN, err := CreateSecretStringWithDefaultKey(t, region, description, name, secretValue)
+	require.NoError(t, err)
+
+	defer deleteSecret(t, region, secretARN)
+
+	storedValue, err := GetSecretValue(t, region, secretARN)
+	require.NoError(t, err)
+	assert.Equal(t, secretValue, storedValue)
+}
+
+func deleteSecret(t *testing.T, region, id string) {
+	err := DeleteSecret(t, region, id, true)
+	require.NoError(t, err)
+
+	_, err = GetSecretValue(t, region, id)
+	require.Error(t, err)
+}


### PR DESCRIPTION
This introduces three helper functions for AWS Secrets Manager:

- `CreateSecretStringWithDefaultKey()` - Create a secret using the default KMS key
- `GetSecretValue()` - Get a secret value by name or ARN
- `DeleteSecret()` - Delete a secret, either immediately or after the default 30 day recovery window

When used with `forceDelete=true` to delete immediately, this should be a very low cost operation since secrets cost $0.40 per month and they are prorated based on the number of hours.