### PR TITLE
Build target flag for docker module

### DIFF
--- a/modules/docker/build.go
+++ b/modules/docker/build.go
@@ -15,6 +15,9 @@ type BuildOptions struct {
 	// Build args to pass the 'docker build' command
 	BuildArgs []string
 
+	// Target build arg to pass to the 'docker build' command
+	Target string
+
 	// Custom CLI options that will be passed as-is to the 'docker build' command. This is an "escape hatch" that allows
 	// Terratest to not have to support every single command-line option offered by the 'docker build' command, and
 	// solely focus on the most important ones.
@@ -59,6 +62,10 @@ func formatDockerBuildArgs(path string, options *BuildOptions) ([]string, error)
 
 	for _, arg := range options.BuildArgs {
 		args = append(args, "--build-arg", arg)
+	}
+
+	if len(options.Target) > 0 {
+		args = append(args, "--target", options.Target)
 	}
 
 	args = append(args, options.OtherOptions...)

--- a/modules/docker/build_test.go
+++ b/modules/docker/build_test.go
@@ -23,3 +23,22 @@ func TestBuild(t *testing.T) {
 	out := Run(t, tag, &RunOptions{Remove: true})
 	require.Contains(t, out, text)
 }
+
+func TestBuildWithTarget(t *testing.T) {
+	t.Parallel()
+
+	tag := "gruntwork-io/test-image:target1"
+	text := "Hello, World!"
+	text1 := "Hello, World! This is build target 1!"
+
+	options := &BuildOptions{
+		Tags:      []string{tag},
+		BuildArgs: []string{fmt.Sprintf("text=%s", text), fmt.Sprintf("text1=%s", text1)},
+		Target:    "step1",
+	}
+
+	Build(t, "../../test/fixtures/docker", options)
+
+	out := Run(t, tag, &RunOptions{Remove: true})
+	require.Contains(t, out, text1)
+}

--- a/test/fixtures/docker/Dockerfile
+++ b/test/fixtures/docker/Dockerfile
@@ -1,5 +1,10 @@
 # A "Hello, World" Docker image used in automated tests for the docker.Build command.
-FROM alpine:3.7
+FROM alpine:3.7 as step1
+ARG text1
+RUN echo $text1 > text.txt
+CMD ["cat", "text.txt"]
+
+FROM step1
 ARG text
 RUN echo $text > text.txt
 CMD ["cat", "text.txt"]


### PR DESCRIPTION
This PR is an implementation for the issue: https://github.com/gruntwork-io/terratest/issues/792
Adding an optional `--target` flag for build options. A bit modified `Dockerfile` used for tests (does not break reverse-compatibility for other tests) and added an additional test to make sure that flag works.

Gist with tests output within `modules/docker` path: https://gist.github.com/ThelonKarrde/9eab7f3172edd8c71032e690618764e1