### PR TITLE
Add GetEcsClusterWithInclude

### DIFF
--- a/modules/aws/ecs.go
+++ b/modules/aws/ecs.go
@@ -18,6 +18,20 @@ func GetEcsCluster(t testing.TestingT, region string, name string) *ecs.Cluster 
 
 // GetEcsClusterE fetches information about specified ECS cluster.
 func GetEcsClusterE(t testing.TestingT, region string, name string) (*ecs.Cluster, error) {
+	return GetEcsClusterWithIncludeE(t, region, name, []string{})
+}
+
+// GetEcsClusterWithInclude fetches extended information about specified ECS cluster.
+// The `include` parameter specifies a list of `ecs.ClusterField*` constants, such as `ecs.ClusterFieldTags`.
+func GetEcsClusterWithInclude(t testing.TestingT, region string, name string, include []string) *ecs.Cluster {
+	clusterInfo, err := GetEcsClusterWithIncludeE(t, region, name, include)
+	require.NoError(t, err)
+	return clusterInfo
+}
+
+// GetEcsClusterWithIncludeE fetches extended information about specified ECS cluster.
+// The `include` parameter specifies a list of `ecs.ClusterField*` constants, such as `ecs.ClusterFieldTags`.
+func GetEcsClusterWithIncludeE(t testing.TestingT, region string, name string, include []string) (*ecs.Cluster, error) {
 	client, err := NewEcsClientE(t, region)
 	if err != nil {
 		return nil, err
@@ -26,6 +40,7 @@ func GetEcsClusterE(t testing.TestingT, region string, name string) (*ecs.Cluste
 		Clusters: []*string{
 			aws.String(name),
 		},
+		Include: aws.StringSlice(include),
 	}
 	output, err := client.DescribeClusters(input)
 	if err != nil {

--- a/modules/aws/ecs_test.go
+++ b/modules/aws/ecs_test.go
@@ -3,6 +3,9 @@ package aws
 import (
 	"testing"
 
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ecs"
+	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -20,4 +23,40 @@ func TestEcsCluster(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.Equal(t, "terratest", *c2.ClusterName)
+}
+
+func TestEcsClusterWithInclude(t *testing.T) {
+	t.Parallel()
+
+	region := GetRandomStableRegion(t, nil, nil)
+	clusterName := "terratest-" + random.UniqueId()
+	tags := []*ecs.Tag{&ecs.Tag{
+		Key:   aws.String("test-tag"),
+		Value: aws.String("hello-world"),
+	}}
+
+	client := NewEcsClient(t, region)
+	c1, err := client.CreateCluster(&ecs.CreateClusterInput{
+		ClusterName: aws.String(clusterName),
+		Tags:        tags,
+	})
+	assert.NoError(t, err)
+
+	defer DeleteEcsCluster(t, region, c1.Cluster)
+
+	assert.Equal(t, clusterName, aws.StringValue(c1.Cluster.ClusterName))
+
+	c2, err := GetEcsClusterWithIncludeE(t, region, clusterName, []string{ecs.ClusterFieldTags})
+	assert.NoError(t, err)
+
+	assert.Equal(t, clusterName, aws.StringValue(c2.ClusterName))
+	assert.Equal(t, tags, c2.Tags)
+	assert.Empty(t, c2.Statistics)
+
+	c3, err := GetEcsClusterWithIncludeE(t, region, clusterName, []string{ecs.ClusterFieldStatistics})
+	assert.NoError(t, err)
+
+	assert.Equal(t, clusterName, aws.StringValue(c3.ClusterName))
+	assert.NotEmpty(t, c3.Statistics)
+	assert.Empty(t, c3.Tags)
 }


### PR DESCRIPTION
Add a new method for getting ECS cluster info, including additional
optional information. This can be used, for example, to fetch tags along
with the cluster info. Therefore the tags property will no longer be
empty, and can be tested against as well.

Fixes #643


I tried to avoid code duplication by moving the main logic for invoking the API to the new method. As far as I see, this should be fully compatible.

Added a new test case for the new method as well.