### PR TITLE
Commercial support bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ Please see the following for more info:
 * [Terratest Website](https://terratest.gruntwork.io)
 * [Getting started with Terratest](https://terratest.gruntwork.io/docs/getting-started/quick-start/)
 * [Terratest Documentation](https://terratest.gruntwork.io/docs/)
-* [Contributing to Terratest](http://terratest.gruntwork.io/docs/community/contributing/)
+* [Contributing to Terratest](https://terratest.gruntwork.io/docs/community/contributing/)
+* [Commercial Support](https://terratest.gruntwork.io/commercial-support/)
 
 
 

--- a/docs/_includes/get-access.html
+++ b/docs/_includes/get-access.html
@@ -1,5 +1,5 @@
 <div class="get-access-cmp">
-    <span>Get access to a library of over 300,000 lines of infrastructure code, all thoroughly tested with Terratest.</span>
+    <span>Get access to a library of over 300,000 lines of battle-tested, production grade infrastructure code, all thoroughly tested with Terratest.</span>
     <a href="https://gruntwork.io" target="_blank" class="btn btn-primary">Explore Gruntwork.io</a>
 </div>
   

--- a/docs/_pages/commercial-support/_pricing-table.html
+++ b/docs/_pages/commercial-support/_pricing-table.html
@@ -179,7 +179,7 @@
 			</div>
 			<div class="cell-cnt col-md-2">
 				<div class="cell">
-					<img class="checkmark" src='{{site.baseurl}}/assets/img/icons/checkmark-blue.svg' />
+					<img class="checkmark" src='{{site.baseurl}}/assets/img/icons/xmark.svg' />
 				</div>
 			</div>
 			<div class="cell-cnt col-md-2">
@@ -201,7 +201,7 @@
 			</div>
 			<div class="cell-cnt col-md-2">
 				<div class="cell">
-					<img class="checkmark" src='{{site.baseurl}}/assets/img/icons/checkmark-blue.svg' />
+					<img class="checkmark" src='{{site.baseurl}}/assets/img/icons/xmark.svg' />
 				</div>
 			</div>
 			<div class="cell-cnt col-md-2">
@@ -223,7 +223,7 @@
 			</div>
 			<div class="cell-cnt col-md-2">
 				<div class="cell">
-					<img class="checkmark" src='{{site.baseurl}}/assets/img/icons/checkmark-blue.svg' />
+					<img class="checkmark" src='{{site.baseurl}}/assets/img/icons/xmark.svg' />
 				</div>
 			</div>
 			<div class="cell-cnt col-md-2">
@@ -409,7 +409,7 @@
 				</div>
 			</div>
 			<div class="feature">
-				<a href="https://stackoverflow.com/questions/ask?tags=terratest" class='pricing-link' target="_blank">
+				<a href="https://stackoverflow.com/questions/tagged/terratest" class='pricing-link' target="_blank">
 					<img class="checkmark" src='{{site.baseurl}}/assets/img/icons/checkmark-blue.svg' />via StackOverflow 
 				</a>
 			</div>

--- a/docs/_pages/commercial-support/index.html
+++ b/docs/_pages/commercial-support/index.html
@@ -23,7 +23,7 @@ custom_js:
         <span>
           <img src='{{site.baseurl}}/assets/img/commercial-support/support-web-bottom-left.svg' alt='Shape' class="shapes-left" />
           <img src='{{site.baseurl}}/assets/img/commercial-support/support-web-bottom-right.svg' alt='Shape' class="shapes-right" />
-          Get access to a library of over 300,000 lines of infrastructure code, all thoroughly tested with Terratest.
+          Get access to a library of over 300,000 lines of battle-tested, production-grade infrastructure code, all thoroughly tested with Terratest.
         </span>
         <a href="https://gruntwork.io" target="_blank" class="btn btn-primary">Explore Gruntwork.io</a>
       </div>

--- a/docs/_pages/thanks/index.html
+++ b/docs/_pages/thanks/index.html
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Thank you.
-excerpt: Thank you for contacting us. A grunt will be in touch soon!
+excerpt: Thank you for contacting us. A Grunt will be in touch soon!
 permalink: /thanks/
 ---
 

--- a/docs/jekyll-serve.sh
+++ b/docs/jekyll-serve.sh
@@ -2,6 +2,5 @@
 
 set -e
 
-bundle exec jekyll build
 echo -e "\e[1;31mRun Jekyll serve to watch for changes"
 bundle exec jekyll serve --livereload --drafts --host 0.0.0.0


### PR DESCRIPTION
1. Fix the features that are included with pro support. 
1. Capitalize the word "Grunt."
1. Strengthen the CTA at the bottom of the page.
1. Add link from the README to the commercial support page.
1. Remove `jekyll build` command from start script as it's redundant with the `jekyll serve` that's already there.