### PR TITLE
Use DOCKER_HOST to find the correct address for exposed container ports

### DIFF
--- a/modules/docker/host.go
+++ b/modules/docker/host.go
@@ -19,18 +19,14 @@ func getDockerHostFromEnv(env []string) string {
 
 	for _, item := range env {
 		envVar := strings.Split(item, "=")
-		if envVar[0] == "DOCKER_HOST" && len(envVar) == 2 {
+		if len(envVar) == 2 && envVar[0] == "DOCKER_HOST" {
 			dockerUrl = strings.Split(envVar[1], ":")
-			if len(dockerUrl) < 2 {
-				// DOCKER_HOST did not split, is empty or ended with ":"
-				return "localhost"
-			}
 			break
 		}
 	}
 
-	if len(dockerUrl) == 0 {
-		// no DOCKER_HOST variable, return default value
+	if len(dockerUrl) < 2 {
+		// DOCKER_HOST was empty, not present or not a valid URL
 		return "localhost"
 	}
 

--- a/modules/docker/host.go
+++ b/modules/docker/host.go
@@ -19,8 +19,12 @@ func getDockerHostFromEnv(env []string) string {
 
 	for _, item := range env {
 		envVar := strings.Split(item, "=")
-		if envVar[0] == "DOCKER_HOST" {
+		if envVar[0] == "DOCKER_HOST" && len(envVar) == 2 {
 			dockerUrl = strings.Split(envVar[1], ":")
+			if len(dockerUrl) < 2 {
+				// DOCKER_HOST did not split, is empty or ended with ":"
+				return "localhost"
+			}
 			break
 		}
 	}
@@ -34,7 +38,7 @@ func getDockerHostFromEnv(env []string) string {
 	case "tcp", "ssh", "fd":
 		return strings.TrimPrefix(dockerUrl[1], "//")
 	default:
-		// if DOCKER_HOST is empty, or not in one of the formats listed above
+		// if DOCKER_HOST is not in one of the formats listed above, return default
 		return "localhost"
 	}
 }

--- a/modules/docker/host.go
+++ b/modules/docker/host.go
@@ -1,0 +1,22 @@
+package docker
+
+import (
+	"os"
+	"strings"
+)
+
+// GetDockerHost returns the name or address of the host on which the Docker engine is running.
+func GetDockerHost() string {
+	// Parses the DOCKER_HOST environment variable to find the address
+	//
+	// For valid formats see:
+	// https://github.com/docker/cli/blob/6916b427a0b07e8581d121967633235ced6db9a1/opts/hosts.go#L69
+	dockerUrl := strings.Split(os.Getenv("DOCKER_HOST"), ":")
+	switch dockerUrl[0] {
+	case "tcp", "ssh", "fd":
+		return strings.TrimPrefix(dockerUrl[1], "//")
+	default:
+		// if DOCKER_HOST is empty, or not in one of the formats listed above
+		return "localhost"
+	}
+}

--- a/modules/docker/host.go
+++ b/modules/docker/host.go
@@ -7,11 +7,24 @@ import (
 
 // GetDockerHost returns the name or address of the host on which the Docker engine is running.
 func GetDockerHost() string {
+	return getDockerHostFromEnv(os.Environ())
+}
+
+func getDockerHostFromEnv(env []string) string {
 	// Parses the DOCKER_HOST environment variable to find the address
 	//
 	// For valid formats see:
 	// https://github.com/docker/cli/blob/6916b427a0b07e8581d121967633235ced6db9a1/opts/hosts.go#L69
-	dockerUrl := strings.Split(os.Getenv("DOCKER_HOST"), ":")
+	var dockerUrl []string
+
+	for _, item := range env {
+		envVar := strings.Split(item, "=")
+		if envVar[0] == "DOCKER_HOST" {
+			dockerUrl = strings.Split(envVar[1], ":")
+			break
+		}
+	}
+
 	switch dockerUrl[0] {
 	case "tcp", "ssh", "fd":
 		return strings.TrimPrefix(dockerUrl[1], "//")

--- a/modules/docker/host.go
+++ b/modules/docker/host.go
@@ -25,6 +25,11 @@ func getDockerHostFromEnv(env []string) string {
 		}
 	}
 
+	if len(dockerUrl) == 0 {
+		// no DOCKER_HOST variable, return default value
+		return "localhost"
+	}
+
 	switch dockerUrl[0] {
 	case "tcp", "ssh", "fd":
 		return strings.TrimPrefix(dockerUrl[1], "//")

--- a/modules/docker/host_test.go
+++ b/modules/docker/host_test.go
@@ -51,7 +51,7 @@ func TestGetDockerHostFromEnv(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		t.Run(fmt.Sprintf("GetDockerHost: %s", test.Input), func(t *testing.T) {
+		t.Run(fmt.Sprintf("GetDockerHostFromEnv: %s", test.Input), func(t *testing.T) {
 
 			testEnv := []string{
 				"FOO=bar",
@@ -63,4 +63,14 @@ func TestGetDockerHostFromEnv(t *testing.T) {
 			assert.Equal(t, test.Expected, host)
 		})
 	}
+
+	t.Run("GetDockerHostFromEnv: DOCKER_HOST unset", func(t *testing.T) {
+		testEnv := []string{
+			"FOO=bar",
+			"BAR=baz",
+		}
+
+		host := getDockerHostFromEnv(testEnv)
+		assert.Equal(t, "localhost", host)
+	})
 }

--- a/modules/docker/host_test.go
+++ b/modules/docker/host_test.go
@@ -9,6 +9,8 @@ import (
 
 func TestGetDockerHostFromEnv(t *testing.T) {
 
+	t.Parallel()
+
 	tests := []struct {
 		Input    string
 		Expected string

--- a/modules/docker/host_test.go
+++ b/modules/docker/host_test.go
@@ -1,0 +1,66 @@
+package docker
+
+import (
+	"fmt"
+	"os"
+	"testing"
+)
+
+func TestGetDockerHost(t *testing.T) {
+
+	tests := []struct {
+		Input    string
+		Expected string
+	}{
+		{
+			"unix:///var/run/docker.sock",
+			"localhost",
+		},
+		{
+			"npipe:////./pipe/docker_engine",
+			"localhost",
+		},
+		{
+			"tcp://1.2.3.4:1234",
+			"1.2.3.4",
+		},
+		{
+			"tcp://1.2.3.4",
+			"1.2.3.4",
+		},
+		{
+			"ssh://1.2.3.4:22",
+			"1.2.3.4",
+		},
+		{
+			"fd://1.2.3.4:1234",
+			"1.2.3.4",
+		},
+		{
+			"",
+			"localhost",
+		},
+		{
+			"invalidValue",
+			"localhost",
+		},
+		{
+			"invalid::value::with::semicolons",
+			"localhost",
+		},
+	}
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("GetDockerHost: %s", test.Input), func(t *testing.T) {
+			// GetHost() uses the DOCKER_HOST environment variable, so we need to set
+			// it to our test input and then reset it afterwards for other tests
+			defer os.Setenv("DOCKER_HOST", os.Getenv("DOCKER_HOST"))
+			os.Setenv("DOCKER_HOST", test.Input)
+
+			host := GetDockerHost()
+
+			if host != test.Expected {
+				t.Fatalf("Error: expected %s, got %s", test.Expected, host)
+			}
+		})
+	}
+}

--- a/modules/docker/host_test.go
+++ b/modules/docker/host_test.go
@@ -2,11 +2,12 @@ package docker
 
 import (
 	"fmt"
-	"os"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
-func TestGetDockerHost(t *testing.T) {
+func TestGetDockerHostFromEnv(t *testing.T) {
 
 	tests := []struct {
 		Input    string
@@ -51,16 +52,15 @@ func TestGetDockerHost(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(fmt.Sprintf("GetDockerHost: %s", test.Input), func(t *testing.T) {
-			// GetHost() uses the DOCKER_HOST environment variable, so we need to set
-			// it to our test input and then reset it afterwards for other tests
-			defer os.Setenv("DOCKER_HOST", os.Getenv("DOCKER_HOST"))
-			os.Setenv("DOCKER_HOST", test.Input)
 
-			host := GetDockerHost()
-
-			if host != test.Expected {
-				t.Fatalf("Error: expected %s, got %s", test.Expected, host)
+			testEnv := []string{
+				"FOO=bar",
+				fmt.Sprintf("DOCKER_HOST=%s", test.Input),
+				"BAR=baz",
 			}
+
+			host := getDockerHostFromEnv(testEnv)
+			assert.Equal(t, test.Expected, host)
 		})
 	}
 }

--- a/modules/docker/host_test.go
+++ b/modules/docker/host_test.go
@@ -52,6 +52,7 @@ func TestGetDockerHostFromEnv(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(fmt.Sprintf("GetDockerHostFromEnv: %s", test.Input), func(t *testing.T) {
+			t.Parallel()
 
 			testEnv := []string{
 				"FOO=bar",
@@ -65,6 +66,8 @@ func TestGetDockerHostFromEnv(t *testing.T) {
 	}
 
 	t.Run("GetDockerHostFromEnv: DOCKER_HOST unset", func(t *testing.T) {
+		t.Parallel()
+
 		testEnv := []string{
 			"FOO=bar",
 			"BAR=baz",

--- a/modules/docker/stop_test.go
+++ b/modules/docker/stop_test.go
@@ -2,7 +2,6 @@ package docker
 
 import (
 	"crypto/tls"
-	"os"
 	"strconv"
 	"strings"
 	"testing"
@@ -19,24 +18,9 @@ func TestStop(t *testing.T) {
 	// appending timestamp to container name to run tests in parallel
 	name := "test-nginx" + strconv.FormatInt(time.Now().UnixNano(), 10)
 
-	// Parse the DOCKER_HOST environment variable so we know where to connect
-	//
-	// For valid formats see:
-	// https://github.com/docker/cli/blob/6916b427a0b07e8581d121967633235ced6db9a1/opts/hosts.go#L69
-	var host string
-
-	dockerUrl := strings.Split(os.Getenv("DOCKER_HOST"), ":")
-	switch dockerUrl[0] {
-	case "tcp", "ssh", "fd":
-		host = strings.TrimPrefix(dockerUrl[1], "//")
-	default:
-		// if DOCKER_HOST is empty, or not in one of the formats listed above
-		host = "localhost"
-	}
-
 	// choosing a unique port since 80 may not fly well on test machines
 	port := "13030"
-	testURL := "http://" + host + ":" + port
+	testURL := "http://" + GetDockerHost() + ":" + port
 
 	// for testing the stopping of a docker container
 	// we got to run a container first and then stop it

--- a/modules/docker/stop_test.go
+++ b/modules/docker/stop_test.go
@@ -2,6 +2,7 @@ package docker
 
 import (
 	"crypto/tls"
+	"os"
 	"strconv"
 	"strings"
 	"testing"
@@ -18,9 +19,24 @@ func TestStop(t *testing.T) {
 	// appending timestamp to container name to run tests in parallel
 	name := "test-nginx" + strconv.FormatInt(time.Now().UnixNano(), 10)
 
+	// Parse the DOCKER_HOST environment variable so we know where to connect
+	//
+	// For valid formats see:
+	// https://github.com/docker/cli/blob/6916b427a0b07e8581d121967633235ced6db9a1/opts/hosts.go#L69
+	var host string
+
+	dockerUrl := strings.Split(os.Getenv("DOCKER_HOST"), ":")
+	switch dockerUrl[0] {
+	case "tcp", "ssh", "fd":
+		host = strings.TrimPrefix(dockerUrl[1], "//")
+	default:
+		// if DOCKER_HOST is empty, or not in one of the formats listed above
+		host = "localhost"
+	}
+
 	// choosing a unique port since 80 may not fly well on test machines
 	port := "13030"
-	testURL := "http://localhost:" + port
+	testURL := "http://" + host + ":" + port
 
 	// for testing the stopping of a docker container
 	// we got to run a container first and then stop it

--- a/modules/docker/stop_test.go
+++ b/modules/docker/stop_test.go
@@ -2,6 +2,7 @@ package docker
 
 import (
 	"crypto/tls"
+	"fmt"
 	"strconv"
 	"strings"
 	"testing"
@@ -20,7 +21,9 @@ func TestStop(t *testing.T) {
 
 	// choosing a unique port since 80 may not fly well on test machines
 	port := "13030"
-	testURL := "http://" + GetDockerHost() + ":" + port
+	host := GetDockerHost()
+
+	testURL := fmt.Sprintf("http://%s:%s", host, port)
 
 	// for testing the stopping of a docker container
 	// we got to run a container first and then stop it


### PR DESCRIPTION
Fixes #670 

This has only been tested on my Mac but I believe the test should now pass when using `docker-machine` (or other remote Docker hosts) as well as native Docker on both Linux and Windows.