### PR TITLE
report back step is fixed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,7 +127,7 @@ jobs:
 
           if [[ -z "$BODY_PAYLOAD" ]]
           then
-                echo "BODY_PAYLOAD is empty"
+            echo "BODY_PAYLOAD is empty"
           else
             echo "Here is the target repository: ${TARGET_REPOSITORY}"
             # TARGET_REPOSITORY is in {owner}/{repo format}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,7 +125,7 @@ jobs:
 
           # if pipeline has something to report back to the PR
 
-          if [ -z "$BODY_PAYLOAD" ]
+          if [[ -z "$BODY_PAYLOAD" ]]
           then
                 echo "BODY_PAYLOAD is empty"
           else

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,12 +109,49 @@ jobs:
           # if no PR number provided, simply exit...
           [[ -z "$TARGET_PR" ]] && { echo "No PR Number provided, exiting..." ; exit 0; }
 
+          echo "PR Number provided... ${TARGET_REPOSITORY}:#${TARGET_PR}"
+
+          BODY_PAYLOAD=""
           # if all the previous steps finished successfully, create a comment on the PR with the "success" information
           if [ "$TEST_RESULT" == "success" ] && [ "$TEST_LINT_RESULT" == "success" ] && [ "$MODULE_LINT_RESULT" == "success" ]; then
             BODY_PAYLOAD="[Microsoft CI Bot] TL;DR; success :thumbsup:\n\nYou can check the status of the CI Pipeline logs here ; https://github.com/${CURRENT_REPOSITORY}/actions/runs/$RUN_ID"
-            curl --request POST --header "Authorization: token ${GITHUB_TOKEN}" --header "Accept: application/vnd.github.v3+json" https://api.github.com/repos/${TARGET_REPOSITORY}/issues/${TARGET_PR}/comments --data "{\"body\":\"${BODY_PAYLOAD}\"}"
           # if at least one of the previous steps failed, create a comment on the PR with the "failure" information
           elif [ "$TEST_RESULT" == "failure" ] || [ "$TEST_LINT_RESULT" == "failure" ] || [ "$MODULE_LINT_RESULT" == "failure" ]; then
             BODY_PAYLOAD="[Microsoft CI Bot] TL;DR; failure :facepalm:\n\nYou can check the status of the CI Pipeline logs here ; https://github.com/${CURRENT_REPOSITORY}/actions/runs/$RUN_ID"
-            curl --request POST --header "Authorization: token ${GITHUB_TOKEN}" --header "Accept: application/vnd.github.v3+json" https://api.github.com/repos/${TARGET_REPOSITORY}/issues/${TARGET_PR}/comments --data "{\"body\":\"${BODY_PAYLOAD}\"}"
+          fi
+
+          echo "Comment message is ready..."
+          echo "${BODY_PAYLOAD}"
+
+          # if pipeline has something to report back to the PR
+
+          if [ -z "$BODY_PAYLOAD" ]
+          then
+                echo "BODY_PAYLOAD is empty"
+          else
+            echo "Here is the target repository: ${TARGET_REPOSITORY}"
+            # TARGET_REPOSITORY is in {owner}/{repo format}
+            [[ $TARGET_REPOSITORY =~ (.*)/(.*)$ ]]
+            # take the {owner} piece from the TARGET_REPOSITORY variable
+            TARGET_REPO_OWNER=${BASH_REMATCH[1]}
+            # take the {repo} piece from the TARGET_REPOSITORY variable
+            TARGET_REPO_NAME=${BASH_REMATCH[2]}
+
+            echo "Target repository is parsed: ${TARGET_REPO_OWNER} <-> ${TARGET_REPO_NAME}"
+
+            # create the query string to get the pr id
+            QUERY_PR_ID="query findPRID { repository(owner: \\\"$TARGET_REPO_OWNER\\\", name: \\\"$TARGET_REPO_NAME\\\") { pullRequest(number: $TARGET_PR) { id } } }"
+
+            # get the pr id from github api
+            PR_ID=$(curl --silent --request POST --header "Authorization: Bearer ${GITHUB_TOKEN}" --data-raw "{\"query\":\"${QUERY_PR_ID}\"}" "https://api.github.com/graphql" | jq -r '.data.repository.pullRequest.id')
+
+            echo "Target PR ID is ${PR_ID}"
+
+            # create the mutation string to create the comment on the pr
+            MUTATION_ADD_COMMENT="mutation addComment { addComment(input: {subjectId: \\\"${PR_ID}\\\", body: \\\"${BODY_PAYLOAD}\\\"}) { commentEdge { node { createdAt body } } subject { id } } }"
+
+            # call the github api to create the comment
+            curl --request POST --header "Authorization: Bearer ${GITHUB_TOKEN}" --data-raw "{\"query\":\"${MUTATION_ADD_COMMENT}\"}" "https://api.github.com/graphql"
+
+            echo "Comment is created..."
           fi


### PR DESCRIPTION
instead of calling github rest api, ci pipeline creates a graphql payload and call the github graphql api.

because, it seems github action is running as a user and that user is degraded to readonly (actions/first-interaction#10 (comment))

so, pipeline couldn't create a comment on the pr, changing the step to use the graphql endpoints fixing that problem.