### PR TITLE
Fix failing test in common_test.go

### DIFF
--- a/test/azure/common_test.go
+++ b/test/azure/common_test.go
@@ -23,6 +23,7 @@ func TestGetTargetAzureSubscription(t *testing.T) {
 	//Lookup ARM_SUBSCRIPTION_ID env variable, if not set, fail test.
 	if id, exists = os.LookupEnv(azure.AzureSubscriptionID); !exists {
 		fmt.Printf("ARM_SUBSCRIPTION_ID environment variable not set")
+		id = ""
 	}
 
 	type args struct {
@@ -43,7 +44,7 @@ func TestGetTargetAzureSubscription(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := azure.GetTargetAzureSubscription(tt.args.subID)
 
-			if tt.wantErr {
+			if !exists && tt.wantErr {
 				require.Error(t, err)
 			} else {
 				require.Equal(t, tt.want, got)

--- a/test/azure/common_test.go
+++ b/test/azure/common_test.go
@@ -6,7 +6,6 @@
 package azure
 
 import (
-	"fmt"
 	"os"
 	"testing"
 
@@ -17,14 +16,8 @@ import (
 func TestGetTargetAzureSubscription(t *testing.T) {
 	t.Parallel()
 
-	var id string
-	var exists bool
-
-	//Lookup ARM_SUBSCRIPTION_ID env variable, CI requires this value to run all test.
-	if id, exists = os.LookupEnv(azure.AzureSubscriptionID); !exists {
-		fmt.Printf("ARM_SUBSCRIPTION_ID environment variable not set")
-		id = ""
-	}
+	//Check that ARM_SUBSCRIPTION_ID env variable is set, CI requires this value to run all test.
+	require.NotEmpty(t, os.Getenv(azure.AzureSubscriptionID), "ARM_SUBSCRIPTION_ID environment variable not set.")
 
 	type args struct {
 		subID string
@@ -37,7 +30,7 @@ func TestGetTargetAzureSubscription(t *testing.T) {
 		wantErr bool
 	}{
 		{name: "subIDProvidedAsArg", args: args{subID: "test"}, want: "test", wantErr: false},
-		{name: "subIDNotProvidedFallbackToEnv", args: args{subID: ""}, want: id, wantErr: false},
+		{name: "subIDNotProvidedFallbackToEnv", args: args{subID: ""}, want: os.Getenv(azure.AzureSubscriptionID), wantErr: false},
 	}
 
 	for _, tt := range tests {

--- a/test/azure/common_test.go
+++ b/test/azure/common_test.go
@@ -20,7 +20,7 @@ func TestGetTargetAzureSubscription(t *testing.T) {
 	var id string
 	var exists bool
 
-	//Lookup ARM_SUBSCRIPTION_ID env variable, if not set, fail test.
+	//Lookup ARM_SUBSCRIPTION_ID env variable, CI requires this value to run all test.
 	if id, exists = os.LookupEnv(azure.AzureSubscriptionID); !exists {
 		fmt.Printf("ARM_SUBSCRIPTION_ID environment variable not set")
 		id = ""
@@ -37,14 +37,14 @@ func TestGetTargetAzureSubscription(t *testing.T) {
 		wantErr bool
 	}{
 		{name: "subIDProvidedAsArg", args: args{subID: "test"}, want: "test", wantErr: false},
-		{name: "subIDNotProvided", args: args{subID: ""}, want: id, wantErr: true},
+		{name: "subIDNotProvidedFallbackToEnv", args: args{subID: ""}, want: id, wantErr: false},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := azure.GetTargetAzureSubscription(tt.args.subID)
 
-			if !exists && tt.wantErr {
+			if tt.wantErr {
 				require.Error(t, err)
 			} else {
 				require.Equal(t, tt.want, got)

--- a/test/azure/common_test.go
+++ b/test/azure/common_test.go
@@ -6,6 +6,8 @@
 package azure
 
 import (
+	"fmt"
+	"os"
 	"testing"
 
 	"github.com/gruntwork-io/terratest/modules/azure"
@@ -14,6 +16,14 @@ import (
 
 func TestGetTargetAzureSubscription(t *testing.T) {
 	t.Parallel()
+
+	var id string
+	var exists bool
+
+	//Lookup ARM_SUBSCRIPTION_ID env variable, if not set, fail test.
+	if id, exists = os.LookupEnv(azure.AzureSubscriptionID); !exists {
+		fmt.Printf("ARM_SUBSCRIPTION_ID environment variable not set")
+	}
 
 	type args struct {
 		subID string
@@ -26,7 +36,7 @@ func TestGetTargetAzureSubscription(t *testing.T) {
 		wantErr bool
 	}{
 		{name: "subIDProvidedAsArg", args: args{subID: "test"}, want: "test", wantErr: false},
-		{name: "subIDNotProvided", args: args{subID: ""}, want: "", wantErr: true},
+		{name: "subIDNotProvided", args: args{subID: ""}, want: id, wantErr: true},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
When we move to CI for Azure, ARM_SUBSCRIPTION_ID is required to be set for all test to run.  This requirement breaks the test TestGetTargetAzureSubscription case subIDNotProvided.  This test cannot pass in CI because if we don't set env all other test fail.  We will try to find a way to add this test case back in but we have modified the test case to test lookup of env value when no subscription id is passed to getTargetAzureSubscription in common.go.  I have added an issue to track adding back the negative test case.  https://github.com/gruntwork-io/terratest/issues/603