### PR TITLE
Implement Terraform Workspace deletion.

### DIFF
--- a/modules/terraform/errors.go
+++ b/modules/terraform/errors.go
@@ -87,3 +87,17 @@ type PanicWhileParsingVarFile struct {
 func (err PanicWhileParsingVarFile) Error() string {
 	return fmt.Sprintf("Recovering panic while parsing '%s'. Got error of type '%v': %v", err.ConfigFile, reflect.TypeOf(err.RecoveredValue), err.RecoveredValue)
 }
+
+// UnsupportedDefaultWorkspaceDeletion is returned when user tries to delete the workspace "default"
+type UnsupportedDefaultWorkspaceDeletion struct{}
+
+func (err *UnsupportedDefaultWorkspaceDeletion) Error() string {
+	return "Deleting the workspace 'default' is not supported"
+}
+
+// WorkspaceDoesNotExist is returned when user tries to delete a workspace which does not exist
+type WorkspaceDoesNotExist string
+
+func (err WorkspaceDoesNotExist) Error() string {
+	return fmt.Sprintf("The workspace %q does not exist.", string(err))
+}

--- a/modules/terraform/workspace.go
+++ b/modules/terraform/workspace.go
@@ -103,10 +103,6 @@ func WorkspaceDeleteE(t testing.TestingT, options *Options, name string) (string
 // If the workspace to delete is the current one, then it tries to switch to the "default" workspace.
 // Deleting the workspace "default" is not supported and only return an empty string (to avoid a fatal error).
 func WorkspaceDelete(t testing.TestingT, options *Options, name string) string {
-	if name == "default" {
-		return name
-	}
-
 	out, err := WorkspaceDeleteE(t, options, name)
 	require.NoError(t, err)
 	return out

--- a/modules/terraform/workspace_test.go
+++ b/modules/terraform/workspace_test.go
@@ -1,6 +1,7 @@
 package terraform
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/gruntwork-io/terratest/modules/files"
@@ -218,7 +219,7 @@ func TestWorkspaceDeleteE(t *testing.T) {
 
 			// Check for errors
 			if testCase.expectedError != nil {
-				assert.EqualError(t, gotErr, testCase.expectedError.Error())
+				assert.True(t, errors.As(gotErr, &testCase.expectedError))
 			} else {
 				assert.NoError(t, gotErr)
 				// Check for results

--- a/modules/terraform/workspace_test.go
+++ b/modules/terraform/workspace_test.go
@@ -130,3 +130,177 @@ func TestNameMatchesWorkspace(t *testing.T) {
 		assert.Equal(t, testCase.expected, actual, "Name: %q, Workspace: %q", testCase.name, testCase.workspace)
 	}
 }
+
+// Please note that this test depends on other functions that should be mocked to be a unit test.
+func TestWorkspaceDeleteE(t *testing.T) {
+	t.Parallel()
+
+	// state describes an expected status when a given testCase begins
+	type state struct {
+		workspaces []string
+		current    string
+	}
+
+	// testCase describes a named test case with a state, args and expcted results
+	type testCase struct {
+		name                 string
+		initialState         state
+		toDeleteWorkspace    string
+		expectedCurrent      string
+		expectedErrorMessage string
+	}
+
+	testCases := []testCase{
+		{
+			name: "delete another existing workspace and stay on current",
+			initialState: state{
+				workspaces: []string{"staging", "production"},
+				current:    "staging",
+			},
+			toDeleteWorkspace:    "production",
+			expectedCurrent:      "staging",
+			expectedErrorMessage: "",
+		},
+		{
+			name: "delete current workspace and switch to a specified",
+			initialState: state{
+				workspaces: []string{"staging", "production"},
+				current:    "production",
+			},
+			toDeleteWorkspace:    "production",
+			expectedCurrent:      "default",
+			expectedErrorMessage: "",
+		},
+		{
+			name: "delete a non existing workspace should trigger an error",
+			initialState: state{
+				workspaces: []string{"staging", "production"},
+				current:    "staging",
+			},
+			toDeleteWorkspace:    "hellothere",
+			expectedCurrent:      "staging",
+			expectedErrorMessage: "The workspace \"hellothere\" does not exist.",
+		},
+		{
+			name: "delete the default workspace triggers an error",
+			initialState: state{
+				workspaces: []string{"staging", "production"},
+				current:    "staging",
+			},
+			toDeleteWorkspace:    "default",
+			expectedCurrent:      "staging",
+			expectedErrorMessage: "Deleting the workspace 'default' is not supported",
+		},
+	}
+
+	for _, tt := range testCases {
+		testFolder, err := files.CopyTerraformFolderToTemp("../../test/fixtures/terraform-workspace", tt.name)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		options := &Options{
+			TerraformDir: testFolder,
+		}
+
+		// Set up pre-existing environment based on test case description
+		for _, existingWorkspace := range tt.initialState.workspaces {
+			_, err = RunTerraformCommandE(t, options, "workspace", "new", existingWorkspace)
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+		// Switch to the specified workspace
+		_, err = RunTerraformCommandE(t, options, "workspace", "select", tt.initialState.current)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Testing time, wooohoooo
+		gotResult, gotErr := WorkspaceDeleteE(t, options, tt.toDeleteWorkspace)
+
+		// Check for errors
+		if tt.expectedErrorMessage != "" {
+			assert.Error(t, gotErr)
+			assert.Equal(t, tt.expectedErrorMessage, gotErr.Error())
+		} else {
+			assert.Nil(t, gotErr)
+			// Check for results
+			assert.Equal(t, tt.expectedCurrent, gotResult)
+			assert.False(t, isExistingWorkspace(RunTerraformCommand(t, options, "workspace", "list"), tt.toDeleteWorkspace))
+		}
+
+	}
+}
+
+// Please note that this test depends on other functions that should be mocked to be a unit test.
+func TestWorkspaceDelete(t *testing.T) {
+	t.Parallel()
+
+	// state describes an expected status when a given testCase begins
+	type state struct {
+		workspaces []string
+		current    string
+	}
+
+	// testCase describes a named test case with a state, args and expcted results
+	type testCase struct {
+		name              string
+		initialState      state
+		toDeleteWorkspace string
+		expectedCurrent   string
+	}
+
+	testCases := []testCase{
+		{
+			name: "delete another existing workspace and stay on current",
+			initialState: state{
+				workspaces: []string{"staging", "production"},
+				current:    "staging",
+			},
+			toDeleteWorkspace: "production",
+			expectedCurrent:   "staging",
+		},
+		{
+			name: "delete current workspace and switch to a specified",
+			initialState: state{
+				workspaces: []string{"staging", "production"},
+				current:    "production",
+			},
+			toDeleteWorkspace: "production",
+			expectedCurrent:   "default",
+		},
+	}
+
+	for _, tt := range testCases {
+		testFolder, err := files.CopyTerraformFolderToTemp("../../test/fixtures/terraform-workspace", tt.name)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		options := &Options{
+			TerraformDir: testFolder,
+		}
+
+		// Set up pre-existing environment based on test case description
+		for _, existingWorkspace := range tt.initialState.workspaces {
+			_, err = RunTerraformCommandE(t, options, "workspace", "new", existingWorkspace)
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+		// Switch to the specified workspace
+		_, err = RunTerraformCommandE(t, options, "workspace", "select", tt.initialState.current)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Testing time, wooohoooo
+		gotResult := WorkspaceDelete(t, options, tt.toDeleteWorkspace)
+
+		// Check for results
+		assert.Equal(t, tt.expectedCurrent, gotResult)
+		assert.False(t, isExistingWorkspace(RunTerraformCommand(t, options, "workspace", "list"), tt.toDeleteWorkspace))
+
+	}
+}

--- a/modules/terraform/workspace_test.go
+++ b/modules/terraform/workspace_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/gruntwork-io/terratest/modules/files"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestWorkspaceNew(t *testing.T) {
@@ -131,110 +132,7 @@ func TestNameMatchesWorkspace(t *testing.T) {
 	}
 }
 
-// Please note that this test depends on other functions that should be mocked to be a unit test.
 func TestWorkspaceDeleteE(t *testing.T) {
-	t.Parallel()
-
-	// state describes an expected status when a given testCase begins
-	type state struct {
-		workspaces []string
-		current    string
-	}
-
-	// testCase describes a named test case with a state, args and expcted results
-	type testCase struct {
-		name                 string
-		initialState         state
-		toDeleteWorkspace    string
-		expectedCurrent      string
-		expectedErrorMessage string
-	}
-
-	testCases := []testCase{
-		{
-			name: "delete another existing workspace and stay on current",
-			initialState: state{
-				workspaces: []string{"staging", "production"},
-				current:    "staging",
-			},
-			toDeleteWorkspace:    "production",
-			expectedCurrent:      "staging",
-			expectedErrorMessage: "",
-		},
-		{
-			name: "delete current workspace and switch to a specified",
-			initialState: state{
-				workspaces: []string{"staging", "production"},
-				current:    "production",
-			},
-			toDeleteWorkspace:    "production",
-			expectedCurrent:      "default",
-			expectedErrorMessage: "",
-		},
-		{
-			name: "delete a non existing workspace should trigger an error",
-			initialState: state{
-				workspaces: []string{"staging", "production"},
-				current:    "staging",
-			},
-			toDeleteWorkspace:    "hellothere",
-			expectedCurrent:      "staging",
-			expectedErrorMessage: "The workspace \"hellothere\" does not exist.",
-		},
-		{
-			name: "delete the default workspace triggers an error",
-			initialState: state{
-				workspaces: []string{"staging", "production"},
-				current:    "staging",
-			},
-			toDeleteWorkspace:    "default",
-			expectedCurrent:      "staging",
-			expectedErrorMessage: "Deleting the workspace 'default' is not supported",
-		},
-	}
-
-	for _, tt := range testCases {
-		testFolder, err := files.CopyTerraformFolderToTemp("../../test/fixtures/terraform-workspace", tt.name)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		options := &Options{
-			TerraformDir: testFolder,
-		}
-
-		// Set up pre-existing environment based on test case description
-		for _, existingWorkspace := range tt.initialState.workspaces {
-			_, err = RunTerraformCommandE(t, options, "workspace", "new", existingWorkspace)
-			if err != nil {
-				t.Fatal(err)
-			}
-		}
-		// Switch to the specified workspace
-		_, err = RunTerraformCommandE(t, options, "workspace", "select", tt.initialState.current)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		// Testing time, wooohoooo
-		gotResult, gotErr := WorkspaceDeleteE(t, options, tt.toDeleteWorkspace)
-
-		// Check for errors
-		if tt.expectedErrorMessage != "" {
-			assert.Error(t, gotErr)
-			assert.Equal(t, tt.expectedErrorMessage, gotErr.Error())
-		} else {
-			assert.Nil(t, gotErr)
-			// Check for results
-			assert.Equal(t, tt.expectedCurrent, gotResult)
-			assert.False(t, isExistingWorkspace(RunTerraformCommand(t, options, "workspace", "list"), tt.toDeleteWorkspace))
-		}
-
-	}
-}
-
-// Please note that this test depends on other functions that should be mocked to be a unit test.
-func TestWorkspaceDelete(t *testing.T) {
 	t.Parallel()
 
 	// state describes an expected status when a given testCase begins
@@ -249,6 +147,7 @@ func TestWorkspaceDelete(t *testing.T) {
 		initialState      state
 		toDeleteWorkspace string
 		expectedCurrent   string
+		expectedError     error
 	}
 
 	testCases := []testCase{
@@ -260,6 +159,7 @@ func TestWorkspaceDelete(t *testing.T) {
 			},
 			toDeleteWorkspace: "production",
 			expectedCurrent:   "staging",
+			expectedError:     nil,
 		},
 		{
 			name: "delete current workspace and switch to a specified",
@@ -269,38 +169,63 @@ func TestWorkspaceDelete(t *testing.T) {
 			},
 			toDeleteWorkspace: "production",
 			expectedCurrent:   "default",
+			expectedError:     nil,
+		},
+		{
+			name: "delete a non existing workspace should trigger an error",
+			initialState: state{
+				workspaces: []string{"staging", "production"},
+				current:    "staging",
+			},
+			toDeleteWorkspace: "hellothere",
+			expectedCurrent:   "staging",
+			expectedError:     WorkspaceDoesNotExist("hellothere"),
+		},
+		{
+			name: "delete the default workspace triggers an error",
+			initialState: state{
+				workspaces: []string{"staging", "production"},
+				current:    "staging",
+			},
+			toDeleteWorkspace: "default",
+			expectedCurrent:   "staging",
+			expectedError:     &UnsupportedDefaultWorkspaceDeletion{},
 		},
 	}
 
-	for _, tt := range testCases {
-		testFolder, err := files.CopyTerraformFolderToTemp("../../test/fixtures/terraform-workspace", tt.name)
-		if err != nil {
-			t.Fatal(err)
-		}
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			testFolder, err := files.CopyTerraformFolderToTemp("../../test/fixtures/terraform-workspace", testCase.name)
+			require.NoError(t, err)
 
-		options := &Options{
-			TerraformDir: testFolder,
-		}
-
-		// Set up pre-existing environment based on test case description
-		for _, existingWorkspace := range tt.initialState.workspaces {
-			_, err = RunTerraformCommandE(t, options, "workspace", "new", existingWorkspace)
-			if err != nil {
-				t.Fatal(err)
+			options := &Options{
+				TerraformDir: testFolder,
 			}
-		}
-		// Switch to the specified workspace
-		_, err = RunTerraformCommandE(t, options, "workspace", "select", tt.initialState.current)
-		if err != nil {
-			t.Fatal(err)
-		}
 
-		// Testing time, wooohoooo
-		gotResult := WorkspaceDelete(t, options, tt.toDeleteWorkspace)
+			// Set up pre-existing environment based on test case description
+			for _, existingWorkspace := range testCase.initialState.workspaces {
+				_, err = RunTerraformCommandE(t, options, "workspace", "new", existingWorkspace)
+				require.NoError(t, err)
+			}
+			// Switch to the specified workspace
+			_, err = RunTerraformCommandE(t, options, "workspace", "select", testCase.initialState.current)
+			require.NoError(t, err)
 
-		// Check for results
-		assert.Equal(t, tt.expectedCurrent, gotResult)
-		assert.False(t, isExistingWorkspace(RunTerraformCommand(t, options, "workspace", "list"), tt.toDeleteWorkspace))
+			// Testing time, wooohoooo
+			gotResult, gotErr := WorkspaceDeleteE(t, options, testCase.toDeleteWorkspace)
+
+			// Check for errors
+			if testCase.expectedError != nil {
+				assert.EqualError(t, gotErr, testCase.expectedError.Error())
+			} else {
+				assert.NoError(t, gotErr)
+				// Check for results
+				assert.Equal(t, testCase.expectedCurrent, gotResult)
+				assert.False(t, isExistingWorkspace(RunTerraformCommand(t, options, "workspace", "list"), testCase.toDeleteWorkspace))
+			}
+		})
 
 	}
 }


### PR DESCRIPTION
Hello there 👋 Thanks for this awesoe tool.

This PR fixes #583 : it implements 2 methods to handle Terraform Workspace's deletion.

Please note that deleting the workspace `default` is not supported as it triggers edgy use cases.