### PR TITLE
Fix terraform string output types conversion; Add all json output.

### DIFF
--- a/modules/terraform/output.go
+++ b/modules/terraform/output.go
@@ -12,7 +12,7 @@ import (
 )
 
 // Output calls terraform output for the given variable and return its string value representation.
-// It is only designed to work for primitive terraform types: string, number and bool.
+// It only designed to work with primitive terraform types: string, number and bool.
 // Please use OutputStruct for anything else.
 func Output(t testing.TestingT, options *Options, key string) string {
 	out, err := OutputE(t, options, key)
@@ -21,7 +21,7 @@ func Output(t testing.TestingT, options *Options, key string) string {
 }
 
 // OutputE calls terraform output for the given variable and return its string value representation.
-// It is only designed to work for primitive terraform types: string, number and bool.
+// It only designed to work with primitive terraform types: string, number and bool.
 // Please use OutputStructE for anything else.
 func OutputE(t testing.TestingT, options *Options, key string) (string, error) {
 	var val interface{}
@@ -263,7 +263,7 @@ func OutputForKeys(t testing.TestingT, options *Options, keys []string) map[stri
 
 // OutputJson calls terraform output for the given variable and returns the
 // result as the json string.
-// If v is an empty string, it will return entire output.
+// If v is an empty string, it will return the entire output.
 func OutputJson(t testing.TestingT, options *Options, key string) string {
 	str, err := OutputJsonE(t, options, key)
 	require.NoError(t, err)
@@ -272,7 +272,7 @@ func OutputJson(t testing.TestingT, options *Options, key string) string {
 
 // OutputJsonE calls terraform output for the given variable and returns the
 // result as the json string.
-// If v is an empty string, it will return entire output.
+// If v is an empty string, it will return the entire output.
 func OutputJsonE(t testing.TestingT, options *Options, key string) (string, error) {
 	args := []string{"output", "-no-color", "-json"}
 	if key != "" {

--- a/modules/terraform/output.go
+++ b/modules/terraform/output.go
@@ -279,12 +279,7 @@ func OutputJsonE(t testing.TestingT, options *Options, key string) (string, erro
 		args = append(args, key)
 	}
 
-	out, err := RunTerraformCommandAndGetStdoutE(t, options, args...)
-	if err != nil {
-		return "", err
-	}
-
-	return out, nil
+	return RunTerraformCommandAndGetStdoutE(t, options, args...)
 }
 
 // OutputStruct calls terraform output for the given variable and stores the

--- a/modules/terraform/output.go
+++ b/modules/terraform/output.go
@@ -263,7 +263,7 @@ func OutputForKeys(t testing.TestingT, options *Options, keys []string) map[stri
 
 // OutputJson calls terraform output for the given variable and returns the
 // result as the json string.
-// If v is an empty string, it will return the entire output.
+// If key is an empty string, it will return all the output variables.
 func OutputJson(t testing.TestingT, options *Options, key string) string {
 	str, err := OutputJsonE(t, options, key)
 	require.NoError(t, err)

--- a/modules/terraform/output.go
+++ b/modules/terraform/output.go
@@ -272,7 +272,7 @@ func OutputJson(t testing.TestingT, options *Options, key string) string {
 
 // OutputJsonE calls terraform output for the given variable and returns the
 // result as the json string.
-// If v is an empty string, it will return the entire output.
+// If key is an empty string, it will return all the output variables.
 func OutputJsonE(t testing.TestingT, options *Options, key string) (string, error) {
 	args := []string{"output", "-no-color", "-json"}
 	if key != "" {

--- a/modules/terraform/output.go
+++ b/modules/terraform/output.go
@@ -12,6 +12,8 @@ import (
 )
 
 // Output calls terraform output for the given variable and return its string value representation.
+// It is only designed to work for primitive terraform types: string, number and bool.
+// Please use OutputStruct for anything else.
 func Output(t testing.TestingT, options *Options, key string) string {
 	out, err := OutputE(t, options, key)
 	require.NoError(t, err)
@@ -19,6 +21,8 @@ func Output(t testing.TestingT, options *Options, key string) string {
 }
 
 // OutputE calls terraform output for the given variable and return its string value representation.
+// It is only designed to work for primitive terraform types: string, number and bool.
+// Please use OutputStructE for anything else.
 func OutputE(t testing.TestingT, options *Options, key string) (string, error) {
 	var val interface{}
 	err := OutputStructE(t, options, key, &val)

--- a/modules/terraform/output.go
+++ b/modules/terraform/output.go
@@ -11,14 +11,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// Output calls terraform output for the given variable and return its value.
+// Output calls terraform output for the given variable and return its string value representation.
 func Output(t testing.TestingT, options *Options, key string) string {
 	out, err := OutputE(t, options, key)
 	require.NoError(t, err)
 	return out
 }
 
-// OutputE calls terraform output for the given variable and return its value.
+// OutputE calls terraform output for the given variable and return its string value representation.
 func OutputE(t testing.TestingT, options *Options, key string) (string, error) {
 	var val interface{}
 	err := OutputStructE(t, options, key, &val)

--- a/modules/terraform/output_test.go
+++ b/modules/terraform/output_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestOutput1(t *testing.T) {
+func TestOutputString(t *testing.T) {
 	t.Parallel()
 
 	testFolder, err := files.CopyTerraformFolderToTemp("../../test/fixtures/terraform-output", t.Name())
@@ -28,6 +28,9 @@ func TestOutput1(t *testing.T) {
 
 	num := Output(t, options, "number")
 	require.Equal(t, num, "3.14", "Number %q should match %q", "3.14", num)
+
+	num1 := Output(t, options, "number1")
+	require.Equal(t, num1, "3", "Number %q should match %q", "3", num1)
 }
 
 func TestOutputList(t *testing.T) {

--- a/modules/terraform/output_test.go
+++ b/modules/terraform/output_test.go
@@ -8,6 +8,28 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestOutput(t *testing.T) {
+	t.Parallel()
+
+	testFolder, err := files.CopyTerraformFolderToTemp("../../test/fixtures/terraform-output", t.Name())
+	require.NoError(t, err)
+
+	options := &Options{
+		TerraformDir: testFolder,
+	}
+
+	InitAndApply(t, options)
+
+	b := Output(t, options, "bool")
+	require.Equal(t, b, "true", "Bool %q should match %q", "true", b)
+
+	str := Output(t, options, "string")
+	require.Equal(t, str, "This is a string.", "String %q should match %q", "This is a string.", str)
+
+	num := Output(t, options, "number")
+	require.Equal(t, num, "3.14", "Number %q should match %q", "3.14", num)
+}
+
 func TestOutputList(t *testing.T) {
 	t.Parallel()
 
@@ -251,6 +273,40 @@ func TestOutputsForKeys(t *testing.T) {
 	outputNotPresentMap, ok := out["constellations"].(map[string]interface{})
 	require.False(t, ok)
 	require.Nil(t, outputNotPresentMap)
+}
+
+func TestOutputJson(t *testing.T) {
+	t.Parallel()
+
+	testFolder, err := files.CopyTerraformFolderToTemp("../../test/fixtures/terraform-output", t.Name())
+	require.NoError(t, err)
+
+	options := &Options{
+		TerraformDir: testFolder,
+	}
+
+	InitAndApply(t, options)
+
+	expected := `{
+  "bool": {
+    "sensitive": false,
+    "type": "bool",
+    "value": true
+  },
+  "number": {
+    "sensitive": false,
+    "type": "number",
+    "value": 3.14
+  },
+  "string": {
+    "sensitive": false,
+    "type": "string",
+    "value": "This is a string."
+  }
+}`
+
+	str := OutputJson(t, options, "")
+	require.Equal(t, str, expected, "JSON %q should match %q", expected, str)
 }
 
 func TestOutputStruct(t *testing.T) {

--- a/modules/terraform/output_test.go
+++ b/modules/terraform/output_test.go
@@ -301,6 +301,11 @@ func TestOutputJson(t *testing.T) {
     "type": "number",
     "value": 3.14
   },
+  "number1": {
+    "sensitive": false,
+    "type": "number",
+    "value": 3
+  },
   "string": {
     "sensitive": false,
     "type": "string",

--- a/modules/terraform/output_test.go
+++ b/modules/terraform/output_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestOutput(t *testing.T) {
+func TestOutput1(t *testing.T) {
 	t.Parallel()
 
 	testFolder, err := files.CopyTerraformFolderToTemp("../../test/fixtures/terraform-output", t.Name())

--- a/test/fixtures/terraform-output/output.tf
+++ b/test/fixtures/terraform-output/output.tf
@@ -9,3 +9,7 @@ output "string" {
 output "number" {
   value = 3.14
 }
+
+output "number1" {
+  value = 3
+}

--- a/test/fixtures/terraform-output/output.tf
+++ b/test/fixtures/terraform-output/output.tf
@@ -1,0 +1,11 @@
+output "bool" {
+  value = true
+}
+
+output "string" {
+  value = "This is a string."
+}
+
+output "number" {
+  value = 3.14
+}


### PR DESCRIPTION
- Fix regression in `OutputE`: now it can also output bool and number as string. I am not sure about other terraform data types but their string representation would be useless and inconsistent anyway, I guess it's one of the reasons TF did that breaking change in the first place. Added suggestion to use `OutputStruct` for non-primitive types.
- `OutputE` and `Output` comment now explicitly says it returns string representation of a value.
- Added `OutputJsonE` and `OutputJson` that will return `-json` tf output as-is - might be useful if user wants to do anything fancy with it
- Some DRY cleanup - other output functions now use the new `OutputJsonE` function instead of `RunTerraformCommandAndGetStdoutE`
- Added missing tests for `Output` as well as for new `OutputJson`