### PR TITLE
Make sure Terragrunt commands can be configured with -lock=true

### DIFF
--- a/modules/terraform/apply.go
+++ b/modules/terraform/apply.go
@@ -60,7 +60,7 @@ func TgApplyAllE(t testing.TestingT, options *Options) (string, error) {
 		return "", TgInvalidBinary(options.TerraformBinary)
 	}
 
-	return RunTerraformCommandE(t, options, FormatArgs(options, "apply-all", "-input=false", "-lock=false", "-auto-approve")...)
+	return RunTerraformCommandE(t, options, FormatArgs(options, "apply-all", "-input=false", "-auto-approve")...)
 }
 
 // ApplyAndIdempotent runs terraform apply with the given options and return stdout/stderr from the apply command. It then runs

--- a/modules/terraform/apply_test.go
+++ b/modules/terraform/apply_test.go
@@ -182,3 +182,21 @@ func TestParallelism(t *testing.T) {
 	duration := end.Sub(start)
 	require.Greater(t, int64(duration.Seconds()), int64(25))
 }
+func TestTgApplyUseLockNoError(t *testing.T) {
+	t.Parallel()
+
+	testFolder, err := files.CopyTerragruntFolderToTemp("../../test/fixtures/terragrunt/terragrunt-no-error", t.Name())
+	require.NoError(t, err)
+
+	options := WithDefaultRetryableErrors(t, &Options{
+		TerraformDir:    testFolder,
+		TerraformBinary: "terragrunt",
+		Lock:            true,
+	})
+
+	out := TgApplyAll(t, options)
+
+	require.Contains(t, out, "Hello, World")
+	// make sure -lock CLI option is passed down correctly
+	require.Contains(t, out, "-lock=true")
+}

--- a/modules/terraform/destroy.go
+++ b/modules/terraform/destroy.go
@@ -30,5 +30,5 @@ func TgDestroyAllE(t testing.TestingT, options *Options) (string, error) {
 		return "", TgInvalidBinary(options.TerraformBinary)
 	}
 
-	return RunTerraformCommandE(t, options, FormatArgs(options, "destroy-all", "-force", "-input=false", "-lock=false")...)
+	return RunTerraformCommandE(t, options, FormatArgs(options, "destroy-all", "-force", "-input=false")...)
 }

--- a/modules/terraform/format.go
+++ b/modules/terraform/format.go
@@ -14,7 +14,9 @@ import (
 var TerraformCommandsWithLockSupport = []string{
 	"plan",
 	"apply",
+	"apply-all",
 	"destroy",
+	"destroy-all",
 	"init",
 	"refresh",
 	"taint",


### PR DESCRIPTION
This fixes https://github.com/gruntwork-io/terratest/issues/785

In the current implementation, when using Terragrunt binary instead of Terraform, Terratest explicitly passes `-lock=false` to the CLI. 
This triggers a bug in Terraform (see issue for details on that), but also doesn't allow us to run integration tests with remote state
backend configured in the same way we would run actual deployment since Terraform uses `-lock=true` by default.

This change allows `Options.Lock` to be passed down to the Terragrunt `apply-all` and `destroy-all` commands. 

Default behavior in Terratest does not change, since `Options.Lock` is still initialized to `false`, but at least we can control it now.  