### PR TITLE
Add function for docker compose to return stdout

### DIFF
--- a/examples/docker-compose-stdout-example/Dockerfile
+++ b/examples/docker-compose-stdout-example/Dockerfile
@@ -1,0 +1,3 @@
+# website::tag::1:: Build a simple Docker image that contains a text file with the contents "Hello, World!"
+FROM ubuntu:20.04
+COPY ./bash_script.sh /usr/local/bin/bash_script.sh

--- a/examples/docker-compose-stdout-example/bash_script.sh
+++ b/examples/docker-compose-stdout-example/bash_script.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+
+echo "stdout: message"
+>&2 echo -e "stderr: error"

--- a/examples/docker-compose-stdout-example/docker-compose.yml
+++ b/examples/docker-compose-stdout-example/docker-compose.yml
@@ -1,0 +1,6 @@
+version: '2.0'
+services:
+  bash_script:
+    build:
+      context: .
+    entrypoint: bash_script.sh

--- a/examples/packer-docker-example/docker-compose.yml
+++ b/examples/packer-docker-example/docker-compose.yml
@@ -17,4 +17,11 @@ services:
     # Expose the sample app's port on the host OS
     ports:
       - "${SERVER_PORT}:${SERVER_PORT}"
+  bash_script:
+    # The name we use for the Docker image in build.json
+    image: gruntwork/packer-docker-example
 
+    volumes:
+      - ./bash_script.sh:/home/ubuntu/bash_script.sh
+
+    entrypoint: bash_script.sh

--- a/go.sum
+++ b/go.sum
@@ -372,6 +372,7 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
+github.com/urfave/cli v1.22.2 h1:gsqYFH8bb9ekPA12kRo0hfjngWQjkJPlN9R0N78BoUo=
 github.com/urfave/cli v1.22.2/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/vdemeester/k8s-pkg-credentialprovider v0.0.0-20200107171650-7c61ffa44238/go.mod h1:JwQJCMWpUDqjZrB5jpw0f5VbN7U95zxFy1ZDpoEarGo=
 github.com/vmware/govmomi v0.20.3/go.mod h1:URlwyTFZX72RmxtxuaFL2Uj3fD1JTvZdx59bHWk6aFU=

--- a/modules/docker/docker_compose.go
+++ b/modules/docker/docker_compose.go
@@ -16,30 +16,20 @@ type Options struct {
 
 // RunDockerCompose runs docker-compose with the given arguments and options and return stdout/stderr.
 func RunDockerCompose(t testing.TestingT, options *Options, args ...string) string {
-	out, err := RunDockerComposeE(t, options, args...)
+	out, err := RunDockerComposeE(t, false, options, args...)
 	if err != nil {
 		t.Fatal(err)
 	}
 	return out
 }
 
-// RunDockerComposeE runs docker-compose with the given arguments and options and return stdout/stderr.
-func RunDockerComposeE(t testing.TestingT, options *Options, args ...string) (string, error) {
-	cmd := shell.Command{
-		Command: "docker-compose",
-		// We append --project-name to ensure containers from multiple different tests using Docker Compose don't end
-		// up in the same project and end up conflicting with each other.
-		Args:       append([]string{"--project-name", t.Name()}, args...),
-		WorkingDir: options.WorkingDir,
-		Env:        options.EnvVars,
-		Logger:     options.Logger,
-	}
-
-	return shell.RunCommandAndGetOutputE(t, cmd)
-}
-
 // RunDockerComposeStdoutE runs docker-compose with the given arguments and options and return only stdout.
 func RunDockerComposeStdOutE(t testing.TestingT, options *Options, args ...string) (string, error) {
+	return RunDockerComposeE(t, true, options, args...)
+}
+
+// RunDockerComposeE runs docker-compose with the given arguments and options and return stdout/stderr.
+func RunDockerComposeE(t testing.TestingT, stdout bool, options *Options, args ...string) (string, error) {
 	cmd := shell.Command{
 		Command: "docker-compose",
 		// We append --project-name to ensure containers from multiple different tests using Docker Compose don't end
@@ -50,5 +40,8 @@ func RunDockerComposeStdOutE(t testing.TestingT, options *Options, args ...strin
 		Logger:     options.Logger,
 	}
 
-	return shell.RunCommandAndGetStdOutE(t, cmd)
+	if stdout {
+		return shell.RunCommandAndGetStdOutE(t, cmd)
+	}
+	return shell.RunCommandAndGetOutputE(t, cmd)
 }

--- a/modules/docker/docker_compose.go
+++ b/modules/docker/docker_compose.go
@@ -37,3 +37,18 @@ func RunDockerComposeE(t testing.TestingT, options *Options, args ...string) (st
 
 	return shell.RunCommandAndGetOutputE(t, cmd)
 }
+
+// RunDockerComposeE runs docker-compose with the given arguments and options and return only stdout.
+func RunDockerComposeStdOutE(t testing.TestingT, options *Options, args ...string) (string, error) {
+	cmd := shell.Command{
+		Command: "docker-compose",
+		// We append --project-name to ensure containers from multiple different tests using Docker Compose don't end
+		// up in the same project and end up conflicting with each other.
+		Args:       append([]string{"--project-name", t.Name()}, args...),
+		WorkingDir: options.WorkingDir,
+		Env:        options.EnvVars,
+		Logger:     options.Logger,
+	}
+
+	return shell.RunCommandAndGetStdOutE(t, cmd)
+}

--- a/modules/docker/docker_compose.go
+++ b/modules/docker/docker_compose.go
@@ -38,7 +38,7 @@ func RunDockerComposeE(t testing.TestingT, options *Options, args ...string) (st
 	return shell.RunCommandAndGetOutputE(t, cmd)
 }
 
-// RunDockerComposeE runs docker-compose with the given arguments and options and return only stdout.
+// RunDockerComposeStdoutE runs docker-compose with the given arguments and options and return only stdout.
 func RunDockerComposeStdOutE(t testing.TestingT, options *Options, args ...string) (string, error) {
 	cmd := shell.Command{
 		Command: "docker-compose",

--- a/modules/docker/docker_compose.go
+++ b/modules/docker/docker_compose.go
@@ -16,7 +16,7 @@ type Options struct {
 
 // RunDockerCompose runs docker-compose with the given arguments and options and return stdout/stderr.
 func RunDockerCompose(t testing.TestingT, options *Options, args ...string) string {
-	out, err := RunDockerComposeE(t, false, options, args...)
+	out, err := runDockerComposeE(t, false, options, args...)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -25,12 +25,16 @@ func RunDockerCompose(t testing.TestingT, options *Options, args ...string) stri
 
 // RunDockerComposeAndGetStdout runs docker-compose with the given arguments and options and returns only stdout.
 func RunDockerComposeAndGetStdOut(t testing.TestingT, options *Options, args ...string) string {
-	out, _ := RunDockerComposeE(t, true, options, args...)
+	out, _ := runDockerComposeE(t, true, options, args...)
 	return out
 }
 
 // RunDockerComposeE runs docker-compose with the given arguments and options and return stdout/stderr.
-func RunDockerComposeE(t testing.TestingT, stdout bool, options *Options, args ...string) (string, error) {
+func RunDockerComposeE(t testing.TestingT, options *Options, args ...string) (string, error) {
+	return runDockerComposeE(t, false, options, args...)
+}
+
+func runDockerComposeE(t testing.TestingT, stdout bool, options *Options, args ...string) (string, error) {
 	cmd := shell.Command{
 		Command: "docker-compose",
 		// We append --project-name to ensure containers from multiple different tests using Docker Compose don't end

--- a/modules/docker/docker_compose.go
+++ b/modules/docker/docker_compose.go
@@ -4,6 +4,7 @@ import (
 	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/shell"
 	"github.com/gruntwork-io/terratest/modules/testing"
+	"github.com/stretchr/testify/require"
 )
 
 // Options are Docker options.

--- a/modules/docker/docker_compose.go
+++ b/modules/docker/docker_compose.go
@@ -23,9 +23,10 @@ func RunDockerCompose(t testing.TestingT, options *Options, args ...string) stri
 	return out
 }
 
-// RunDockerComposeStdoutE runs docker-compose with the given arguments and options and return only stdout.
-func RunDockerComposeStdOutE(t testing.TestingT, options *Options, args ...string) (string, error) {
-	return RunDockerComposeE(t, true, options, args...)
+// RunDockerComposeAndGetStdout runs docker-compose with the given arguments and options and returns only stdout.
+func RunDockerComposeAndGetStdOut(t testing.TestingT, options *Options, args ...string) string {
+	out, _ := RunDockerComposeE(t, true, options, args...)
+	return out
 }
 
 // RunDockerComposeE runs docker-compose with the given arguments and options and return stdout/stderr.
@@ -41,7 +42,7 @@ func RunDockerComposeE(t testing.TestingT, stdout bool, options *Options, args .
 	}
 
 	if stdout {
-		return shell.RunCommandAndGetStdOutE(t, cmd)
+		return shell.RunCommandAndGetStdOut(t, cmd), nil
 	}
 	return shell.RunCommandAndGetOutputE(t, cmd)
 }

--- a/test/docker_stdout_example_test.go
+++ b/test/docker_stdout_example_test.go
@@ -25,7 +25,8 @@ func TestDockerComposeStdoutExample(t *testing.T) {
 		&docker.Options{},
 		"-f",
 		dockerComposeFile,
-		"up",
+		"run",
+		"bash_script",
 	)
 
 	assert.Contains(t, output, "stdout: message")

--- a/test/docker_stdout_example_test.go
+++ b/test/docker_stdout_example_test.go
@@ -8,9 +8,10 @@ import (
 )
 
 func TestDockerComposeStdoutExample(t *testing.T) {
+	t.Parallel()
 	dockerComposeFile := "../examples/docker-compose-stdout-example/docker-compose.yml"
 
-	// Build the Docker image.
+	// Run the build step first so that the build output doesn't go to stdout during the compose step.
 	docker.RunDockerCompose(
 		t,
 		&docker.Options{},
@@ -19,7 +20,9 @@ func TestDockerComposeStdoutExample(t *testing.T) {
 		"build",
 	)
 
-	// Run the Docker image, read the text file from it, and make sure it contains the expected output.
+	// Run the Docker image, read the stdout from it, and make sure it contains the expected output.
+	// The script must be run using `run bash_script` rather than `up`, so that the echo output from the script
+	// is the only thing that outputs to stdout.
 	output := docker.RunDockerComposeAndGetStdOut(
 		t,
 		&docker.Options{},

--- a/test/docker_stdout_example_test.go
+++ b/test/docker_stdout_example_test.go
@@ -1,0 +1,33 @@
+package test
+
+import (
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/docker"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDockerComposeStdoutExample(t *testing.T) {
+	dockerComposeFile := "../examples/docker-compose-stdout-example/docker-compose.yml"
+
+	// Build the Docker image.
+	docker.RunDockerCompose(
+		t,
+		&docker.Options{},
+		"-f",
+		dockerComposeFile,
+		"build",
+	)
+
+	// Run the Docker image, read the text file from it, and make sure it contains the expected output.
+	output := docker.RunDockerComposeAndGetStdOut(
+		t,
+		&docker.Options{},
+		"-f",
+		dockerComposeFile,
+		"up",
+	)
+
+	assert.Contains(t, output, "stdout: message")
+	assert.NotContains(t, output, "stderr: error")
+}


### PR DESCRIPTION
What else does this PR need? 

Purpose: I've just added a function that lets docker compose return only `stdout`, so that TLS Scripts followups can get just the Certificate ARN from `stdout` and clean up the resource during the test cleanup stage.