### PR TITLE
Allow extra args for helm Install/Upgrade

### DIFF
--- a/modules/helm/install.go
+++ b/modules/helm/install.go
@@ -32,6 +32,9 @@ func InstallE(t testing.TestingT, options *Options, chart string, releaseName st
 	// Declare err here so that we can update args later
 	var err error
 	args := []string{}
+	if options.ExtraArgs != nil {
+		args = append(args, options.ExtraArgs...)
+	}
 	args = append(args, getNamespaceArgs(options)...)
 	if options.Version != "" {
 		args = append(args, "--version", options.Version)

--- a/modules/helm/install_test.go
+++ b/modules/helm/install_test.go
@@ -65,6 +65,8 @@ func TestRemoteChartInstall(t *testing.T) {
 
 	// Fix chart version and retry install
 	options.Version = "2.3.0"
+	// Test that passing extra arguments doesn't error, by changing default timeout
+	options.ExtraArgs = []string{"--timeout", "5m1s"}
 	require.NoError(t, InstallE(t, options, helmChart, releaseName))
 	waitForRemoteChartPods(t, kubectlOptions, releaseName, 1)
 

--- a/modules/helm/options.go
+++ b/modules/helm/options.go
@@ -15,4 +15,5 @@ type Options struct {
 	EnvVars        map[string]string   // Environment variables to set when running helm
 	Version        string              // Version of chart
 	Logger         *logger.Logger      // Set a non-default logger that should be used. See the logger package for more info.
+	ExtraArgs      []string            // Extra arguments to pass to the helm install/upgrade command
 }

--- a/modules/helm/upgrade.go
+++ b/modules/helm/upgrade.go
@@ -29,6 +29,9 @@ func UpgradeE(t testing.TestingT, options *Options, chart string, releaseName st
 
 	var err error
 	args := []string{}
+	if options.ExtraArgs != nil {
+		args = append(args, options.ExtraArgs...)
+	}
 	args = append(args, getNamespaceArgs(options)...)
 	args, err = getValuesArgsE(t, options, args...)
 	if err != nil {

--- a/modules/helm/upgrade_test.go
+++ b/modules/helm/upgrade_test.go
@@ -64,6 +64,8 @@ func TestRemoteChartInstallUpgradeRollback(t *testing.T) {
 		"replicaCount": "2",
 		"service.type": "NodePort",
 	}
+	// Test that passing extra arguments doesn't error, by changing default timeout
+	options.ExtraArgs = []string{"--timeout", "5m1s"}
 	Upgrade(t, options, helmChart, releaseName)
 	waitForRemoteChartPods(t, kubectlOptions, releaseName, 2)
 


### PR DESCRIPTION
### GH Issue
[GH Issue 726](https://github.com/gruntwork-io/terratest/issues/726)

### Changes Proposed
This PR allows passing arguments to the helm command when using the `Install` and `Upgrade` functions in the `helm` module.

### Test output
The test output can be found in this [gist](https://gist.github.com/ndhanushkodi/006b904a188604099654f0f3280762c4)

### Description of code changes
Adds an option to [options.go](https://github.com/gruntwork-io/terratest/blob/2afcf242dd02ba62bc1ca5fe555b4e6550dbffcf/modules/helm/options.go#L17) called `ExtraArgs` and modifies [`InstallE`](https://github.com/gruntwork-io/terratest/blob/2afcf242dd02ba62bc1ca5fe555b4e6550dbffcf/modules/helm/install.go#L34)  and [`UpgradeE`](https://github.com/gruntwork-io/terratest/blob/2afcf242dd02ba62bc1ca5fe555b4e6550dbffcf/modules/helm/upgrade.go#L31) to check if `options.ExtraArgs` is set, and passes those along to [`RunHelmCommandAndGetOutputE`](https://github.com/gruntwork-io/terratest/blob/2afcf242dd02ba62bc1ca5fe555b4e6550dbffcf/modules/helm/install.go#L44). This would be backwards compatible since it doesn't change the signature of the `Install` or `Upgrade` functions in the helm module.











Closes #726 