### PR TITLE
Use terraform-json to have better terraform plan testing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/gruntwork-io/go-commons v0.8.0
 	github.com/hashicorp/go-multierror v1.1.0
 	github.com/hashicorp/hcl/v2 v2.8.2
+	github.com/hashicorp/terraform-json v0.9.0
 	github.com/imdario/mergo v0.3.7 // indirect
 	github.com/jinzhu/copier v0.0.0-20190924061706-b57f9002281a
 	github.com/jstemmer/go-junit-report v0.9.1
@@ -35,7 +36,7 @@ require (
 	github.com/sirupsen/logrus v1.4.2
 	github.com/stretchr/testify v1.4.0
 	github.com/urfave/cli v1.22.2
-	github.com/zclconf/go-cty v1.2.0
+	github.com/zclconf/go-cty v1.2.1
 	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
 	golang.org/x/net v0.0.0-20200707034311-ab3426394381
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d

--- a/go.sum
+++ b/go.sum
@@ -263,6 +263,8 @@ github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hashicorp/hcl/v2 v2.8.2 h1:wmFle3D1vu0okesm8BTLVDyJ6/OL9DCLUwn0b2OptiY=
 github.com/hashicorp/hcl/v2 v2.8.2/go.mod h1:bQTN5mpo+jewjJgh8jr0JUguIi7qPHUF6yIfAEN3jqY=
+github.com/hashicorp/terraform-json v0.9.0 h1:WE7+Wt93W93feOiCligElSyS0tlDzwZUtJuDGIBr8zg=
+github.com/hashicorp/terraform-json v0.9.0/go.mod h1:3defM4kkMfttwiE7VakJDwCd4R+umhSQnvJwORXbprE=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
@@ -424,6 +426,8 @@ github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 github.com/zclconf/go-cty v1.2.0 h1:sPHsy7ADcIZQP3vILvTjrh74ZA175TFP5vqiNK1UmlI=
 github.com/zclconf/go-cty v1.2.0/go.mod h1:hOPWgoHbaTUnI5k4D2ld+GRpFJSCe6bCM7m1q/N4PQ8=
+github.com/zclconf/go-cty v1.2.1 h1:vGMsygfmeCl4Xb6OA5U5XVAaQZ69FvoG7X2jUtQujb8=
+github.com/zclconf/go-cty v1.2.1/go.mod h1:hOPWgoHbaTUnI5k4D2ld+GRpFJSCe6bCM7m1q/N4PQ8=
 go.etcd.io/bbolt v1.3.3/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/etcd v0.0.0-20191023171146-3cf2f69b5738/go.mod h1:dnLIgRNXwCJa5e+c6mIZCrds/GIG4ncV9HhK5PX7jPg=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=

--- a/modules/terraform/plan.go
+++ b/modules/terraform/plan.go
@@ -63,6 +63,24 @@ func InitAndPlanAndShowE(t testing.TestingT, options *Options) (string, error) {
 	return ShowE(t, options)
 }
 
+// InitAndPlanAndShowWithStruct runs terraform init, then terraform plan, and then terraform show with the given
+// options, and parses the json result into a go struct. This will fail the test if there is an error in the command.
+func InitAndPlanAndShowWithStruct(t testing.TestingT, options *Options) *PlanStruct {
+	plan, err := InitAndPlanAndShowWithStructE(t, options)
+	require.NoError(t, err)
+	return plan
+}
+
+// InitAndPlanAndShowWithStructE runs terraform init, then terraform plan, and then terraform show with the given options, and
+// parses the json result into a go struct.
+func InitAndPlanAndShowWithStructE(t testing.TestingT, options *Options) (*PlanStruct, error) {
+	jsonOut, err := InitAndPlanAndShowE(t, options)
+	if err != nil {
+		return nil, err
+	}
+	return parsePlanJson(jsonOut)
+}
+
 // InitAndPlanWithExitCode runs terraform init and plan with the given options and returns exitcode for the plan command.
 // This will fail the test if there is an error in the command.
 func InitAndPlanWithExitCode(t testing.TestingT, options *Options) int {

--- a/modules/terraform/plan_struct.go
+++ b/modules/terraform/plan_struct.go
@@ -9,14 +9,22 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// PlanStruct is a Go Struct representation of the plan object returned from Terraform. Unlike the raw plan representation
-// returned by terraform-json, this struct provides a map that maps the resource addresses to the changes and planned
-// values to make it easier to navigate the raw plan struct.
+// PlanStruct is a Go Struct representation of the plan object returned from Terraform (after running `terraform show`).
+// Unlike the raw plan representation returned by terraform-json, this struct provides a map that maps the resource
+// addresses to the changes and planned values to make it easier to navigate the raw plan struct.
 type PlanStruct struct {
+	// The raw representation of the plan. See
+	// https://www.terraform.io/docs/internals/json-format.html#plan-representation for details on the structure of the
+	// plan output.
 	RawPlan tfjson.Plan
 
+	// A map that maps full resource addresses (e.g., module.foo.null_resource.test) to the planned values of that
+	// resource.
 	ResourcePlannedValuesMap map[string]*tfjson.StateResource
-	ResourceChangesMap       map[string]*tfjson.ResourceChange
+
+	// A map that maps full resource addresses (e.g., module.foo.null_resource.test) to the planned actions terraform
+	// will take on that resource.
+	ResourceChangesMap map[string]*tfjson.ResourceChange
 }
 
 // parsePlanJson takes in the json string representation of the terraform plan and returns a go struct representation

--- a/modules/terraform/plan_struct.go
+++ b/modules/terraform/plan_struct.go
@@ -1,0 +1,108 @@
+package terraform
+
+import (
+	"encoding/json"
+
+	"github.com/gruntwork-io/terratest/modules/testing"
+	tfjson "github.com/hashicorp/terraform-json"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// PlanStruct is a Go Struct representation of the plan object returned from Terraform. Unlike the raw plan representation
+// returned by terraform-json, this struct provides a map that maps the resource addresses to the changes and planned
+// values to make it easier to navigate the raw plan struct.
+type PlanStruct struct {
+	RawPlan tfjson.Plan
+
+	ResourcePlannedValuesMap map[string]*tfjson.StateResource
+	ResourceChangesMap       map[string]*tfjson.ResourceChange
+}
+
+// parsePlanJson takes in the json string representation of the terraform plan and returns a go struct representation
+// for easy introspection.
+func parsePlanJson(jsonStr string) (*PlanStruct, error) {
+	plan := &PlanStruct{}
+
+	if err := json.Unmarshal([]byte(jsonStr), &plan.RawPlan); err != nil {
+		return nil, err
+	}
+
+	plan.ResourcePlannedValuesMap = parsePlannedValues(plan)
+	plan.ResourceChangesMap = parseResourceChanges(plan)
+	return plan, nil
+}
+
+// parseResourceChanges takes a plan and returns a map that maps resource addresses to the planned changes for that
+// resource. If there are no changes, this returns an empty map instead of erroring.
+func parseResourceChanges(plan *PlanStruct) map[string]*tfjson.ResourceChange {
+	out := map[string]*tfjson.ResourceChange{}
+	for _, change := range plan.RawPlan.ResourceChanges {
+		out[change.Address] = change
+	}
+	return out
+}
+
+// parsePlannedValues takes a plan and walks through the planned values to return a map that maps the full resource
+// addresses to the planned resources. If there are no planned values, this returns an empty map instead of erroring.
+func parsePlannedValues(plan *PlanStruct) map[string]*tfjson.StateResource {
+	plannedValues := plan.RawPlan.PlannedValues
+	if plannedValues == nil {
+		// No planned values, so return empty map.
+		return map[string]*tfjson.StateResource{}
+	}
+
+	rootModule := plannedValues.RootModule
+	if rootModule == nil {
+		// No module resources, so return empty map.
+		return map[string]*tfjson.StateResource{}
+	}
+	return parseModulePlannedValues(rootModule)
+}
+
+// parseModulePlannedValues will recursively walk through the modules in the planned_values of the plan struct to
+// construct a map that maps the full resource addresses to the planned resource.
+func parseModulePlannedValues(module *tfjson.StateModule) map[string]*tfjson.StateResource {
+	out := map[string]*tfjson.StateResource{}
+	for _, resource := range module.Resources {
+		// NOTE: the Address attribute of the module resource always returns the full address, even when the resource is
+		// nested within sub modules.
+		out[resource.Address] = resource
+	}
+
+	// NOTE: base case of recursion is when ChildModules is empty list.
+	for _, child := range module.ChildModules {
+		// Recurse in to the child module. We take a recursive approach here despite limitations of the recursion stack
+		// in golang due to the fact that it is rare to have heavily deep module calls in Terraform. So we optimize for
+		// code readability as opposed to performance.
+		childMap := parseModulePlannedValues(child)
+		for k, v := range childMap {
+			out[k] = v
+		}
+	}
+	return out
+}
+
+// AssertPlannedValuesMapKeyExists checks if the given key exists in the map, failing the test if it does not.
+func AssertPlannedValuesMapKeyExists(t testing.TestingT, plan *PlanStruct, keyQuery string) {
+	_, hasKey := plan.ResourcePlannedValuesMap[keyQuery]
+	assert.Truef(t, hasKey, "Given planned values map does not have key %s", keyQuery)
+}
+
+// RequirePlannedValuesMapKeyExists checks if the given key exists in the map, failing and halting the test if it does not.
+func RequirePlannedValuesMapKeyExists(t testing.TestingT, plan *PlanStruct, keyQuery string) {
+	_, hasKey := plan.ResourcePlannedValuesMap[keyQuery]
+	require.Truef(t, hasKey, "Given planned values map does not have key %s", keyQuery)
+}
+
+// AssertResourceChangesMapKeyExists checks if the given key exists in the map, failing the test if it does not.
+func AssertResourceChangesMapKeyExists(t testing.TestingT, plan *PlanStruct, keyQuery string) {
+	_, hasKey := plan.ResourceChangesMap[keyQuery]
+	assert.Truef(t, hasKey, "Given resource changes map does not have key %s", keyQuery)
+}
+
+// RequireResourceChangesMapKeyExists checks if the given key exists in the map, failing the test if it does not.
+func RequireResourceChangesMapKeyExists(t testing.TestingT, plan *PlanStruct, keyQuery string) {
+	_, hasKey := plan.ResourceChangesMap[keyQuery]
+	require.Truef(t, hasKey, "Given resource changes map does not have key %s", keyQuery)
+}

--- a/modules/terraform/plan_struct_test.go
+++ b/modules/terraform/plan_struct_test.go
@@ -1,0 +1,78 @@
+package terraform
+
+import (
+	"testing"
+
+	http_helper "github.com/gruntwork-io/terratest/modules/http-helper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	basicJsonUrl      = "https://raw.githubusercontent.com/hashicorp/terraform-json/v0.8.0/testdata/basic/plan.json"
+	deepModuleJsonUrl = "https://raw.githubusercontent.com/hashicorp/terraform-json/v0.8.0/testdata/deep_module/plan.json"
+
+	changesJsonUrl = "https://raw.githubusercontent.com/hashicorp/terraform-json/v0.8.0/testdata/has_changes/plan.json"
+)
+
+func TestPlannedValuesMapWithBasicJson(t *testing.T) {
+	t.Parallel()
+
+	// Retrieve test data from the terraform-json project.
+	_, jsonData := http_helper.HttpGet(t, basicJsonUrl, nil)
+	plan, err := parsePlanJson(jsonData)
+	require.NoError(t, err)
+
+	query := []string{
+		"data.null_data_source.baz",
+		"null_resource.bar",
+		"null_resource.baz[0]",
+		"null_resource.baz[1]",
+		"null_resource.baz[2]",
+		"null_resource.foo",
+		"module.foo.null_resource.aliased",
+		"module.foo.null_resource.foo",
+	}
+	for _, key := range query {
+		RequirePlannedValuesMapKeyExists(t, plan, key)
+		resource := plan.ResourcePlannedValuesMap[key]
+		assert.Equal(t, resource.Address, key)
+	}
+}
+
+func TestPlannedValuesMapWithDeepModuleJson(t *testing.T) {
+	t.Parallel()
+
+	// Retrieve test data from the terraform-json project.
+	_, jsonData := http_helper.HttpGet(t, deepModuleJsonUrl, nil)
+	plan, err := parsePlanJson(jsonData)
+	require.NoError(t, err)
+
+	query := []string{
+		"module.foo.module.bar.null_resource.baz",
+	}
+	for _, key := range query {
+		AssertPlannedValuesMapKeyExists(t, plan, key)
+	}
+}
+
+func TestResourceChangesJson(t *testing.T) {
+	t.Parallel()
+
+	// Retrieve test data from the terraform-json project.
+	_, jsonData := http_helper.HttpGet(t, changesJsonUrl, nil)
+	plan, err := parsePlanJson(jsonData)
+	require.NoError(t, err)
+
+	// Spot check a few changes to make sure the right address was registered
+	RequireResourceChangesMapKeyExists(t, plan, "module.foo.null_resource.foo")
+	fooChanges := plan.ResourceChangesMap["module.foo.null_resource.foo"]
+	require.NotNil(t, fooChanges.Change)
+	assert.Equal(t, fooChanges.Change.After.(map[string]interface{})["triggers"].(map[string]interface{})["foo"].(string), "bar")
+
+	RequireResourceChangesMapKeyExists(t, plan, "null_resource.bar")
+	barChanges := plan.ResourceChangesMap["null_resource.bar"]
+	require.NotNil(t, barChanges.Change)
+	assert.Equal(t, barChanges.Change.After.(map[string]interface{})["triggers"].(map[string]interface{})["foo_id"].(string), "424881806176056736")
+
+}

--- a/modules/terraform/plan_struct_test.go
+++ b/modules/terraform/plan_struct_test.go
@@ -9,6 +9,9 @@ import (
 )
 
 const (
+	// NOTE: We pull down the json files from github during test runtime as opposed to checking it in as these source
+	// files are licensed under MPL and we want to avoid a dual license scenario where some source files in terratest
+	// are licensed under a different license.
 	basicJsonUrl      = "https://raw.githubusercontent.com/hashicorp/terraform-json/v0.8.0/testdata/basic/plan.json"
 	deepModuleJsonUrl = "https://raw.githubusercontent.com/hashicorp/terraform-json/v0.8.0/testdata/deep_module/plan.json"
 


### PR DESCRIPTION
Now that our opensource policy allows MPL, here is a PR that updates our examples to use `terraform-json`. Note that this also implements a struct that wraps [terraform-json](https://github.com/hashicorp/terraform-json) to provide a more ergonomic interface to navigate the plan struct by providing a map that maps the resource addresses to the corresponding struct values.