### PR TITLE
Fix IsPodAvailable readiness check

### DIFF
--- a/modules/k8s/pod.go
+++ b/modules/k8s/pod.go
@@ -142,7 +142,7 @@ func IsPodAvailable(pod *corev1.Pod) bool {
 		isContainerStarted := containerStatus.Started
 		isContainerReady := containerStatus.Ready
 
-		if !isContainerReady && isContainerStarted != nil && !*isContainerStarted {
+		if !isContainerReady || (isContainerStarted != nil && !*isContainerStarted) {
 			return false
 		}
 	}


### PR DESCRIPTION
Hey there!

It appears to me as if the condition in `k8s.IsPodAvailable` should return false either if:
- the pod's container is not started
- or if the pod's container is not ready

However, the current implem will return false only if both conditions are true.
This PR fixes it.