### PR TITLE
WIP feat: add podman module

### DIFF
--- a/modules/podman/build.go
+++ b/modules/podman/build.go
@@ -34,10 +34,7 @@ func Build(t testing.TestingT, path string, options *BuildOptions) {
 func BuildE(t testing.TestingT, path string, options *BuildOptions) error {
 	options.Logger.Logf(t, "Running 'podman build' in %s", path)
 
-	args, err := formatPodmanBuildArgs(path, options)
-	if err != nil {
-		return err
-	}
+	args := formatPodmanBuildArgs(path, options)
 
 	cmd := shell.Command{
 		Command: "podman",
@@ -46,11 +43,12 @@ func BuildE(t testing.TestingT, path string, options *BuildOptions) error {
 	}
 
 	_, buildErr := shell.RunCommandAndGetOutputE(t, cmd)
+
 	return buildErr
 }
 
 // formatPodmanBuildArgs formats the arguments for the 'podman build' command.
-func formatPodmanBuildArgs(path string, options *BuildOptions) ([]string, error) {
+func formatPodmanBuildArgs(path string, options *BuildOptions) []string {
 	args := []string{"build"}
 
 	for _, tag := range options.Tags {
@@ -65,5 +63,5 @@ func formatPodmanBuildArgs(path string, options *BuildOptions) ([]string, error)
 
 	args = append(args, path)
 
-	return args, nil
+	return args
 }

--- a/modules/podman/build.go
+++ b/modules/podman/build.go
@@ -1,0 +1,69 @@
+package podman
+
+import (
+	"github.com/gruntwork-io/terratest/modules/logger"
+	"github.com/gruntwork-io/terratest/modules/shell"
+	"github.com/gruntwork-io/terratest/modules/testing"
+	"github.com/stretchr/testify/require"
+)
+
+// BuildOptions defines options that can be passed to the 'podman build' command.
+type BuildOptions struct {
+	// Tags for the Docker image
+	Tags []string
+
+	// Build args to pass the 'podman build' command
+	BuildArgs []string
+
+	// Custom CLI options that will be passed as-is to the 'podman build' command. This is an "escape hatch" that allows
+	// Terratest to not have to support every single command-line option offered by the 'podman build' command, and
+	// solely focus on the most important ones.
+	OtherOptions []string
+
+	// Set a logger that should be used. See the logger package for more info.
+	Logger *logger.Logger
+}
+
+// Build runs the 'podman build' command at the given path with the given options and fails the test if there are any
+// errors.
+func Build(t testing.TestingT, path string, options *BuildOptions) {
+	require.NoError(t, BuildE(t, path, options))
+}
+
+// BuildE runs the 'podman build' command at the given path with the given options and returns any errors.
+func BuildE(t testing.TestingT, path string, options *BuildOptions) error {
+	options.Logger.Logf(t, "Running 'podman build' in %s", path)
+
+	args, err := formatPodmanBuildArgs(path, options)
+	if err != nil {
+		return err
+	}
+
+	cmd := shell.Command{
+		Command: "podman",
+		Args:    args,
+		Logger:  options.Logger,
+	}
+
+	_, buildErr := shell.RunCommandAndGetOutputE(t, cmd)
+	return buildErr
+}
+
+// formatPodmanBuildArgs formats the arguments for the 'podman build' command.
+func formatPodmanBuildArgs(path string, options *BuildOptions) ([]string, error) {
+	args := []string{"build"}
+
+	for _, tag := range options.Tags {
+		args = append(args, "--tag", tag)
+	}
+
+	for _, arg := range options.BuildArgs {
+		args = append(args, "--build-arg", arg)
+	}
+
+	args = append(args, options.OtherOptions...)
+
+	args = append(args, path)
+
+	return args, nil
+}

--- a/modules/podman/inspect.go
+++ b/modules/podman/inspect.go
@@ -1,0 +1,206 @@
+package podman
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gruntwork-io/terratest/modules/logger"
+	"github.com/gruntwork-io/terratest/modules/shell"
+	"github.com/stretchr/testify/require"
+)
+
+// ContainerInspect defines the output of the Inspect method, with the options returned by 'podman inspect'
+// converted into a more friendly and testable interface
+type ContainerInspect struct {
+	// ID of the inspected container
+	ID string
+
+	// Name of the inspected container
+	Name string
+
+	// time.Time that the container was created
+	Created time.Time
+
+	// String representing the container's status
+	Status string
+
+	// Whether the container is currently running or not
+	Running bool
+
+	// Container's exit code
+	ExitCode uint8
+
+	// String with the container's error message, if there is any
+	Error string
+
+	// Ports exposed by the container
+	Ports []Port
+
+	// Volume bindings made to the container
+	Binds []VolumeBind
+
+	// Health check
+	Health HealthCheck
+}
+
+// Port represents a single port mapping exported by the container
+type Port struct {
+	HostPort      uint16
+	ContainerPort uint16
+	Protocol      string
+}
+
+// VolumeBind represents a single volume binding made to the container
+type VolumeBind struct {
+	Source      string
+	Destination string
+}
+
+// HealthCheck represents the current health history of the container
+type HealthCheck struct {
+	// Health check status
+	Status string
+
+	// Current count of failing health checks
+	FailingStreak uint8
+
+	// Log of failures
+	Log []HealthLog
+}
+
+// HealthLog represents the output of a single Health check of the container
+type HealthLog struct {
+	// Start time of health check
+	Start string
+
+	// End time of health check
+	End string
+
+	// Exit code of health check
+	ExitCode uint8
+
+	// Output of health check
+	Output string
+}
+
+// inspectOutput defines options that will be returned by 'podman inspect', in JSON format.
+// Not all options are included here, only the ones that we might need
+type inspectOutput struct {
+	Id      string
+	Created string
+	Name    string
+	State   struct {
+		Health   HealthCheck
+		Status   string
+		Running  bool
+		ExitCode uint8
+		Error    string
+	}
+	NetworkSettings struct {
+		Ports []Port
+	}
+	HostConfig struct {
+		Binds []string
+	}
+}
+
+// Inspect runs the 'podman inspect {container id}' command and returns a ContainerInspect
+// struct, converted from the output JSON, along with any errors
+func Inspect(t *testing.T, id string) *ContainerInspect {
+	out, err := InspectE(t, id)
+	require.NoError(t, err)
+
+	return out
+}
+
+// InspectE runs the 'podman inspect {container id}' command and returns a ContainerInspect
+// struct, converted from the output JSON, along with any errors
+func InspectE(t *testing.T, id string) (*ContainerInspect, error) {
+	cmd := shell.Command{
+		Command: "podman",
+		Args:    []string{"container", "inspect", id},
+		// inspect is a short-running command, don't print the output.
+		Logger: logger.Discard,
+	}
+
+	out, err := shell.RunCommandAndGetStdOutE(t, cmd)
+	if err != nil {
+		return nil, err
+	}
+
+	var containers []inspectOutput
+	err = json.Unmarshal([]byte(out), &containers)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(containers) == 0 {
+		return nil, fmt.Errorf("no container found with ID %s", id)
+	}
+
+	container := containers[0]
+
+	return transformContainer(t, container)
+}
+
+// transformContainerPorts converts 'podman inspect' output JSON into a more friendly and testable format
+func transformContainer(t *testing.T, container inspectOutput) (*ContainerInspect, error) {
+	name := strings.TrimLeft(container.Name, "/")
+
+	volumes := transformContainerVolumes(container)
+
+	created, err := time.Parse(time.RFC3339Nano, container.Created)
+	if err != nil {
+		return nil, err
+	}
+
+	inspect := ContainerInspect{
+		ID:       container.Id,
+		Name:     name,
+		Created:  created,
+		Status:   container.State.Status,
+		Running:  container.State.Running,
+		ExitCode: container.State.ExitCode,
+		Error:    container.State.Error,
+		Ports:    container.NetworkSettings.Ports,
+		Binds:    volumes,
+		Health: HealthCheck{
+			Status:        container.State.Health.Status,
+			FailingStreak: container.State.Health.FailingStreak,
+			Log:           container.State.Health.Log,
+		},
+	}
+
+	return &inspect, nil
+}
+
+// transformContainerVolumes converts Podman's volume bindings from the
+// format "/foo/bar:/foo/baz" into a more testable one
+func transformContainerVolumes(container inspectOutput) []VolumeBind {
+	binds := container.HostConfig.Binds
+	volumes := make([]VolumeBind, 0, len(binds))
+
+	for _, bind := range binds {
+		var source, dest string
+
+		split := strings.Split(bind, ":")
+
+		// Considering it as an unbound volume
+		dest = split[0]
+
+		if len(split) == 2 {
+			source = split[0]
+			dest = split[1]
+		}
+
+		volumes = append(volumes, VolumeBind{
+			Source:      source,
+			Destination: dest,
+		})
+	}
+
+	return volumes
+}

--- a/modules/podman/inspect.go
+++ b/modules/podman/inspect.go
@@ -3,6 +3,7 @@ package podman
 import (
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -89,7 +90,7 @@ type HealthLog struct {
 // inspectOutput defines options that will be returned by 'podman inspect', in JSON format.
 // Not all options are included here, only the ones that we might need
 type inspectOutput struct {
-	Id      string
+	ID      string `json:"Id"`
 	Created string
 	Name    string
 	State   struct {
@@ -107,6 +108,38 @@ type inspectOutput struct {
 	}
 }
 
+type inspectOutputV2 struct {
+	ID      string
+	Created string
+	Name    string
+	State   struct {
+		Health   HealthCheck
+		Status   string
+		Running  bool
+		ExitCode uint8
+		Error    string
+	}
+	NetworkSettings struct {
+		Ports inspectPortsV2
+	}
+	HostConfig struct {
+		Binds []string
+	}
+}
+
+type inspectPortsV2 map[string][]PortV2
+
+type PortV2 struct {
+	HostIP   string `json:"HostIp"`
+	HostPort string
+}
+
+type Version struct {
+	Client struct {
+		Version string
+	}
+}
+
 // Inspect runs the 'podman inspect {container id}' command and returns a ContainerInspect
 // struct, converted from the output JSON, along with any errors
 func Inspect(t *testing.T, id string) *ContainerInspect {
@@ -114,6 +147,53 @@ func Inspect(t *testing.T, id string) *ContainerInspect {
 	require.NoError(t, err)
 
 	return out
+}
+
+func getVersion(t *testing.T) (*Version, error) {
+	var (
+		version Version
+		err     error
+	)
+
+	cmd := shell.Command{
+		Command: "podman",
+		Args:    []string{"version", "--format", "json"},
+		// inspect is a short-running command, don't print the output.
+		Logger: logger.Discard,
+	}
+
+	out, err := shell.RunCommandAndGetStdOutE(t, cmd)
+	if err != nil {
+		return nil, err
+	}
+
+	err = json.Unmarshal([]byte(out), &version)
+	if err != nil {
+		return nil, err
+	}
+
+	return &version, nil
+}
+
+func convertV2Output(containersV2 []inspectOutputV2) (*inspectOutput, error) {
+	containerV2 := containersV2[0]
+	container := inspectOutput{}
+	container.ID = containerV2.ID
+	container.Created = containerV2.Created
+	container.Name = containerV2.Name
+	container.State = containerV2.State
+	container.HostConfig = containerV2.HostConfig
+
+	var ports []Port
+
+	ports, err := transformContainerPorts(containerV2.NetworkSettings.Ports)
+	if err != nil {
+		return nil, err
+	}
+
+	container.NetworkSettings.Ports = ports
+
+	return &container, nil
 }
 
 // InspectE runs the 'podman inspect {container id}' command and returns a ContainerInspect
@@ -131,10 +211,37 @@ func InspectE(t *testing.T, id string) (*ContainerInspect, error) {
 		return nil, err
 	}
 
-	var containers []inspectOutput
-	err = json.Unmarshal([]byte(out), &containers)
+	version, err := getVersion(t)
 	if err != nil {
 		return nil, err
+	}
+
+	var containers []inspectOutput
+
+	if !strings.HasPrefix(version.Client.Version, "1") {
+		// Podman 2.x.x has a different inspect output
+		// It is now similar to Docker inspect output
+		// We will convert V2 to v1 here
+		var containersV2 []inspectOutputV2
+
+		err = json.Unmarshal([]byte(out), &containersV2)
+		if err != nil {
+			return nil, err
+		}
+
+		var containerOutput *inspectOutput
+
+		containerOutput, err = convertV2Output(containersV2)
+		if err != nil {
+			return nil, err
+		}
+
+		containers = append(containers, *containerOutput)
+	} else {
+		err = json.Unmarshal([]byte(out), &containers)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	if len(containers) == 0 {
@@ -143,14 +250,14 @@ func InspectE(t *testing.T, id string) (*ContainerInspect, error) {
 
 	container := containers[0]
 
-	return transformContainer(t, container)
+	return transformContainer(container)
 }
 
-// transformContainerPorts converts 'podman inspect' output JSON into a more friendly and testable format
-func transformContainer(t *testing.T, container inspectOutput) (*ContainerInspect, error) {
+// transformContainerPorts converts 'docker inspect' output JSON into a more friendly and testable format
+func transformContainer(container inspectOutput) (*ContainerInspect, error) {
 	name := strings.TrimLeft(container.Name, "/")
 
-	volumes := transformContainerVolumes(container)
+	volumes := transformContainerVolumes(container.HostConfig.Binds)
 
 	created, err := time.Parse(time.RFC3339Nano, container.Created)
 	if err != nil {
@@ -158,7 +265,7 @@ func transformContainer(t *testing.T, container inspectOutput) (*ContainerInspec
 	}
 
 	inspect := ContainerInspect{
-		ID:       container.Id,
+		ID:       container.ID,
 		Name:     name,
 		Created:  created,
 		Status:   container.State.Status,
@@ -179,8 +286,7 @@ func transformContainer(t *testing.T, container inspectOutput) (*ContainerInspec
 
 // transformContainerVolumes converts Podman's volume bindings from the
 // format "/foo/bar:/foo/baz" into a more testable one
-func transformContainerVolumes(container inspectOutput) []VolumeBind {
-	binds := container.HostConfig.Binds
+func transformContainerVolumes(binds []string) []VolumeBind {
 	volumes := make([]VolumeBind, 0, len(binds))
 
 	for _, bind := range binds {
@@ -203,4 +309,46 @@ func transformContainerVolumes(container inspectOutput) []VolumeBind {
 	}
 
 	return volumes
+}
+
+// transformContainerPorts converts podman's v2.x ports from the following json into a more testable format
+// {
+//   "80/tcp": [
+//     {
+// 	     "HostIp": ""
+//       "HostPort": "8080"
+//     }
+//   ]
+// }
+func transformContainerPorts(cPorts inspectPortsV2) ([]Port, error) {
+	var ports []Port
+
+	for key, portBinding := range cPorts {
+		split := strings.Split(key, "/")
+
+		containerPort, err := strconv.ParseUint(split[0], 10, 16)
+		if err != nil {
+			return nil, err
+		}
+
+		var protocol string
+		if len(split) > 1 {
+			protocol = split[1]
+		}
+
+		for _, port := range portBinding {
+			hostPort, err := strconv.ParseUint(port.HostPort, 10, 16)
+			if err != nil {
+				return nil, err
+			}
+
+			ports = append(ports, Port{
+				HostPort:      uint16(hostPort),
+				ContainerPort: uint16(containerPort),
+				Protocol:      protocol,
+			})
+		}
+	}
+
+	return ports, nil
 }

--- a/modules/podman/podman.go
+++ b/modules/podman/podman.go
@@ -1,0 +1,2 @@
+// Package docker allows to interact with podman resources.
+package podman

--- a/modules/podman/remove.go
+++ b/modules/podman/remove.go
@@ -1,0 +1,49 @@
+package podman
+
+import (
+	"github.com/gruntwork-io/terratest/modules/logger"
+	"github.com/gruntwork-io/terratest/modules/shell"
+	"github.com/gruntwork-io/terratest/modules/testing"
+	"github.com/stretchr/testify/require"
+)
+
+// RemoveOptions defines the options that can be passed to the 'podman rm' command
+type RemoveOptions struct {
+	// Set a logger that should be used. See the logger package for more info.
+	Logger *logger.Logger
+}
+
+// Remove runs the 'podman rm' command for the given containers and return the stdout/stderr. This method fails
+// the test if there are any errors
+func Remove(t testing.TestingT, containers []string, options *RemoveOptions) string {
+	out, err := RemoveE(t, containers, options)
+	require.NoError(t, err)
+	return out
+}
+
+// RemoveE runs the 'podman rm' command for the given containers and returns any errors.
+func RemoveE(t testing.TestingT, containers []string, options *RemoveOptions) (string, error) {
+	options.Logger.Logf(t, "Running 'podman rm' on containers '%s'", containers)
+
+	args, err := formatDockerRemoveArgs(containers, options)
+	if err != nil {
+		return "", err
+	}
+
+	cmd := shell.Command{
+		Command: "podman",
+		Args:    args,
+		Logger:  options.Logger,
+	}
+
+	return shell.RunCommandAndGetOutputE(t, cmd)
+}
+
+// formatDockerRemoveArgs formats the arguments for the 'podman rm' command
+func formatDockerRemoveArgs(containers []string, options *RemoveOptions) ([]string, error) {
+	args := []string{"rm"}
+
+	args = append(args, containers...)
+
+	return args, nil
+}

--- a/modules/podman/run.go
+++ b/modules/podman/run.go
@@ -1,0 +1,159 @@
+package podman
+
+import (
+	"github.com/gruntwork-io/terratest/modules/logger"
+	"github.com/gruntwork-io/terratest/modules/shell"
+	"github.com/gruntwork-io/terratest/modules/testing"
+	"github.com/stretchr/testify/require"
+)
+
+// RunOptions defines options that can be passed to the 'podman run' command.
+type RunOptions struct {
+	// Override the default COMMAND of the Docker image
+	Command []string
+
+	// If set to true, pass the --detach flag to 'podman run' to run the container in the background
+	Detach bool
+
+	// Override the default ENTRYPOINT of the Docker image
+	Entrypoint string
+
+	// Set environment variables
+	EnvironmentVariables []string
+
+	// If set to true, pass the --init flag to 'podman run' to run an init inside the container that forwards signals
+	// and reaps processes
+	Init bool
+
+	// Assign a name to the container
+	Name string
+
+	// If set to true, pass the --privileged flag to 'podman run' to give extended privileges to the container
+	Privileged bool
+
+	// If set to true, pass the --rm flag to 'podman run' to automatically remove the container when it exits
+	Remove bool
+
+	// If set to true, pass the -tty flag to 'podman run' to allocate a pseudo-TTY
+	Tty bool
+
+	// Username or UID
+	User string
+
+	// Bind mount these volume(s) when running the container
+	Volumes []string
+
+	// Custom CLI options that will be passed as-is to the 'podman run' command. This is an "escape hatch" that allows
+	// Terratest to not have to support every single command-line option offered by the 'podman run' command, and
+	// solely focus on the most important ones.
+	OtherOptions []string
+
+	// Set a logger that should be used. See the logger package for more info.
+	Logger *logger.Logger
+}
+
+// Run runs the 'podman run' command on the given image with the given options and return stdout/stderr. This method
+// fails the test if there are any errors.
+func Run(t testing.TestingT, image string, options *RunOptions) string {
+	out, err := RunE(t, image, options)
+	require.NoError(t, err)
+	return out
+}
+
+// RunE runs the 'podman run' command on the given image with the given options and return stdout/stderr, or any error.
+func RunE(t testing.TestingT, image string, options *RunOptions) (string, error) {
+	options.Logger.Logf(t, "Running 'podman run' on image '%s'", image)
+
+	args, err := formatPodmanRunArgs(image, options)
+	if err != nil {
+		return "", err
+	}
+
+	cmd := shell.Command{
+		Command: "podman",
+		Args:    args,
+		Logger:  options.Logger,
+	}
+
+	return shell.RunCommandAndGetOutputE(t, cmd)
+}
+
+// RunAndGetID runs the 'podman run' command on the given image with the given options and returns the container ID
+// that is returned in stdout. This method fails the test if there are any errors.
+func RunAndGetID(t testing.TestingT, image string, options *RunOptions) string {
+	out, err := RunAndGetIDE(t, image, options)
+	require.NoError(t, err)
+	return out
+}
+
+// RunAndGetIDE runs the 'podman run' command on the given image with the given options and returns the container ID
+// that is returned in stdout, or any error.
+func RunAndGetIDE(t testing.TestingT, image string, options *RunOptions) (string, error) {
+	options.Logger.Logf(t, "Running 'podman run' on image '%s', returning stdout", image)
+
+	args, err := formatPodmanRunArgs(image, options)
+	if err != nil {
+		return "", err
+	}
+
+	cmd := shell.Command{
+		Command: "podman",
+		Args:    args,
+		Logger:  options.Logger,
+	}
+
+	return shell.RunCommandAndGetStdOutE(t, cmd)
+}
+
+// formatPodmanRunArgs formats the arguments for the 'podman run' command.
+func formatPodmanRunArgs(image string, options *RunOptions) ([]string, error) {
+	args := []string{"run"}
+
+	if options.Detach {
+		args = append(args, "--detach")
+	}
+
+	if options.Entrypoint != "" {
+		args = append(args, "--entrypoint", options.Entrypoint)
+	}
+
+	for _, envVar := range options.EnvironmentVariables {
+		args = append(args, "--env", envVar)
+	}
+
+	if options.Init {
+		args = append(args, "--init")
+	}
+
+	if options.Name != "" {
+		args = append(args, "--name", options.Name)
+	}
+
+	if options.Privileged {
+		args = append(args, "--privileged")
+	}
+
+	if options.Remove {
+		args = append(args, "--rm")
+	}
+
+	if options.Tty {
+		args = append(args, "--tty")
+	}
+
+	if options.User != "" {
+		args = append(args, "--user", options.User)
+	}
+
+	for _, volume := range options.Volumes {
+		args = append(args, "--volume", volume)
+	}
+
+	args = append(args, options.OtherOptions...)
+
+	args = append(args, image)
+
+	args = append(args, options.Command...)
+
+	return args, nil
+}

--- a/modules/podman/start.go
+++ b/modules/podman/start.go
@@ -1,0 +1,52 @@
+package podman
+
+import (
+	"fmt"
+
+	"github.com/gruntwork-io/terratest/modules/logger"
+	"github.com/gruntwork-io/terratest/modules/shell"
+	"github.com/gruntwork-io/terratest/modules/testing"
+	"github.com/stretchr/testify/require"
+)
+
+// StartOptions defines the options that can be passed to the 'podman start' command
+type StartOptions struct {
+	// Set a logger that should be used. See the logger package for more info.
+	Logger *logger.Logger
+}
+
+// Start runs the 'podman start' command for the given containers and return the stdout/stderr. This method fails
+// the test if there are any errors
+func Start(t testing.TestingT, containers []string, options *StartOptions) string {
+	out, err := StartE(t, containers, options)
+	require.NoError(t, err)
+	return out
+}
+
+// StartE runs the 'podman start' command for the given containers and returns any errors.
+func StartE(t testing.TestingT, containers []string, options *StartOptions) (string, error) {
+	options.Logger.Logf(t, "Running 'podman start' on containers '%s'", containers)
+
+	args, err := formatPodmanStartArgs(containers, options)
+	if err != nil {
+		return "", err
+	}
+
+	cmd := shell.Command{
+		Command: "podman",
+		Args:    args,
+		Logger:  options.Logger,
+	}
+
+	return shell.RunCommandAndGetOutputE(t, cmd)
+}
+
+// formatPodmanStartArgs formats the arguments for the 'podman start' command
+func formatPodmanStartArgs(containers []string, options *StartOptions) ([]string, error) {
+	args := []string{"start"}
+
+	args = append(args, containers...)
+	fmt.Println(containers)
+	fmt.Println(args)
+	return args, nil
+}

--- a/modules/podman/stop.go
+++ b/modules/podman/stop.go
@@ -1,0 +1,58 @@
+package podman
+
+import (
+	"strconv"
+
+	"github.com/gruntwork-io/terratest/modules/logger"
+	"github.com/gruntwork-io/terratest/modules/shell"
+	"github.com/gruntwork-io/terratest/modules/testing"
+	"github.com/stretchr/testify/require"
+)
+
+// StopOptions defines the options that can be passed to the 'podman stop' command
+type StopOptions struct {
+	// Seconds to wait for stop before killing the container (default 10)
+	Time int
+
+	// Set a logger that should be used. See the logger package for more info.
+	Logger *logger.Logger
+}
+
+// Stop runs the 'podman stop' command for the given containers and return the stdout/stderr. This method fails
+// the test if there are any errors
+func Stop(t testing.TestingT, containers []string, options *StopOptions) string {
+	out, err := StopE(t, containers, options)
+	require.NoError(t, err)
+	return out
+}
+
+// StopE runs the 'podman stop' command for the given containers and returns any errors.
+func StopE(t testing.TestingT, containers []string, options *StopOptions) (string, error) {
+	options.Logger.Logf(t, "Running 'podman stop' on containers '%s'", containers)
+
+	args, err := formatDockerStopArgs(containers, options)
+	if err != nil {
+		return "", err
+	}
+
+	cmd := shell.Command{
+		Command: "podman",
+		Args:    args,
+		Logger:  options.Logger,
+	}
+
+	return shell.RunCommandAndGetOutputE(t, cmd)
+}
+
+// formatDockerStopArgs formats the arguments for the 'podman stop' command
+func formatDockerStopArgs(containers []string, options *StopOptions) ([]string, error) {
+	args := []string{"stop"}
+
+	if options.Time != 0 {
+		args = append(args, "--time", strconv.Itoa(options.Time))
+	}
+
+	args = append(args, containers...)
+
+	return args, nil
+}


### PR DESCRIPTION
Implement `build`, `inspect`, `run` and `stop` for podman containers.

Initial implementation copy most of the docker module.
This implementation has been tested using podman 1.6.4, 1.7.0 and 2.0.6

Not unittest yet, WIP. Want to verify that this might be interesting for you first.

