### PR TITLE
feat: adding Azure Load Balancer module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ vendor
 .DS_Store
 # Intermediate file for testing
 kubeconfig
+
+# dev env config
+.env

--- a/examples/azure/terraform-azure-loadbalancer-example/README.md
+++ b/examples/azure/terraform-azure-loadbalancer-example/README.md
@@ -1,0 +1,106 @@
+# Terraform Azure Example
+
+This folder contains a simple Terraform module that deploys resources in [Azure](https://azure.microsoft.com/) to demonstrate
+how you can use Terratest to write automated tests for your Azure Terraform code. This module deploys the following resources:
+- Resource Group
+- Public IP Resource
+- Virtual Network (vnet) with a Subnet
+- Load Balancer, associated with Public IP
+- Load Balancer with Private IP, associated with vnet
+
+For more information on the above resources, you may visit the official Azure website for more information:
+- Resource Groups: https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/manage-resource-groups-portal#what-is-a-resource-group
+- Public IPs: https://docs.microsoft.com/en-us/azure/virtual-network/public-ip-addresses
+- Virtual Networks: https://docs.microsoft.com/en-us/azure/virtual-network/virtual-networks-overview
+- Subnets: https://docs.microsoft.com/en-us/azure/virtual-network/virtual-network-manage-subnet
+- Load Balancers: https://docs.microsoft.com/en-us/azure/load-balancer/load-balancer-overview
+
+Check out [/test/terraform_azure_loadbalancer_example_test.go](/test/terraform_azure_loadbalancer_example_test.go) to see how you can write
+automated tests for this module.
+
+**WARNING**: This module and the automated tests for it deploy real resources into your Azure account which can cost you
+money. The resources are all part of the [Azure Free Account](https://azure.microsoft.com/en-us/free/), so if you haven't used that up,
+it should be free, but you are completely responsible for all Azure charges.
+
+## Running this module manually
+
+1. Sign up for [Azure](https://azure.microsoft.com/).
+1. Configure your Azure credentials using one of the [supported methods for Azure CLI
+   tools](https://docs.microsoft.com/en-us/cli/azure/azure-cli-configuration?view=azure-cli-latest).
+1. Install [Terraform](https://www.terraform.io/) and make sure it's on your `PATH`.
+1. Run `terraform init`.
+1. Run `terraform apply`.
+1. When you're done, run `terraform destroy`.
+
+## Running automated tests against this module
+
+1. Sign up for [Azure](https://azure.microsoft.com/).
+1. Configure your Azure credentials using one of the [supported methods for Azure CLI
+   tools](https://docs.microsoft.com/en-us/cli/azure/azure-cli-configuration?view=azure-cli-latest).
+1. Install [Terraform](https://www.terraform.io/) and make sure it's on your `PATH`.
+1. [Review environment variables](#review-environment-variables).
+1. Install [Golang](https://golang.org/) and make sure this code is checked out into your `GOPATH`.
+1. `cd test`
+1. Make sure [the azure-sdk-for-go versions match](#check-go-dependencies) in [/test/go.mod](/test/go.mod) and in [test/terraform_azure_loadbalancer_example_test.go](/test/terraform_azure_loadbalancer_example_test.go).
+1. `go build terraform_azure_loadbalancer_example_test.go`
+1. `go test -v -run TestTerraformAzureLoadBalancerExample`
+
+## Check Go Dependencies
+
+Check that the `github.com/Azure/azure-sdk-for-go` version in your generated `go.mod` for this test matches the version in the terratest [go.mod](https://github.com/gruntwork-io/terratest/blob/master/go.mod) file.  
+
+> This was tested with **go1.14.1**.
+
+### Check Azure-sdk-for-go version
+
+Let's make sure [go.mod](https://github.com/gruntwork-io/terratest/blob/master/go.mod) includes the appropriate [azure-sdk-for-go version](https://github.com/Azure/azure-sdk-for-go/releases/tag/v38.1.0):
+
+```go
+require (
+    ...
+    github.com/Azure/azure-sdk-for-go v38.1.0+incompatible
+    ...
+)
+```
+
+We should check that [test/terraform_azure_example_test.go](/test/terraform_azure_example_test.go) includes the corresponding [azure-sdk-for-go package](https://github.com/Azure/azure-sdk-for-go/tree/master/services/compute/mgmt/2019-07-01/compute):
+
+```go
+import (
+    "github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-07-01/compute"
+    ...
+)
+```
+
+If we make changes to either the **go.mod** or the **go test file**, we should make sure that the go build command works still.
+
+```powershell
+go build terraform_azure_example_test.go
+```
+
+## Review Environment Variables
+
+As part of configuring terraform for Azure, we'll want to check that we have set the appropriate [credentials](https://docs.microsoft.com/en-us/azure/terraform/terraform-install-configure?toc=https%3A%2F%2Fdocs.microsoft.com%2Fen-us%2Fazure%2Fterraform%2Ftoc.json&bc=https%3A%2F%2Fdocs.microsoft.com%2Fen-us%2Fazure%2Fbread%2Ftoc.json#set-up-terraform-access-to-azure) and also that we set the [environment variables](https://docs.microsoft.com/en-us/azure/terraform/terraform-install-configure?toc=https%3A%2F%2Fdocs.microsoft.com%2Fen-us%2Fazure%2Fterraform%2Ftoc.json&bc=https%3A%2F%2Fdocs.microsoft.com%2Fen-us%2Fazure%2Fbread%2Ftoc.json#configure-terraform-environment-variables) on the testing host.
+
+```bash
+export ARM_CLIENT_ID=your_app_id
+export ARM_CLIENT_SECRET=your_password
+export ARM_SUBSCRIPTION_ID=your_subscription_id
+export ARM_TENANT_ID=your_tenant_id
+```
+
+Note, in a Windows environment, these should be set as **system environment variables**.  We can use a PowerShell console with administrative rights to update these environment variables:
+
+```powershell
+[System.Environment]::SetEnvironmentVariable("ARM_CLIENT_ID",$your_app_id,[System.EnvironmentVariableTarget]::Machine)
+[System.Environment]::SetEnvironmentVariable("ARM_CLIENT_SECRET",$your_password,[System.EnvironmentVariableTarget]::Machine)
+[System.Environment]::SetEnvironmentVariable("ARM_SUBSCRIPTION_ID",$your_subscription_id,[System.EnvironmentVariableTarget]::Machine)
+[System.Environment]::SetEnvironmentVariable("ARM_TENANT_ID",$your_tenant_id,[System.EnvironmentVariableTarget]::Machine)
+```
+
+## Load Balancer Module APIs
+* `LoadBalancerExistsE` checks if the given Load Balancer exists in the given subscription and returns true/false
+* `GetLoadBalancerE` checks if the given Load Balancer exists in the given subscription and returns a Load Balancer resource (or nil if not found)
+* `GetLoadBalancerClientE` checks if the given Load Balancer exists in the given subscription and returns a Load Balancer client object (or nil if not found)
+* `GetPublicIPAddressE` checks if the given Public IP Address resource exists in the given subscription and returns a Public IP Address object (or nil if not found)
+* `GetPublicIPAddressClientE` checks if the given Public IP Address resource exists in the given subscription and returns a Public IP Address client object (or nil if not found)

--- a/examples/azure/terraform-azure-loadbalancer-example/README.md
+++ b/examples/azure/terraform-azure-loadbalancer-example/README.md
@@ -63,19 +63,20 @@ require (
 )
 ```
 
-We should check that [test/terraform_azure_example_test.go](/test/terraform_azure_example_test.go) includes the corresponding [azure-sdk-for-go package](https://github.com/Azure/azure-sdk-for-go/tree/master/services/compute/mgmt/2019-07-01/compute):
+We should check that [test/terraform_azure_loadbalancer_example_test.go](/test/terraform_azure_loadbalancer_example_test.go) includes the corresponding [azure-sdk-for-go package](https://github.com/Azure/azure-sdk-for-go/services/network/mgmt/2019-09-01/network):
 
 ```go
 import (
-    "github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-07-01/compute"
+    "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2019-09-01/network"
     ...
+    
 )
 ```
 
 If we make changes to either the **go.mod** or the **go test file**, we should make sure that the go build command works still.
 
 ```powershell
-go build terraform_azure_example_test.go
+go build terraform_azure_loadbalancer_example_test.go
 ```
 
 ## Review Environment Variables
@@ -99,8 +100,8 @@ Note, in a Windows environment, these should be set as **system environment vari
 ```
 
 ## Load Balancer Module APIs
-* `LoadBalancerExistsE` checks if the given Load Balancer exists in the given subscription and returns true/false
-* `GetLoadBalancerE` checks if the given Load Balancer exists in the given subscription and returns a Load Balancer resource (or nil if not found)
+* `LoadBalancerExistsE` checks if the given Load Balancer exists in the given subscription and returns true if the load balancer exists, else returns false with err
+* `GetLoadBalancerE` checks if the given Load Balancer exists in the given subscription and returns a load balancer resource as specified by name, else returns nil with err
 * `GetLoadBalancerClientE` checks if the given Load Balancer exists in the given subscription and returns a Load Balancer client object (or nil if not found)
 * `GetPublicIPAddressE` checks if the given Public IP Address resource exists in the given subscription and returns a Public IP Address object (or nil if not found)
 * `GetPublicIPAddressClientE` checks if the given Public IP Address resource exists in the given subscription and returns a Public IP Address client object (or nil if not found)

--- a/examples/azure/terraform-azure-loadbalancer-example/main.tf
+++ b/examples/azure/terraform-azure-loadbalancer-example/main.tf
@@ -1,5 +1,6 @@
 provider "azurerm" {
-  version = "=1.31.0"
+  version = "~>2.20"
+  features {}
 }
 
 # ---------------------------------------------------------------------------------------------------------------------
@@ -31,7 +32,7 @@ resource "azurerm_public_ip" "main" {
   location            = azurerm_resource_group.main.location
   allocation_method       = "Static"
   ip_version              = "IPv4"
-  sku                     = "Standard"
+  sku                     = "Basic"
   idle_timeout_in_minutes = "4"
 }
 
@@ -39,7 +40,7 @@ resource "azurerm_lb" "main01" {
   name     =  "${var.loadbalancer01_name}"
   location            = azurerm_resource_group.main.location
   resource_group_name = azurerm_resource_group.main.name
-  sku                 = "Standard"
+  sku                 = "Basic"
 
     frontend_ip_configuration {
       name     =  "${var.lb01_feconfig}"
@@ -71,7 +72,7 @@ resource "azurerm_lb" "main02" {
   name     =  "${var.loadbalancer02_name}"
   location            = azurerm_resource_group.main.location
   resource_group_name = azurerm_resource_group.main.name
-  sku                 = "Standard"
+  sku                 = "Basic"
 
     frontend_ip_configuration {
       name     =  "${var.feIPConfig_forlb02}"

--- a/examples/azure/terraform-azure-loadbalancer-example/main.tf
+++ b/examples/azure/terraform-azure-loadbalancer-example/main.tf
@@ -16,8 +16,15 @@ terraform {
 # See test/terraform_azure_example_test.go for how to write automated tests for this code.
 # ---------------------------------------------------------------------------------------------------------------------
 
+resource "random_string" "default" {
+  length = 3  
+  lower = true
+  number = false
+  special = false
+}
+
 resource "azurerm_resource_group" "main" {
-  name     = "${var.prefix}-resources"
+  name     =  format("%s-%s-%s", "terratest", lower(random_string.default.result), "loadbalancer")
   location = "East US"
 }
 
@@ -26,7 +33,7 @@ resource "azurerm_resource_group" "main" {
 # ---------------------------------------------------------------------------------------------------------------------
 
 resource "azurerm_public_ip" "main" {
-  name                    = "${var.prefix}-pip"
+  name     =  format("%s-%s", lower(random_string.default.result), "pip")
   resource_group_name = azurerm_resource_group.main.name
   location            = azurerm_resource_group.main.location
   allocation_method       = "Static"
@@ -36,13 +43,13 @@ resource "azurerm_public_ip" "main" {
 }
 
 resource "azurerm_lb" "main01" {
-  name                = "${var.prefix}-lb01"
+  name     =  format("%s-%s", lower(random_string.default.result), "lb01")
   location            = azurerm_resource_group.main.location
   resource_group_name = azurerm_resource_group.main.name
   sku                 = "Standard"
 
     frontend_ip_configuration {
-      name                 = "${var.prefix}-frontendip01"
+      name     =  format("%s-%s", lower(random_string.default.result), "frontendip01")
       public_ip_address_id = azurerm_public_ip.main.id
     }
 }
@@ -52,7 +59,7 @@ resource "azurerm_lb" "main01" {
 # ---------------------------------------------------------------------------------------------------------------------
 
 resource "azurerm_virtual_network" "main" {
-  name                = "${var.prefix}-vnet01"
+  name     =  format("%s-%s", lower(random_string.default.result), "vnet01")
   location            = azurerm_resource_group.main.location
   resource_group_name = azurerm_resource_group.main.name
   address_space       = ["10.200.0.0/21"]
@@ -61,20 +68,20 @@ resource "azurerm_virtual_network" "main" {
 }
 
 resource "azurerm_subnet" "main" {
-  name                = "${var.prefix}-subnet01"
+  name     =  format("%s-%s", lower(random_string.default.result), "subnet01")
   resource_group_name = azurerm_resource_group.main.name
   virtual_network_name = azurerm_virtual_network.main.name
   address_prefix     = "10.200.2.0/25"
 }
 
 resource "azurerm_lb" "main02" {
-  name                = "${var.prefix}-lb02"
+  name     =  format("%s-%s", lower(random_string.default.result), "lb02")
   location            = azurerm_resource_group.main.location
   resource_group_name = azurerm_resource_group.main.name
   sku                 = "Standard"
 
     frontend_ip_configuration {
-      name                 = "${var.prefix}-frontendip02"
+      name     =  format("%s-%s", lower(random_string.default.result), "frontendip02")
       subnet_id                     = azurerm_subnet.main.id
       private_ip_address            = "10.200.2.10"
       private_ip_address_allocation = "Static"

--- a/examples/azure/terraform-azure-loadbalancer-example/main.tf
+++ b/examples/azure/terraform-azure-loadbalancer-example/main.tf
@@ -16,15 +16,8 @@ terraform {
 # See test/terraform_azure_example_test.go for how to write automated tests for this code.
 # ---------------------------------------------------------------------------------------------------------------------
 
-resource "random_string" "default" {
-  length = 3  
-  lower = true
-  number = false
-  special = false
-}
-
 resource "azurerm_resource_group" "main" {
-  name     =  format("%s-%s-%s", "terratest", lower(random_string.default.result), "loadbalancer")
+  name     =  "${var.resource_group_name}"
   location = "East US"
 }
 
@@ -33,7 +26,7 @@ resource "azurerm_resource_group" "main" {
 # ---------------------------------------------------------------------------------------------------------------------
 
 resource "azurerm_public_ip" "main" {
-  name     =  format("%s-%s", lower(random_string.default.result), "pip")
+  name     =  "${var.pip_forlb01}"
   resource_group_name = azurerm_resource_group.main.name
   location            = azurerm_resource_group.main.location
   allocation_method       = "Static"
@@ -43,13 +36,13 @@ resource "azurerm_public_ip" "main" {
 }
 
 resource "azurerm_lb" "main01" {
-  name     =  format("%s-%s", lower(random_string.default.result), "lb01")
+  name     =  "${var.loadbalancer01_name}"
   location            = azurerm_resource_group.main.location
   resource_group_name = azurerm_resource_group.main.name
   sku                 = "Standard"
 
     frontend_ip_configuration {
-      name     =  format("%s-%s", lower(random_string.default.result), "frontendip01")
+      name     =  "${var.lb01_feconfig}"
       public_ip_address_id = azurerm_public_ip.main.id
     }
 }
@@ -59,7 +52,7 @@ resource "azurerm_lb" "main01" {
 # ---------------------------------------------------------------------------------------------------------------------
 
 resource "azurerm_virtual_network" "main" {
-  name     =  format("%s-%s", lower(random_string.default.result), "vnet01")
+  name     =  "${var.vnet_name}"
   location            = azurerm_resource_group.main.location
   resource_group_name = azurerm_resource_group.main.name
   address_space       = ["10.200.0.0/21"]
@@ -68,20 +61,20 @@ resource "azurerm_virtual_network" "main" {
 }
 
 resource "azurerm_subnet" "main" {
-  name     =  format("%s-%s", lower(random_string.default.result), "subnet01")
+  name     =  "${var.feSubnet_forlb02}"
   resource_group_name = azurerm_resource_group.main.name
   virtual_network_name = azurerm_virtual_network.main.name
   address_prefix     = "10.200.2.0/25"
 }
 
 resource "azurerm_lb" "main02" {
-  name     =  format("%s-%s", lower(random_string.default.result), "lb02")
+  name     =  "${var.loadbalancer02_name}"
   location            = azurerm_resource_group.main.location
   resource_group_name = azurerm_resource_group.main.name
   sku                 = "Standard"
 
     frontend_ip_configuration {
-      name     =  format("%s-%s", lower(random_string.default.result), "frontendip02")
+      name     =  "${var.feIPConfig_forlb02}"
       subnet_id                     = azurerm_subnet.main.id
       private_ip_address            = "10.200.2.10"
       private_ip_address_allocation = "Static"

--- a/examples/azure/terraform-azure-loadbalancer-example/main.tf
+++ b/examples/azure/terraform-azure-loadbalancer-example/main.tf
@@ -1,0 +1,82 @@
+provider "azurerm" {
+  version = "=1.31.0"
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# PIN TERRAFORM VERSION TO >= 0.12
+# The examples have been upgraded to 0.12 syntax
+# ---------------------------------------------------------------------------------------------------------------------
+
+terraform {
+  required_version = ">= 0.12"
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# DEPLOY A RESOURCE GROUP
+# See test/terraform_azure_example_test.go for how to write automated tests for this code.
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "azurerm_resource_group" "main" {
+  name     = "${var.prefix}-resources"
+  location = "East US"
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# DEPLOY LOAD BALANCER WITH PUBLIC IP 
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "azurerm_public_ip" "main" {
+  name                    = "${var.prefix}-pip"
+  resource_group_name = azurerm_resource_group.main.name
+  location            = azurerm_resource_group.main.location
+  allocation_method       = "Static"
+  ip_version              = "IPv4"
+  sku                     = "Standard"
+  idle_timeout_in_minutes = "4"
+}
+
+resource "azurerm_lb" "main01" {
+  name                = "${var.prefix}-lb01"
+  location            = azurerm_resource_group.main.location
+  resource_group_name = azurerm_resource_group.main.name
+  sku                 = "Standard"
+
+    frontend_ip_configuration {
+      name                 = "${var.prefix}-frontendip01"
+      public_ip_address_id = azurerm_public_ip.main.id
+    }
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# DEPLOY LOAD BALANCER WITH PRIVATE IP 
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "azurerm_virtual_network" "main" {
+  name                = "${var.prefix}-vnet01"
+  location            = azurerm_resource_group.main.location
+  resource_group_name = azurerm_resource_group.main.name
+  address_space       = ["10.200.0.0/21"]
+  dns_servers         = ["10.200.0.5", "10.200.0.6"]
+
+}
+
+resource "azurerm_subnet" "main" {
+  name                = "${var.prefix}-subnet01"
+  resource_group_name = azurerm_resource_group.main.name
+  virtual_network_name = azurerm_virtual_network.main.name
+  address_prefix     = "10.200.2.0/25"
+}
+
+resource "azurerm_lb" "main02" {
+  name                = "${var.prefix}-lb02"
+  location            = azurerm_resource_group.main.location
+  resource_group_name = azurerm_resource_group.main.name
+  sku                 = "Standard"
+
+    frontend_ip_configuration {
+      name                 = "${var.prefix}-frontendip02"
+      subnet_id                     = azurerm_subnet.main.id
+      private_ip_address            = "10.200.2.10"
+      private_ip_address_allocation = "Static"
+    }
+}

--- a/examples/azure/terraform-azure-loadbalancer-example/outputs.tf
+++ b/examples/azure/terraform-azure-loadbalancer-example/outputs.tf
@@ -1,0 +1,26 @@
+output "resource_group_name" {
+  value = azurerm_resource_group.main.name
+}
+
+output "loadbalancer01_name" {
+  value = azurerm_lb.main01.name
+}
+
+output "lb01_feconfig" {
+  value = azurerm_lb.main01.frontend_ip_configuration[0].name
+}
+
+output "pip_forlb01" {
+  value = azurerm_public_ip.main.name
+}
+
+output "loadbalancer02_name" {
+  value = azurerm_lb.main02.name
+}
+output "feIPConfig_forlb02" {
+  value = azurerm_lb.main02.frontend_ip_configuration[0].private_ip_address
+}
+
+output "feSubnet_forlb02" {
+  value = azurerm_lb.main02.frontend_ip_configuration[0].subnet_id
+}

--- a/examples/azure/terraform-azure-loadbalancer-example/variables.tf
+++ b/examples/azure/terraform-azure-loadbalancer-example/variables.tf
@@ -1,0 +1,25 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# ENVIRONMENT VARIABLES
+# Define these secrets as environment variables
+# ---------------------------------------------------------------------------------------------------------------------
+
+# ARM_CLIENT_ID
+# ARM_CLIENT_SECRET
+# ARM_SUBSCRIPTION_ID
+# ARM_TENANT_ID
+
+# ---------------------------------------------------------------------------------------------------------------------
+# REQUIRED PARAMETERS
+# You must provide a value for each of these parameters.
+# ---------------------------------------------------------------------------------------------------------------------
+
+# ---------------------------------------------------------------------------------------------------------------------
+# OPTIONAL PARAMETERS
+# These parameters have reasonable defaults.
+# ---------------------------------------------------------------------------------------------------------------------
+
+variable "prefix" {
+  description = "The prefix that will be attached to all resources deployed"
+  type        = string
+  default     = "terratest-example"
+}

--- a/examples/azure/terraform-azure-loadbalancer-example/variables.tf
+++ b/examples/azure/terraform-azure-loadbalancer-example/variables.tf
@@ -21,5 +21,5 @@
 variable "prefix" {
   description = "The prefix that will be attached to all resources deployed"
   type        = string
-  default     = "terratest-example"
+  default     = "lbtests"
 }

--- a/examples/azure/terraform-azure-loadbalancer-example/variables.tf
+++ b/examples/azure/terraform-azure-loadbalancer-example/variables.tf
@@ -18,8 +18,50 @@
 # These parameters have reasonable defaults.
 # ---------------------------------------------------------------------------------------------------------------------
 
-variable "prefix" {
-  description = "The prefix that will be attached to all resources deployed"
+variable "resource_group_name" {
+  description = "The resource group where all resources will be deployed"
   type        = string
-  default     = "terratest-lb"
+  default     = "terratest-keyvault-rg"
+}
+
+variable "loadbalancer01_name" {
+  description = "Load balancer with a public IP"
+  type        = string
+  default     = "terratest-loadbalancer-lb-01"
+}
+
+variable "loadbalancer02_name" {
+  description = "Load balancer with a private IP"
+  type        = string
+  default     = "terratest-loadbalancer-lb-02"
+}
+
+variable "vnet_name" {
+  description = "Virtual Network for Load Balancer 02"
+  type        = string
+  default     = "terratest-loadbalancer-vnet"
+}
+
+variable "lb01_feconfig" {
+  description = "Frontend Config for Load Balancer 01"
+  type        = string
+  default     = "terratest-loadbalancer-cfg-01"
+}
+
+variable "pip_forlb01" {
+  description = "Public IP for Load Balancer 01"
+  type        = string
+  default     = "terratest-loadbalancer-pip-01"
+}
+
+variable "feIPConfig_forlb02" {
+  description = "Frontend Config for Load Balancer 02"
+  type        = string
+  default     = "terratest-loadbalancer-cfg-02"
+}
+
+variable "feSubnet_forlb02" {
+  description = "Frontend Subnet for Load Balancer 02"
+  type        = string
+  default     = "terratest-loadbalancer-snt-02"
 }

--- a/examples/azure/terraform-azure-loadbalancer-example/variables.tf
+++ b/examples/azure/terraform-azure-loadbalancer-example/variables.tf
@@ -21,5 +21,5 @@
 variable "prefix" {
   description = "The prefix that will be attached to all resources deployed"
   type        = string
-  default     = "lbtests"
+  default     = "terratest-lb"
 }

--- a/modules/azure/loadbalancer.go
+++ b/modules/azure/loadbalancer.go
@@ -9,7 +9,13 @@ import (
 // LoadBalancerExistsE returns true if the load balancer exists, else returns false with err
 func LoadBalancerExistsE(loadBalancerName string, resourceGroupName string, subscriptionID string) (bool, error) {
 	subscriptionID, err := getTargetAzureSubscription(subscriptionID)
+	if err != nil {
+		return false, err
+	}
 	client, err := GetLoadBalancerClientE(subscriptionID)
+	if err != nil {
+		return false, err
+	}
 	lb, err := client.Get(context.Background(), resourceGroupName, loadBalancerName, "")
 	if err != nil {
 		return false, err
@@ -21,7 +27,13 @@ func LoadBalancerExistsE(loadBalancerName string, resourceGroupName string, subs
 // GetLoadBalancerE returns a load balancer resource as specified by name, else returns nil with err
 func GetLoadBalancerE(loadBalancerName string, resourceGroupName string, subscriptionID string) (*network.LoadBalancer, error) {
 	subscriptionID, err := getTargetAzureSubscription(subscriptionID)
+	if err != nil {
+		return nil, err
+	}
 	client, err := GetLoadBalancerClientE(subscriptionID)
+	if err != nil {
+		return nil, err
+	}
 	lb, err := client.Get(context.Background(), resourceGroupName, loadBalancerName, "")
 	if err != nil {
 		return nil, err

--- a/modules/azure/loadbalancer.go
+++ b/modules/azure/loadbalancer.go
@@ -6,12 +6,8 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2019-09-01/network"
 )
 
-const (
-	AzureEnvironmentEnvName = "AZURE_ENVIRONMENT"
-)
-
-// LoadBalancerExistsE returns an LB client
-func LoadBalancerExistsE(loadBalancerName, resourceGroupName, subscriptionID string) (bool, error) {
+// LoadBalancerExistsE returns true if the load balancer exists, else returns false with err
+func LoadBalancerExistsE(loadBalancerName string, resourceGroupName string, subscriptionID string) (bool, error) {
 	subscriptionID, err := getTargetAzureSubscription(subscriptionID)
 	client, err := GetLoadBalancerClientE(subscriptionID)
 	lb, err := client.Get(context.Background(), resourceGroupName, loadBalancerName, "")
@@ -22,7 +18,7 @@ func LoadBalancerExistsE(loadBalancerName, resourceGroupName, subscriptionID str
 	return *lb.Name == loadBalancerName, nil
 }
 
-// GetLoadBalancerE returns a load balancer resource as specified by name.
+// GetLoadBalancerE returns a load balancer resource as specified by name, else returns nil with err
 func GetLoadBalancerE(loadBalancerName string, resourceGroupName string, subscriptionID string) (*network.LoadBalancer, error) {
 	subscriptionID, err := getTargetAzureSubscription(subscriptionID)
 	client, err := GetLoadBalancerClientE(subscriptionID)
@@ -45,8 +41,8 @@ func GetLoadBalancerClientE(subscriptionID string) (*network.LoadBalancersClient
 	return &loadBalancerClient, nil
 }
 
-// GetPublicIPAddressE will return a Public IP Address object and an error object
-func GetPublicIPAddressE(resourceGroupName, publicIPAddressName, subscriptionID string) (*network.PublicIPAddress, error) {
+// GetPublicIPAddressE returns a Public IP Address resource, else returns nil with err
+func GetPublicIPAddressE(publicIPAddressName string, resourceGroupName string, subscriptionID string) (*network.PublicIPAddress, error) {
 	subscriptionID, err := getTargetAzureSubscription(subscriptionID)
 	client, err := GetPublicIPAddressClientE(subscriptionID)
 	if err != nil {

--- a/modules/azure/loadbalancer.go
+++ b/modules/azure/loadbalancer.go
@@ -56,6 +56,9 @@ func GetLoadBalancerClientE(subscriptionID string) (*network.LoadBalancersClient
 // GetPublicIPAddressE returns a Public IP Address resource, else returns nil with err
 func GetPublicIPAddressE(publicIPAddressName string, resourceGroupName string, subscriptionID string) (*network.PublicIPAddress, error) {
 	subscriptionID, err := getTargetAzureSubscription(subscriptionID)
+	if err != nil {
+		return nil, err
+	}
 	client, err := GetPublicIPAddressClientE(subscriptionID)
 	if err != nil {
 		return nil, err

--- a/modules/azure/loadbalancer.go
+++ b/modules/azure/loadbalancer.go
@@ -1,0 +1,71 @@
+package azure
+
+import (
+	"context"
+
+	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2019-09-01/network"
+)
+
+const (
+	AzureEnvironmentEnvName = "AZURE_ENVIRONMENT"
+)
+
+// LoadBalancerExistsE returns an LB client
+func LoadBalancerExistsE(loadBalancerName, resourceGroupName, subscriptionID string) (bool, error) {
+	subscriptionID, err := getTargetAzureSubscription(subscriptionID)
+	client, err := GetLoadBalancerClientE(subscriptionID)
+	lb, err := client.Get(context.Background(), resourceGroupName, loadBalancerName, "")
+	if err != nil {
+		return false, err
+	}
+
+	return *lb.Name == loadBalancerName, nil
+}
+
+// GetLoadBalancerE returns a load balancer resource as specified by name.
+func GetLoadBalancerE(loadBalancerName string, resourceGroupName string, subscriptionID string) (*network.LoadBalancer, error) {
+	subscriptionID, err := getTargetAzureSubscription(subscriptionID)
+	client, err := GetLoadBalancerClientE(subscriptionID)
+	lb, err := client.Get(context.Background(), resourceGroupName, loadBalancerName, "")
+	if err != nil {
+		return nil, err
+	}
+
+	return &lb, nil
+}
+
+// GetLoadBalancerClientE creates a load balancer client.
+func GetLoadBalancerClientE(subscriptionID string) (*network.LoadBalancersClient, error) {
+	loadBalancerClient := network.NewLoadBalancersClient(subscriptionID)
+	authorizer, err := NewAuthorizer()
+	if err != nil {
+		return nil, err
+	}
+	loadBalancerClient.Authorizer = *authorizer
+	return &loadBalancerClient, nil
+}
+
+// GetPublicIPAddressE will return a Public IP Address object and an error object
+func GetPublicIPAddressE(resourceGroupName, publicIPAddressName, subscriptionID string) (*network.PublicIPAddress, error) {
+	subscriptionID, err := getTargetAzureSubscription(subscriptionID)
+	client, err := GetPublicIPAddressClientE(subscriptionID)
+	if err != nil {
+		return nil, err
+	}
+	publicIPAddress, err := client.Get(context.Background(), resourceGroupName, publicIPAddressName, "")
+	if err != nil {
+		return nil, err
+	}
+	return &publicIPAddress, nil
+}
+
+// GetPublicIPAddressClientE creates a PublicIPAddresses client
+func GetPublicIPAddressClientE(subscriptionID string) (*network.PublicIPAddressesClient, error) {
+	client := network.NewPublicIPAddressesClient(subscriptionID)
+	authorizer, err := NewAuthorizer()
+	if err != nil {
+		return nil, err
+	}
+	client.Authorizer = *authorizer
+	return &client, nil
+}

--- a/modules/azure/resourceid.go
+++ b/modules/azure/resourceid.go
@@ -1,0 +1,36 @@
+package azure
+
+import (
+	"errors"
+	"strings"
+)
+
+// GetNameFromResourceID gets the Name from an Azure Resource ID
+func GetNameFromResourceID(resourceID string) string {
+	lastValue, err := GetSliceLastValueE(resourceID, "/")
+	if err != nil {
+		return ""
+	}
+	return lastValue
+}
+
+// GetSliceLastValueE will take a source string and returns the last value when split by the seperaror char
+func GetSliceLastValueE(source string, seperator string) (string, error) {
+	if !(len(source) == 0 || len(seperator) == 0 || !strings.Contains(source, seperator)) {
+		tmp := strings.Split(source, seperator)
+		return tmp[len(tmp)-1], nil
+	}
+	return "", errors.New("invalid input or no slice available")
+}
+
+// GetSliceIndexValueE will take a source string and returns the value at the given index when split by the seperaror char
+func GetSliceIndexValueE(source string, seperator string, index int) (string, error) {
+	if !(len(source) == 0 || len(seperator) == 0 || !strings.Contains(source, seperator) || index < 0) {
+		tmp := strings.Split(source, seperator)
+		if !(len(tmp) >= index) {
+			return "", errors.New("index out of slice range")
+		}
+		return tmp[index], nil
+	}
+	return "", errors.New("invalid input or no slice available")
+}

--- a/test/azure/loadbalancer_test.go
+++ b/test/azure/loadbalancer_test.go
@@ -1,0 +1,54 @@
+// +build azure azureslim,network
+
+// NOTE: We use build tags to differentiate azure testing because we currently do not have azure access setup for
+// CircleCI.
+
+package test
+
+import (
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/azure"
+	"github.com/stretchr/testify/require"
+)
+
+/*
+The below tests are currently stubbed out, with the expectation that they will throw errors.
+If/when methods can be mocked or Create/Delete APIs are added, these tests can be extended.
+*/
+
+func TestLoadBalancerExistsE(t *testing.T) {
+	t.Parallel()
+
+	loadBalancerName := ""
+	resourceGroupName := ""
+	subscriptionID := ""
+
+	_, err := azure.LoadBalancerExistsE(loadBalancerName, resourceGroupName, subscriptionID)
+
+	require.Error(t, err)
+}
+
+func TestGetLoadBalancerE(t *testing.T) {
+	t.Parallel()
+
+	loadBalancerName := ""
+	resourceGroupName := ""
+	subscriptionID := ""
+
+	_, err := azure.GetLoadBalancerE(loadBalancerName, resourceGroupName, subscriptionID)
+
+	require.Error(t, err)
+}
+
+func TestGetPublicIPAddressE(t *testing.T) {
+	t.Parallel()
+
+	publicIPAddressName := ""
+	resourceGroupName := ""
+	subscriptionID := ""
+
+	_, err := azure.GetPublicIPAddressE(publicIPAddressName, resourceGroupName, subscriptionID)
+
+	require.Error(t, err)
+}

--- a/test/azure/resourceid_test.go
+++ b/test/azure/resourceid_test.go
@@ -1,0 +1,96 @@
+// +build azure
+
+// NOTE: We use build tags to differentiate azure testing because we currently do not have azure access setup for
+// CircleCI.
+
+package test
+
+import (
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/azure"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetNameFromResourceID(t *testing.T) {
+	// set slice variables
+	sliceSource := "this/is/a/long/slash/separated/string/ResourceID"
+	sliceResult := "ResourceID"
+	sliceNotFound := "noresourcepresent"
+
+	// verify success
+	resultSuccess := azure.GetNameFromResourceID(sliceSource)
+	assert.Equal(t, sliceResult, resultSuccess)
+
+	// verify error when seperator not found
+	resultBadSeperator := azure.GetNameFromResourceID(sliceNotFound)
+	assert.Equal(t, "", resultBadSeperator)
+}
+
+func TestGetSliceLastValue(t *testing.T) {
+	// set slice variables
+	sliceSeperator := "/"
+	sliceBadSeperator := "*"
+	sliceNotFound := "noslicepresent"
+	sliceSource := "this/is/a/long/slash/separated/string/success"
+	sliceResult := "success"
+
+	// verify success
+	resultSuccess, err := azure.GetSliceLastValueE(sliceSource, sliceSeperator)
+	require.NoError(t, err)
+	assert.Equal(t, sliceResult, resultSuccess)
+
+	// verify error when seperator not found
+	resultBadSeperator, err := azure.GetSliceLastValueE(sliceSource, sliceBadSeperator)
+	require.Error(t, err)
+	assert.Equal(t, err.Error(), "invalid input or no slice available")
+	assert.Equal(t, "", resultBadSeperator)
+
+	// verify error when slice does not have seperator
+	resultNotFound, err := azure.GetSliceLastValueE(sliceNotFound, sliceSeperator)
+	require.Error(t, err)
+	assert.Equal(t, err.Error(), "invalid input or no slice available")
+	assert.Equal(t, "", resultNotFound)
+}
+
+func TestGetSliceIndexValue(t *testing.T) {
+	// set slice variables
+	sliceSource := "this/is/a/long/slash/separated/string/success"
+	sliceSeperator := "/"
+	sliceSelectorNeg := -1
+	sliceSelector0 := 0
+	sliceSelector4 := 4
+	sliceSelector7 := 7
+	sliceSelector10 := 10
+	sliceResult0 := "this"
+	sliceResult4 := "slash"
+	sliceResult7 := "success"
+
+	// verify success index 0
+	resultSuccess0, err := azure.GetSliceIndexValueE(sliceSource, sliceSeperator, sliceSelector0)
+	require.NoError(t, err)
+	assert.Equal(t, sliceResult0, resultSuccess0)
+
+	// verify success index 4
+	resultSuccess4, err := azure.GetSliceIndexValueE(sliceSource, sliceSeperator, sliceSelector4)
+	require.NoError(t, err)
+	assert.Equal(t, sliceResult4, resultSuccess4)
+
+	// verify success index 7
+	resultSuccess7, err := azure.GetSliceIndexValueE(sliceSource, sliceSeperator, sliceSelector7)
+	require.NoError(t, err)
+	assert.Equal(t, sliceResult7, resultSuccess7)
+
+	// verify error with negative index
+	resultNegIndex, err := azure.GetSliceIndexValueE(sliceSource, sliceSeperator, sliceSelectorNeg)
+	require.Error(t, err)
+	assert.Equal(t, err.Error(), "invalid input or no slice available")
+	assert.Equal(t, "", resultNegIndex)
+
+	// verify error when seperator not found
+	resultBadIndex10, err := azure.GetSliceIndexValueE(sliceSource, sliceSeperator, sliceSelector10)
+	require.Error(t, err)
+	assert.Equal(t, err.Error(), "index out of slice range")
+	assert.Equal(t, "", resultBadIndex10)
+}

--- a/test/azure/terraform_azure_loadbalancer_example_test.go
+++ b/test/azure/terraform_azure_loadbalancer_example_test.go
@@ -28,8 +28,6 @@ func TestTerraformAzureLoadBalancerExample(t *testing.T) {
 	publicIPAddressForLB01 := fmt.Sprintf("terratest-loadbalancer-pip-%s", random.UniqueId())
 
 	vnetForLB02 := fmt.Sprintf("terratest-loadbalancer-vnet-%s", random.UniqueId())
-	//frontendIPConfigForLB02 := fmt.Sprintf("terratest-loadbalancer-cfg-%s", random.UniqueId())
-	//frontendIPAllocForLB02 := "Static"
 	frontendSubnetID := fmt.Sprintf("terratest-loadbalancer-snt-%s", random.UniqueId())
 
 	// loadbalancer::tag::1:: Configure Terraform setting up a path to Terraform code.
@@ -59,16 +57,9 @@ func TestTerraformAzureLoadBalancerExample(t *testing.T) {
 	terraform.InitAndApply(t, terraformOptions)
 
 	// loadbalancer::tag::3:: Run `terraform output` to get the values of output variables
-	//resourceGroupName := terraform.Output(t, terraformOptions, "resource_group_name")
-	//loadBalancer01Name := terraform.Output(t, terraformOptions, "loadbalancer01_name")
-	//loadBalancer02Name := terraform.Output(t, terraformOptions, "loadbalancer02_name")
-
-	//frontendIPConfigForLB01 := terraform.Output(t, terraformOptions, "lb01_feconfig")
-	//publicIPAddressForLB01 := terraform.Output(t, terraformOptions, "pip_forlb01")
 
 	frontendIPConfigForLB02 := terraform.Output(t, terraformOptions, "feIPConfig_forlb02")
 	frontendIPAllocForLB02 := "Static"
-	//frontendSubnetID := terraform.Output(t, terraformOptions, "feSubnet_forlb02")
 
 	// loadbalancer::tag::5 Set expected variables for test
 
@@ -87,7 +78,6 @@ func TestTerraformAzureLoadBalancerExample(t *testing.T) {
 		require.NoError(t, err)
 		lb01Props := lb01.LoadBalancerPropertiesFormat
 		fe01Config := (*lb01Props.FrontendIPConfigurations)[0]
-		//fe01Props := *fe01Config.FrontendIPConfigurationPropertiesFormat
 
 		// Verify settings
 		assert.Equal(t, frontendIPConfigForLB01, *fe01Config.Name, "LB01 Frontend IP config name")
@@ -139,5 +129,4 @@ func TestTerraformAzureLoadBalancerExample(t *testing.T) {
 		require.NoError(t, err, "LB02 Frontend subnet not found")
 		assert.Equal(t, frontendSubnetID, subnetID, "LB02 Frontend subnet ID")
 	})
-
 }

--- a/test/azure/terraform_azure_loadbalancer_example_test.go
+++ b/test/azure/terraform_azure_loadbalancer_example_test.go
@@ -1,0 +1,130 @@
+// +build azure
+
+// NOTE: We use build tags to differentiate azure testing because we currently do not have azure access setup for
+// CircleCI.
+
+package test
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/azure"
+	"github.com/gruntwork-io/terratest/modules/terraform"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTerraformAzureLoadBalancerExample(t *testing.T) {
+	t.Parallel()
+
+	// loadbalancer::tag::1:: Configure Terraform setting up a path to Terraform code.
+	terraformOptions := &terraform.Options{
+		// The path to where our Terraform code is located
+		TerraformDir: "../examples/terraform-azure-loadbalancer-example",
+	}
+
+	// config
+	FrontendIPAllocationMethod := "Dynamic"
+
+	// loadbalancer::tag::4:: At the end of the test, run `terraform destroy` to clean up any resources that were created
+	defer terraform.Destroy(t, terraformOptions)
+
+	// loadbalancer::tag::2:: Run `terraform init` and `terraform apply`. Fail the test if there are any errors.
+	terraform.InitAndApply(t, terraformOptions)
+
+	// loadbalancer::tag::3:: Run `terraform output` to get the values of output variables
+	resourceGroupName := terraform.Output(t, terraformOptions, "resource_group_name")
+	loadBalancer01Name := terraform.Output(t, terraformOptions, "loadbalancer01_name")
+	loadBalancer02Name := terraform.Output(t, terraformOptions, "loadbalancer02_name")
+
+	frontendIPConfigForLB01 := terraform.Output(t, terraformOptions, "lb01_feconfig")
+	publicIPAddressForLB01 := terraform.Output(t, terraformOptions, "pip_forlb01")
+
+	frontendIPConfigForLB02 := terraform.Output(t, terraformOptions, "feIPConfig_forlb02")
+	frontendIPAllocForLB02 := "Static"
+	frontendSubnetID := terraform.Output(t, terraformOptions, "feSubnet_forlb02")
+
+	// loadbalancer::tag::5 Set expected variables for test
+
+	// happy path tests
+	t.Run("Load Balancer 01", func(t *testing.T) {
+		// load balancer 01 (with Public IP) exists
+		lb01Exists, err := azure.LoadBalancerExistsE(loadBalancer01Name, resourceGroupName, "")
+		assert.NoError(t, err, "Load Balancer error.")
+		assert.True(t, lb01Exists)
+
+	})
+
+	t.Run("Frontend Config for LB01", func(t *testing.T) {
+		// Read the LB information
+		lb01, err := azure.GetLoadBalancerE(loadBalancer01Name, resourceGroupName, "")
+		require.NoError(t, err)
+		lb01Props := lb01.LoadBalancerPropertiesFormat
+		fe01Config := (*lb01Props.FrontendIPConfigurations)[0]
+		//fe01Props := *fe01Config.FrontendIPConfigurationPropertiesFormat
+
+		// Verify settings
+		assert.Equal(t, frontendIPConfigForLB01, *fe01Config.Name, "LB01 Frontend IP config name")
+	})
+
+	t.Run("IP Checks for LB01", func(t *testing.T) {
+		// Read the LB information
+		lb01, err := azure.GetLoadBalancerE(loadBalancer01Name, resourceGroupName, "")
+		require.NoError(t, err)
+		lb01Props := lb01.LoadBalancerPropertiesFormat
+		fe01Config := (*lb01Props.FrontendIPConfigurations)[0]
+		fe01Props := *fe01Config.FrontendIPConfigurationPropertiesFormat
+
+		// Ensure PrivateIPAddress is nil for LB01
+		assert.Nil(t, fe01Props.PrivateIPAddress, "LB01 shouldn't have PrivateIPAddress")
+
+		// Ensure PublicIPAddress Resource exists, no need to check PublicIPAddress value
+		publicIPAddressResource, err := azure.GetPublicIPAddressE(resourceGroupName, publicIPAddressForLB01, "")
+		require.NoError(t, err)
+		assert.NotNil(t, publicIPAddressResource, fmt.Sprintf("Public IP Resource for LB01 Frontend: %s", publicIPAddressForLB01))
+
+		// Verify that expected PublicIPAddressResource is assigned to Load Balancer
+		pipResourceName, err := GetSliceLastValueLocal(*fe01Props.PublicIPAddress.ID, "/")
+		require.NoError(t, err)
+		assert.Equal(t, publicIPAddressForLB01, pipResourceName, "LB01 Public IP Address Resource Name")
+
+		assert.Equal(t, FrontendIPAllocationMethod, string(fe01Props.PrivateIPAllocationMethod), "LB01 Frontend IP allocation method")
+		assert.Nil(t, fe01Props.Subnet, "LB01 shouldn't have Subnet")
+	})
+
+	t.Run("Load Balancer 02", func(t *testing.T) {
+		// load balancer 02 (with Private IP on vnet/subnet) exists
+		lb02Exists, err := azure.LoadBalancerExistsE(loadBalancer02Name, resourceGroupName, "")
+		assert.NoError(t, err, "Load Balancer error.")
+		assert.True(t, lb02Exists)
+	})
+
+	t.Run("IP Check for Load Balancer 02", func(t *testing.T) {
+		// Read LB02 information
+		lb02, err := azure.GetLoadBalancerE(loadBalancer02Name, resourceGroupName, "")
+		require.NoError(t, err)
+		lb02Props := lb02.LoadBalancerPropertiesFormat
+		fe02Config := (*lb02Props.FrontendIPConfigurations)[0]
+		fe02Props := *fe02Config.FrontendIPConfigurationPropertiesFormat
+
+		assert.Equal(t, frontendIPConfigForLB02, *fe02Props.PrivateIPAddress, "LB02 Frontend IP address")
+		assert.Equal(t, frontendIPAllocForLB02, string(fe02Props.PrivateIPAllocationMethod), "LB02 Frontend IP allocation method")
+		subnetID, err := GetSliceLastValueLocal(*fe02Props.Subnet.ID, "/")
+		require.NoError(t, err, "LB02 Frontend subnet not found")
+		frontendSubnetID, err := GetSliceLastValueLocal(frontendSubnetID, "/")
+		assert.Equal(t, frontendSubnetID, subnetID, "LB02 Frontend subnet ID")
+	})
+
+}
+
+// GetSliceLastValue will take a source string and returns the last value when split by the seperaror char
+func GetSliceLastValueLocal(source string, seperator string) (string, error) {
+	if !(len(source) == 0 || len(seperator) == 0 || !strings.Contains(source, seperator)) {
+		tmp := strings.Split(source, seperator)
+		return tmp[len(tmp)-1], nil
+	}
+	return "", errors.New("invalid input or no slice available")
+}

--- a/test/azure/terraform_azure_loadbalancer_example_test.go
+++ b/test/azure/terraform_azure_loadbalancer_example_test.go
@@ -115,6 +115,7 @@ func TestTerraformAzureLoadBalancerExample(t *testing.T) {
 		subnetID, err := GetSliceLastValueLocal(*fe02Props.Subnet.ID, "/")
 		require.NoError(t, err, "LB02 Frontend subnet not found")
 		frontendSubnetID, err := GetSliceLastValueLocal(frontendSubnetID, "/")
+		require.NoError(t, err, "LB02 Frontend subnet ID not detected")
 		assert.Equal(t, frontendSubnetID, subnetID, "LB02 Frontend subnet ID")
 	})
 

--- a/test/azure/terraform_azure_loadbalancer_example_test.go
+++ b/test/azure/terraform_azure_loadbalancer_example_test.go
@@ -6,9 +6,7 @@
 package test
 
 import (
-	"errors"
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/gruntwork-io/terratest/modules/azure"
@@ -87,7 +85,7 @@ func TestTerraformAzureLoadBalancerExample(t *testing.T) {
 		assert.NotNil(t, publicIPAddressResource, fmt.Sprintf("Public IP Resource for LB01 Frontend: %s", publicIPAddressForLB01))
 
 		// Verify that expected PublicIPAddressResource is assigned to Load Balancer
-		pipResourceName, err := GetSliceLastValueLocal(*fe01Props.PublicIPAddress.ID, "/")
+		pipResourceName, err := azure.GetSliceLastValueE(*fe01Props.PublicIPAddress.ID, "/")
 		require.NoError(t, err)
 		assert.Equal(t, publicIPAddressForLB01, pipResourceName, "LB01 Public IP Address Resource Name")
 
@@ -112,20 +110,11 @@ func TestTerraformAzureLoadBalancerExample(t *testing.T) {
 
 		assert.Equal(t, frontendIPConfigForLB02, *fe02Props.PrivateIPAddress, "LB02 Frontend IP address")
 		assert.Equal(t, frontendIPAllocForLB02, string(fe02Props.PrivateIPAllocationMethod), "LB02 Frontend IP allocation method")
-		subnetID, err := GetSliceLastValueLocal(*fe02Props.Subnet.ID, "/")
+		subnetID, err := azure.GetSliceLastValueE(*fe02Props.Subnet.ID, "/")
 		require.NoError(t, err, "LB02 Frontend subnet not found")
-		frontendSubnetID, err := GetSliceLastValueLocal(frontendSubnetID, "/")
+		frontendSubnetID, err := azure.GetSliceLastValueE(frontendSubnetID, "/")
 		require.NoError(t, err, "LB02 Frontend subnet ID not detected")
 		assert.Equal(t, frontendSubnetID, subnetID, "LB02 Frontend subnet ID")
 	})
 
-}
-
-// GetSliceLastValue will take a source string and returns the last value when split by the seperaror char
-func GetSliceLastValueLocal(source string, seperator string) (string, error) {
-	if !(len(source) == 0 || len(seperator) == 0 || !strings.Contains(source, seperator)) {
-		tmp := strings.Split(source, seperator)
-		return tmp[len(tmp)-1], nil
-	}
-	return "", errors.New("invalid input or no slice available")
 }

--- a/test/azure/terraform_azure_loadbalancer_example_test.go
+++ b/test/azure/terraform_azure_loadbalancer_example_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 
 	"github.com/gruntwork-io/terratest/modules/azure"
-	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/gruntwork-io/terratest/modules/terraform"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -19,17 +18,10 @@ import (
 func TestTerraformAzureLoadBalancerExample(t *testing.T) {
 	t.Parallel()
 
-	prefix := "terratest-lb-" + random.UniqueId()
-
 	// loadbalancer::tag::1:: Configure Terraform setting up a path to Terraform code.
 	terraformOptions := &terraform.Options{
 		// The path to where our Terraform code is located
 		TerraformDir: "../../examples/azure/terraform-azure-loadbalancer-example",
-
-		// Variables to pass to our Terraform code using -var options
-		Vars: map[string]interface{}{
-			"prefix": prefix,
-		},
 	}
 
 	// config

--- a/test/azure/terraform_azure_loadbalancer_example_test.go
+++ b/test/azure/terraform_azure_loadbalancer_example_test.go
@@ -23,7 +23,7 @@ func TestTerraformAzureLoadBalancerExample(t *testing.T) {
 	// loadbalancer::tag::1:: Configure Terraform setting up a path to Terraform code.
 	terraformOptions := &terraform.Options{
 		// The path to where our Terraform code is located
-		TerraformDir: "../examples/terraform-azure-loadbalancer-example",
+		TerraformDir: "../../examples/azure/terraform-azure-loadbalancer-example",
 	}
 
 	// config

--- a/test/azure/terraform_azure_loadbalancer_example_test.go
+++ b/test/azure/terraform_azure_loadbalancer_example_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/gruntwork-io/terratest/modules/azure"
+	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/gruntwork-io/terratest/modules/terraform"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -18,10 +19,17 @@ import (
 func TestTerraformAzureLoadBalancerExample(t *testing.T) {
 	t.Parallel()
 
+	prefix := "terratest-lb-" + random.UniqueId()
+
 	// loadbalancer::tag::1:: Configure Terraform setting up a path to Terraform code.
 	terraformOptions := &terraform.Options{
 		// The path to where our Terraform code is located
 		TerraformDir: "../../examples/azure/terraform-azure-loadbalancer-example",
+
+		// Variables to pass to our Terraform code using -var options
+		Vars: map[string]interface{}{
+			"prefix": prefix,
+		},
 	}
 
 	// config

--- a/test/azure/terraform_azure_loadbalancer_example_test.go
+++ b/test/azure/terraform_azure_loadbalancer_example_test.go
@@ -21,14 +21,14 @@ func TestTerraformAzureLoadBalancerExample(t *testing.T) {
 
 	// initialize resource names, with random unique suffixes
 	resourceGroupName := fmt.Sprintf("terratest-loadbalancer-rg-%s", random.UniqueId())
-	loadBalancer01Name := fmt.Sprintf("terratest-loadbalancer-lb-%s", random.UniqueId())
-	loadBalancer02Name := fmt.Sprintf("terratest-loadbalancer-lb-%s", random.UniqueId())
+	loadBalancer01Name := fmt.Sprintf("lb-public-%s", random.UniqueId())
+	loadBalancer02Name := fmt.Sprintf("lb-private-%s", random.UniqueId())
 
-	frontendIPConfigForLB01 := fmt.Sprintf("terratest-loadbalancer-cfg-%s", random.UniqueId())
-	publicIPAddressForLB01 := fmt.Sprintf("terratest-loadbalancer-pip-%s", random.UniqueId())
+	frontendIPConfigForLB01 := fmt.Sprintf("cfg-%s", random.UniqueId())
+	publicIPAddressForLB01 := fmt.Sprintf("pip-%s", random.UniqueId())
 
-	vnetForLB02 := fmt.Sprintf("terratest-loadbalancer-vnet-%s", random.UniqueId())
-	frontendSubnetID := fmt.Sprintf("terratest-loadbalancer-snt-%s", random.UniqueId())
+	vnetForLB02 := fmt.Sprintf("vnet-%s", random.UniqueId())
+	frontendSubnetID := fmt.Sprintf("snt-%s", random.UniqueId())
 
 	// loadbalancer::tag::1:: Configure Terraform setting up a path to Terraform code.
 	terraformOptions := &terraform.Options{

--- a/test/azure/terraform_azure_loadbalancer_example_test.go
+++ b/test/azure/terraform_azure_loadbalancer_example_test.go
@@ -82,7 +82,7 @@ func TestTerraformAzureLoadBalancerExample(t *testing.T) {
 		assert.Nil(t, fe01Props.PrivateIPAddress, "LB01 shouldn't have PrivateIPAddress")
 
 		// Ensure PublicIPAddress Resource exists, no need to check PublicIPAddress value
-		publicIPAddressResource, err := azure.GetPublicIPAddressE(resourceGroupName, publicIPAddressForLB01, "")
+		publicIPAddressResource, err := azure.GetPublicIPAddressE(publicIPAddressForLB01, resourceGroupName, "")
 		require.NoError(t, err)
 		assert.NotNil(t, publicIPAddressResource, fmt.Sprintf("Public IP Resource for LB01 Frontend: %s", publicIPAddressForLB01))
 


### PR DESCRIPTION
Adding the following module and releated tests and examples
- loadbalancer.go

NOTES:
- includes external Load Balancer with Public IP, which is its own resource
- includes internal Load Balancer with Private IP, attached to a subnet in a VNET (separate resource) 
- Link to Issue https://github.com/gruntwork-io/terratest/issues/606