### PR TITLE
Using the built-in lib function to generate the 'host:port' value

### DIFF
--- a/modules/ssh/session.go
+++ b/modules/ssh/session.go
@@ -1,10 +1,10 @@
 package ssh
 
 import (
-	"fmt"
 	"io"
 	"net"
 	"reflect"
+	"strconv"
 
 	"github.com/gruntwork-io/terratest/modules/collections"
 	"github.com/gruntwork-io/terratest/modules/logger"
@@ -24,7 +24,7 @@ type SshConnectionOptions struct {
 
 // ConnectionString returns the connection string for an SSH connection.
 func (options *SshConnectionOptions) ConnectionString() string {
-	return fmt.Sprintf("%s:%d", options.Address, options.Port)
+	return net.JoinHostPort(options.Address, strconv.Itoa(options.Port))
 }
 
 // SshSession is a container object for all resources created by an SSH session. The reason we need this is so that we can do a

--- a/modules/ssh/session_test.go
+++ b/modules/ssh/session_test.go
@@ -1,0 +1,54 @@
+package ssh
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSshConnectionOptions_ConnectionString(t *testing.T) {
+	type fields struct {
+		Address string
+		Port    int
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   string
+	}{
+		{
+			name: "plain ipv4",
+			fields: fields{
+				Address: "192.168.86.68",
+				Port:    22,
+			},
+			want: "192.168.86.68:22",
+		},
+		{
+			name: "plain ipv6",
+			fields: fields{
+				Address: "2001:0db8:85a3:0000:0000:8a2e:0370:7334",
+				Port:    22,
+			},
+			want: "[2001:0db8:85a3:0000:0000:8a2e:0370:7334]:22",
+		},
+		{
+			name: "host fqdn",
+			fields: fields{
+				Address: "host.for.test.com",
+				Port:    443,
+			},
+			want: "host.for.test.com:443",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			options := &SshConnectionOptions{
+				Address: tt.fields.Address,
+				Port:    tt.fields.Port,
+			}
+			got := options.ConnectionString()
+			require.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
Thus, the host value can contain any IPv6 address.