### PR TITLE
Kubernetes Secret helper method

### DIFF
--- a/modules/k8s/secret.go
+++ b/modules/k8s/secret.go
@@ -2,7 +2,11 @@ package k8s
 
 import (
 	"context"
+	"fmt"
+	"time"
 
+	"github.com/gruntwork-io/terratest/modules/logger"
+	"github.com/gruntwork-io/terratest/modules/retry"
 	"github.com/gruntwork-io/terratest/modules/testing"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -25,4 +29,24 @@ func GetSecretE(t testing.TestingT, options *KubectlOptions, secretName string) 
 		return nil, err
 	}
 	return clientset.CoreV1().Secrets(options.Namespace).Get(context.Background(), secretName, metav1.GetOptions{})
+}
+
+// WaitUntilSecretAvailable waits until the secret is present on the cluster.
+func WaitUntilSecretAvailable(t testing.TestingT, options *KubectlOptions, secretName string, retries int, sleepBetweenRetries time.Duration) {
+	statusMsg := fmt.Sprintf("Wait for secret %s to be provisioned.", secretName)
+	message := retry.DoWithRetry(
+		t,
+		statusMsg,
+		retries,
+		sleepBetweenRetries,
+		func() (string, error) {
+			_, err := GetSecretE(t, options, secretName)
+			if err != nil {
+				return "", err
+			}
+
+			return "Secret is now available", nil
+		},
+	)
+	logger.Logf(t, message)
 }

--- a/modules/k8s/secret.go
+++ b/modules/k8s/secret.go
@@ -31,7 +31,8 @@ func GetSecretE(t testing.TestingT, options *KubectlOptions, secretName string) 
 	return clientset.CoreV1().Secrets(options.Namespace).Get(context.Background(), secretName, metav1.GetOptions{})
 }
 
-// WaitUntilSecretAvailable waits until the secret is present on the cluster.
+// WaitUntilSecretAvailable waits until the secret is present on the cluster in cases where it is not immediately
+// available (for example, when using ClusterIssuer to request a certificate).
 func WaitUntilSecretAvailable(t testing.TestingT, options *KubectlOptions, secretName string, retries int, sleepBetweenRetries time.Duration) {
 	statusMsg := fmt.Sprintf("Wait for secret %s to be provisioned.", secretName)
 	message := retry.DoWithRetry(

--- a/modules/k8s/secret_test.go
+++ b/modules/k8s/secret_test.go
@@ -50,7 +50,7 @@ func TestWaitUntilSecretAvailableReturnsSuccessfully(t *testing.T) {
 	defer KubectlDeleteFromString(t, options, configData)
 
 	KubectlApplyFromString(t, options, configData)
-	WaitUntilSecretAvailable(t, options, uniqueID, 10, 1*time.Second)
+	WaitUntilSecretAvailable(t, options, "master-password", 10, 1*time.Second)
 }
 
 const EXAMPLE_SECRET_YAML_TEMPLATE = `---

--- a/modules/k8s/secret_test.go
+++ b/modules/k8s/secret_test.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 

--- a/modules/k8s/secret_test.go
+++ b/modules/k8s/secret_test.go
@@ -49,7 +49,7 @@ func TestWaitUntilSecretAvailableReturnsSuccessfully(t *testing.T) {
 	defer KubectlDeleteFromString(t, options, configData)
 
 	KubectlApplyFromString(t, options, configData)
-	WaitUntilServiceAvailable(t, options, uniqueID, 10, 1*time.Second)
+	WaitUntilSecretAvailable(t, options, uniqueID, 10, 1*time.Second)
 }
 
 const EXAMPLE_SECRET_YAML_TEMPLATE = `---

--- a/modules/k8s/secret_test.go
+++ b/modules/k8s/secret_test.go
@@ -40,6 +40,18 @@ func TestGetSecretEReturnsCorrectSecretInCorrectNamespace(t *testing.T) {
 	require.Equal(t, secret.Namespace, uniqueID)
 }
 
+func TestWaitUntilSecretAvailableReturnsSuccessfully(t *testing.T) {
+	t.Parallel()
+
+	uniqueID := strings.ToLower(random.UniqueId())
+	options := NewKubectlOptions("", "", uniqueID)
+	configData := fmt.Sprintf(EXAMPLE_SECRET_YAML_TEMPLATE, uniqueID, uniqueID)
+	defer KubectlDeleteFromString(t, options, configData)
+
+	KubectlApplyFromString(t, options, configData)
+	WaitUntilServiceAvailable(t, options, uniqueID, 10, 1*time.Second)
+}
+
 const EXAMPLE_SECRET_YAML_TEMPLATE = `---
 apiVersion: v1
 kind: Namespace


### PR DESCRIPTION
I create a helper method for situations where a k8s secret is created asynchronously, for example, by a certificate issuer like letsencrypt. We use this method at work and it has been very useful for our e2e infrastructure tests. I assume this would be useful for others, but I will understand if it violates the "bloating the Terratest API" criteria. 

