### PR TITLE
Allow extra args for all helm commands: Install, Upgrade, Delete, and Rollback

### DIFF
--- a/modules/helm/delete.go
+++ b/modules/helm/delete.go
@@ -18,6 +18,11 @@ func DeleteE(t testing.TestingT, options *Options, releaseName string, purge boo
 	if !purge {
 		args = append(args, "--keep-history")
 	}
+	if options.ExtraArgs != nil {
+		if deleteArgs, ok := options.ExtraArgs["delete"]; ok {
+			args = append(args, deleteArgs...)
+		}
+	}
 	args = append(args, getNamespaceArgs(options)...)
 	args = append(args, releaseName)
 	_, err := RunHelmCommandAndGetOutputE(t, options, "delete", args...)

--- a/modules/helm/install.go
+++ b/modules/helm/install.go
@@ -33,7 +33,9 @@ func InstallE(t testing.TestingT, options *Options, chart string, releaseName st
 	var err error
 	args := []string{}
 	if options.ExtraArgs != nil {
-		args = append(args, options.ExtraArgs...)
+		if installArgs, ok := options.ExtraArgs["install"]; ok {
+			args = append(args, installArgs...)
+		}
 	}
 	args = append(args, getNamespaceArgs(options)...)
 	if options.Version != "" {

--- a/modules/helm/install_test.go
+++ b/modules/helm/install_test.go
@@ -66,7 +66,8 @@ func TestRemoteChartInstall(t *testing.T) {
 	// Fix chart version and retry install
 	options.Version = "2.3.0"
 	// Test that passing extra arguments doesn't error, by changing default timeout
-	options.ExtraArgs = []string{"--timeout", "5m1s"}
+	options.ExtraArgs = map[string][]string{"install": []string{"--timeout", "5m1s"}}
+	options.ExtraArgs["delete"] = []string{"--timeout", "5m1s"}
 	require.NoError(t, InstallE(t, options, helmChart, releaseName))
 	waitForRemoteChartPods(t, kubectlOptions, releaseName, 1)
 

--- a/modules/helm/options.go
+++ b/modules/helm/options.go
@@ -15,5 +15,5 @@ type Options struct {
 	EnvVars        map[string]string   // Environment variables to set when running helm
 	Version        string              // Version of chart
 	Logger         *logger.Logger      // Set a non-default logger that should be used. See the logger package for more info.
-	ExtraArgs      []string            // Extra arguments to pass to the helm install/upgrade command
+	ExtraArgs      map[string][]string // Extra arguments to pass to the helm install/upgrade/rollback/delete command. The key signals the command (e.g., install) while the values are the extra arguments to pass through.
 }

--- a/modules/helm/rollback.go
+++ b/modules/helm/rollback.go
@@ -15,6 +15,11 @@ func Rollback(t testing.TestingT, options *Options, releaseName string, revision
 func RollbackE(t testing.TestingT, options *Options, releaseName string, revision string) error {
 	var err error
 	args := []string{}
+	if options.ExtraArgs != nil {
+		if rollbackArgs, ok := options.ExtraArgs["rollback"]; ok {
+			args = append(args, rollbackArgs...)
+		}
+	}
 	args = append(args, getNamespaceArgs(options)...)
 	args = append(args, releaseName)
 	if revision != "" {

--- a/modules/helm/upgrade.go
+++ b/modules/helm/upgrade.go
@@ -30,7 +30,9 @@ func UpgradeE(t testing.TestingT, options *Options, chart string, releaseName st
 	var err error
 	args := []string{}
 	if options.ExtraArgs != nil {
-		args = append(args, options.ExtraArgs...)
+		if upgradeArgs, ok := options.ExtraArgs["upgrade"]; ok {
+			args = append(args, upgradeArgs...)
+		}
 	}
 	args = append(args, getNamespaceArgs(options)...)
 	args, err = getValuesArgsE(t, options, args...)

--- a/modules/helm/upgrade_test.go
+++ b/modules/helm/upgrade_test.go
@@ -65,7 +65,8 @@ func TestRemoteChartInstallUpgradeRollback(t *testing.T) {
 		"service.type": "NodePort",
 	}
 	// Test that passing extra arguments doesn't error, by changing default timeout
-	options.ExtraArgs = []string{"--timeout", "5m1s"}
+	options.ExtraArgs = map[string][]string{"upgrade": []string{"--timeout", "5m1s"}}
+	options.ExtraArgs["rollback"] = []string{"--timeout", "5m1s"}
 	Upgrade(t, options, helmChart, releaseName)
 	waitForRemoteChartPods(t, kubectlOptions, releaseName, 2)
 


### PR DESCRIPTION
This addresses @yorinasub17 's comment on my previous PR that ExtraArgs should be for every command, and implements their suggestion to have a map from subcommand to a list of args.

### GH Issue
[GH Issue 731](https://github.com/gruntwork-io/terratest/issues/731)
[GH Issue 726](https://github.com/gruntwork-io/terratest/issues/726)

### Changes Proposed
This PR allows passing arguments to the helm command when using the `Install`, `Upgrade`, `Delete`, and `Rollback` functions in the `helm` module.

### Test output
The test output can be found in this [gist](https://gist.github.com/ndhanushkodi/12e4c428b2f2d48d78decdb1eda00e67)

Closes #731 