### PR TITLE
Add rendomization to resource name generation to fix collision issue …

### DIFF
--- a/test/azure/terraform_azure_example_test.go
+++ b/test/azure/terraform_azure_example_test.go
@@ -6,10 +6,12 @@
 package test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-07-01/compute"
 	"github.com/gruntwork-io/terratest/modules/azure"
+	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/gruntwork-io/terratest/modules/terraform"
 	"github.com/stretchr/testify/assert"
 )
@@ -17,10 +19,15 @@ import (
 func TestTerraformAzureExample(t *testing.T) {
 	t.Parallel()
 
+	prefix := fmt.Sprintf("terratest-%s", random.UniqueId())
+
 	// website::tag::1:: Configure Terraform setting up a path to Terraform code.
 	terraformOptions := &terraform.Options{
 		// The path to where our Terraform code is located
 		TerraformDir: "../../examples/azure/terraform-azure-example",
+		Vars: map[string]interface{}{
+			"prefix": prefix,
+		},
 	}
 
 	// website::tag::4:: At the end of the test, run `terraform destroy` to clean up any resources that were created


### PR DESCRIPTION
Resolve issue #646  with naming collision that was found doing multiple CI runs for Azure.  Passing CI run https://github.com/rguthriemsft/terratest/actions/runs/261222297