### PR TITLE
Add func for creating a namespace by passing in the entire ObjectMeta to allow more configuration (setting labels)

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -646,6 +646,7 @@ k8s.io/api v0.19.3/go.mod h1:VF+5FT1B74Pw3KxMdKyinLo+zynBaMBiAfGMuldcNDs=
 k8s.io/apimachinery v0.17.0/go.mod h1:b9qmWdKlLuU9EBh+06BtLcSf/Mu89rWL33naRxs1uZg=
 k8s.io/apimachinery v0.19.3 h1:bpIQXlKjB4cB/oNpnNnV+BybGPR7iP5oYpsOTEJ4hgc=
 k8s.io/apimachinery v0.19.3/go.mod h1:DnPGDnARWFvYa3pMHgSxtbZb7gpzzAZ1pTfaUNDVlmA=
+k8s.io/apimachinery v0.20.1 h1:LAhz8pKbgR8tUwn7boK+b2HZdt7MiTu2mkYtFMUjTRQ=
 k8s.io/apiserver v0.17.0/go.mod h1:ABM+9x/prjINN6iiffRVNCBR2Wk7uY4z+EtEGZD48cg=
 k8s.io/client-go v0.17.0/go.mod h1:TYgR6EUHs6k45hb6KWjVD6jFZvJV4gHDikv/It0xz+k=
 k8s.io/client-go v0.19.3 h1:ctqR1nQ52NUs6LpI0w+a5U+xjYwflFwA13OJKcicMxg=

--- a/go.sum
+++ b/go.sum
@@ -646,7 +646,6 @@ k8s.io/api v0.19.3/go.mod h1:VF+5FT1B74Pw3KxMdKyinLo+zynBaMBiAfGMuldcNDs=
 k8s.io/apimachinery v0.17.0/go.mod h1:b9qmWdKlLuU9EBh+06BtLcSf/Mu89rWL33naRxs1uZg=
 k8s.io/apimachinery v0.19.3 h1:bpIQXlKjB4cB/oNpnNnV+BybGPR7iP5oYpsOTEJ4hgc=
 k8s.io/apimachinery v0.19.3/go.mod h1:DnPGDnARWFvYa3pMHgSxtbZb7gpzzAZ1pTfaUNDVlmA=
-k8s.io/apimachinery v0.20.1 h1:LAhz8pKbgR8tUwn7boK+b2HZdt7MiTu2mkYtFMUjTRQ=
 k8s.io/apiserver v0.17.0/go.mod h1:ABM+9x/prjINN6iiffRVNCBR2Wk7uY4z+EtEGZD48cg=
 k8s.io/client-go v0.17.0/go.mod h1:TYgR6EUHs6k45hb6KWjVD6jFZvJV4gHDikv/It0xz+k=
 k8s.io/client-go v0.19.3 h1:ctqR1nQ52NUs6LpI0w+a5U+xjYwflFwA13OJKcicMxg=

--- a/modules/k8s/namespace.go
+++ b/modules/k8s/namespace.go
@@ -20,12 +20,11 @@ func CreateNamespaceE(t testing.TestingT, options *KubectlOptions, namespaceName
 	namespaceObject := metav1.ObjectMeta{
 		Name: namespaceName,
 	}
-	err := CreateNamespaceWithMetadataE(t, options, namespaceObject)
-	return err
+	return CreateNamespaceWithMetadataE(t, options, namespaceObject)
 }
 
 // CreateNamespaceWithMetadataE will create a new Kubernetes namespace on the cluster targeted by the provided options and
-// expects the entire namespace ObjectMeta to be passed in.
+// with the provided metadata. This method expects the entire namespace ObjectMeta to be passed in, so you'll need to set the name within the ObjectMeta struct yourself.
 func CreateNamespaceWithMetadataE(t testing.TestingT, options *KubectlOptions, namespaceObjectMeta metav1.ObjectMeta) error {
 	clientset, err := GetKubernetesClientFromOptionsE(t, options)
 	if err != nil {
@@ -37,6 +36,19 @@ func CreateNamespaceWithMetadataE(t testing.TestingT, options *KubectlOptions, n
 	}
 	_, err = clientset.CoreV1().Namespaces().Create(context.Background(), &namespace, metav1.CreateOptions{})
 	return err
+}
+
+// CreateNamespaceWithMetadata will create a new Kubernetes namespace on the cluster targeted by the provided options and
+// with the provided metadata. This method expects the entire namespace ObjectMeta to be passed in, so you'll need to set the name within the ObjectMeta struct yourself.
+func CreateNamespaceWithMetadata(t testing.TestingT, options *KubectlOptions, namespaceObjectMeta metav1.ObjectMeta) {
+	clientset, err := GetKubernetesClientFromOptionsE(t, options)
+	require.NoError(t, err)
+
+	namespace := corev1.Namespace{
+		ObjectMeta: namespaceObjectMeta,
+	}
+	_, err = clientset.CoreV1().Namespaces().Create(context.Background(), &namespace, metav1.CreateOptions{})
+	require.NoError(t, err)
 }
 
 // GetNamespace will query the Kubernetes cluster targeted by the provided options for the requested namespace. This will

--- a/modules/k8s/namespace.go
+++ b/modules/k8s/namespace.go
@@ -40,15 +40,9 @@ func CreateNamespaceWithMetadataE(t testing.TestingT, options *KubectlOptions, n
 
 // CreateNamespaceWithMetadata will create a new Kubernetes namespace on the cluster targeted by the provided options and
 // with the provided metadata. This method expects the entire namespace ObjectMeta to be passed in, so you'll need to set the name within the ObjectMeta struct yourself.
+// This will fail the test if there is an error while creating the namespace.
 func CreateNamespaceWithMetadata(t testing.TestingT, options *KubectlOptions, namespaceObjectMeta metav1.ObjectMeta) {
-	clientset, err := GetKubernetesClientFromOptionsE(t, options)
-	require.NoError(t, err)
-
-	namespace := corev1.Namespace{
-		ObjectMeta: namespaceObjectMeta,
-	}
-	_, err = clientset.CoreV1().Namespaces().Create(context.Background(), &namespace, metav1.CreateOptions{})
-	require.NoError(t, err)
+	require.NoError(t, CreateNamespaceWithMetadataE(t, options, namespaceObjectMeta))
 }
 
 // GetNamespace will query the Kubernetes cluster targeted by the provided options for the requested namespace. This will

--- a/modules/k8s/namespace.go
+++ b/modules/k8s/namespace.go
@@ -17,15 +17,23 @@ func CreateNamespace(t testing.TestingT, options *KubectlOptions, namespaceName 
 
 // CreateNamespaceE will create a new Kubernetes namespace on the cluster targeted by the provided options.
 func CreateNamespaceE(t testing.TestingT, options *KubectlOptions, namespaceName string) error {
+	namespaceObject := metav1.ObjectMeta{
+		Name: namespaceName,
+	}
+	err := CreateNamespaceWithMetadataE(t, options, namespaceObject)
+	return err
+}
+
+// CreateNamespaceWithMetadataE will create a new Kubernetes namespace on the cluster targeted by the provided options and
+// expects the entire namespace ObjectMeta to be passed in.
+func CreateNamespaceWithMetadataE(t testing.TestingT, options *KubectlOptions, namespaceObjectMeta metav1.ObjectMeta) error {
 	clientset, err := GetKubernetesClientFromOptionsE(t, options)
 	if err != nil {
 		return err
 	}
 
 	namespace := corev1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: namespaceName,
-		},
+		ObjectMeta: namespaceObjectMeta,
 	}
 	_, err = clientset.CoreV1().Namespaces().Create(context.Background(), &namespace, metav1.CreateOptions{})
 	return err

--- a/modules/k8s/namespace_test.go
+++ b/modules/k8s/namespace_test.go
@@ -36,7 +36,7 @@ func TestNamespaces(t *testing.T) {
 	require.Equal(t, namespace.Name, namespaceName)
 }
 
-func TestNamespaceWithLabels(t *testing.T) {
+func TestNamespaceWithMetadataE(t *testing.T) {
 	t.Parallel()
 
 	uniqueId := random.UniqueId()
@@ -49,6 +49,29 @@ func TestNamespaceWithLabels(t *testing.T) {
 	}
 	err := CreateNamespaceWithMetadataE(t, options, namespaceObjectMetaWithLabels)
 	require.NoError(t, err)
+	defer func() {
+		DeleteNamespace(t, options, namespaceName)
+		namespace := GetNamespace(t, options, namespaceName)
+		require.Equal(t, namespace.Status.Phase, corev1.NamespaceTerminating)
+	}()
+
+	namespace := GetNamespace(t, options, namespaceName)
+	require.Equal(t, namespace.Name, namespaceName)
+	require.Equal(t, namespace.Labels, namespaceLabels)
+}
+
+func TestNamespaceWithMetadata(t *testing.T) {
+	t.Parallel()
+
+	uniqueId := random.UniqueId()
+	namespaceName := strings.ToLower(uniqueId)
+	options := NewKubectlOptions("", "", namespaceName)
+	namespaceLabels := map[string]string{"foo": "bar"}
+	namespaceObjectMetaWithLabels := metav1.ObjectMeta{
+		Name:   namespaceName,
+		Labels: namespaceLabels,
+	}
+	CreateNamespaceWithMetadata(t, options, namespaceObjectMetaWithLabels)
 	defer func() {
 		DeleteNamespace(t, options, namespaceName)
 		namespace := GetNamespace(t, options, namespaceName)

--- a/modules/k8s/namespace_test.go
+++ b/modules/k8s/namespace_test.go
@@ -36,30 +36,6 @@ func TestNamespaces(t *testing.T) {
 	require.Equal(t, namespace.Name, namespaceName)
 }
 
-func TestNamespaceWithMetadataE(t *testing.T) {
-	t.Parallel()
-
-	uniqueId := random.UniqueId()
-	namespaceName := strings.ToLower(uniqueId)
-	options := NewKubectlOptions("", "", namespaceName)
-	namespaceLabels := map[string]string{"foo": "bar"}
-	namespaceObjectMetaWithLabels := metav1.ObjectMeta{
-		Name:   namespaceName,
-		Labels: namespaceLabels,
-	}
-	err := CreateNamespaceWithMetadataE(t, options, namespaceObjectMetaWithLabels)
-	require.NoError(t, err)
-	defer func() {
-		DeleteNamespace(t, options, namespaceName)
-		namespace := GetNamespace(t, options, namespaceName)
-		require.Equal(t, namespace.Status.Phase, corev1.NamespaceTerminating)
-	}()
-
-	namespace := GetNamespace(t, options, namespaceName)
-	require.Equal(t, namespace.Name, namespaceName)
-	require.Equal(t, namespace.Labels, namespaceLabels)
-}
-
 func TestNamespaceWithMetadata(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
This PR aims to close #575.

I saw this issue had been hanging around for a while and I'll need it for some upcoming testing!

As discussed in the issue, I added a new func `CreateNamespaceWithMetadataE` for backwards compatibility. It will accept the Namespace ObjectMeta as an argument instead of the Namespace name so further configuration can be done (adding labels). 

Let me know how this looks!

Thanks


---

Here is the test output

```
 $ go test --tags=kubeall -run TestNamespace
TestNamespaces 2021-01-03T22:48:16-05:00 client.go:33: Configuring kubectl using config file /Users/caseybuto/.kube/config with context 
TestNamespaceWithLabels 2021-01-03T22:48:16-05:00 client.go:33: Configuring kubectl using config file /Users/caseybuto/.kube/config with context 
TestNamespaces 2021-01-03T22:48:16-05:00 client.go:33: Configuring kubectl using config file /Users/caseybuto/.kube/config with context 
TestNamespaceWithLabels 2021-01-03T22:48:16-05:00 client.go:33: Configuring kubectl using config file /Users/caseybuto/.kube/config with context 
TestNamespaces 2021-01-03T22:48:16-05:00 client.go:33: Configuring kubectl using config file /Users/caseybuto/.kube/config with context 
TestNamespaceWithLabels 2021-01-03T22:48:16-05:00 client.go:33: Configuring kubectl using config file /Users/caseybuto/.kube/config with context 
TestNamespaces 2021-01-03T22:48:16-05:00 client.go:33: Configuring kubectl using config file /Users/caseybuto/.kube/config with context 
TestNamespaceWithLabels 2021-01-03T22:48:16-05:00 client.go:33: Configuring kubectl using config file /Users/caseybuto/.kube/config with context 
PASS
ok      github.com/gruntwork-io/terratest/modules/k8s   1.923s
```