### PR TITLE
feat: add dns-helper module

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/jstemmer/go-junit-report v0.9.1
 	github.com/magiconair/properties v1.8.0
 	github.com/mattn/go-zglob v0.0.2-0.20190814121620-e3c945676326 // indirect
+	github.com/miekg/dns v1.1.31
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/oracle/oci-go-sdk v7.1.0+incompatible
 	github.com/pkg/errors v0.9.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -282,6 +282,8 @@ github.com/mattn/go-zglob v0.0.2-0.20190814121620-e3c945676326 h1:ofNAzWCcyTALn2
 github.com/mattn/go-zglob v0.0.2-0.20190814121620-e3c945676326/go.mod h1:9fxibJccNxU2cnpIKLRRFA7zX7qhkJIQWBb449FYHOo=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/maxbrunsfeld/counterfeiter/v6 v6.2.2/go.mod h1:eD9eIE7cdwcMi9rYluz88Jz2VyhSmden33/aXg4oVIY=
+github.com/miekg/dns v1.1.31 h1:sJFOl9BgwbYAWOGEwr61FU28pqsBNdpRBnhGXtO06Oo=
+github.com/miekg/dns v1.1.31/go.mod h1:KNUDUusw/aVsxyTYZM1oqvCicbwhgbNgztCETuNZ7xM=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
@@ -440,6 +442,7 @@ golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20190628185345-da137c7871d7/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190813141303-74dc4d7220e7/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190827160401-ba9fcec4b297/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20190923162816-aa69164e4478/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20191004110552-13f9640d40b9/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20191209160850-c0dbc17a3553 h1:efeOvDhwQ29Dj3SdAV/MJf8oukgn+8D8WgaCaRMchF8=
 golang.org/x/net v0.0.0-20191209160850-c0dbc17a3553/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
@@ -476,6 +479,7 @@ golang.org/x/sys v0.0.0-20190616124812-15dcb6c0061f/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190624142023-c5567b49c5d0/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190626221950-04f50cda93cb/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190826190057-c7b8b68b1456/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190924154521-2837fb4f24fe/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191010194322-b09406accb47/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191022100944-742c48ecaeb7/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -516,6 +520,7 @@ golang.org/x/tools v0.0.0-20190920225731-5eefd052ad72/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20191012152004-8de300cfc20a/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191125144606-a911d9008d1f/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191205215504-7b8c8591a921/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/tools v0.0.0-20191216052735-49a3e744a425/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20191227053925-7b8e75db28f4/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200113040837-eac381796e91 h1:OOkytthzFBKHY5EfEgLUabprb0LtJVkQtNxAQ02+UE4=
 golang.org/x/tools v0.0.0-20200113040837-eac381796e91/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=

--- a/modules/dns-helper/dns_helper.go
+++ b/modules/dns-helper/dns_helper.go
@@ -12,17 +12,14 @@ import (
 	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/testing"
 	"github.com/miekg/dns"
+	"github.com/stretchr/testify/require"
 )
 
 // DNSFindNameservers tries to find the NS record for the given FQDN, iterating down the domain hierarchy
 // until it founds the NS records and returns it. Fails if there's any error or no NS record is found up to the apex domain.
 func DNSFindNameservers(t testing.TestingT, fqdn string, resolvers []string) []string {
 	nameservers, err := DNSFindNameserversE(t, fqdn, resolvers)
-
-	if err != nil {
-		t.Fatal(err)
-	}
-
+	require.NoError(t, err)
 	return nameservers
 }
 
@@ -87,11 +84,7 @@ func DNSFindNameserversE(t testing.TestingT, fqdn string, resolvers []string) ([
 // Fails on any error from DNSLookupAuthoritativeE.
 func DNSLookupAuthoritative(t testing.TestingT, query DNSQuery, resolvers []string) DNSAnswers {
 	res, err := DNSLookupAuthoritativeE(t, query, resolvers)
-
-	if err != nil {
-		t.Fatal(err)
-	}
-
+	require.NoError(t, err)
 	return res
 }
 
@@ -126,11 +119,7 @@ func DNSLookupAuthoritativeE(t testing.TestingT, query DNSQuery, resolvers []str
 // Fails on any error from DNSLookupAuthoritativeWithRetryE.
 func DNSLookupAuthoritativeWithRetry(t testing.TestingT, query DNSQuery, resolvers []string, maxRetries int, sleepBetweenRetries time.Duration) DNSAnswers {
 	res, err := DNSLookupAuthoritativeWithRetryE(t, query, resolvers, maxRetries, sleepBetweenRetries)
-
-	if err != nil {
-		t.Fatal(err)
-	}
-
+	require.NoError(t, err)
 	return res
 }
 
@@ -155,11 +144,7 @@ func DNSLookupAuthoritativeWithRetryE(t testing.TestingT, query DNSQuery, resolv
 // Fails on any error from DNSLookupAuthoritativeAllE.
 func DNSLookupAuthoritativeAll(t testing.TestingT, query DNSQuery, resolvers []string) DNSAnswers {
 	res, err := DNSLookupAuthoritativeAllE(t, query, resolvers)
-
-	if err != nil {
-		t.Fatal(err)
-	}
-
+	require.NoError(t, err)
 	return res
 }
 
@@ -203,10 +188,7 @@ func DNSLookupAuthoritativeAllE(t testing.TestingT, query DNSQuery, resolvers []
 // Fails when max retries has been exceeded.
 func DNSLookupAuthoritativeAllWithRetry(t testing.TestingT, query DNSQuery, resolvers []string, maxRetries int, sleepBetweenRetries time.Duration) {
 	_, err := DNSLookupAuthoritativeAllWithRetryE(t, query, resolvers, maxRetries, sleepBetweenRetries)
-
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 }
 
 // DNSLookupAuthoritativeAllWithRetryE repeatedly sends DNS requests for the specified record and type,
@@ -229,10 +211,7 @@ func DNSLookupAuthoritativeAllWithRetryE(t testing.TestingT, query DNSQuery, res
 // Fails on any underlying error from DNSLookupAuthoritativeAllWithValidationE.
 func DNSLookupAuthoritativeAllWithValidation(t testing.TestingT, query DNSQuery, resolvers []string, expectedAnswers DNSAnswers) {
 	err := DNSLookupAuthoritativeAllWithValidationE(t, query, resolvers, expectedAnswers)
-
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 }
 
 // DNSLookupAuthoritativeAllWithValidationE gets authoritative answers for the specified record and type.
@@ -264,10 +243,7 @@ func DNSLookupAuthoritativeAllWithValidationE(t testing.TestingT, query DNSQuery
 // Fails when max retries has been exceeded.
 func DNSLookupAuthoritativeAllWithValidationRetry(t testing.TestingT, query DNSQuery, resolvers []string, expectedAnswers DNSAnswers, maxRetries int, sleepBetweenRetries time.Duration) {
 	err := DNSLookupAuthoritativeAllWithValidationRetryE(t, query, resolvers, expectedAnswers, maxRetries, sleepBetweenRetries)
-
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 }
 
 // DNSLookupAuthoritativeAllWithValidationRetryE repeatedly gets authoritative answers for the specified record and type
@@ -313,11 +289,7 @@ func DNSDoWithRetryE(t testing.TestingT, actionDescription string, maxRetries in
 // Supported record types: A, AAAA, CNAME, MX, NS, TXT
 func DNSLookup(t testing.TestingT, query DNSQuery, resolvers []string) DNSAnswers {
 	res, err := DNSLookupE(t, query, resolvers)
-
-	if err != nil {
-		t.Fatal(err)
-	}
-
+	require.NoError(t, err)
 	return res
 }
 

--- a/modules/dns-helper/dns_helper.go
+++ b/modules/dns-helper/dns_helper.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/gruntwork-io/terratest/modules/logger"
+	"github.com/gruntwork-io/terratest/modules/retry"
 	"github.com/gruntwork-io/terratest/modules/testing"
 	"github.com/miekg/dns"
 	"github.com/stretchr/testify/require"
@@ -116,14 +117,14 @@ func DNSLookupAuthoritativeWithRetry(t testing.TestingT, query DNSQuery, resolve
 // or until max retries has been exceeded.
 // If resolvers are defined, uses them instead of the default system ones to find the authoritative nameservers.
 func DNSLookupAuthoritativeWithRetryE(t testing.TestingT, query DNSQuery, resolvers []string, maxRetries int, sleepBetweenRetries time.Duration) (DNSAnswers, error) {
-	res, err := DNSDoWithRetryE(
+	res, err := retry.DoWithRetryInterfaceE(
 		t, fmt.Sprintf("DNSLookupAuthoritativeE %s record for %s using authoritative nameservers", query.Type, query.Name),
 		maxRetries, sleepBetweenRetries,
-		func() (DNSAnswers, error) {
+		func() (interface{}, error) {
 			return DNSLookupAuthoritativeE(t, query, resolvers)
 		})
 
-	return res, err
+	return res.(DNSAnswers), err
 }
 
 // DNSLookupAuthoritativeAll gets authoritative answers for the specified record and type.
@@ -183,14 +184,14 @@ func DNSLookupAuthoritativeAllWithRetry(t testing.TestingT, query DNSQuery, reso
 // until ALL authoritative nameservers reply with the exact same non-empty answers or until max retries has been exceeded.
 // If defined, uses the given resolvers instead of the default system ones to find the authoritative nameservers.
 func DNSLookupAuthoritativeAllWithRetryE(t testing.TestingT, query DNSQuery, resolvers []string, maxRetries int, sleepBetweenRetries time.Duration) (DNSAnswers, error) {
-	res, err := DNSDoWithRetryE(
+	res, err := retry.DoWithRetryInterfaceE(
 		t, fmt.Sprintf("DNSLookupAuthoritativeAllE %s record for %s using authoritative nameservers", query.Type, query.Name),
 		maxRetries, sleepBetweenRetries,
-		func() (DNSAnswers, error) {
+		func() (interface{}, error) {
 			return DNSLookupAuthoritativeAllE(t, query, resolvers)
 		})
 
-	return res, err
+	return res.(DNSAnswers), err
 }
 
 // DNSLookupAuthoritativeAllWithValidation gets authoritative answers for the specified record and type.
@@ -239,10 +240,10 @@ func DNSLookupAuthoritativeAllWithValidationRetry(t testing.TestingT, query DNSQ
 // or until max retries has been exceeded.
 // If resolvers are defined, uses them instead of the default system ones to find the authoritative nameservers.
 func DNSLookupAuthoritativeAllWithValidationRetryE(t testing.TestingT, query DNSQuery, resolvers []string, expectedAnswers DNSAnswers, maxRetries int, sleepBetweenRetries time.Duration) error {
-	_, err := DNSDoWithRetryE(
+	_, err := retry.DoWithRetryInterfaceE(
 		t, fmt.Sprintf("DNSLookupAuthoritativeAllWithValidationRetryE %s record for %s using authoritative nameservers", query.Type, query.Name),
 		maxRetries, sleepBetweenRetries,
-		func() (DNSAnswers, error) {
+		func() (interface{}, error) {
 			return nil, DNSLookupAuthoritativeAllWithValidationE(t, query, resolvers, expectedAnswers)
 		})
 

--- a/modules/dns-helper/dns_helper.go
+++ b/modules/dns-helper/dns_helper.go
@@ -26,9 +26,6 @@ func DNSFindNameservers(t testing.TestingT, fqdn string, resolvers []string) []s
 // DNSFindNameserversE tries to find the NS record for the given FQDN, iterating down the domain hierarchy
 // until it founds the NS records and returns it. Returns the last error if the apex domain is reached with no result.
 func DNSFindNameserversE(t testing.TestingT, fqdn string, resolvers []string) ([]string, error) {
-	var res []string
-	var err error
-	var domain string
 	var lookupFunc func(domain string) ([]string, error)
 
 	if resolvers == nil {
@@ -55,9 +52,10 @@ func DNSFindNameserversE(t testing.TestingT, fqdn string, resolvers []string) ([
 
 	parts := strings.Split(fqdn, ".")
 
+	var domain string
 	for i := range parts[:len(parts)-1] {
 		domain = strings.Join(parts[i:], ".")
-		res, err = lookupFunc(domain)
+		res, err := lookupFunc(domain)
 
 		if len(res) > 0 {
 			var nameservers []string
@@ -75,7 +73,7 @@ func DNSFindNameserversE(t testing.TestingT, fqdn string, resolvers []string) ([
 		}
 	}
 
-	err = &NSNotFoundError{fqdn, domain}
+	err := &NSNotFoundError{fqdn, domain}
 	return nil, err
 }
 
@@ -298,14 +296,13 @@ func DNSLookup(t testing.TestingT, query DNSQuery, resolvers []string) DNSAnswer
 // Returns any underlying error.
 // Supported record types: A, AAAA, CNAME, MX, NS, TXT
 func DNSLookupE(t testing.TestingT, query DNSQuery, resolvers []string) (DNSAnswers, error) {
-	var dnsAnswers DNSAnswers
-	var err error
-
 	if len(resolvers) == 0 {
 		err := &NoResolversError{}
 		return nil, err
 	}
 
+	var dnsAnswers DNSAnswers
+	var err error
 	for _, resolver := range resolvers {
 		dnsAnswers, err = dnsLookup(t, query, resolver)
 

--- a/modules/dns-helper/dns_helper.go
+++ b/modules/dns-helper/dns_helper.go
@@ -80,7 +80,7 @@ func DNSFindNameserversE(t testing.TestingT, fqdn string, resolvers []string) ([
 
 // DNSLookupAuthoritative gets authoritative answers for the specified record and type.
 // If resolvers are defined, uses them instead of the default system ones to find the authoritative nameservers.
-// Fails on any error.
+// Fails on any error from DNSLookupAuthoritativeE.
 func DNSLookupAuthoritative(t testing.TestingT, query DNSQuery, resolvers []string) DNSAnswers {
 	res, err := DNSLookupAuthoritativeE(t, query, resolvers)
 
@@ -115,6 +115,21 @@ func DNSLookupAuthoritativeE(t testing.TestingT, query DNSQuery, resolvers []str
 	return res, nil
 }
 
+// DNSLookupAuthoritativeWithRetry repeatedly gets authoritative answers for the specified record and type
+// until ANY of the authoritative nameservers found replies with non-empty answer matching the expectedAnswers,
+// or until max retries has been exceeded.
+// If resolvers are defined, uses them instead of the default system ones to find the authoritative nameservers.
+// Fails on any error from DNSLookupAuthoritativeWithRetryE.
+func DNSLookupAuthoritativeWithRetry(t testing.TestingT, query DNSQuery, resolvers []string, maxRetries int, sleepBetweenRetries time.Duration) DNSAnswers {
+	res, err := DNSLookupAuthoritativeWithRetryE(t, query, resolvers, maxRetries, sleepBetweenRetries)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return res
+}
+
 // DNSLookupAuthoritativeWithRetryE repeatedly gets authoritative answers for the specified record and type
 // until ANY of the authoritative nameservers found replies with non-empty answer matching the expectedAnswers,
 // or until max retries has been exceeded.
@@ -133,7 +148,7 @@ func DNSLookupAuthoritativeWithRetryE(t testing.TestingT, query DNSQuery, resolv
 // DNSLookupAuthoritativeAll gets authoritative answers for the specified record and type.
 // All the authoritative nameservers found must give the same answers.
 // If resolvers are defined, uses them instead of the default system ones to find the authoritative nameservers.
-// Fails on any error.
+// Fails on any error from DNSLookupAuthoritativeAllE.
 func DNSLookupAuthoritativeAll(t testing.TestingT, query DNSQuery, resolvers []string) DNSAnswers {
 	res, err := DNSLookupAuthoritativeAllE(t, query, resolvers)
 

--- a/modules/dns-helper/dns_helper.go
+++ b/modules/dns-helper/dns_helper.go
@@ -1,0 +1,413 @@
+// Package dns_helper contains helpers to interact with the Domain Name System.
+package dns_helper
+
+import (
+	"fmt"
+	"net"
+	"reflect"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/gruntwork-io/terratest/modules/logger"
+	"github.com/gruntwork-io/terratest/modules/testing"
+	"github.com/miekg/dns"
+)
+
+// DNSFindNameservers tries to find the NS record for the given FQDN, iterating down the domain hierarchy
+// until it founds the NS records and returns it. Fails if there's any error or no NS record is found up to the apex domain.
+func DNSFindNameservers(t testing.TestingT, fqdn string, resolvers []string) []string {
+	nameservers, err := DNSFindNameserversE(t, fqdn, resolvers)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return nameservers
+}
+
+// DNSFindNameserversE tries to find the NS record for the given FQDN, iterating down the domain hierarchy
+// until it founds the NS records and returns it. Returns the last error if the apex domain is reached with no result.
+func DNSFindNameserversE(t testing.TestingT, fqdn string, resolvers []string) ([]string, error) {
+	var res []string
+	var err error
+	var domain string
+	var lookupFunc func(domain string) ([]string, error)
+
+	if resolvers == nil {
+		lookupFunc = func(domain string) ([]string, error) {
+			var nameservers []string
+			res, err := net.LookupNS(domain)
+			for _, ns := range res {
+				nameservers = append(nameservers, ns.Host)
+			}
+			return nameservers, err
+		}
+	} else {
+		lookupFunc = func(domain string) ([]string, error) {
+			var nameservers []string
+			res, err := DNSLookupE(t, DNSQuery{"NS", domain}, resolvers)
+			for _, r := range res {
+				if r.Type == "NS" {
+					nameservers = append(nameservers, r.Value)
+				}
+			}
+			return nameservers, err
+		}
+	}
+
+	parts := strings.Split(fqdn, ".")
+
+	for i := range parts[:len(parts)-1] {
+		domain = strings.Join(parts[i:], ".")
+		res, err = lookupFunc(domain)
+
+		if err == nil || len(res) > 0 {
+			var nameservers []string
+
+			for _, ns := range res {
+				nameservers = append(nameservers, strings.TrimSuffix(ns, "."))
+			}
+
+			logger.Logf(t, "FQDN %s belongs to domain %s, found NS record: %s", fqdn, domain, nameservers)
+			return nameservers, nil
+		}
+	}
+
+	err = &NSNotFoundError{fqdn, domain}
+	return nil, err
+}
+
+// DNSLookupAuthoritative gets authoritative answers for the specified record and type.
+// If resolvers are defined, uses them instead of the default system ones to find the authoritative nameservers.
+// Fails on any error.
+func DNSLookupAuthoritative(t testing.TestingT, query DNSQuery, resolvers []string) DNSAnswers {
+	res, err := DNSLookupAuthoritativeE(t, query, resolvers)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return res
+}
+
+// DNSLookupAuthoritativeE gets authoritative answers for the specified record and type.
+// If resolvers are defined, uses them instead of the default system ones to find the authoritative nameservers.
+// Returns NotFoundAuthoritativeError when no answer found in any authoritative nameserver.
+// Returns any underlying error other than NotFoundError from individual lookups.
+func DNSLookupAuthoritativeE(t testing.TestingT, query DNSQuery, resolvers []string) (DNSAnswers, error) {
+	nameservers, err := DNSFindNameserversE(t, query.Name, resolvers)
+
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := DNSLookupE(t, query, nameservers)
+
+	if err != nil {
+		if _, ok := err.(*NotFoundError); !ok {
+			return nil, err
+		}
+		err = &NotFoundAuthoritativeError{query, nameservers}
+		return nil, err
+	}
+
+	return res, nil
+}
+
+// DNSLookupAuthoritativeWithRetryE repeatedly gets authoritative answers for the specified record and type
+// until ANY of the authoritative nameservers found replies with non-empty answer matching the expectedAnswers,
+// or until max retries has been exceeded.
+// If resolvers are defined, uses them instead of the default system ones to find the authoritative nameservers.
+func DNSLookupAuthoritativeWithRetryE(t testing.TestingT, query DNSQuery, resolvers []string, maxRetries int, sleepBetweenRetries time.Duration) (DNSAnswers, error) {
+	res, err := DNSDoWithRetryE(
+		t, fmt.Sprintf("DNSLookupAuthoritativeE %s record for %s using authoritative nameservers", query.Type, query.Name),
+		maxRetries, sleepBetweenRetries,
+		func() (DNSAnswers, error) {
+			return DNSLookupAuthoritativeE(t, query, resolvers)
+		})
+
+	return res, err
+}
+
+// DNSLookupAuthoritativeAll gets authoritative answers for the specified record and type.
+// All the authoritative nameservers found must give the same answers.
+// If resolvers are defined, uses them instead of the default system ones to find the authoritative nameservers.
+// Fails on any error.
+func DNSLookupAuthoritativeAll(t testing.TestingT, query DNSQuery, resolvers []string) DNSAnswers {
+	res, err := DNSLookupAuthoritativeAllE(t, query, resolvers)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return res
+}
+
+// DNSLookupAuthoritativeAllE gets authoritative answers for the specified record and type.
+// All the authoritative nameservers found must give the same answers.
+// If resolvers are defined, uses them instead of the default system ones to find the authoritative nameservers.
+// Returns InconsistentAuthoritativeError when any authoritative nameserver gives a different answer.
+// Returns any underlying error.
+func DNSLookupAuthoritativeAllE(t testing.TestingT, query DNSQuery, resolvers []string) (DNSAnswers, error) {
+	nameservers, err := DNSFindNameserversE(t, query.Name, resolvers)
+
+	if err != nil {
+		return nil, err
+	}
+
+	var answers DNSAnswers
+
+	for _, ns := range nameservers {
+		res, err := DNSLookupE(t, query, []string{ns})
+
+		if err != nil {
+			return nil, err
+		}
+
+		if len(answers) > 0 {
+			if !reflect.DeepEqual(answers, res) {
+				err := &InconsistentAuthoritativeError{Query: query, Answers: res, Nameserver: ns, PreviousAnswers: answers}
+				return nil, err
+			}
+		} else {
+			answers = res
+		}
+	}
+
+	return answers, nil
+}
+
+// DNSLookupAuthoritativeAllWithRetry repeatedly sends DNS requests for the specified record and type,
+// until ALL authoritative nameservers reply with the exact same non-empty answers or until max retries has been exceeded.
+// If defined, uses the given resolvers instead of the default system ones to find the authoritative nameservers.
+// Fails when max retries has been exceeded.
+func DNSLookupAuthoritativeAllWithRetry(t testing.TestingT, query DNSQuery, resolvers []string, maxRetries int, sleepBetweenRetries time.Duration) {
+	_, err := DNSLookupAuthoritativeAllWithRetryE(t, query, resolvers, maxRetries, sleepBetweenRetries)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+// DNSLookupAuthoritativeAllWithRetryE repeatedly sends DNS requests for the specified record and type,
+// until ALL authoritative nameservers reply with the exact same non-empty answers or until max retries has been exceeded.
+// If defined, uses the given resolvers instead of the default system ones to find the authoritative nameservers.
+func DNSLookupAuthoritativeAllWithRetryE(t testing.TestingT, query DNSQuery, resolvers []string, maxRetries int, sleepBetweenRetries time.Duration) (DNSAnswers, error) {
+	res, err := DNSDoWithRetryE(
+		t, fmt.Sprintf("DNSLookupAuthoritativeAllE %s record for %s using authoritative nameservers", query.Type, query.Name),
+		maxRetries, sleepBetweenRetries,
+		func() (DNSAnswers, error) {
+			return DNSLookupAuthoritativeAllE(t, query, resolvers)
+		})
+
+	return res, err
+}
+
+// DNSLookupAuthoritativeAllWithValidation gets authoritative answers for the specified record and type.
+// All the authoritative nameservers found must give the same answers and match the expectedAnswers.
+// If resolvers are defined, uses them instead of the default system ones to find the authoritative nameservers.
+// Fails on any underlying error from DNSLookupAuthoritativeAllWithValidationE.
+func DNSLookupAuthoritativeAllWithValidation(t testing.TestingT, query DNSQuery, resolvers []string, expectedAnswers DNSAnswers) {
+	err := DNSLookupAuthoritativeAllWithValidationE(t, query, resolvers, expectedAnswers)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+// DNSLookupAuthoritativeAllWithValidationE gets authoritative answers for the specified record and type.
+// All the authoritative nameservers found must give the same answers and match the expectedAnswers.
+// If resolvers are defined, uses them instead of the default system ones to find the authoritative nameservers.
+// Returns ValidationError when expectedAnswers differ from the obtained ones.
+// Returns any underlying error from DNSLookupAuthoritativeAllE.
+func DNSLookupAuthoritativeAllWithValidationE(t testing.TestingT, query DNSQuery, resolvers []string, expectedAnswers DNSAnswers) error {
+	expectedAnswers.Sort()
+
+	answers, err := DNSLookupAuthoritativeAllE(t, query, resolvers)
+
+	if err != nil {
+		return err
+	}
+
+	if !reflect.DeepEqual(answers, expectedAnswers) {
+		err := &ValidationError{Query: query, Answers: answers, ExpectedAnswers: expectedAnswers}
+		return err
+	}
+
+	return nil
+}
+
+// DNSLookupAuthoritativeAllWithValidationRetry repeatedly gets authoritative answers for the specified record and type
+// until ALL the authoritative nameservers found give the same answers and match the expectedAnswers,
+// or until max retries has been exceeded.
+// If resolvers are defined, uses them instead of the default system ones to find the authoritative nameservers.
+// Fails when max retries has been exceeded.
+func DNSLookupAuthoritativeAllWithValidationRetry(t testing.TestingT, query DNSQuery, resolvers []string, expectedAnswers DNSAnswers, maxRetries int, sleepBetweenRetries time.Duration) {
+	err := DNSLookupAuthoritativeAllWithValidationRetryE(t, query, resolvers, expectedAnswers, maxRetries, sleepBetweenRetries)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+// DNSLookupAuthoritativeAllWithValidationRetryE repeatedly gets authoritative answers for the specified record and type
+// until ALL the authoritative nameservers found give the same answers and match the expectedAnswers,
+// or until max retries has been exceeded.
+// If resolvers are defined, uses them instead of the default system ones to find the authoritative nameservers.
+func DNSLookupAuthoritativeAllWithValidationRetryE(t testing.TestingT, query DNSQuery, resolvers []string, expectedAnswers DNSAnswers, maxRetries int, sleepBetweenRetries time.Duration) error {
+	_, err := DNSDoWithRetryE(
+		t, fmt.Sprintf("DNSLookupAuthoritativeAllWithValidationRetryE %s record for %s using authoritative nameservers", query.Type, query.Name),
+		maxRetries, sleepBetweenRetries,
+		func() (DNSAnswers, error) {
+			return nil, DNSLookupAuthoritativeAllWithValidationE(t, query, resolvers, expectedAnswers)
+		})
+
+	return err
+}
+
+// DNSDoWithRetryE sends a DNS query for the specified record and type to the given nameserver.
+// If it returns a response with records, return their values.
+// If it returns an error, sleep for sleepBetweenRetries and try again, up to a maximum of
+// maxRetries retries. If maxRetries is exceeded, return a MaxRetriesExceeded error.
+func DNSDoWithRetryE(t testing.TestingT, actionDescription string, maxRetries int, sleepBetweenRetries time.Duration, action func() (DNSAnswers, error)) (DNSAnswers, error) {
+	var res DNSAnswers
+	var err error
+
+	for i := 0; i <= maxRetries; i++ {
+		res, err = action()
+		if err == nil {
+			return res, nil
+		}
+
+		if i < maxRetries {
+			logger.Logf(t, "%s returned an error: %s. Sleeping for %s and will try again.", actionDescription, err.Error(), sleepBetweenRetries)
+			time.Sleep(sleepBetweenRetries)
+		}
+	}
+
+	return res, &MaxRetriesExceeded{Description: actionDescription, MaxRetries: maxRetries}
+}
+
+// DNSLookup sends a DNS query for the specified record and type using the given resolvers.
+// Fails on any error.
+// Supported record types: A, AAAA, CNAME, MX, NS, TXT
+func DNSLookup(t testing.TestingT, query DNSQuery, resolvers []string) DNSAnswers {
+	res, err := DNSLookupE(t, query, resolvers)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return res
+}
+
+// DNSLookupE sends a DNS query for the specified record and type using the given resolvers.
+// Returns QueryTypeError when record type is not supported.
+// Returns any underlying error.
+// Supported record types: A, AAAA, CNAME, MX, NS, TXT
+func DNSLookupE(t testing.TestingT, query DNSQuery, resolvers []string) (DNSAnswers, error) {
+	var dnsAnswers DNSAnswers
+	var err error
+
+	if len(resolvers) == 0 {
+		err := &NoResolversError{}
+		return nil, err
+	}
+
+	for _, resolver := range resolvers {
+		dnsAnswers, err = dnsLookup(t, query, resolver)
+
+		if err == nil {
+			return dnsAnswers, nil
+		}
+	}
+
+	return nil, err
+}
+
+// dnsLookup sends a DNS query for the specified record and type using the given resolver.
+// Returns DNSAnswers to the DNSQuery.
+// If no records found, returns NotFoundError.
+func dnsLookup(t testing.TestingT, query DNSQuery, resolver string) (DNSAnswers, error) {
+	switch query.Type {
+	case "A", "AAAA", "CNAME", "MX", "NS", "TXT":
+	default:
+		err := &QueryTypeError{query.Type}
+		return nil, err
+	}
+
+	qType, ok := dns.StringToType[strings.ToUpper(query.Type)]
+	if !ok {
+		err := &QueryTypeError{query.Type}
+		return nil, err
+	}
+
+	if strings.LastIndex(resolver, ":") <= strings.LastIndex(resolver, "]") {
+		resolver += ":53"
+	}
+
+	c := new(dns.Client)
+	m := new(dns.Msg)
+	m.SetQuestion(dns.Fqdn(query.Name), qType)
+
+	in, _, err := c.Exchange(m, resolver)
+	if err != nil {
+		logger.Logf(t, "Error sending DNS query %s: %s", query, err)
+		return nil, err
+	}
+
+	if len(in.Answer) == 0 {
+		err := &NotFoundError{query, resolver}
+		return nil, err
+	}
+
+	var dnsAnswers DNSAnswers
+
+	for _, a := range in.Answer {
+		switch at := a.(type) {
+		case *dns.A:
+			dnsAnswers = append(dnsAnswers, DNSAnswer{"A", at.A.String()})
+		case *dns.AAAA:
+			dnsAnswers = append(dnsAnswers, DNSAnswer{"AAAA", at.AAAA.String()})
+		case *dns.CNAME:
+			dnsAnswers = append(dnsAnswers, DNSAnswer{"CNAME", at.Target})
+		case *dns.NS:
+			dnsAnswers = append(dnsAnswers, DNSAnswer{"NS", at.Ns})
+		case *dns.MX:
+			dnsAnswers = append(dnsAnswers, DNSAnswer{"MX", fmt.Sprintf("%d %s", at.Preference, at.Mx)})
+		case *dns.TXT:
+			for _, txt := range at.Txt {
+				dnsAnswers = append(dnsAnswers, DNSAnswer{"TXT", fmt.Sprintf(`"%s"`, txt)})
+			}
+		}
+	}
+
+	dnsAnswers.Sort()
+
+	return dnsAnswers, nil
+}
+
+// DNSQuery type
+type DNSQuery struct {
+	Type, Name string
+}
+
+// DNSAnswer type
+type DNSAnswer struct {
+	Type, Value string
+}
+
+func (a DNSAnswer) String() string {
+	return fmt.Sprintf("%s %s", a.Type, a.Value)
+}
+
+// DNSAnswers type
+type DNSAnswers []DNSAnswer
+
+// Sort sorts the answers by type and value
+func (a DNSAnswers) Sort() {
+	sort.Slice(a, func(i, j int) bool {
+		return a[i].Type < a[j].Type || a[i].Value < a[j].Value
+	})
+}

--- a/modules/dns-helper/dns_helper.go
+++ b/modules/dns-helper/dns_helper.go
@@ -88,8 +88,8 @@ func DNSLookupAuthoritative(t testing.TestingT, query DNSQuery, resolvers []stri
 
 // DNSLookupAuthoritativeE gets authoritative answers for the specified record and type.
 // If resolvers are defined, uses them instead of the default system ones to find the authoritative nameservers.
-// Returns NotFoundAuthoritativeError when no answer found in any authoritative nameserver.
-// Returns any underlying error other than NotFoundError from individual lookups.
+// Returns NotFoundError when no answer found in any authoritative nameserver.
+// Returns any underlying error from individual lookups.
 func DNSLookupAuthoritativeE(t testing.TestingT, query DNSQuery, resolvers []string) (DNSAnswers, error) {
 	nameservers, err := DNSFindNameserversE(t, query.Name, resolvers)
 
@@ -97,17 +97,7 @@ func DNSLookupAuthoritativeE(t testing.TestingT, query DNSQuery, resolvers []str
 		return nil, err
 	}
 
-	res, err := DNSLookupE(t, query, nameservers)
-
-	if err != nil {
-		if _, ok := err.(*NotFoundError); !ok {
-			return nil, err
-		}
-		err = &NotFoundAuthoritativeError{query, nameservers}
-		return nil, err
-	}
-
-	return res, nil
+	return DNSLookupE(t, query, nameservers)
 }
 
 // DNSLookupAuthoritativeWithRetry repeatedly gets authoritative answers for the specified record and type

--- a/modules/dns-helper/dns_helper.go
+++ b/modules/dns-helper/dns_helper.go
@@ -250,29 +250,6 @@ func DNSLookupAuthoritativeAllWithValidationRetryE(t testing.TestingT, query DNS
 	return err
 }
 
-// DNSDoWithRetryE sends a DNS query for the specified record and type to the given nameserver.
-// If it returns a response with records, return their values.
-// If it returns an error, sleep for sleepBetweenRetries and try again, up to a maximum of
-// maxRetries retries. If maxRetries is exceeded, return a MaxRetriesExceeded error.
-func DNSDoWithRetryE(t testing.TestingT, actionDescription string, maxRetries int, sleepBetweenRetries time.Duration, action func() (DNSAnswers, error)) (DNSAnswers, error) {
-	var res DNSAnswers
-	var err error
-
-	for i := 0; i <= maxRetries; i++ {
-		res, err = action()
-		if err == nil {
-			return res, nil
-		}
-
-		if i < maxRetries {
-			logger.Logf(t, "%s returned an error: %s. Sleeping for %s and will try again.", actionDescription, err.Error(), sleepBetweenRetries)
-			time.Sleep(sleepBetweenRetries)
-		}
-	}
-
-	return res, &MaxRetriesExceeded{Description: actionDescription, MaxRetries: maxRetries}
-}
-
 // DNSLookup sends a DNS query for the specified record and type using the given resolvers.
 // Fails on any error.
 // Supported record types: A, AAAA, CNAME, MX, NS, TXT

--- a/modules/dns-helper/dns_helper.go
+++ b/modules/dns-helper/dns_helper.go
@@ -62,7 +62,7 @@ func DNSFindNameserversE(t testing.TestingT, fqdn string, resolvers []string) ([
 		domain = strings.Join(parts[i:], ".")
 		res, err = lookupFunc(domain)
 
-		if err == nil && len(res) > 0 {
+		if len(res) > 0 {
 			var nameservers []string
 
 			for _, ns := range res {
@@ -71,6 +71,10 @@ func DNSFindNameserversE(t testing.TestingT, fqdn string, resolvers []string) ([
 
 			logger.Logf(t, "FQDN %s belongs to domain %s, found NS record: %s", fqdn, domain, nameservers)
 			return nameservers, nil
+		}
+
+		if err != nil {
+			logger.Logf(t, err.Error())
 		}
 	}
 

--- a/modules/dns-helper/dns_helper.go
+++ b/modules/dns-helper/dns_helper.go
@@ -62,7 +62,7 @@ func DNSFindNameserversE(t testing.TestingT, fqdn string, resolvers []string) ([
 		domain = strings.Join(parts[i:], ".")
 		res, err = lookupFunc(domain)
 
-		if err == nil || len(res) > 0 {
+		if err == nil && len(res) > 0 {
 			var nameservers []string
 
 			for _, ns := range res {

--- a/modules/dns-helper/dns_helper_test.go
+++ b/modules/dns-helper/dns_helper_test.go
@@ -95,7 +95,7 @@ func TestErrorLocalDNSLookupAuthoritative(t *testing.T) {
 	defer shutDownServers(t, s1, s2)
 	dnsQuery := DNSQuery{"A", "txt." + testDomain}
 	_, err := DNSLookupAuthoritativeE(t, dnsQuery, []string{s1.Address(), s2.Address()})
-	if _, ok := err.(*NotFoundAuthoritativeError); !ok {
+	if _, ok := err.(*NotFoundError); !ok {
 		t.Errorf("unexpected error, got %q", err)
 	}
 }

--- a/modules/dns-helper/dns_helper_test.go
+++ b/modules/dns-helper/dns_helper_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gruntwork-io/terratest/modules/retry"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -198,7 +199,7 @@ func TestErrorDNSLookupAuthoritativeWithRetry(t *testing.T) {
 	dnsQuery := DNSQuery{"A", "txt." + testDomain}
 	_, err := DNSLookupAuthoritativeWithRetryE(t, dnsQuery, []string{s1.Address(), s2.Address()}, 5, time.Second)
 	require.Error(t, err)
-	if _, ok := err.(*MaxRetriesExceeded); !ok {
+	if _, ok := err.(retry.MaxRetriesExceeded); !ok {
 		t.Errorf("unexpected error, got %q", err)
 	}
 }
@@ -248,7 +249,7 @@ func TestErrorDNSLookupAuthoritativeAllWithRetry(t *testing.T) {
 	s2.AddEntryToDNSDatabaseRetry(dnsQuery, DNSAnswers{{"A", "1.1.1.1"}})
 	_, err := DNSLookupAuthoritativeAllWithRetryE(t, dnsQuery, []string{s1.Address(), s2.Address()}, 5, time.Second)
 	require.Error(t, err)
-	if _, ok := err.(*MaxRetriesExceeded); !ok {
+	if _, ok := err.(retry.MaxRetriesExceeded); !ok {
 		t.Errorf("unexpected error, got %q", err)
 	}
 }
@@ -369,7 +370,7 @@ func TestErrorDNSLookupAuthoritativeAllWithValidationRetry(t *testing.T) {
 	s1.AddEntryToDNSDatabaseRetry(dnsQuery, expectedRes)
 	s2.AddEntryToDNSDatabaseRetry(dnsQuery, DNSAnswers{{"A", "2.2.2.2"}})
 	err := DNSLookupAuthoritativeAllWithValidationRetryE(t, dnsQuery, []string{s1.Address(), s2.Address()}, expectedRes, 5, time.Second)
-	if _, ok := err.(*MaxRetriesExceeded); !ok {
+	if _, ok := err.(retry.MaxRetriesExceeded); !ok {
 		t.Errorf("unexpected error, got %q", err)
 	}
 }

--- a/modules/dns-helper/dns_helper_test.go
+++ b/modules/dns-helper/dns_helper_test.go
@@ -92,7 +92,7 @@ func TestOkTerratestDNSLookupAuthoritative(t *testing.T) {
 // Lookup should succeed with answers from just one authoritative nameserver
 func TestOkLocalDNSLookupAuthoritative(t *testing.T) {
 	t.Parallel()
-	s1, s2 := setupTestDNSServers()
+	s1, s2 := setupTestDNSServers(t)
 	defer shutDownServers(t, s1, s2)
 	for dnsQuery, expected := range testDNSDatabase {
 		s1.AddEntryToDNSDatabase(dnsQuery, expected)
@@ -105,7 +105,7 @@ func TestOkLocalDNSLookupAuthoritative(t *testing.T) {
 // Lookup should fail because of missing answers from all authoritative nameservers
 func TestErrorLocalDNSLookupAuthoritative(t *testing.T) {
 	t.Parallel()
-	s1, s2 := setupTestDNSServers()
+	s1, s2 := setupTestDNSServers(t)
 	defer shutDownServers(t, s1, s2)
 	dnsQuery := DNSQuery{"A", "txt." + testDomain}
 	_, err := DNSLookupAuthoritativeE(t, dnsQuery, []string{s1.Address(), s2.Address()})
@@ -117,7 +117,7 @@ func TestErrorLocalDNSLookupAuthoritative(t *testing.T) {
 // Lookup should succeed with consistent answers from all authoritative nameservers
 func TestOkLocalDNSLookupAuthoritativeAll(t *testing.T) {
 	t.Parallel()
-	s1, s2 := setupTestDNSServers()
+	s1, s2 := setupTestDNSServers(t)
 	defer shutDownServers(t, s1, s2)
 	for dnsQuery, expected := range testDNSDatabase {
 		s1.AddEntryToDNSDatabase(dnsQuery, expected)
@@ -131,7 +131,7 @@ func TestOkLocalDNSLookupAuthoritativeAll(t *testing.T) {
 // Lookup should fail because of missing answers from all authoritative nameservers
 func TestError1DNSLookupAuthoritativeAll(t *testing.T) {
 	t.Parallel()
-	s1, s2 := setupTestDNSServers()
+	s1, s2 := setupTestDNSServers(t)
 	defer shutDownServers(t, s1, s2)
 	dnsQuery := DNSQuery{"A", "txt." + testDomain}
 	_, err := DNSLookupAuthoritativeAllE(t, dnsQuery, []string{s1.Address(), s2.Address()})
@@ -143,7 +143,7 @@ func TestError1DNSLookupAuthoritativeAll(t *testing.T) {
 // Lookup should fail because of missing answers from one authoritative nameserver
 func TestError2DNSLookupAuthoritativeAll(t *testing.T) {
 	t.Parallel()
-	s1, s2 := setupTestDNSServers()
+	s1, s2 := setupTestDNSServers(t)
 	defer shutDownServers(t, s1, s2)
 	dnsQuery := DNSQuery{"A", "a." + testDomain}
 	s1.AddEntryToDNSDatabase(dnsQuery, DNSAnswers{{"A", "1.1.1.1"}})
@@ -156,7 +156,7 @@ func TestError2DNSLookupAuthoritativeAll(t *testing.T) {
 // Lookup should fail because of inconsistent answers from authoritative nameservers
 func TestError3DNSLookupAuthoritativeAll(t *testing.T) {
 	t.Parallel()
-	s1, s2 := setupTestDNSServers()
+	s1, s2 := setupTestDNSServers(t)
 	defer shutDownServers(t, s1, s2)
 	dnsQuery := DNSQuery{"A", "a." + testDomain}
 	s1.AddEntryToDNSDatabase(dnsQuery, DNSAnswers{{"A", "1.1.1.1"}})
@@ -170,7 +170,7 @@ func TestError3DNSLookupAuthoritativeAll(t *testing.T) {
 // Lookup should fail because of inexistent domain
 func TestError4DNSLookupAuthoritativeAll(t *testing.T) {
 	t.Parallel()
-	s1, s2 := setupTestDNSServers()
+	s1, s2 := setupTestDNSServers(t)
 	defer shutDownServers(t, s1, s2)
 	dnsQuery := DNSQuery{"A", "this.domain.doesnt.exist"}
 	_, err := DNSLookupAuthoritativeAllE(t, dnsQuery, []string{s1.Address(), s2.Address()})
@@ -183,7 +183,7 @@ func TestError4DNSLookupAuthoritativeAll(t *testing.T) {
 // Retry lookups should succeed with answers from just one authoritative nameserver
 func TestOkDNSLookupAuthoritativeWithRetry(t *testing.T) {
 	t.Parallel()
-	s1, s2 := setupTestDNSServersRetry()
+	s1, s2 := setupTestDNSServersRetry(t)
 	defer shutDownServers(t, s1, s2)
 	dnsQuery := DNSQuery{"A", "a." + testDomain}
 	expectedRes := DNSAnswers{{"A", "1.1.1.1"}, {"A", "2.2.2.2"}}
@@ -197,7 +197,7 @@ func TestOkDNSLookupAuthoritativeWithRetry(t *testing.T) {
 // Retry lookups should fail because of missing answers from all authoritative nameservers
 func TestErrorDNSLookupAuthoritativeWithRetry(t *testing.T) {
 	t.Parallel()
-	s1, s2 := setupTestDNSServersRetry()
+	s1, s2 := setupTestDNSServersRetry(t)
 	defer shutDownServers(t, s1, s2)
 	dnsQuery := DNSQuery{"A", "txt." + testDomain}
 	_, err := DNSLookupAuthoritativeWithRetryE(t, dnsQuery, []string{s1.Address(), s2.Address()}, 5, time.Second)
@@ -211,7 +211,7 @@ func TestErrorDNSLookupAuthoritativeWithRetry(t *testing.T) {
 // Retry lookups should succeed with consistent answers
 func TestOkDNSLookupAuthoritativeAllWithRetryNotfound(t *testing.T) {
 	t.Parallel()
-	s1, s2 := setupTestDNSServersRetry()
+	s1, s2 := setupTestDNSServersRetry(t)
 	defer shutDownServers(t, s1, s2)
 	dnsQuery := DNSQuery{"A", "a." + testDomain}
 	expectedRes := DNSAnswers{{"A", "1.1.1.1"}, {"A", "2.2.2.2"}}
@@ -227,7 +227,7 @@ func TestOkDNSLookupAuthoritativeAllWithRetryNotfound(t *testing.T) {
 // Retry lookups should succeed with consistent answers
 func TestOkDNSLookupAuthoritativeAllWithRetryInconsistent(t *testing.T) {
 	t.Parallel()
-	s1, s2 := setupTestDNSServersRetry()
+	s1, s2 := setupTestDNSServersRetry(t)
 	defer shutDownServers(t, s1, s2)
 	dnsQuery := DNSQuery{"A", "a." + testDomain}
 	expectedRes := DNSAnswers{{"A", "1.1.1.1"}, {"A", "2.2.2.2"}}
@@ -244,7 +244,7 @@ func TestOkDNSLookupAuthoritativeAllWithRetryInconsistent(t *testing.T) {
 // Retry lookups should fail because of inconsistent answers from authoritative nameservers
 func TestErrorDNSLookupAuthoritativeAllWithRetry(t *testing.T) {
 	t.Parallel()
-	s1, s2 := setupTestDNSServersRetry()
+	s1, s2 := setupTestDNSServersRetry(t)
 	defer shutDownServers(t, s1, s2)
 	dnsQuery := DNSQuery{"A", "a." + testDomain}
 	s1.AddEntryToDNSDatabase(dnsQuery, DNSAnswers{{"A", "2.2.2.2"}})
@@ -260,7 +260,7 @@ func TestErrorDNSLookupAuthoritativeAllWithRetry(t *testing.T) {
 // Lookup should succeed with consistent and validated replies
 func TestOkDNSLookupAuthoritativeAllWithValidation(t *testing.T) {
 	t.Parallel()
-	s1, s2 := setupTestDNSServers()
+	s1, s2 := setupTestDNSServers(t)
 	defer shutDownServers(t, s1, s2)
 	dnsQuery := DNSQuery{"A", "a." + testDomain}
 	expectedRes := DNSAnswers{{"A", "1.1.1.1"}, {"A", "2.2.2.2"}}
@@ -273,7 +273,7 @@ func TestOkDNSLookupAuthoritativeAllWithValidation(t *testing.T) {
 // Lookup should fail because of missing answers from all authoritative nameservers
 func TestErrorDNSLookupAuthoritativeAllWithValidation(t *testing.T) {
 	t.Parallel()
-	s1, s2 := setupTestDNSServers()
+	s1, s2 := setupTestDNSServers(t)
 	defer shutDownServers(t, s1, s2)
 	dnsQuery := DNSQuery{"A", "a." + testDomain}
 	expectedRes := DNSAnswers{{"A", "1.1.1.1"}, {"A", "2.2.2.2"}}
@@ -287,7 +287,7 @@ func TestErrorDNSLookupAuthoritativeAllWithValidation(t *testing.T) {
 // Lookup should fail because of missing answers from one authoritative nameservers
 func TestError2DNSLookupAuthoritativeAllWithValidation(t *testing.T) {
 	t.Parallel()
-	s1, s2 := setupTestDNSServers()
+	s1, s2 := setupTestDNSServers(t)
 	defer shutDownServers(t, s1, s2)
 	dnsQuery := DNSQuery{"A", "a." + testDomain}
 	expectedRes := DNSAnswers{{"A", "1.1.1.1"}, {"A", "2.2.2.2"}}
@@ -302,7 +302,7 @@ func TestError2DNSLookupAuthoritativeAllWithValidation(t *testing.T) {
 // Lookup should fail because of inconsistent authoritative replies
 func TestError3DNSLookupAuthoritativeAllWithValidation(t *testing.T) {
 	t.Parallel()
-	s1, s2 := setupTestDNSServers()
+	s1, s2 := setupTestDNSServers(t)
 	defer shutDownServers(t, s1, s2)
 	dnsQuery := DNSQuery{"A", "a." + testDomain}
 	expectedRes := DNSAnswers{{"A", "1.1.1.1"}, {"A", "2.2.2.2"}}
@@ -319,7 +319,7 @@ func TestError3DNSLookupAuthoritativeAllWithValidation(t *testing.T) {
 // Retry lookups should succeed with consistent and validated replies
 func TestOkDNSLookupAuthoritativeAllWithValidationRetry(t *testing.T) {
 	t.Parallel()
-	s1, s2 := setupTestDNSServersRetry()
+	s1, s2 := setupTestDNSServersRetry(t)
 	defer shutDownServers(t, s1, s2)
 	dnsQuery := DNSQuery{"A", "a." + testDomain}
 	expectedRes := DNSAnswers{{"A", "1.1.1.1"}, {"A", "2.2.2.2"}}
@@ -333,7 +333,7 @@ func TestOkDNSLookupAuthoritativeAllWithValidationRetry(t *testing.T) {
 // Retry lookups should succeed with consistent and validated replies
 func TestOk2DNSLookupAuthoritativeAllWithValidationRetry(t *testing.T) {
 	t.Parallel()
-	s1, s2 := setupTestDNSServersRetry()
+	s1, s2 := setupTestDNSServersRetry(t)
 	defer shutDownServers(t, s1, s2)
 	dnsQuery := DNSQuery{"A", "a." + testDomain}
 	expectedRes := DNSAnswers{{"A", "1.1.1.1"}, {"A", "2.2.2.2"}}
@@ -348,7 +348,7 @@ func TestOk2DNSLookupAuthoritativeAllWithValidationRetry(t *testing.T) {
 // Retry lookups should succeed with consistent and validated replies
 func TestOk3DNSLookupAuthoritativeAllWithValidationRetry(t *testing.T) {
 	t.Parallel()
-	s1, s2 := setupTestDNSServersRetry()
+	s1, s2 := setupTestDNSServersRetry(t)
 	defer shutDownServers(t, s1, s2)
 	dnsQuery := DNSQuery{"A", "a." + testDomain}
 	expectedRes := DNSAnswers{{"A", "1.1.1.1"}, {"A", "2.2.2.2"}}
@@ -364,7 +364,7 @@ func TestOk3DNSLookupAuthoritativeAllWithValidationRetry(t *testing.T) {
 // Retry lookups should fail also because of inconsistent authoritative replies
 func TestErrorDNSLookupAuthoritativeAllWithValidationRetry(t *testing.T) {
 	t.Parallel()
-	s1, s2 := setupTestDNSServersRetry()
+	s1, s2 := setupTestDNSServersRetry(t)
 	defer shutDownServers(t, s1, s2)
 	dnsQuery := DNSQuery{"A", "a." + testDomain}
 	expectedRes := DNSAnswers{{"A", "1.1.1.1"}, {"A", "2.2.2.2"}}

--- a/modules/dns-helper/dns_helper_test.go
+++ b/modules/dns-helper/dns_helper_test.go
@@ -9,6 +9,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// These are the current public nameservers for gruntwork.io domain
+// They should be updated whenever they change to pass the tests
+// relying on the public DNS infrastructure
 var publicDomainNameservers = []string{
 	"ns-1499.awsdns-59.org",
 	"ns-190.awsdns-23.com",

--- a/modules/dns-helper/dns_helper_test.go
+++ b/modules/dns-helper/dns_helper_test.go
@@ -1,0 +1,289 @@
+package dns_helper
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+var publicDomainNameservers = []string{
+	"ns-1499.awsdns-59.org",
+	"ns-190.awsdns-23.com",
+	"ns-1989.awsdns-56.co.uk",
+	"ns-853.awsdns-42.net",
+}
+
+var testDNSData = DNSData{
+	DNSQuery{"A", "a." + testDomain}: DNSAnswers{
+		{"A", "2.2.2.2"},
+		{"A", "1.1.1.1"},
+	},
+
+	DNSQuery{"AAAA", "aaaa." + testDomain}: DNSAnswers{
+		{"AAAA", "2001:db8::aaaa"},
+	},
+
+	DNSQuery{"CNAME", "terratest." + testDomain}: DNSAnswers{
+		{"CNAME", "gruntwork-io.github.io."},
+	},
+
+	DNSQuery{"CNAME", "cname1." + testDomain}: DNSAnswers{
+		{"CNAME", "cname2." + testDomain + "."},
+	},
+
+	DNSQuery{"A", "cname1." + testDomain}: DNSAnswers{
+		{"CNAME", "cname2." + testDomain + "."},
+		{"CNAME", "cname3." + testDomain + "."},
+		{"CNAME", "cname4." + testDomain + "."},
+		{"CNAME", "cnamefinal." + testDomain + "."},
+		{"A", "1.1.1.1"},
+	},
+
+	DNSQuery{"TXT", "txt." + testDomain}: DNSAnswers{
+		{"TXT", `"This is a text."`},
+	},
+
+	DNSQuery{"MX", testDomain}: DNSAnswers{
+		{"MX", "10 mail." + testDomain + "."},
+	},
+}
+
+func TestOkDNSFindNameservers(t *testing.T) {
+	t.Parallel()
+	fqdn := "terratest.gruntwork.io"
+	expectedNameservers := publicDomainNameservers
+	nameservers, err := DNSFindNameserversE(t, fqdn, nil)
+	require.NoError(t, err)
+	require.ElementsMatch(t, nameservers, expectedNameservers)
+}
+
+func TestErrorDNSFindNameservers(t *testing.T) {
+	t.Parallel()
+	fqdn := "this.domain.doesnt.exist"
+	nameservers, err := DNSFindNameserversE(t, fqdn, nil)
+	require.Error(t, err)
+	require.Nil(t, nameservers)
+}
+
+func TestOkTerratestDNSLookupAuthoritative(t *testing.T) {
+	t.Parallel()
+	dnsQuery := DNSQuery{"CNAME", "terratest." + testDomain}
+	expected := DNSAnswers{{"CNAME", "gruntwork-io.github.io."}}
+	res, err := DNSLookupAuthoritativeE(t, dnsQuery, nil)
+	require.NoError(t, err)
+	require.ElementsMatch(t, res, expected)
+}
+
+func TestOkLocalDNSLookupAuthoritative(t *testing.T) {
+	t.Parallel()
+	ns1, ns2, dnsData1, dnsData2 := setupTestDNSServers()
+	dnsData1 = dnsData2
+	for dnsQuery, expected := range testDNSData {
+		(*dnsData1)[dnsQuery] = expected
+		res, err := DNSLookupAuthoritativeE(t, dnsQuery, []string{ns1, ns2})
+		require.NoError(t, err)
+		require.ElementsMatch(t, res, expected)
+	}
+}
+
+func TestErrorLocalDNSLookupAuthoritative(t *testing.T) {
+	t.Parallel()
+	ns1, ns2, _, _ := setupTestDNSServers()
+	dnsQuery := DNSQuery{"A", "txt." + testDomain}
+	_, err := DNSLookupAuthoritativeE(t, dnsQuery, []string{ns1, ns2})
+	if _, ok := err.(*NotFoundAuthoritativeError); !ok {
+		t.Errorf("unexpected error, got %q", err)
+	}
+}
+
+func TestOkLocalDNSLookupAuthoritativeAll(t *testing.T) {
+	t.Parallel()
+	ns1, ns2, dnsData1, dnsData2 := setupTestDNSServers()
+	(*dnsData1) = (*dnsData2)
+	for dnsQuery, expected := range testDNSData {
+		(*dnsData1)[dnsQuery] = expected
+		res, err := DNSLookupAuthoritativeAllE(t, dnsQuery, []string{ns1, ns2})
+		require.NoError(t, err)
+		require.ElementsMatch(t, res, expected)
+	}
+}
+
+func TestError1DNSLookupAuthoritativeAll(t *testing.T) {
+	t.Parallel()
+	ns1, ns2, _, _ := setupTestDNSServers()
+	dnsQuery := DNSQuery{"A", "txt." + testDomain}
+	_, err := DNSLookupAuthoritativeAllE(t, dnsQuery, []string{ns1, ns2})
+	if _, ok := err.(*NotFoundError); !ok {
+		t.Errorf("unexpected error, got %q", err)
+	}
+}
+
+func TestError2DNSLookupAuthoritativeAll(t *testing.T) {
+	t.Parallel()
+	ns1, ns2, dnsData1, _ := setupTestDNSServers()
+	dnsQuery := DNSQuery{"A", "a." + testDomain}
+	(*dnsData1)[dnsQuery] = DNSAnswers{{"A", "1.1.1.1"}}
+	_, err := DNSLookupAuthoritativeAllE(t, dnsQuery, []string{ns1, ns2})
+	if _, ok := err.(*NotFoundError); !ok {
+		t.Errorf("unexpected error, got %q", err)
+	}
+}
+
+func TestError3DNSLookupAuthoritativeAll(t *testing.T) {
+	t.Parallel()
+	ns1, ns2, dnsData1, dnsData2 := setupTestDNSServers()
+	dnsQuery := DNSQuery{"A", "a." + testDomain}
+	(*dnsData1)[dnsQuery] = DNSAnswers{{"A", "1.1.1.1"}}
+	(*dnsData2)[dnsQuery] = DNSAnswers{{"A", "2.2.2.2"}}
+	_, err := DNSLookupAuthoritativeAllE(t, dnsQuery, []string{ns1, ns2})
+	if _, ok := err.(*InconsistentAuthoritativeError); !ok {
+		t.Errorf("unexpected error, got %q", err)
+	}
+}
+
+func TestError4DNSLookupAuthoritativeAll(t *testing.T) {
+	t.Parallel()
+	ns1, ns2, _, _ := setupTestDNSServers()
+	dnsQuery := DNSQuery{"A", "this.domain.doesnt.exist"}
+	_, err := DNSLookupAuthoritativeAllE(t, dnsQuery, []string{ns1, ns2})
+	if _, ok := err.(*NSNotFoundError); !ok {
+		t.Errorf("unexpected error, got %q", err)
+	}
+}
+
+// Retry until any authoritative nameserver gives an answer
+func TestOkDNSLookupAuthoritativeWithRetry(t *testing.T) {
+	t.Parallel()
+	ns1, ns2, _, _, dnsDataRetry1, _ := setupTestDNSServersRetry()
+	dnsQuery := DNSQuery{"A", "a." + testDomain}
+	expectedRes := DNSAnswers{{"A", "1.1.1.1"}, {"A", "2.2.2.2"}}
+	(*dnsDataRetry1)[dnsQuery] = expectedRes
+	res, err := DNSLookupAuthoritativeWithRetryE(t, dnsQuery, []string{ns1, ns2}, 5, time.Second)
+	require.NoError(t, err)
+	require.ElementsMatch(t, res, expectedRes)
+}
+
+// Retry will fail as the record will never exist
+func TestErrorDNSLookupAuthoritativeWithRetry(t *testing.T) {
+	t.Parallel()
+	ns1, ns2, _, _, _, _ := setupTestDNSServersRetry()
+	dnsQuery := DNSQuery{"A", "txt." + testDomain}
+	_, err := DNSLookupAuthoritativeWithRetryE(t, dnsQuery, []string{ns1, ns2}, 5, time.Second)
+	require.Error(t, err)
+	if _, ok := err.(*MaxRetriesExceeded); !ok {
+		t.Errorf("unexpected error, got %q", err)
+	}
+}
+
+// Retry until all authoritative nameservers give the same answers
+func TestOkDNSLookupAuthoritativeAllWithRetryNotfound(t *testing.T) {
+	t.Parallel()
+	ns1, ns2, dnsData1, _, dnsDataRetry1, dnsDataRetry2 := setupTestDNSServersRetry()
+	dnsQuery := DNSQuery{"A", "a." + testDomain}
+	expectedRes := DNSAnswers{{"A", "1.1.1.1"}, {"A", "2.2.2.2"}}
+	(*dnsData1)[dnsQuery] = expectedRes
+	(*dnsDataRetry1)[dnsQuery] = expectedRes
+	(*dnsDataRetry2)[dnsQuery] = expectedRes
+	res, err := DNSLookupAuthoritativeAllWithRetryE(t, dnsQuery, []string{ns1, ns2}, 5, time.Second)
+	require.NoError(t, err)
+	require.ElementsMatch(t, res, expectedRes)
+}
+
+// Retry until all authoritative nameservers give the same answers
+func TestOkDNSLookupAuthoritativeAllWithRetryInconsistent(t *testing.T) {
+	t.Parallel()
+	ns1, ns2, dnsData1, dnsData2, dnsDataRetry1, dnsDataRetry2 := setupTestDNSServersRetry()
+	dnsQuery := DNSQuery{"A", "a." + testDomain}
+	expectedRes := DNSAnswers{{"A", "1.1.1.1"}, {"A", "2.2.2.2"}}
+	(*dnsData1)[dnsQuery] = expectedRes
+	(*dnsData2)[dnsQuery] = DNSAnswers{{"A", "2.2.2.2"}}
+	(*dnsDataRetry1)[dnsQuery] = expectedRes
+	(*dnsDataRetry2)[dnsQuery] = expectedRes
+	res, err := DNSLookupAuthoritativeAllWithRetryE(t, dnsQuery, []string{ns1, ns2}, 5, time.Second)
+	require.NoError(t, err)
+	require.ElementsMatch(t, res, expectedRes)
+}
+
+// Retry will fail as one authoritative nameserver will always give an extra answer
+func TestErrorDNSLookupAuthoritativeAllWithRetry(t *testing.T) {
+	t.Parallel()
+	ns1, ns2, dnsData1, _, dnsDataRetry1, dnsDataRetry2 := setupTestDNSServersRetry()
+	dnsQuery := DNSQuery{"A", "a." + testDomain}
+	(*dnsData1)[dnsQuery] = DNSAnswers{{"A", "2.2.2.2"}}
+	(*dnsDataRetry1)[dnsQuery] = DNSAnswers{{"A", "1.1.1.1"}, {"A", "2.2.2.2"}}
+	(*dnsDataRetry2)[dnsQuery] = DNSAnswers{{"A", "1.1.1.1"}}
+	_, err := DNSLookupAuthoritativeAllWithRetryE(t, dnsQuery, []string{ns1, ns2}, 5, time.Second)
+	require.Error(t, err)
+	if _, ok := err.(*MaxRetriesExceeded); !ok {
+		t.Errorf("unexpected error, got %q", err)
+	}
+}
+
+// Validate all authoritative nameservers give the expected answers
+func TestOkDNSLookupAuthoritativeAllWithValidation(t *testing.T) {
+	t.Parallel()
+	ns1, ns2, dnsData1, dnsData2, _, _ := setupTestDNSServersRetry()
+	dnsQuery := DNSQuery{"A", "a." + testDomain}
+	expectedRes := DNSAnswers{{"A", "1.1.1.1"}, {"A", "2.2.2.2"}}
+	(*dnsData1)[dnsQuery] = expectedRes
+	(*dnsData2)[dnsQuery] = expectedRes
+	err := DNSLookupAuthoritativeAllWithValidationE(t, dnsQuery, []string{ns1, ns2}, expectedRes)
+	require.NoError(t, err)
+}
+
+// Retry until all authoritative nameservers give the expected answers
+func TestOkDNSLookupAuthoritativeAllWithValidationRetry(t *testing.T) {
+	t.Parallel()
+	ns1, ns2, _, _, dnsDataRetry1, dnsDataRetry2 := setupTestDNSServersRetry()
+	dnsQuery := DNSQuery{"A", "a." + testDomain}
+	expectedRes := DNSAnswers{{"A", "1.1.1.1"}, {"A", "2.2.2.2"}}
+	(*dnsDataRetry1)[dnsQuery] = expectedRes
+	(*dnsDataRetry2)[dnsQuery] = expectedRes
+	err := DNSLookupAuthoritativeAllWithValidationRetryE(t, dnsQuery, []string{ns1, ns2}, expectedRes, 5, time.Second)
+	require.NoError(t, err)
+}
+
+// Retry until all authoritative nameservers give the expected answers
+func TestOk2DNSLookupAuthoritativeAllWithValidationRetry(t *testing.T) {
+	t.Parallel()
+	ns1, ns2, dnsData1, dnsData2, dnsDataRetry1, dnsDataRetry2 := setupTestDNSServersRetry()
+	dnsQuery := DNSQuery{"A", "a." + testDomain}
+	expectedRes := DNSAnswers{{"A", "1.1.1.1"}, {"A", "2.2.2.2"}}
+	(*dnsData1)[dnsQuery] = DNSAnswers{{"A", "2.2.2.2"}}
+	(*dnsData2)[dnsQuery] = DNSAnswers{{"A", "2.2.2.2"}}
+	(*dnsDataRetry1)[dnsQuery] = expectedRes
+	(*dnsDataRetry2)[dnsQuery] = expectedRes
+	err := DNSLookupAuthoritativeAllWithValidationRetryE(t, dnsQuery, []string{ns1, ns2}, expectedRes, 5, time.Second)
+	require.NoError(t, err)
+}
+
+// Retry until all authoritative nameservers give the expected answers
+func TestOk3DNSLookupAuthoritativeAllWithValidationRetry(t *testing.T) {
+	t.Parallel()
+	ns1, ns2, dnsData1, dnsData2, dnsDataRetry1, dnsDataRetry2 := setupTestDNSServersRetry()
+	dnsQuery := DNSQuery{"A", "a." + testDomain}
+	expectedRes := DNSAnswers{{"A", "1.1.1.1"}, {"A", "2.2.2.2"}}
+	(*dnsData1)[dnsQuery] = expectedRes
+	(*dnsData2)[dnsQuery] = DNSAnswers{{"A", "2.2.2.2"}}
+	(*dnsDataRetry1)[dnsQuery] = expectedRes
+	(*dnsDataRetry2)[dnsQuery] = expectedRes
+	err := DNSLookupAuthoritativeAllWithValidationRetryE(t, dnsQuery, []string{ns1, ns2}, expectedRes, 5, time.Second)
+	require.NoError(t, err)
+}
+
+// Retry will fail as one authoritative nameserver will never give the expected answers
+func TestErrorDNSLookupAuthoritativeAllWithValidationRetry(t *testing.T) {
+	t.Parallel()
+	ns1, ns2, dnsData1, dnsData2, dnsDataRetry1, dnsDataRetry2 := setupTestDNSServersRetry()
+	dnsQuery := DNSQuery{"A", "a." + testDomain}
+	expectedRes := DNSAnswers{{"A", "1.1.1.1"}, {"A", "2.2.2.2"}}
+	(*dnsData1)[dnsQuery] = expectedRes
+	(*dnsData2)[dnsQuery] = DNSAnswers{{"A", "2.2.2.2"}}
+	(*dnsDataRetry1)[dnsQuery] = expectedRes
+	(*dnsDataRetry2)[dnsQuery] = DNSAnswers{{"A", "2.2.2.2"}}
+	err := DNSLookupAuthoritativeAllWithValidationRetryE(t, dnsQuery, []string{ns1, ns2}, expectedRes, 5, time.Second)
+	if _, ok := err.(*MaxRetriesExceeded); !ok {
+		t.Errorf("unexpected error, got %q", err)
+	}
+}

--- a/modules/dns-helper/dns_local_server.go
+++ b/modules/dns-helper/dns_local_server.go
@@ -1,0 +1,112 @@
+package dns_helper
+
+import (
+	"fmt"
+	"log"
+	"net"
+	"strings"
+	"time"
+
+	"github.com/miekg/dns"
+)
+
+var testDomain = "gruntwork.io"
+
+// DNSData type
+type DNSData map[DNSQuery][]DNSAnswer
+
+func setupTestDNSServers() (ns1, ns2 string, dnsData1, dnsData2 *DNSData) {
+	ns1, mux1 := runTestDNSServer("0")
+	ns2, mux2 := runTestDNSServer("0")
+
+	q := DNSQuery{"NS", testDomain}
+	dnsData1 = &DNSData{q: DNSAnswers{{"NS", ns1}, {"NS", ns2}}}
+	dnsData2 = &DNSData{q: DNSAnswers{{"NS", ns1}, {"NS", ns2}}}
+
+	mux1.HandleFunc(testDomain+".", func(w dns.ResponseWriter, r *dns.Msg) { stdDNSHandler(w, r, dnsData1, false) })
+	mux2.HandleFunc(testDomain+".", func(w dns.ResponseWriter, r *dns.Msg) { stdDNSHandler(w, r, dnsData2, true) })
+
+	return
+}
+
+func setupTestDNSServersRetry() (ns1, ns2 string, dnsData1, dnsData2, dnsDataRetry1, dnsDataRetry2 *DNSData) {
+	ns1, mux1 := runTestDNSServer("0")
+	ns2, mux2 := runTestDNSServer("0")
+
+	q := DNSQuery{"NS", testDomain}
+	dnsData1 = &DNSData{q: DNSAnswers{{"NS", ns1}, {"NS", ns2}}}
+	dnsData2 = &DNSData{q: DNSAnswers{{"NS", ns1}, {"NS", ns2}}}
+	dnsDataRetry1 = &DNSData{q: DNSAnswers{{"NS", ns1}, {"NS", ns2}}}
+	dnsDataRetry2 = &DNSData{q: DNSAnswers{{"NS", ns1}, {"NS", ns2}}}
+
+	mux1.HandleFunc(testDomain+".", func(w dns.ResponseWriter, r *dns.Msg) { retryDNSHandler(w, r, dnsData1, dnsDataRetry1, false) })
+	mux2.HandleFunc(testDomain+".", func(w dns.ResponseWriter, r *dns.Msg) { retryDNSHandler(w, r, dnsData2, dnsDataRetry2, true) })
+
+	return
+}
+
+func runTestDNSServer(port string) (string, *dns.ServeMux) {
+	listener, err := net.ListenPacket("udp", "127.0.0.1:"+port)
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	mux := dns.NewServeMux()
+	server := &dns.Server{PacketConn: listener, Net: "udp", Handler: mux}
+
+	go func() {
+		log.Fatal(server.ActivateAndServe())
+		defer server.Shutdown()
+	}()
+
+	return listener.LocalAddr().String(), mux
+}
+
+func doDNSAnswer(w dns.ResponseWriter, r *dns.Msg, dnsData *DNSData, invertAnswers bool) {
+	m := new(dns.Msg)
+	m.SetReply(r)
+	m.Authoritative = true
+	q := m.Question[0]
+	qtype := dns.TypeToString[q.Qtype]
+	answers := (*dnsData)[DNSQuery{qtype, strings.TrimSuffix(q.Name, ".")}]
+
+	var seen = make(map[DNSAnswer]bool)
+
+	for _, r := range answers {
+		if seen[r] {
+			continue
+		}
+		seen[r] = true
+
+		rr, err := dns.NewRR(fmt.Sprintf("%s %s", q.Name, r.String()))
+
+		if err != nil {
+			log.Fatalf("err: %s", err)
+		}
+
+		m.Answer = append(m.Answer, rr)
+	}
+
+	if invertAnswers {
+		for i, j := 0, len(m.Answer)-1; i < j; i, j = i+1, j-1 {
+			m.Answer[i], m.Answer[j] = m.Answer[j], m.Answer[i]
+		}
+	}
+
+	w.WriteMsg(m)
+}
+
+func stdDNSHandler(w dns.ResponseWriter, r *dns.Msg, dnsData *DNSData, invertAnswers bool) {
+	doDNSAnswer(w, r, dnsData, invertAnswers)
+}
+
+var startTime = time.Now()
+
+func retryDNSHandler(w dns.ResponseWriter, r *dns.Msg, dnsData, dnsDataRetry *DNSData, invertAnswers bool) {
+	if time.Now().Sub(startTime).Seconds() > 3 {
+		dnsData = dnsDataRetry
+	}
+
+	doDNSAnswer(w, r, dnsData, invertAnswers)
+}

--- a/modules/dns-helper/errors.go
+++ b/modules/dns-helper/errors.go
@@ -28,16 +28,6 @@ func (err NotFoundError) Error() string {
 	return fmt.Sprintf("No %s record found for %s querying nameserver %s", err.Query.Type, err.Query.Name, err.Nameserver)
 }
 
-// NotFoundAuthoritativeError is an error that occurs if no authoritative answer found
-type NotFoundAuthoritativeError struct {
-	Query       DNSQuery
-	Nameservers []string
-}
-
-func (err NotFoundAuthoritativeError) Error() string {
-	return fmt.Sprintf("No %s record found for %s in any authoritative nameservers %s", err.Query.Type, err.Query.Name, err.Nameservers)
-}
-
 // InconsistentAuthoritativeError is an error that occurs if an authoritative answer is different from another
 type InconsistentAuthoritativeError struct {
 	Query           DNSQuery

--- a/modules/dns-helper/errors.go
+++ b/modules/dns-helper/errors.go
@@ -1,0 +1,82 @@
+package dns_helper
+
+import "fmt"
+
+// NoResolversError is an error that occurs if no resolvers have been set for DNSLookupE
+type NoResolversError struct{}
+
+func (err NoResolversError) Error() string {
+	return fmt.Sprintf("No resolvers set for DNSLookupE call")
+}
+
+// QueryTypeError is an error that occurs if the DNS query type is not supported
+type QueryTypeError struct {
+	Type string
+}
+
+func (err QueryTypeError) Error() string {
+	return fmt.Sprintf("Wrong DNS query type: %s", err.Type)
+}
+
+// NotFoundError is an error that occurs if no answer found
+type NotFoundError struct {
+	Query      DNSQuery
+	Nameserver string
+}
+
+func (err NotFoundError) Error() string {
+	return fmt.Sprintf("No %s record found for %s querying nameserver %s", err.Query.Type, err.Query.Name, err.Nameserver)
+}
+
+// NotFoundAuthoritativeError is an error that occurs if no authoritative answer found
+type NotFoundAuthoritativeError struct {
+	Query       DNSQuery
+	Nameservers []string
+}
+
+func (err NotFoundAuthoritativeError) Error() string {
+	return fmt.Sprintf("No %s record found for %s in any authoritative nameservers %s", err.Query.Type, err.Query.Name, err.Nameservers)
+}
+
+// InconsistentAuthoritativeError is an error that occurs if an authoritative answer is different from another
+type InconsistentAuthoritativeError struct {
+	Query           DNSQuery
+	Answers         DNSAnswers
+	Nameserver      string
+	PreviousAnswers DNSAnswers
+}
+
+func (err InconsistentAuthoritativeError) Error() string {
+	return fmt.Sprintf("Inconsistent authoritative answer from %s to DNS query %s. Got: %s Previous: %s", err.Nameserver, err.Query, err.Answers, err.PreviousAnswers)
+}
+
+// NSNotFoundError is an error that occurs if no NS records found
+type NSNotFoundError struct {
+	FQDN       string
+	Nameserver string
+}
+
+func (err NSNotFoundError) Error() string {
+	return fmt.Sprintf("No NS record found for %s up to apex domain %s", err.FQDN, err.Nameserver)
+}
+
+// MaxRetriesExceeded is an error that occurs when the maximum amount of retries is exceeded.
+type MaxRetriesExceeded struct {
+	Description string
+	MaxRetries  int
+}
+
+func (err MaxRetriesExceeded) Error() string {
+	return fmt.Sprintf("'%s' unsuccessful after %d retries", err.Description, err.MaxRetries)
+}
+
+// ValidationError is an error that occurs when answers validation fails
+type ValidationError struct {
+	Query           DNSQuery
+	Answers         DNSAnswers
+	ExpectedAnswers DNSAnswers
+}
+
+func (err ValidationError) Error() string {
+	return fmt.Sprintf("Unexpected answer to DNS query %s. Got: %s Expected: %s", err.Query, err.Answers, err.ExpectedAnswers)
+}

--- a/modules/retry/retry.go
+++ b/modules/retry/retry.go
@@ -50,7 +50,7 @@ func DoWithTimeoutE(t testing.TestingT, actionDescription string, timeout time.D
 	}
 }
 
-// DoWithRetry runs the specified action. If it returns a value, return that value. If it returns a FatalError, return that error
+// DoWithRetry runs the specified action. If it returns a string, return that string. If it returns a FatalError, return that error
 // immediately. If it returns any other type of error, sleep for sleepBetweenRetries and try again, up to a maximum of
 // maxRetries retries. If maxRetries is exceeded, fail the test.
 func DoWithRetry(t testing.TestingT, actionDescription string, maxRetries int, sleepBetweenRetries time.Duration, action func() (string, error)) string {
@@ -61,11 +61,30 @@ func DoWithRetry(t testing.TestingT, actionDescription string, maxRetries int, s
 	return out
 }
 
-// DoWithRetryE runs the specified action. If it returns a value, return that value. If it returns a FatalError, return that error
+// DoWithRetryE runs the specified action. If it returns a string, return that string. If it returns a FatalError, return that error
 // immediately. If it returns any other type of error, sleep for sleepBetweenRetries and try again, up to a maximum of
 // maxRetries retries. If maxRetries is exceeded, return a MaxRetriesExceeded error.
 func DoWithRetryE(t testing.TestingT, actionDescription string, maxRetries int, sleepBetweenRetries time.Duration, action func() (string, error)) (string, error) {
-	var output string
+	out, err := DoWithRetryInterfaceE(t, actionDescription, maxRetries, sleepBetweenRetries, func() (interface{}, error) { return action() })
+	return out.(string), err
+}
+
+// DoWithRetryInterface runs the specified action. If it returns a value, return that value. If it returns a FatalError, return that error
+// immediately. If it returns any other type of error, sleep for sleepBetweenRetries and try again, up to a maximum of
+// maxRetries retries. If maxRetries is exceeded, fail the test.
+func DoWithRetryInterface(t testing.TestingT, actionDescription string, maxRetries int, sleepBetweenRetries time.Duration, action func() (interface{}, error)) interface{} {
+	out, err := DoWithRetryInterfaceE(t, actionDescription, maxRetries, sleepBetweenRetries, action)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return out
+}
+
+// DoWithRetryInterfaceE runs the specified action. If it returns a value, return that value. If it returns a FatalError, return that error
+// immediately. If it returns any other type of error, sleep for sleepBetweenRetries and try again, up to a maximum of
+// maxRetries retries. If maxRetries is exceeded, return a MaxRetriesExceeded error.
+func DoWithRetryInterfaceE(t testing.TestingT, actionDescription string, maxRetries int, sleepBetweenRetries time.Duration, action func() (interface{}, error)) (interface{}, error) {
+	var output interface{}
 	var err error
 
 	for i := 0; i <= maxRetries; i++ {


### PR DESCRIPTION
I've been missing some DNS lookup helper functions, so as an excuse to improve my Go skills and have some fun in the process, I decided to contribute with this new dns-helper module. I hope some of you will find this useful and I'm looking forward to getting your feedback.

Tries to deal with https://github.com/gruntwork-io/terratest/issues/660

Motivation:

I was struggling to write reliable tests for k8s deployments with public ingresses, i.e. http retry requests to public DNS hostnames asynchronously created by external-dns for ingresses in those deployments:

1. Install helm chart for a web application, including an ingress resource with a custom public DNS name.
2. Wait until ingress is ready and get its public DNS name.
2.1. Eventually, some tool in k8s like external-dns creates a public DNS record pointing to the ingress. Terratest doesn't provide a reliable way to wait for this yet.
3. Start retrying http requests to public DNS name...

If the DNS record has not been created/updated yet when the first http request is sent, chances are the system where the test runs caches the negative/old reply for a very long time (some systems behave worse than others, not even honoring original TTL set by authoritative nameservers), and the test will most likely fail.

To avoid being affected by this local DNS cache, the dns-helper module provides several convenient ways of checking DNS records directly with their authoritative nameservers, like waiting until all the nameservers reply with the expected answers. It bypasses the local DNS resolver configuration, except to find the authoritative nameservers for the DNS name being checked.

Usage example:

```go
k8s.WaitUntilIngressAvailable(t, kubectlOptions, ingressName, maxRetries, sleepBetweenRetries)
ingress := k8s.GetIngress(t, kubectlOptions, ingressName)
hostname := ingress.Spec.Rules[0].Host
dnsQuery := dns_helper.DNSQuery{"A", hostname}
dns_helper.DNSLookupAuthoritativeAllWithRetry(t, dnsQuery, nil, maxRetries, sleepBetweenRetries)
response := http_helper.HTTPDoWithRetry(t, "GET", "https://"+hostname, nil, nil, 200, maxRetries, sleepBetweenRetries, nil)
require.Contains(t, response, expectedResponse)
```

- It supports DNS records types A, AAAA, CNAME, MX, NS, TXT.
- Provides `All` versions of the functions, to require consistency in all authoritative answers.
- Provides retry versions of some functions.
- Provides with-validation versions as well. 
- All the functions in fail-on-error and return-error flavors.
- Extensive testing. Sample tests results https://gist.github.com/askainet/93d334396fd2ded4f0148ddcacc6c680

As a bonus, and as suggested by @yorinasub17, add a new retry function DoWithRetryInterfaceE to return output in any format, updating the original DoWithRetryE to use it while keeping compatibility with string output.