### PR TITLE
GetCurrentBranchName update and GetCurrentGitRef creation

### DIFF
--- a/modules/git/git.go
+++ b/modules/git/git.go
@@ -14,12 +14,57 @@ func GetCurrentBranchName(t testing.TestingT) string {
 	if err != nil {
 		t.Fatal(err)
 	}
+	if out == "HEAD" {
+		return ""
+	}
 	return out
 }
 
-// GetCurrentBranchNameE retrieves the current branch name.
-func GetCurrentBranchNameE(t testing.TestingT) (string, error) {
+// GetCurrentBranchNameE retrieves the current branch name. Created as variable
+// to enable mocking within the tests.
+var GetCurrentBranchNameE = func(t testing.TestingT) (string, error) {
 	cmd := exec.Command("git", "rev-parse", "--abbrev-ref", "HEAD")
+	bytes, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(bytes)), nil
+}
+
+// GetCurrentGitRef retrieves current branch name or most recent tag from a commit. If the tag
+// points to the commit, then only tag is returned.
+func GetCurrentGitRef(t testing.TestingT) string {
+	out, err := GetCurrentGitRefE(t)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return out
+}
+
+// GetCurrentGitRefE retrieves current branch name or most recent tag from a commit. If the tag
+// points to the commit, then only tag is returned.
+func GetCurrentGitRefE(t testing.TestingT) (string, error) {
+	out, err := GetCurrentBranchNameE(t)
+
+	if err != nil {
+		return "", err
+	}
+
+	if out != "" {
+		return out, nil
+	}
+
+	out, err = GetMostRecentTagE(t)
+	if err != nil {
+		return "", err
+	}
+	return out, nil
+}
+
+// GetMostRecentTagE retrieves most recent tag that is reachable from a commit. If the tag points
+// to the commit, then only the tag is returned. Created as variable to enable mocking within tests.
+var GetMostRecentTagE = func(t testing.TestingT) (string, error) {
+	cmd := exec.Command("git", "describe", "--tags")
 	bytes, err := cmd.Output()
 	if err != nil {
 		return "", err

--- a/modules/git/git.go
+++ b/modules/git/git.go
@@ -49,7 +49,7 @@ func GetCurrentGitRef(t testing.TestingT) string {
 
 // GetCurrentGitRefE retrieves current branch name, lightweight (non-annotated) tag or
 // if tag points to the commit exact tag value.
-var GetCurrentGitRefE = func(t testing.TestingT) (string, error) {
+func GetCurrentGitRefE(t testing.TestingT) (string, error) {
 	out, err := GetCurrentBranchNameE(t)
 
 	if err != nil {

--- a/modules/git/git.go
+++ b/modules/git/git.go
@@ -12,7 +12,8 @@ import (
 var branchNameExecCommand = exec.Command
 var tagExecCommand = exec.Command
 
-// GetCurrentBranchName retrieves the current branch name.
+// GetCurrentBranchName retrieves the current branch name or
+// empty string in case of detached state.
 func GetCurrentBranchName(t testing.TestingT) string {
 	out, err := GetCurrentBranchNameE(t)
 	if err != nil {
@@ -21,7 +22,8 @@ func GetCurrentBranchName(t testing.TestingT) string {
 	return out
 }
 
-// GetCurrentBranchNameE retrieves the current branch name.
+// GetCurrentBranchNameE retrieves the current branch name or
+// empty string in case of detached state.
 func GetCurrentBranchNameE(t testing.TestingT) (string, error) {
 	cmd := branchNameExecCommand("git", "rev-parse", "--abbrev-ref", "HEAD")
 	bytes, err := cmd.Output()

--- a/modules/git/git.go
+++ b/modules/git/git.go
@@ -38,7 +38,7 @@ func GetCurrentBranchNameE(t testing.TestingT) (string, error) {
 }
 
 // GetCurrentGitRef retrieves current branch name, lightweight (non-annotated) tag or
-// if tag points to the commit function will return exact tag value.
+// if tag points to the commit exact tag value.
 func GetCurrentGitRef(t testing.TestingT) string {
 	out, err := GetCurrentGitRefE(t)
 	if err != nil {
@@ -48,7 +48,7 @@ func GetCurrentGitRef(t testing.TestingT) string {
 }
 
 // GetCurrentGitRefE retrieves current branch name, lightweight (non-annotated) tag or
-// if tag points to the commit function will return exact tag value.
+// if tag points to the commit exact tag value.
 var GetCurrentGitRefE = func(t testing.TestingT) (string, error) {
 	out, err := GetCurrentBranchNameE(t)
 
@@ -68,7 +68,7 @@ var GetCurrentGitRefE = func(t testing.TestingT) (string, error) {
 }
 
 // GetTagE retrieves lightweight (non-annotated) tag or if tag points
-// to the commit function will return exact tag value.
+// to the commit exact tag value.
 func GetTagE(t testing.TestingT) (string, error) {
 	cmd := tagExecCommand("git", "describe", "--tags")
 	bytes, err := cmd.Output()

--- a/modules/git/git.go
+++ b/modules/git/git.go
@@ -8,10 +8,6 @@ import (
 	"github.com/gruntwork-io/terratest/modules/testing"
 )
 
-// Separate variables created to be able to mock commands in tests
-var branchNameExecCommand = exec.Command
-var tagExecCommand = exec.Command
-
 // GetCurrentBranchName retrieves the current branch name or
 // empty string in case of detached state.
 func GetCurrentBranchName(t testing.TestingT) string {
@@ -25,7 +21,7 @@ func GetCurrentBranchName(t testing.TestingT) string {
 // GetCurrentBranchNameE retrieves the current branch name or
 // empty string in case of detached state.
 func GetCurrentBranchNameE(t testing.TestingT) (string, error) {
-	cmd := branchNameExecCommand("git", "rev-parse", "--abbrev-ref", "HEAD")
+	cmd := exec.Command("git", "rev-parse", "--abbrev-ref", "HEAD")
 	bytes, err := cmd.Output()
 	if err != nil {
 		return "", err
@@ -72,7 +68,7 @@ func GetCurrentGitRefE(t testing.TestingT) (string, error) {
 // GetTagE retrieves lightweight (non-annotated) tag or if tag points
 // to the commit exact tag value.
 func GetTagE(t testing.TestingT) (string, error) {
-	cmd := tagExecCommand("git", "describe", "--tags")
+	cmd := exec.Command("git", "describe", "--tags")
 	bytes, err := cmd.Output()
 	if err != nil {
 		return "", err

--- a/modules/git/git.go
+++ b/modules/git/git.go
@@ -8,6 +8,7 @@ import (
 	"github.com/gruntwork-io/terratest/modules/testing"
 )
 
+// Separate variables created to be able to mock commands in tests
 var branchNameExecCommand = exec.Command
 var tagExecCommand = exec.Command
 

--- a/modules/git/git_test.go
+++ b/modules/git/git_test.go
@@ -41,7 +41,7 @@ func TestGetCurrentRefReturnsTagValueForEmptyBranchName(t *testing.T) {
 	assert.Equal(t, "v0.0.1", name)
 }
 
-// Mock function for branchNameExecCommand return value
+// Mock function for branchNameExecCommand
 func branchNameExecCommandMock(command string, args ...string) *exec.Cmd {
 	cs := []string{"-test.run=TestExecCommandHelper", "--", command}
 	cs = append(cs, args...)
@@ -53,7 +53,7 @@ func branchNameExecCommandMock(command string, args ...string) *exec.Cmd {
 	return cmd
 }
 
-// Mock function for tagExecCommand return value
+// Mock function for tagExecCommand
 func tagExecCommandMock(command string, args ...string) *exec.Cmd {
 	cs := []string{"-test.run=TestExecCommandHelper", "--", command}
 	cs = append(cs, args...)

--- a/modules/git/git_test.go
+++ b/modules/git/git_test.go
@@ -41,7 +41,6 @@ func TestGetCurrentRefReturnsTagValueForEmptyBranchName(t *testing.T) {
 	assert.Equal(t, "v0.0.1", name)
 }
 
-// Mock function for branchNameExecCommand
 func branchNameExecCommandMock(command string, args ...string) *exec.Cmd {
 	cs := []string{"-test.run=TestExecCommandHelper", "--", command}
 	cs = append(cs, args...)
@@ -53,7 +52,6 @@ func branchNameExecCommandMock(command string, args ...string) *exec.Cmd {
 	return cmd
 }
 
-// Mock function for tagExecCommand
 func tagExecCommandMock(command string, args ...string) *exec.Cmd {
 	cs := []string{"-test.run=TestExecCommandHelper", "--", command}
 	cs = append(cs, args...)

--- a/modules/git/git_test.go
+++ b/modules/git/git_test.go
@@ -3,12 +3,53 @@ package git
 import (
 	"testing"
 
+	terratest_testing "github.com/gruntwork-io/terratest/modules/testing"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestGetCurrentBranchName(t *testing.T) {
+func TestGetCurrentBranchNameReturnsBranchName(t *testing.T) {
 	t.Parallel()
 
+	GetCurrentBranchNameE = func(t terratest_testing.TestingT) (string, error) {
+		return "master", nil
+	}
 	name := GetCurrentBranchName(t)
-	assert.NotEmpty(t, name)
+
+	assert.Equal(t, name, "master")
+}
+
+func TestGetCurrentBranchNameReturnsEmptyForDetachedState(t *testing.T) {
+	t.Parallel()
+
+	GetCurrentBranchNameE = func(t terratest_testing.TestingT) (string, error) {
+		return "HEAD", nil
+	}
+
+	name := GetCurrentBranchName(t)
+	assert.Empty(t, name)
+}
+
+func TestGetCurrentRefReturnsBranchName(t *testing.T) {
+	t.Parallel()
+
+	GetCurrentBranchNameE = func(t terratest_testing.TestingT) (string, error) {
+		return "master", nil
+	}
+
+	name := GetCurrentGitRef(t)
+	assert.Equal(t, "master", name)
+}
+
+func TestGetCurrentRefReturns(t *testing.T) {
+	t.Parallel()
+
+	GetCurrentBranchNameE = func(t terratest_testing.TestingT) (string, error) {
+		return "", nil
+	}
+	GetCurrentGitRefE = func(t terratest_testing.TestingT) (string, error) {
+		return "v0.0.1", nil
+	}
+
+	name := GetCurrentGitRef(t)
+	assert.Equal(t, "v0.0.1", name)
 }

--- a/modules/git/git_test.go
+++ b/modules/git/git_test.go
@@ -1,55 +1,87 @@
 package git
 
 import (
+	"fmt"
+	"os"
+	"os/exec"
 	"testing"
 
-	terratest_testing "github.com/gruntwork-io/terratest/modules/testing"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestGetCurrentBranchNameReturnsBranchName(t *testing.T) {
-	t.Parallel()
+var branchNameMock string
+var tagMock string
 
-	GetCurrentBranchNameE = func(t terratest_testing.TestingT) (string, error) {
-		return "master", nil
-	}
+func TestGetCurrentBranchNameReturnsBranchName(t *testing.T) {
+	branchNameMock = "master"
 	name := GetCurrentBranchName(t)
 
-	assert.Equal(t, name, "master")
+	assert.Equal(t, "master", name)
 }
 
 func TestGetCurrentBranchNameReturnsEmptyForDetachedState(t *testing.T) {
-	t.Parallel()
-
-	GetCurrentBranchNameE = func(t terratest_testing.TestingT) (string, error) {
-		return "HEAD", nil
-	}
-
+	branchNameMock = "HEAD"
 	name := GetCurrentBranchName(t)
+
 	assert.Empty(t, name)
 }
 
 func TestGetCurrentRefReturnsBranchName(t *testing.T) {
-	t.Parallel()
-
-	GetCurrentBranchNameE = func(t terratest_testing.TestingT) (string, error) {
-		return "master", nil
-	}
-
+	branchNameMock = "master"
 	name := GetCurrentGitRef(t)
+
 	assert.Equal(t, "master", name)
 }
 
-func TestGetCurrentRefReturns(t *testing.T) {
-	t.Parallel()
-
-	GetCurrentBranchNameE = func(t terratest_testing.TestingT) (string, error) {
-		return "", nil
-	}
-	GetCurrentGitRefE = func(t terratest_testing.TestingT) (string, error) {
-		return "v0.0.1", nil
-	}
-
+func TestGetCurrentRefReturnsTagValueForEmptyBranchName(t *testing.T) {
+	branchNameMock = ""
+	tagMock = "v0.0.1"
 	name := GetCurrentGitRef(t)
+
 	assert.Equal(t, "v0.0.1", name)
+}
+
+// Mock function for branchNameExecCommand return value
+func branchNameExecCommandMock(command string, args ...string) *exec.Cmd {
+	cs := []string{"-test.run=TestExecCommandHelper", "--", command}
+	cs = append(cs, args...)
+	cmd := exec.Command(os.Args[0], cs...)
+	cmd.Env = []string{
+		"GO_WANT_HELPER_PROCESS=1",
+		"STDOUT=" + branchNameMock,
+	}
+	return cmd
+}
+
+// Mock function for tagExecCommand return value
+func tagExecCommandMock(command string, args ...string) *exec.Cmd {
+	cs := []string{"-test.run=TestExecCommandHelper", "--", command}
+	cs = append(cs, args...)
+	cmd := exec.Command(os.Args[0], cs...)
+	cmd.Env = []string{
+		"GO_WANT_HELPER_PROCESS=1",
+		"STDOUT=" + tagMock,
+	}
+	return cmd
+}
+
+func TestExecCommandHelper(t *testing.T) {
+	if os.Getenv("GO_WANT_HELPER_PROCESS") != "1" {
+		return
+	}
+
+	fmt.Fprintf(os.Stdout, os.Getenv("STDOUT"))
+	os.Exit(0)
+}
+
+// Setup and teardown
+func TestMain(m *testing.M) {
+	branchNameExecCommand = branchNameExecCommandMock
+	tagExecCommand = tagExecCommandMock
+	defer func() { branchNameExecCommand = exec.Command }()
+	defer func() { tagExecCommand = exec.Command }()
+
+	code := m.Run()
+
+	os.Exit(code)
 }

--- a/modules/git/git_test.go
+++ b/modules/git/git_test.go
@@ -9,77 +9,80 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var branchNameMock string
-var tagMock string
-
 func TestGetCurrentBranchNameReturnsBranchName(t *testing.T) {
-	branchNameMock = "master"
+	err := exec.Command("git", "checkout", "master").Run()
+	assert.Nil(t, err)
+
 	name := GetCurrentBranchName(t)
 
 	assert.Equal(t, "master", name)
 }
 
 func TestGetCurrentBranchNameReturnsEmptyForDetachedState(t *testing.T) {
-	branchNameMock = "HEAD"
+	err := exec.Command("git", "checkout", "v0.0.1").Run()
+	assert.Nil(t, err)
+
 	name := GetCurrentBranchName(t)
 
 	assert.Empty(t, name)
 }
 
 func TestGetCurrentRefReturnsBranchName(t *testing.T) {
-	branchNameMock = "master"
+	err := exec.Command("git", "checkout", "master").Run()
+	assert.Nil(t, err)
+
 	name := GetCurrentGitRef(t)
 
 	assert.Equal(t, "master", name)
 }
 
-func TestGetCurrentRefReturnsTagValueForEmptyBranchName(t *testing.T) {
-	branchNameMock = ""
-	tagMock = "v0.0.1"
+func TestGetCurrentRefReturnsTagValue(t *testing.T) {
+	err := exec.Command("git", "checkout", "v0.0.1").Run()
+	assert.Nil(t, err)
+
 	name := GetCurrentGitRef(t)
 
 	assert.Equal(t, "v0.0.1", name)
 }
 
-func branchNameExecCommandMock(command string, args ...string) *exec.Cmd {
-	cs := []string{"-test.run=TestExecCommandHelper", "--", command}
-	cs = append(cs, args...)
-	cmd := exec.Command(os.Args[0], cs...)
-	cmd.Env = []string{
-		"GO_WANT_HELPER_PROCESS=1",
-		"STDOUT=" + branchNameMock,
-	}
-	return cmd
+func TestGetCurrentRefReturnsLightTagValue(t *testing.T) {
+	err := exec.Command("git", "checkout", "58d3ea8").Run()
+	assert.Nil(t, err)
+
+	name := GetCurrentGitRef(t)
+
+	assert.Equal(t, "v0.0.1-1-g58d3ea8", name)
 }
 
-func tagExecCommandMock(command string, args ...string) *exec.Cmd {
-	cs := []string{"-test.run=TestExecCommandHelper", "--", command}
-	cs = append(cs, args...)
-	cmd := exec.Command(os.Args[0], cs...)
-	cmd.Env = []string{
-		"GO_WANT_HELPER_PROCESS=1",
-		"STDOUT=" + tagMock,
-	}
-	return cmd
-}
-
-func TestExecCommandHelper(t *testing.T) {
-	if os.Getenv("GO_WANT_HELPER_PROCESS") != "1" {
-		return
+func setup(tempDirName string) {
+	os.RemoveAll(tempDirName)
+	url := "https://github.com/gruntwork-io/terratest.git"
+	err := exec.Command("git", "clone", url, tempDirName).Run()
+	if err != nil {
+		fmt.Println("Test setup - Terratest git repository clone failed")
+		os.Exit(1)
 	}
 
-	fmt.Fprintf(os.Stdout, os.Getenv("STDOUT"))
-	os.Exit(0)
+	err = os.Chdir(tempDirName)
+	if err != nil {
+		fmt.Println("Test setup - Change directory failed")
+		os.Exit(1)
+	}
 }
 
-// Setup and teardown
+func teardown(tempDirName string) {
+	err := os.RemoveAll("../" + tempDirName + "/")
+	if err != nil {
+		fmt.Println("Test teardown - remove temp directory failed")
+	}
+}
+
 func TestMain(m *testing.M) {
-	branchNameExecCommand = branchNameExecCommandMock
-	tagExecCommand = tagExecCommandMock
-	defer func() { branchNameExecCommand = exec.Command }()
-	defer func() { tagExecCommand = exec.Command }()
+	tempDirName := "temp_terratest_clone"
+	setup(tempDirName)
 
 	code := m.Run()
 
+	teardown(tempDirName)
 	os.Exit(code)
 }

--- a/modules/git/git_test.go
+++ b/modules/git/git_test.go
@@ -55,7 +55,6 @@ func TestGetCurrentRefReturnsLightTagValue(t *testing.T) {
 }
 
 func setup(tempDirName string) {
-	os.RemoveAll(tempDirName)
 	url := "https://github.com/gruntwork-io/terratest.git"
 	err := exec.Command("git", "clone", url, tempDirName).Run()
 	if err != nil {
@@ -78,11 +77,13 @@ func teardown(tempDirName string) {
 }
 
 func TestMain(m *testing.M) {
+	os.Exit(testMainWrapper(m))
+}
+
+func testMainWrapper(m *testing.M) int {
 	tempDirName := "temp_terratest_clone"
 	setup(tempDirName)
+	defer teardown(tempDirName)
 
-	code := m.Run()
-
-	teardown(tempDirName)
-	os.Exit(code)
+	return m.Run()
 }


### PR DESCRIPTION
Fixes #574 

- Updated GetCurrentBranchNameE function so that it returns empty string for detached state. GetCurrentBranchName function behaviour is updated too since it uses GetCurrentBranchNameE.
- Added GetCurrentGitRef and GetCurrentGitRefE functions which will return:
    - Branch name - in case of non-detached state
    - Light (non-annotated) tag - in case of detached state and non existing tag on commit
    - Tag - in case of detached state and existing tag on commit

Additional notes:
- Similar git command mocking approach used as within https://github.com/golang/go/blob/master/src/os/exec/exec_test.go