### PR TITLE
Remove bash_script reference from packer-docker-example

### DIFF
--- a/examples/packer-docker-example/docker-compose.yml
+++ b/examples/packer-docker-example/docker-compose.yml
@@ -17,11 +17,3 @@ services:
     # Expose the sample app's port on the host OS
     ports:
       - "${SERVER_PORT}:${SERVER_PORT}"
-  bash_script:
-    # The name we use for the Docker image in build.json
-    image: gruntwork/packer-docker-example
-
-    volumes:
-      - ./bash_script.sh:/home/ubuntu/bash_script.sh
-
-    entrypoint: bash_script.sh


### PR DESCRIPTION
It looks like #665 added the ability to run `docker-compose` and get `stdout`. As part of this work, a new example in `examples/docker-compose-stdout-example` was added that had a `bash_script.sh` that was used for testing. All this works fine, but it looks like #665 _also_ added a reference to `bash_script.sh` to the `docker-compose.yml` in `examples/packer-docker-example`... But not `bash_script.sh` itself, so it's making tests fail.

This seems like a copy/paste error, or perhaps a leftover of some previous test, so I'm removing this mention.