### PR TITLE
Update examples to work with AWS Provider 3.x

### DIFF
--- a/examples/terraform-asg-scp-example/main.tf
+++ b/examples/terraform-asg-scp-example/main.tf
@@ -30,7 +30,6 @@ resource "aws_launch_template" "sample_launch_template" {
 
 resource "aws_autoscaling_group" "sample_asg" {
   vpc_zone_identifier = data.aws_subnet_ids.default_subnets.ids
-  availability_zones  = []
 
   desired_capacity = 1
   max_size         = 1

--- a/examples/terraform-redeploy-example/main.tf
+++ b/examples/terraform-redeploy-example/main.tf
@@ -247,8 +247,9 @@ resource "aws_alb_listener_rule" "send_all_to_web_servers" {
   }
 
   condition {
-    field  = "path-pattern"
-    values = ["*"]
+    path_pattern {
+      values = ["*"]
+    }
   }
 }
 


### PR DESCRIPTION
AWS Provider 3.0.0 just came out recently with a number of backwards incompatible changes. This PR updates a couple of the Terratest examples to work with 3.x.