### PR TITLE
Fallback to in-cluster authentication via service account token

### DIFF
--- a/modules/k8s/client.go
+++ b/modules/k8s/client.go
@@ -2,6 +2,7 @@ package k8s
 
 import (
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 
 	// The following line loads the gcp plugin which is required to authenticate against GKE clusters.
 	// See: https://github.com/kubernetes/client-go/issues/242
@@ -25,6 +26,7 @@ func GetKubernetesClientE(t testing.TestingT) (*kubernetes.Clientset, error) {
 // GetKubernetesClientFromOptionsE returns a Kubernetes API client given a configured KubectlOptions object.
 func GetKubernetesClientFromOptionsE(t testing.TestingT, options *KubectlOptions) (*kubernetes.Clientset, error) {
 	var err error
+	var config *rest.Config
 
 	kubeConfigPath, err := options.GetConfigPath(t)
 	if err != nil {
@@ -32,9 +34,14 @@ func GetKubernetesClientFromOptionsE(t testing.TestingT, options *KubectlOptions
 	}
 	logger.Logf(t, "Configuring kubectl using config file %s with context %s", kubeConfigPath, options.ContextName)
 	// Load API config (instead of more low level ClientConfig)
-	config, err := LoadApiClientConfigE(kubeConfigPath, options.ContextName)
+	config, err = LoadApiClientConfigE(kubeConfigPath, options.ContextName)
 	if err != nil {
-		return nil, err
+		logger.Logf(t, "Error loading api client config, falling back to in-cluster authentication via serviceaccount token: %s", err)
+		config, err = rest.InClusterConfig()
+		if err != nil {
+			return nil, err
+		}
+		logger.Log(t, "Configuring kubectl using in-cluster serviceaccount token")
 	}
 
 	clientset, err := kubernetes.NewForConfig(config)


### PR DESCRIPTION
This PR implements a fallback to in-cluster authentication via service account token when no valid kubeconfig can be found.

For more info see: https://github.com/gruntwork-io/terratest/issues/753

I manually tested this by running the following inside a Kubernetes pod:

```go
package test

import (
	"fmt"
	"testing"

	"github.com/gruntwork-io/terratest/modules/k8s"
	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
)

func TestInClusterAuth(t *testing.T) {
	options := k8s.NewKubectlOptions("", "", "default")

	pods := k8s.ListPods(t, options, v1.ListOptions{})
	for _, p := range pods {
		fmt.Println(p.Name)
	}
}
```

Which resulted in:

```
root@golang:/go/terratest# go test -v auth_test.go
=== RUN   TestInClusterAuth
TestInClusterAuth 2021-01-15T10:35:14Z client.go:35: Configuring kubectl using config file /root/.kube/config with context
TestInClusterAuth 2021-01-15T10:35:14Z client.go:39: Error loading api client config, falling back to in-cluster authentication via serviceaccount token: stat /root/.kube/config: no such file or directory
TestInClusterAuth 2021-01-15T10:35:14Z client.go:44: Configuring kubectl using in-cluster serviceaccount token
golang
nginx-deployment-c9dcf7b89-jhff4
nginx-deployment-c9dcf7b89-th97v
rabbitmq-0
redis-master-0
redis-slave-0
redis-slave-1
--- PASS: TestInClusterAuth (0.02s)
PASS
ok      command-line-arguments  0.038s
```