### PR TITLE
terraform: add Int/Float output methods

### DIFF
--- a/modules/terraform/output.go
+++ b/modules/terraform/output.go
@@ -46,6 +46,34 @@ func OutputRequiredE(t testing.TestingT, options *Options, key string) (string, 
 	return out, nil
 }
 
+// OutputInt calls terraform output for the given variable and returns its value as an int.
+func OutputInt(t testing.TestingT, options *Options, key string) int {
+	out, err := OutputIntE(t, options, key)
+	require.NoError(t, err)
+	return out
+}
+
+// OutputIntE calls terraform output for the given variable and returns its value as an int.
+func OutputIntE(t testing.TestingT, options *Options, key string) (int, error) {
+	var i int
+	err := OutputStructE(t, options, key, &i)
+	return i, err
+}
+
+// OutputFloat calls terraform output for the given variable and returns its value as a float64.
+func OutputFloat(t testing.TestingT, options *Options, key string) float64 {
+	out, err := OutputFloatE(t, options, key)
+	require.NoError(t, err)
+	return out
+}
+
+// OutputFloatE calls terraform output for the given variable and returns its value as a float64.
+func OutputFloatE(t testing.TestingT, options *Options, key string) (float64, error) {
+	var f float64
+	err := OutputStructE(t, options, key, &f)
+	return f, err
+}
+
 // parseListOfMaps takes a list of maps and parses the types.
 // It is mainly a wrapper for parseMap to support lists.
 func parseListOfMaps(l []interface{}) ([]map[string]interface{}, error) {

--- a/modules/terraform/output_test.go
+++ b/modules/terraform/output_test.go
@@ -8,6 +8,76 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestOutputInt(t *testing.T) {
+	t.Parallel()
+
+	testFolder, err := files.CopyTerraformFolderToTemp("../../test/fixtures/terraform-output-int", t.Name())
+	require.NoError(t, err)
+
+	options := &Options{
+		TerraformDir: testFolder,
+	}
+
+	InitAndApply(t, options)
+	out := OutputInt(t, options, "int")
+
+	require.Equal(t, 1, out)
+}
+
+func TestOutputIntError(t *testing.T) {
+	t.Parallel()
+
+	testFolder, err := files.CopyTerraformFolderToTemp("../../test/fixtures/terraform-output-int", t.Name())
+	require.NoError(t, err)
+
+	options := &Options{
+		TerraformDir: testFolder,
+	}
+
+	InitAndApply(t, options)
+	_, err = OutputIntE(t, options, "float")
+
+	require.Error(t, err)
+}
+
+func TestOutputFloat(t *testing.T) {
+	t.Parallel()
+
+	testFolder, err := files.CopyTerraformFolderToTemp("../../test/fixtures/terraform-output-float", t.Name())
+	require.NoError(t, err)
+
+	options := &Options{
+		TerraformDir: testFolder,
+	}
+
+	InitAndApply(t, options)
+
+	out := OutputFloat(t, options, "float")
+	require.Equal(t, 1.1, out)
+
+	out = OutputFloat(t, options, "float_0")
+	require.Equal(t, 1.0, out)
+
+	out = OutputFloat(t, options, "int")
+	require.Equal(t, 1, out)
+}
+
+func TestOutputFloatError(t *testing.T) {
+	t.Parallel()
+
+	testFolder, err := files.CopyTerraformFolderToTemp("../../test/fixtures/terraform-output-float", t.Name())
+	require.NoError(t, err)
+
+	options := &Options{
+		TerraformDir: testFolder,
+	}
+
+	InitAndApply(t, options)
+	_, err = OutputFloatE(t, options, "string")
+
+	require.Error(t, err)
+}
+
 func TestOutputList(t *testing.T) {
 	t.Parallel()
 

--- a/test/fixtures/terraform-output-float/output.tf
+++ b/test/fixtures/terraform-output-float/output.tf
@@ -1,0 +1,15 @@
+output "int" {
+  value = 1
+}
+
+output "float_0" {
+  value = 1.0
+}
+
+output "float" {
+  value = 1.1
+}
+
+output "string" {
+  value = "foo"
+}

--- a/test/fixtures/terraform-output-int/output.tf
+++ b/test/fixtures/terraform-output-int/output.tf
@@ -1,0 +1,7 @@
+output "int" {
+  value = 1
+}
+
+output "float" {
+  value = 1.1
+}


### PR DESCRIPTION
In Terraform 0.14, numeric outputs are returned as JSON. In Terraform 0.13, they were returned as strings. This results in an unmarshaling error when calling `Output` for a value that is a number. This PR adds new methods for outputting as an `int` or `float64`. 

Here's an example of the output/test failure:

```
2020-12-04T15:56:45.2623179Z TestNanoInstance 2020-12-04T15:56:45Z retry.go:91: terraform [apply -input=false -auto-approve -var instance_type=t3.nano -lock=false]
2020-12-04T15:56:45.2626238Z TestNanoInstance 2020-12-04T15:56:45Z logger.go:66: Running command terraform with args [apply -input=false -auto-approve -var instance_type=t3.nano -lock=false]
2020-12-04T15:56:47.2545571Z TestNanoInstance 2020-12-04T15:56:47Z logger.go:66: 
2020-12-04T15:56:47.2546648Z TestNanoInstance 2020-12-04T15:56:47Z logger.go:66: Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
2020-12-04T15:56:47.2547546Z TestNanoInstance 2020-12-04T15:56:47Z logger.go:66: 
2020-12-04T15:56:47.2548265Z TestNanoInstance 2020-12-04T15:56:47Z logger.go:66: Outputs:
2020-12-04T15:56:47.2551669Z TestNanoInstance 2020-12-04T15:56:47Z logger.go:66: 
2020-12-04T15:56:47.2552412Z TestNanoInstance 2020-12-04T15:56:47Z logger.go:66: cpus = 2
2020-12-04T15:56:47.2553332Z TestNanoInstance 2020-12-04T15:56:47Z logger.go:66: memory = 0.5
2020-12-04T15:56:47.2574545Z TestNanoInstance 2020-12-04T15:56:47Z retry.go:91: terraform [output -no-color -json cpus]
2020-12-04T15:56:47.2576276Z TestNanoInstance 2020-12-04T15:56:47Z logger.go:66: Running command terraform with args [output -no-color -json cpus]
2020-12-04T15:56:47.8104739Z TestNanoInstance 2020-12-04T15:56:47Z logger.go:66: 2
2020-12-04T15:56:47.8139242Z --- FAIL: TestNanoInstance (8.35s)
2020-12-04T15:56:47.8140321Z     output.go:17: 
2020-12-04T15:56:47.8141309Z         	Error Trace:	output.go:17
2020-12-04T15:56:47.8142093Z         	            				pricing_test.go:40
2020-12-04T15:56:47.8142926Z         	Error:      	Received unexpected error:
2020-12-04T15:56:47.8143992Z         	            	json: cannot unmarshal number into Go value of type string
2020-12-04T15:56:47.8145134Z         	Test:       	TestNanoInstance
2020-12-04T15:56:47.8146116Z FAIL
2020-12-04T15:56:47.8147555Z FAIL	github.com/bendrucker/terraform-aws-ec2-pricing/test	17.488s
2020-12-04T15:56:47.8149133Z FAIL
```

https://github.com/bendrucker/terraform-aws-ec2-pricing/runs/1499762332