### PR TITLE
Add configuration option for terraform plugin dir

### DIFF
--- a/modules/terraform/format.go
+++ b/modules/terraform/format.go
@@ -87,6 +87,16 @@ func FormatTerraformLockAsArgs(lockCheck bool, lockTimeout string) []string {
 	return lockArgs
 }
 
+// FormatTerraformPluginDirAsArgs formats the plugin-dir variable
+// -plugin-dir
+func FormatTerraformPluginDirAsArgs(pluginDir string) []string {
+	pluginArgs := []string{fmt.Sprintf("-plugin-dir=%v", pluginDir)}
+	if pluginDir == "" {
+		return nil
+	}
+	return pluginArgs
+}
+
 // FormatTerraformArgs will format multiple args with the arg name (e.g. "-var-file", []string{"foo.tfvars", "bar.tfvars"})
 // returns "-var-file foo.tfvars -var-file bar.tfvars"
 func FormatTerraformArgs(argName string, args []string) []string {

--- a/modules/terraform/format_test.go
+++ b/modules/terraform/format_test.go
@@ -30,6 +30,24 @@ func TestFormatTerraformPlanFileAsArgs(t *testing.T) {
 	}
 }
 
+func TestFormatTerraformPluginDirAsArgs(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		dir      string
+		expected []string
+	}{
+		{"/some/plugin/dir", []string{"-plugin-dir=/some/plugin/dir"}},
+		{"", nil},
+	}
+
+	for _, testCase := range testCases {
+		checkResultWithRetry(t, 100, testCase.expected, fmt.Sprintf("FormatTerraformPluginDirAsArgs(%v)", testCase.dir), func() interface{} {
+			return FormatTerraformPluginDirAsArgs(testCase.dir)
+		})
+	}
+}
+
 func TestFormatTerraformVarsAsArgs(t *testing.T) {
 	t.Parallel()
 

--- a/modules/terraform/init.go
+++ b/modules/terraform/init.go
@@ -19,5 +19,6 @@ func Init(t testing.TestingT, options *Options) string {
 func InitE(t testing.TestingT, options *Options) (string, error) {
 	args := []string{"init", fmt.Sprintf("-upgrade=%t", options.Upgrade)}
 	args = append(args, FormatTerraformBackendConfigAsArgs(options.BackendConfig)...)
+	args = append(args, FormatTerraformPluginDirAsArgs(options.PluginDir)...)
 	return RunTerraformCommandE(t, options, args...)
 }

--- a/modules/terraform/init_test.go
+++ b/modules/terraform/init_test.go
@@ -2,6 +2,7 @@ package terraform
 
 import (
 	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -51,19 +52,26 @@ func TestInitPluginDir(t *testing.T) {
 	testFolder, err := files.CopyTerraformFolderToTemp(terraformFixture, t.Name())
 	require.NoError(t, err)
 
+	defer os.RemoveAll(initializePluginsFolder)
+	defer os.RemoveAll(testFolder)
+	defer os.RemoveAll(pluginDir)
+
 	terraformOptions := &Options{
 		TerraformDir: initializePluginsFolder,
 	}
-
-	Init(t, terraformOptions)
-
-	initializedPluginDir := initializePluginsFolder + "/.terraform/plugins"
-	files.CopyFolderContents(initializedPluginDir, pluginDir)
 
 	terraformOptionsPluginDir := &Options{
 		TerraformDir: testFolder,
 		PluginDir:    pluginDir,
 	}
+
+	Init(t, terraformOptions)
+
+	_, err = InitE(t, terraformOptionsPluginDir)
+	require.Error(t, err)
+
+	initializedPluginDir := initializePluginsFolder + "/.terraform/plugins"
+	files.CopyFolderContents(initializedPluginDir, pluginDir)
 
 	initOutput := Init(t, terraformOptionsPluginDir)
 

--- a/modules/terraform/init_test.go
+++ b/modules/terraform/init_test.go
@@ -43,18 +43,17 @@ func TestInitPluginDir(t *testing.T) {
 
 	pluginDir, err := ioutil.TempDir("", t.Name())
 	require.NoError(t, err)
+	defer os.RemoveAll(pluginDir)
 
 	terraformFixture := "../../test/fixtures/terraform-basic-configuration"
 
 	initializePluginsFolder, err := files.CopyTerraformFolderToTemp(terraformFixture, t.Name())
 	require.NoError(t, err)
+	defer os.RemoveAll(initializePluginsFolder)
 
 	testFolder, err := files.CopyTerraformFolderToTemp(terraformFixture, t.Name())
 	require.NoError(t, err)
-
-	defer os.RemoveAll(initializePluginsFolder)
 	defer os.RemoveAll(testFolder)
-	defer os.RemoveAll(pluginDir)
 
 	terraformOptions := &Options{
 		TerraformDir: initializePluginsFolder,

--- a/modules/terraform/options.go
+++ b/modules/terraform/options.go
@@ -67,7 +67,7 @@ type Options struct {
 	Logger                   *logger.Logger         // Set a non-default logger that should be used. See the logger package for more info.
 	Parallelism              int                    // Set the parallelism setting for Terraform
 	PlanFilePath             string                 // The path to output a plan file to (for the plan command) or read one from (for the apply command)
-	PluginDir                string                 // The path of downloaded plugins to pass to the terraform command --plugin-dir
+	PluginDir                string                 // The path of downloaded plugins to pass to the terraform init command (-plugin-dir)
 }
 
 // Clone makes a deep copy of most fields on the Options object and returns it.

--- a/modules/terraform/options.go
+++ b/modules/terraform/options.go
@@ -67,6 +67,7 @@ type Options struct {
 	Logger                   *logger.Logger         // Set a non-default logger that should be used. See the logger package for more info.
 	Parallelism              int                    // Set the parallelism setting for Terraform
 	PlanFilePath             string                 // The path to output a plan file to (for the plan command) or read one from (for the apply command)
+	PluginDir                string                 // The path of downloaded plugins to pass to the terraform command --plugin-dir
 }
 
 // Clone makes a deep copy of most fields on the Options object and returns it.


### PR DESCRIPTION
Fixes #565. 

I posed a question on the issue itself about testing but its probably better to have the conversation here:

I'm having a hard time figuring out the best way to implement a test that would be easy to maintain long term. Testing that the `-plugin-dir` option is actually working requires having pre-downloaded providers. I wrote a test that uses a fixture with a pre-downloaded provider locally but i don't think committing the actual provider binary to the repo is a viable solution.

Do you have any suggestions on how to implement an actual test for this? 

Thanks!