### PR TITLE
Use git branch --show-current because it works when there are no commits

### DIFF
--- a/modules/git/git.go
+++ b/modules/git/git.go
@@ -26,17 +26,7 @@ func GetCurrentBranchNameE(t testing.TestingT) (string, error) {
 	cmd := exec.Command("git", "branch", "--show-current")
 	bytes, err := cmd.Output()
 	if err != nil {
-		cmd := exec.Command("git", "rev-parse", "--abbrev-ref", "HEAD")
-		bytes, err := cmd.Output()
-		if err != nil {
-			return "", err
-		}
-		name := strings.TrimSpace(string(bytes))
-		if name == "HEAD" {
-			return "", nil
-		}
-
-		return name, nil
+		return GetCurrentBranchNameOldE(t)
 	}
 
 	name := strings.TrimSpace(string(bytes))
@@ -48,7 +38,8 @@ func GetCurrentBranchNameE(t testing.TestingT) (string, error) {
 }
 
 // GetCurrentBranchNameOldE retrieves the current branch name or
-// empty string in case of detached state.
+// empty string in case of detached state. This uses the older pattern
+// of `git rev-parse` rather than `git branch --show-current`.
 func GetCurrentBranchNameOldE(t testing.TestingT) (string, error) {
 	cmd := exec.Command("git", "rev-parse", "--abbrev-ref", "HEAD")
 	bytes, err := cmd.Output()

--- a/modules/git/git.go
+++ b/modules/git/git.go
@@ -20,8 +20,37 @@ func GetCurrentBranchName(t testing.TestingT) string {
 
 // GetCurrentBranchNameE retrieves the current branch name or
 // empty string in case of detached state.
+// Uses branch --show-current, which was introduced in git v2.22.
+// Falls back to rev-parse for users of the older version, like Ubuntu 18.04.
 func GetCurrentBranchNameE(t testing.TestingT) (string, error) {
 	cmd := exec.Command("git", "branch", "--show-current")
+	bytes, err := cmd.Output()
+	if err != nil {
+		cmd := exec.Command("git", "rev-parse", "--abbrev-ref", "HEAD")
+		bytes, err := cmd.Output()
+		if err != nil {
+			return "", err
+		}
+		name := strings.TrimSpace(string(bytes))
+		if name == "HEAD" {
+			return "", nil
+		}
+
+		return name, nil
+	}
+
+	name := strings.TrimSpace(string(bytes))
+	if name == "HEAD" {
+		return "", nil
+	}
+
+	return name, nil
+}
+
+// GetCurrentBranchNameOldE retrieves the current branch name or
+// empty string in case of detached state.
+func GetCurrentBranchNameOldE(t testing.TestingT) (string, error) {
+	cmd := exec.Command("git", "rev-parse", "--abbrev-ref", "HEAD")
 	bytes, err := cmd.Output()
 	if err != nil {
 		return "", err

--- a/modules/git/git.go
+++ b/modules/git/git.go
@@ -21,7 +21,7 @@ func GetCurrentBranchName(t testing.TestingT) string {
 // GetCurrentBranchNameE retrieves the current branch name or
 // empty string in case of detached state.
 func GetCurrentBranchNameE(t testing.TestingT) (string, error) {
-	cmd := exec.Command("git", "rev-parse", "--abbrev-ref", "HEAD")
+	cmd := exec.Command("git", "branch", "--show-current")
 	bytes, err := cmd.Output()
 	if err != nil {
 		return "", err


### PR DESCRIPTION
Needed for https://github.com/gruntwork-io/terraform-aws-architecture-catalog/pull/138