### PR TITLE
Check if folder exists before attempting to copy folders

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -389,6 +389,7 @@ github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DMA2s=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.2.0 h1:Hbg2NidpLE8veEBkEZTL3CvlkUIVzuU9jDplZO54c48=
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
 github.com/stretchr/testify v0.0.0-20151208002404-e3a8ff8ce365/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=

--- a/modules/files/errors.go
+++ b/modules/files/errors.go
@@ -1,0 +1,12 @@
+package files
+
+import "fmt"
+
+// DirNotFoundError is an error that occurs if a directory doesn't exist
+type DirNotFoundError struct {
+	Directory string
+}
+
+func (err DirNotFoundError) Error() string {
+	return fmt.Sprintf("Directory was not found: \"%s\"", err.Directory)
+}

--- a/modules/files/files.go
+++ b/modules/files/files.go
@@ -2,7 +2,6 @@
 package files
 
 import (
-	"errors"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -80,7 +79,7 @@ func CopyFolderToTemp(folderPath string, tempFolderPrefix string, filter func(pa
 		return "", err
 	}
 	if !exists {
-		return "", errors.New("Provided folder does not exist: " + folderPath)
+		return "", DirNotFoundError{Directory: folderPath}
 	}
 
 	tmpDir, err := ioutil.TempDir("", tempFolderPrefix)

--- a/modules/files/files.go
+++ b/modules/files/files.go
@@ -24,16 +24,6 @@ func FileExistsE(path string) (bool, error) {
 	return err == nil, nil
 }
 
-// DirExistsE returns true if the given file exists
-// It will return an error if os.Stat error is a ErrNotExist
-func DirExistsE(path string) (bool, error) {
-	_, err := os.Stat(path)
-	if err != nil && os.IsNotExist(err) {
-		return false, err
-	}
-	return err == nil, nil
-}
-
 // IsExistingFile returns true if the path exists and is a file.
 func IsExistingFile(path string) bool {
 	fileInfo, err := os.Stat(path)
@@ -84,9 +74,12 @@ func CopyTerragruntFolderToTemp(folderPath string, tempFolderPrefix string) (str
 // CopyFolderToTemp creates a copy of the given folder and all its filtered contents in a temp folder
 // with a unique name and the given prefix.
 func CopyFolderToTemp(folderPath string, tempFolderPrefix string, filter func(path string) bool) (string, error) {
-	_, err := DirExistsE(folderPath)
+	exists, err := FileExistsE(folderPath)
 	if err != nil {
 		return "", err
+	}
+	if !exists {
+		return "", os.ErrNotExist
 	}
 
 	tmpDir, err := ioutil.TempDir("", tempFolderPrefix)

--- a/modules/files/files.go
+++ b/modules/files/files.go
@@ -2,6 +2,7 @@
 package files
 
 import (
+	"errors"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -79,7 +80,7 @@ func CopyFolderToTemp(folderPath string, tempFolderPrefix string, filter func(pa
 		return "", err
 	}
 	if !exists {
-		return "", os.ErrNotExist
+		return "", errors.New("Provided folder does not exist: " + folderPath)
 	}
 
 	tmpDir, err := ioutil.TempDir("", tempFolderPrefix)

--- a/modules/files/files.go
+++ b/modules/files/files.go
@@ -24,6 +24,16 @@ func FileExistsE(path string) (bool, error) {
 	return err == nil, nil
 }
 
+// DirExistsE returns true if the given file exists
+// It will return an error if os.Stat error is a ErrNotExist
+func DirExistsE(path string) (bool, error) {
+	_, err := os.Stat(path)
+	if err != nil && os.IsNotExist(err) {
+		return false, err
+	}
+	return err == nil, nil
+}
+
 // IsExistingFile returns true if the path exists and is a file.
 func IsExistingFile(path string) bool {
 	fileInfo, err := os.Stat(path)
@@ -74,6 +84,11 @@ func CopyTerragruntFolderToTemp(folderPath string, tempFolderPrefix string) (str
 // CopyFolderToTemp creates a copy of the given folder and all its filtered contents in a temp folder
 // with a unique name and the given prefix.
 func CopyFolderToTemp(folderPath string, tempFolderPrefix string, filter func(path string) bool) (string, error) {
+	_, err := DirExistsE(folderPath)
+	if err != nil {
+		return "", err
+	}
+
 	tmpDir, err := ioutil.TempDir("", tempFolderPrefix)
 	if err != nil {
 		return "", err

--- a/modules/files/files_test.go
+++ b/modules/files/files_test.go
@@ -61,12 +61,11 @@ func TestCopyFolderToTemp(t *testing.T) {
 
 	folder, err := CopyFolderToTemp("/not/a/real/path", tempFolderPrefix, filter)
 	require.Error(t, err)
-	exists := FileExists(folder)
-	assert.False(t, exists)
+	assert.False(t, FileExists(folder))
 
 	folder, err = CopyFolderToTemp(tmpDir, tempFolderPrefix, filter)
 	assert.DirExists(t, folder)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestCopyFolderContents(t *testing.T) {

--- a/modules/test-structure/test_structure.go
+++ b/modules/test-structure/test_structure.go
@@ -74,9 +74,12 @@ func CopyTerraformFolderToTemp(t testing.TestingT, rootFolder string, terraformM
 
 	fullTerraformModuleFolder := filepath.Join(rootFolder, terraformModuleFolder)
 
-	_, err := files.DirExistsE(fullTerraformModuleFolder)
+	exists, err := files.FileExistsE(fullTerraformModuleFolder)
 	if err != nil {
 		t.Fatal(err)
+	}
+	if !exists {
+		t.Fatal(os.ErrNotExist, fullTerraformModuleFolder)
 	}
 
 	tmpRootFolder, err := files.CopyTerraformFolderToTemp(rootFolder, cleanName(t.Name()))

--- a/modules/test-structure/test_structure.go
+++ b/modules/test-structure/test_structure.go
@@ -78,7 +78,7 @@ func CopyTerraformFolderToTemp(t testing.TestingT, rootFolder string, terraformM
 	exists, err := files.FileExistsE(fullTerraformModuleFolder)
 	require.NoError(t, err)
 	if !exists {
-		t.Fatal(os.ErrNotExist, fullTerraformModuleFolder)
+		t.Fatal(files.DirNotFoundError{Directory: fullTerraformModuleFolder})
 	}
 
 	tmpRootFolder, err := files.CopyTerraformFolderToTemp(rootFolder, cleanName(t.Name()))

--- a/modules/test-structure/test_structure.go
+++ b/modules/test-structure/test_structure.go
@@ -72,6 +72,13 @@ func CopyTerraformFolderToTemp(t testing.TestingT, rootFolder string, terraformM
 		return filepath.Join(rootFolder, terraformModuleFolder)
 	}
 
+	fullTerraformModuleFolder := filepath.Join(rootFolder, terraformModuleFolder)
+
+	_, err := files.DirExistsE(fullTerraformModuleFolder)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	tmpRootFolder, err := files.CopyTerraformFolderToTemp(rootFolder, cleanName(t.Name()))
 	if err != nil {
 		t.Fatal(err)
@@ -80,7 +87,7 @@ func CopyTerraformFolderToTemp(t testing.TestingT, rootFolder string, terraformM
 	tmpTestFolder := filepath.Join(tmpRootFolder, terraformModuleFolder)
 
 	// Log temp folder so we can see it
-	logger.Logf(t, "Copied terraform folder %s to %s", filepath.Join(rootFolder, terraformModuleFolder), tmpTestFolder)
+	logger.Logf(t, "Copied terraform folder %s to %s", fullTerraformModuleFolder, tmpTestFolder)
 
 	return tmpTestFolder
 }

--- a/modules/test-structure/test_structure.go
+++ b/modules/test-structure/test_structure.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gruntwork-io/terratest/modules/files"
 	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/testing"
+	"github.com/stretchr/testify/require"
 )
 
 // SKIP_STAGE_ENV_VAR_PREFIX is the prefix used for skipping stage environment variables.
@@ -75,9 +76,7 @@ func CopyTerraformFolderToTemp(t testing.TestingT, rootFolder string, terraformM
 	fullTerraformModuleFolder := filepath.Join(rootFolder, terraformModuleFolder)
 
 	exists, err := files.FileExistsE(fullTerraformModuleFolder)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	if !exists {
 		t.Fatal(os.ErrNotExist, fullTerraformModuleFolder)
 	}


### PR DESCRIPTION
This PR attempts to close #738.

I ran through the unit tests that were affected by these changes. I'm not sure if the output is super useful for those but I also ran some of the automated tests that use `CopyTerraformFolderToTemp` which look good. I was unable to run the full automated test suite right now, but I can look at doing at later if needed.

Here is the output from the automated test I did run:

https://gist.github.com/cbuto/13dd83b40d29503288b11192ee2c4149

