### PR TITLE
Adding support to get details for TargetPrefix

### DIFF
--- a/examples/terraform-aws-s3-example/main.tf
+++ b/examples/terraform-aws-s3-example/main.tf
@@ -75,7 +75,7 @@ resource "aws_s3_bucket" "test_bucket" {
 
   logging {
     target_bucket = aws_s3_bucket.test_bucket_logs.id
-    target_prefix = "/"
+    target_prefix = "TFStateLogs/"
   }
 
   tags = {

--- a/examples/terraform-aws-s3-example/outputs.tf
+++ b/examples/terraform-aws-s3-example/outputs.tf
@@ -9,3 +9,7 @@ output "bucket_arn" {
 output "logging_target_bucket" {
   value = tolist(aws_s3_bucket.test_bucket.logging)[0].target_bucket
 }
+
+output "logging_target_prefix" {
+  value = tolist(aws_s3_bucket.test_bucket.logging)[0].target_prefix
+}

--- a/modules/aws/s3.go
+++ b/modules/aws/s3.go
@@ -263,15 +263,15 @@ func EmptyS3BucketE(t testing.TestingT, region string, name string) error {
 
 // GetS3BucketLoggingTarget fetches the given bucket's logging target bucket and returns it as a string
 func GetS3BucketLoggingTarget(t testing.TestingT, awsRegion string, bucket string) string {
-	loggingTarget, err := GetS3BucketLoggingTargeE(t, awsRegion, bucket)
+	loggingTarget, err := GetS3BucketLoggingTargetE(t, awsRegion, bucket)
 	require.NoError(t, err)
 
 	return loggingTarget
 }
 
-// GetS3BucketLoggingTargeE fetches the given bucket's logging target bucket and returns it as the following string:
+// GetS3BucketLoggingTargetE fetches the given bucket's logging target bucket and returns it as the following string:
 // `TargetBucket` of the `LoggingEnabled` property for an S3 bucket
-func GetS3BucketLoggingTargeE(t testing.TestingT, awsRegion string, bucket string) (string, error) {
+func GetS3BucketLoggingTargetE(t testing.TestingT, awsRegion string, bucket string) (string, error) {
 	s3Client, err := NewS3ClientE(t, awsRegion)
 	if err != nil {
 		return "", err

--- a/modules/aws/s3.go
+++ b/modules/aws/s3.go
@@ -261,17 +261,17 @@ func EmptyS3BucketE(t testing.TestingT, region string, name string) error {
 	return err
 }
 
-// GetS3BucketLoggingTargetBucket fetches the given bucket's logging target bucket and returns it as a string
-func GetS3BucketLoggingTargetBucket(t testing.TestingT, awsRegion string, bucket string) string {
-	loggingTarget, err := GetS3BucketLoggingTargetBucketE(t, awsRegion, bucket)
+// GetS3BucketLoggingTarget fetches the given bucket's logging target bucket and returns it as a string
+func GetS3BucketLoggingTarget(t testing.TestingT, awsRegion string, bucket string) string {
+	loggingTarget, err := GetS3BucketLoggingTargeE(t, awsRegion, bucket)
 	require.NoError(t, err)
 
 	return loggingTarget
 }
 
-// GetS3BucketLoggingTargetBucketE fetches the given bucket's logging target bucket and returns it as the following string:
+// GetS3BucketLoggingTargeE fetches the given bucket's logging target bucket and returns it as the following string:
 // `TargetBucket` of the `LoggingEnabled` property for an S3 bucket
-func GetS3BucketLoggingTargetBucketE(t testing.TestingT, awsRegion string, bucket string) (string, error) {
+func GetS3BucketLoggingTargeE(t testing.TestingT, awsRegion string, bucket string) (string, error) {
 	s3Client, err := NewS3ClientE(t, awsRegion)
 	if err != nil {
 		return "", err

--- a/modules/aws/s3.go
+++ b/modules/aws/s3.go
@@ -261,25 +261,17 @@ func EmptyS3BucketE(t testing.TestingT, region string, name string) error {
 	return err
 }
 
-// GetS3BucketLoggingTarget fetches the given bucket's logging configuration status and returns it as a string
-func GetS3BucketLoggingTarget(t testing.TestingT, awsRegion string, bucket string) string {
-	loggingTarget, err := GetS3BucketLoggingTargetE(t, awsRegion, bucket)
+// GetS3BucketLoggingTargetBucket fetches the given bucket's logging target bucket and returns it as a string
+func GetS3BucketLoggingTargetBucket(t testing.TestingT, awsRegion string, bucket string) string {
+	loggingTarget, err := GetS3BucketLoggingTargetBucketE(t, awsRegion, bucket)
 	require.NoError(t, err)
 
 	return loggingTarget
 }
 
-// GetS3BucketLoggingTarget fetches the given bucket's logging configuration status and returns it as a string
-func GetS3BucketLoggingTargetPrefix(t testing.TestingT, awsRegion string, bucket string) string {
-	loggingObjectTargetPrefix, err := GetS3BucketLoggingTargetPrefixE(t, awsRegion, bucket)
-	require.NoError(t, err)
-
-	return loggingObjectTargetPrefix
-}
-
-// GetS3BucketLoggingE fetches the given bucket's logging configuration status and returns it as the following strings:
-// `TargetBucket` and `TargetPrefix` of the `LoggingEnabled` property for an S3 bucket
-func GetS3BucketLoggingTargetE(t testing.TestingT, awsRegion string, bucket string) (string, error) {
+// GetS3BucketLoggingTargetBucketE fetches the given bucket's logging target bucket and returns it as the following string:
+// `TargetBucket` of the `LoggingEnabled` property for an S3 bucket
+func GetS3BucketLoggingTargetBucketE(t testing.TestingT, awsRegion string, bucket string) (string, error) {
 	s3Client, err := NewS3ClientE(t, awsRegion)
 	if err != nil {
 		return "", err
@@ -300,7 +292,15 @@ func GetS3BucketLoggingTargetE(t testing.TestingT, awsRegion string, bucket stri
 	return aws.StringValue(res.LoggingEnabled.TargetBucket), nil
 }
 
-// GetS3BucketLoggingE fetches the given bucket's logging configuration status and returns it as the following strings:
+// GetS3BucketLoggingTargetPrefix fetches the given bucket's logging object prefix and returns it as a string
+func GetS3BucketLoggingTargetPrefix(t testing.TestingT, awsRegion string, bucket string) string {
+	loggingObjectTargetPrefix, err := GetS3BucketLoggingTargetPrefixE(t, awsRegion, bucket)
+	require.NoError(t, err)
+
+	return loggingObjectTargetPrefix
+}
+
+// GetS3BucketLoggingTargetPrefixE fetches the given bucket's logging object prefix and returns it as the following string:
 // `TargetPrefix` of the `LoggingEnabled` property for an S3 bucket
 func GetS3BucketLoggingTargetPrefixE(t testing.TestingT, awsRegion string, bucket string) (string, error) {
 	s3Client, err := NewS3ClientE(t, awsRegion)

--- a/test/terraform_aws_s3_example_test.go
+++ b/test/terraform_aws_s3_example_test.go
@@ -62,7 +62,7 @@ func TestTerraformAwsS3Example(t *testing.T) {
 	aws.AssertS3BucketPolicyExists(t, awsRegion, bucketID)
 
 	// Verify that our bucket has server access logging TargetBucket set to what's expected
-	loggingTargetBucket := aws.GetS3BucketLoggingTarget(t, awsRegion, bucketID)
+	loggingTargetBucket := aws.GetS3BucketLoggingTargetBucket(t, awsRegion, bucketID)
 	expectedLogsTargetBucket := fmt.Sprintf("%s-logs", bucketID)
 	loggingObjectTargetPrefix := aws.GetS3BucketLoggingTargetPrefix(t, awsRegion, bucketID)
 	expectedLogsTargetPrefix := "TFStateLogs/"

--- a/test/terraform_aws_s3_example_test.go
+++ b/test/terraform_aws_s3_example_test.go
@@ -62,8 +62,9 @@ func TestTerraformAwsS3Example(t *testing.T) {
 	aws.AssertS3BucketPolicyExists(t, awsRegion, bucketID)
 
 	// Verify that our bucket has server access logging TargetBucket set to what's expected
-	loggingTargetBucket, loggingObjectTargetPrefix := aws.GetS3BucketLoggingTarget(t, awsRegion, bucketID)
+	loggingTargetBucket := aws.GetS3BucketLoggingTarget(t, awsRegion, bucketID)
 	expectedLogsTargetBucket := fmt.Sprintf("%s-logs", bucketID)
+	loggingObjectTargetPrefix := aws.GetS3BucketLoggingTargetPrefix(t, awsRegion, bucketID)
 	expectedLogsTargetPrefix := "TFStateLogs/"
 
 	assert.Equal(t, expectedLogsTargetBucket, loggingTargetBucket)

--- a/test/terraform_aws_s3_example_test.go
+++ b/test/terraform_aws_s3_example_test.go
@@ -62,7 +62,10 @@ func TestTerraformAwsS3Example(t *testing.T) {
 	aws.AssertS3BucketPolicyExists(t, awsRegion, bucketID)
 
 	// Verify that our bucket has server access logging TargetBucket set to what's expected
-	loggingTargetBucket := aws.GetS3BucketLoggingTarget(t, awsRegion, bucketID)
+	loggingTargetBucket, loggingObjectTargetPrefix := aws.GetS3BucketLoggingTarget(t, awsRegion, bucketID)
 	expectedLogsTargetBucket := fmt.Sprintf("%s-logs", bucketID)
+	expectedLogsTargetPrefix := "TFStateLogs/"
+
 	assert.Equal(t, expectedLogsTargetBucket, loggingTargetBucket)
+	assert.Equal(t, expectedLogsTargetPrefix, loggingObjectTargetPrefix)
 }

--- a/test/terraform_aws_s3_example_test.go
+++ b/test/terraform_aws_s3_example_test.go
@@ -62,7 +62,7 @@ func TestTerraformAwsS3Example(t *testing.T) {
 	aws.AssertS3BucketPolicyExists(t, awsRegion, bucketID)
 
 	// Verify that our bucket has server access logging TargetBucket set to what's expected
-	loggingTargetBucket := aws.GetS3BucketLoggingTargetBucket(t, awsRegion, bucketID)
+	loggingTargetBucket := aws.GetS3BucketLoggingTarget(t, awsRegion, bucketID)
 	expectedLogsTargetBucket := fmt.Sprintf("%s-logs", bucketID)
 	loggingObjectTargetPrefix := aws.GetS3BucketLoggingTargetPrefix(t, awsRegion, bucketID)
 	expectedLogsTargetPrefix := "TFStateLogs/"


### PR DESCRIPTION
This PR adds the functionality needed in this code changes: https://github.com/gruntwork-io/terragrunt/pull/1507

With this PR we can:
- get the `TargetPrefix` specified for a state bucket with enabled access logging

Issue linked: https://github.com/gruntwork-io/terragrunt/issues/1437