### PR TITLE
[docker] Helper function to get exposed host ports for -P flag

### DIFF
--- a/modules/docker/inspect.go
+++ b/modules/docker/inspect.go
@@ -230,7 +230,7 @@ func transformContainerPorts(container inspectOutput) ([]Port, error) {
 	return ports, nil
 }
 
-// GetExposedHostPort returns an exposed host port according to requested container port
+// GetExposedHostPort returns an exposed host port according to requested container port. Returns 0 if the requested port is not exposed.
 func (inspectOutput ContainerInspect) GetExposedHostPort(containerPort uint16) uint16 {
 	for _, port := range inspectOutput.Ports {
 		if port.ContainerPort == containerPort {

--- a/modules/docker/inspect.go
+++ b/modules/docker/inspect.go
@@ -230,6 +230,16 @@ func transformContainerPorts(container inspectOutput) ([]Port, error) {
 	return ports, nil
 }
 
+// GetExposedHostPort returns an exposed host port according to requested container port
+func (inspectOutput ContainerInspect) GetExposedHostPort(containerPort uint16) uint16 {
+	for _, port := range inspectOutput.Ports {
+		if port.ContainerPort == containerPort {
+			return port.HostPort
+		}
+	}
+	return uint16(0)
+}
+
 // transformContainerVolumes converts Docker's volume bindings from the
 // format "/foo/bar:/foo/baz" into a more testable one
 func transformContainerVolumes(container inspectOutput) []VolumeBind {

--- a/modules/docker/inspect_test.go
+++ b/modules/docker/inspect_test.go
@@ -56,6 +56,26 @@ func TestInspectWithExposedPort(t *testing.T) {
 	require.EqualValues(t, port, c.Ports[0].HostPort)
 }
 
+func TestInspectWithRandomExposedPort(t *testing.T) {
+	t.Parallel()
+
+	var expectedPort uint16 = 80
+	var unexpectedPort uint16 = 1234
+	options := &RunOptions{
+		Detach:       true,
+		OtherOptions: []string{fmt.Sprintf("-P")},
+	}
+
+	id := RunAndGetID(t, dockerInspectTestImage, options)
+	defer removeContainer(t, id)
+
+	c := Inspect(t, id)
+
+	require.NotEmptyf(t, c.Ports, "Container's exposed ports should not be empty")
+	require.NotEqualf(t, uint16(0), c.GetExposedHostPort(expectedPort), fmt.Sprintf("There are no exposed port %d!", expectedPort))
+	require.Equalf(t, uint16(0), c.GetExposedHostPort(unexpectedPort), fmt.Sprintf("There is an unexpected exposed port %d!", unexpectedPort))
+}
+
 func TestInspectWithHostVolume(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Relates to: `docker` module

The problem:
If you have at least two concurrent builds of the same image with exposed ports to host on the same build agent (on whatever CI tool you use) you unable to use direct port mapping. So you must use `-P` flag for the `run` command to get random host port assignments and then use the `inspect` function to get a list of exposed and mapped ports and choose the port that you want to test from this list. However, if you have more than two ports you might not know under what index will be this port or you need to check Dockerfile if you changed the order and make changes to test. Otherwise, you can write your own helper to search in the port list and migrated it from one project/test to another.
It's sort of painful to maintain and uncomfortable to use.

The solution:
I simply added a helper for host port search to the `ContainerInspect` structure as a function.
I'm not sure is it a convenient place for this helper, so let me know if I need to move it somewhere else in the package or it might just doesn't make sense :) 

p.s. I also write a test to make sure that the helper works as expected, as an "error code" I'm using `0` value.