### PR TITLE
Pin importlib-resources

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,7 +72,7 @@ jobs:
             # transitive dependencies that are being pulled in which released new versions that are no longer compatible
             # with any python < 3.6.
             pyenv global 3.5.2
-            pip install pre-commit==1.21.0 cfgv==2.0.1 zipp==1.1.0
+            pip install pre-commit==1.21.0 cfgv==2.0.1 zipp==1.1.0 importlib-resources==3.2.0
             pre-commit install
             pre-commit run --all-files
 


### PR DESCRIPTION
This is an attempt to fix an error when running `pre-commit`:

```
Traceback (most recent call last):
  File "/opt/circleci/.pyenv/versions/3.5.2/bin/pre-commit", line 7, in <module>
    from pre_commit.main import main
  File "/opt/circleci/.pyenv/versions/3.5.2/lib/python3.5/site-packages/pre_commit/main.py", line 11, in <module>
    from pre_commit import git
  File "/opt/circleci/.pyenv/versions/3.5.2/lib/python3.5/site-packages/pre_commit/git.py", line 7, in <module>
    from pre_commit.util import cmd_output
  File "/opt/circleci/.pyenv/versions/3.5.2/lib/python3.5/site-packages/pre_commit/util.py", line 21, in <module>
    from importlib_resources import open_binary
  File "/opt/circleci/.pyenv/versions/3.5.2/lib/python3.5/site-packages/importlib_resources/__init__.py", line 31, in <module>
    from importlib_resources._py3 import (
  File "/opt/circleci/.pyenv/versions/3.5.2/lib/python3.5/site-packages/importlib_resources/_py3.py", line 20, in <module>
    Resource = Union[str, os.PathLike]
AttributeError: module 'os' has no attribute 'PathLike'
```

`importlib-resources` 3.3.0 came out yesterday, so I think that's the cause. Hopefully, pinning to the previous version works around it.