### PR TITLE
fix pod availability checking logic

### DIFF
--- a/modules/k8s/pod.go
+++ b/modules/k8s/pod.go
@@ -142,7 +142,7 @@ func IsPodAvailable(pod *corev1.Pod) bool {
 		isContainerStarted := containerStatus.Started
 		isContainerReady := containerStatus.Ready
 
-		if !isContainerReady || isContainerStarted == nil || !*isContainerStarted {
+		if !isContainerReady || isContainerStarted == nil || *isContainerStarted == false {
 			return false
 		}
 	}

--- a/modules/k8s/pod.go
+++ b/modules/k8s/pod.go
@@ -142,7 +142,7 @@ func IsPodAvailable(pod *corev1.Pod) bool {
 		isContainerStarted := containerStatus.Started
 		isContainerReady := containerStatus.Ready
 
-		if !isContainerReady && isContainerStarted != nil && !*isContainerStarted {
+		if !isContainerReady || isContainerStarted == nil || !*isContainerStarted {
 			return false
 		}
 	}

--- a/modules/k8s/pod.go
+++ b/modules/k8s/pod.go
@@ -142,7 +142,7 @@ func IsPodAvailable(pod *corev1.Pod) bool {
 		isContainerStarted := containerStatus.Started
 		isContainerReady := containerStatus.Ready
 
-		if !isContainerReady || isContainerStarted == nil || *isContainerStarted == false {
+		if !isContainerReady || (isContainerStarted != nil && *isContainerStarted == false) {
 			return false
 		}
 	}

--- a/modules/k8s/pod_test.go
+++ b/modules/k8s/pod_test.go
@@ -112,7 +112,7 @@ func TestWaitUntilPodAvailableWithFailingReadinessProbe(t *testing.T) {
 
 	uniqueID := strings.ToLower(random.UniqueId())
 	options := NewKubectlOptions("", "", uniqueID)
-	configData := fmt.Sprintf(EXAMPLE_POD_WITH_READINESS_PROBE, uniqueID, uniqueID)
+	configData := fmt.Sprintf(EXAMPLE_POD_WITH_FAILING_READINESS_PROBE, uniqueID, uniqueID)
 	defer KubectlDeleteFromString(t, options, configData)
 	KubectlApplyFromString(t, options, configData)
 

--- a/modules/k8s/pod_test.go
+++ b/modules/k8s/pod_test.go
@@ -164,7 +164,7 @@ const EXAMPLE_POD_WITH_FAILING_READINESS_PROBE = EXAMPLE_POD_YAML_TEMPLATE + `
 func TestIsPodAvailable(t *testing.T) {
 	t.Parallel()
 
-	cases := []struct{
+	cases := []struct {
 		title          string
 		pod            *corev1.Pod
 		expectedResult bool
@@ -175,8 +175,8 @@ func TestIsPodAvailable(t *testing.T) {
 				Status: corev1.PodStatus{
 					ContainerStatuses: []corev1.ContainerStatus{
 						{
-							Name: "container1",
-							Ready: false,
+							Name:    "container1",
+							Ready:   false,
 							Started: &[]bool{true}[0],
 						},
 					},
@@ -191,8 +191,8 @@ func TestIsPodAvailable(t *testing.T) {
 				Status: corev1.PodStatus{
 					ContainerStatuses: []corev1.ContainerStatus{
 						{
-							Name: "container1",
-							Ready: true,
+							Name:    "container1",
+							Ready:   true,
 							Started: &[]bool{true}[0],
 						},
 					},

--- a/modules/k8s/pod_test.go
+++ b/modules/k8s/pod_test.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/gruntwork-io/terratest/modules/random"
@@ -94,6 +95,31 @@ func TestWaitUntilPodWithMultipleContainersAvailableReturnsSuccessfully(t *testi
 	WaitUntilPodAvailable(t, options, "nginx-pod", 60, 1*time.Second)
 }
 
+func TestWaitUntilPodAvailableWithReadinessProbe(t *testing.T) {
+	t.Parallel()
+
+	uniqueID := strings.ToLower(random.UniqueId())
+	options := NewKubectlOptions("", "", uniqueID)
+	configData := fmt.Sprintf(EXAMPLE_POD_WITH_READINESS_PROBE, uniqueID, uniqueID)
+	defer KubectlDeleteFromString(t, options, configData)
+	KubectlApplyFromString(t, options, configData)
+
+	WaitUntilPodAvailable(t, options, "nginx-pod", 60, 1*time.Second)
+}
+
+func TestWaitUntilPodAvailableWithFailingReadinessProbe(t *testing.T) {
+	t.Parallel()
+
+	uniqueID := strings.ToLower(random.UniqueId())
+	options := NewKubectlOptions("", "", uniqueID)
+	configData := fmt.Sprintf(EXAMPLE_POD_WITH_READINESS_PROBE, uniqueID, uniqueID)
+	defer KubectlDeleteFromString(t, options, configData)
+	KubectlApplyFromString(t, options, configData)
+
+	err := WaitUntilPodAvailableE(t, options, "nginx-pod", 60, 1*time.Second)
+	require.Error(t, err)
+}
+
 const EXAMPLE_POD_YAML_TEMPLATE = `---
 apiVersion: v1
 kind: Namespace
@@ -119,3 +145,69 @@ const EXAMPLE_POD_WITH_MULTIPLE_CONTAINERS_YAML_TEMPLATE = EXAMPLE_POD_YAML_TEMP
     ports:
     - containerPort: 80
 `
+
+const EXAMPLE_POD_WITH_READINESS_PROBE = EXAMPLE_POD_YAML_TEMPLATE + `
+    readinessProbe:
+      httpGet:
+        path: /
+        port: 80
+`
+
+const EXAMPLE_POD_WITH_FAILING_READINESS_PROBE = EXAMPLE_POD_YAML_TEMPLATE + `
+    readinessProbe:
+      httpGet:
+        path: /not-ready
+        port: 80
+      periodSeconds: 1
+`
+
+func TestIsPodAvailable(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct{
+		title          string
+		pod            *corev1.Pod
+		expectedResult bool
+	}{
+		{
+			title: "TestIsPodAvailableStartedButNotReady",
+			pod: &corev1.Pod{
+				Status: corev1.PodStatus{
+					ContainerStatuses: []corev1.ContainerStatus{
+						{
+							Name: "container1",
+							Ready: false,
+							Started: &[]bool{true}[0],
+						},
+					},
+					Phase: corev1.PodRunning,
+				},
+			},
+			expectedResult: false,
+		},
+		{
+			title: "TestIsPodAvailableStartedAndReady",
+			pod: &corev1.Pod{
+				Status: corev1.PodStatus{
+					ContainerStatuses: []corev1.ContainerStatus{
+						{
+							Name: "container1",
+							Ready: true,
+							Started: &[]bool{true}[0],
+						},
+					},
+					Phase: corev1.PodRunning,
+				},
+			},
+			expectedResult: true,
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.title, func(t *testing.T) {
+			t.Parallel()
+			actualResult := IsPodAvailable(tc.pod)
+			require.Equal(t, tc.expectedResult, actualResult)
+		})
+	}
+}


### PR DESCRIPTION
The changes to `IsPodAvailable` introduced in https://github.com/gruntwork-io/terratest/pull/480 incorrectly reported pods as available when the readinessProbe is failing but the containers were in a started state. Namely, when there is no startupProbe, `containerStatus.Started` will always be true ([ref](https://godoc.org/k8s.io/api/core/v1#ContainerStatus)) and the pod will be incorrectly reported as available.

This PR fixes the availability checking logic and adds a few test cases to validate the fix.