### PR TITLE
Add two new functions for testing if existing file is a dir or file

### DIFF
--- a/modules/files/files.go
+++ b/modules/files/files.go
@@ -24,6 +24,18 @@ func FileExistsE(path string) (bool, error) {
 	return err == nil, nil
 }
 
+// IsExistingFile returns true if the path exists and is a file.
+func IsExistingFile(path string) bool {
+	fileInfo, err := os.Stat(path)
+	return err == nil && !fileInfo.IsDir()
+}
+
+// IsExistingDir returns true if the path exists and is a directory
+func IsExistingDir(path string) bool {
+	fileInfo, err := os.Stat(path)
+	return err == nil && fileInfo.IsDir()
+}
+
 // CopyTerraformFolderToTemp creates a copy of the given folder and all its contents in a temp folder with a unique name and the given prefix.
 // This is useful when running multiple tests in parallel against the same set of Terraform files to ensure the
 // tests don't overwrite each other's .terraform working directory and terraform.tfstate files. This method returns

--- a/modules/files/files_test.go
+++ b/modules/files/files_test.go
@@ -24,6 +24,30 @@ func TestFileExists(t *testing.T) {
 	assert.False(t, FileExists("/not/a/real/path"))
 }
 
+func TestIsExistingFile(t *testing.T) {
+	t.Parallel()
+
+	currentFile, err := filepath.Abs(os.Args[0])
+	require.NoError(t, err)
+	currentFileDir := filepath.Dir(currentFile)
+
+	assert.True(t, IsExistingFile(currentFile))
+	assert.False(t, IsExistingFile("/not/a/real/path"))
+	assert.False(t, IsExistingFile(currentFileDir))
+}
+
+func TestIsExistingDir(t *testing.T) {
+	t.Parallel()
+
+	currentFile, err := filepath.Abs(os.Args[0])
+	require.NoError(t, err)
+	currentFileDir := filepath.Dir(currentFile)
+
+	assert.False(t, IsExistingDir(currentFile))
+	assert.False(t, IsExistingDir("/not/a/real/path"))
+	assert.True(t, IsExistingDir(currentFileDir))
+}
+
 func TestCopyFolderContents(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
This adds helper functions for ensuring that a given path exists and is a dir or file.

NOTE: This doesn't pass the complexity litmus test, but I think there is an argument to be made for the completeness litmus test where `FileExists` is sometimes not a sufficient test as you want to make sure the path is a directory.