### PR TITLE
Add the CircleCI GCP context

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -238,6 +238,7 @@ workflows:
       - setup:
           context:
             - Gruntwork Admin
+            - Gruntwork GCP
           filters:
             tags:
               only: /^v.*/
@@ -245,6 +246,7 @@ workflows:
       - test:
           context:
             - Gruntwork Admin
+            - Gruntwork GCP
           requires:
             - setup
           filters:
@@ -254,6 +256,7 @@ workflows:
       - kubernetes_test:
           context:
             - Gruntwork Admin
+            - Gruntwork GCP
           requires:
             - setup
           filters:
@@ -263,6 +266,7 @@ workflows:
       - helm_test:
           context:
             - Gruntwork Admin
+            - Gruntwork GCP
           requires:
             - setup
           filters:
@@ -272,6 +276,7 @@ workflows:
       - deploy:
           context:
             - Gruntwork Admin
+            - Gruntwork GCP
           requires:
             - setup
           filters:


### PR DESCRIPTION
This PR adds the CircleCI GCP context to the repo.

**Note**: I haven't yet deleted the GCP environment variables from the terratest project.