### PR TITLE
Update Azure NIC and NSG modules to support sovereign cloud environments

### DIFF
--- a/modules/azure/client_factory.go
+++ b/modules/azure/client_factory.go
@@ -171,6 +171,8 @@ func GetKeyVaultURISuffixE() (string, error) {
 	return env.KeyVaultDNSSuffix, nil
 }
 
+// CreateNsgDefaultRulesClientE returns an NSG default (platform) rules client instance configured with the
+// correct BaseURI depending on the Azure environment that is currently setup (or "Public", if none is setup).
 func CreateNsgDefaultRulesClientE(subscriptionID string) (*network.DefaultSecurityRulesClient, error) {
 	// Validate Azure subscription ID
 	subscriptionID, err := getTargetAzureSubscription(subscriptionID)
@@ -189,6 +191,8 @@ func CreateNsgDefaultRulesClientE(subscriptionID string) (*network.DefaultSecuri
 	return &nsgClient, nil
 }
 
+// CreateNsgCustomRulesClientE returns an NSG custom (user) rules client instance configured with the
+// correct BaseURI depending on the Azure environment that is currently setup (or "Public", if none is setup).
 func CreateNsgCustomRulesClientE(subscriptionID string) (*network.SecurityRulesClient, error) {
 	// Validate Azure subscription ID
 	subscriptionID, err := getTargetAzureSubscription(subscriptionID)
@@ -207,6 +211,8 @@ func CreateNsgCustomRulesClientE(subscriptionID string) (*network.SecurityRulesC
 	return &nsgClient, nil
 }
 
+// CreateNewNetworkInterfacesClientE returns an NIC client instance configured with the
+// correct BaseURI depending on the Azure environment that is currently setup (or "Public", if none is setup).
 func CreateNewNetworkInterfacesClientE(subscriptionID string) (*network.InterfacesClient, error) {
 	// Validate Azure subscription ID
 	subscriptionID, err := getTargetAzureSubscription(subscriptionID)
@@ -225,6 +231,8 @@ func CreateNewNetworkInterfacesClientE(subscriptionID string) (*network.Interfac
 	return &nicClient, nil
 }
 
+// CreateNewNetworkInterfaceIPConfigurationClientE returns an NIC IP configuration client instance configured with the
+// correct BaseURI depending on the Azure environment that is currently setup (or "Public", if none is setup).
 func CreateNewNetworkInterfaceIPConfigurationClientE(subscriptionID string) (*network.InterfaceIPConfigurationsClient, error) {
 	// Validate Azure subscription ID
 	subscriptionID, err := getTargetAzureSubscription(subscriptionID)

--- a/modules/azure/client_factory.go
+++ b/modules/azure/client_factory.go
@@ -18,6 +18,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-07-01/compute"
 	"github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2019-11-01/containerservice"
 	kvmng "github.com/Azure/azure-sdk-for-go/services/keyvault/mgmt/2016-10-01/keyvault"
+	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2019-09-01/network"
 	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2019-06-01/subscriptions"
 	autorestAzure "github.com/Azure/go-autorest/autorest/azure"
 )
@@ -168,6 +169,78 @@ func GetKeyVaultURISuffixE() (string, error) {
 		return "", err
 	}
 	return env.KeyVaultDNSSuffix, nil
+}
+
+func CreateNsgDefaultRulesClientE(subscriptionID string) (*network.DefaultSecurityRulesClient, error) {
+	// Validate Azure subscription ID
+	subscriptionID, err := getTargetAzureSubscription(subscriptionID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Lookup environment URI
+	baseURI, err := getEnvironmentEndpointE(ResourceManagerEndpointName)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create new client
+	nsgClient := network.NewDefaultSecurityRulesClientWithBaseURI(baseURI, subscriptionID)
+	return &nsgClient, nil
+}
+
+func CreateNsgCustomRulesClientE(subscriptionID string) (*network.SecurityRulesClient, error) {
+	// Validate Azure subscription ID
+	subscriptionID, err := getTargetAzureSubscription(subscriptionID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Lookup environment URI
+	baseURI, err := getEnvironmentEndpointE(ResourceManagerEndpointName)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create new client
+	nsgClient := network.NewSecurityRulesClientWithBaseURI(baseURI, subscriptionID)
+	return &nsgClient, nil
+}
+
+func CreateNewNetworkInterfacesClientE(subscriptionID string) (*network.InterfacesClient, error) {
+	// Validate Azure subscription ID
+	subscriptionID, err := getTargetAzureSubscription(subscriptionID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Lookup environment URI
+	baseURI, err := getEnvironmentEndpointE(ResourceManagerEndpointName)
+	if err != nil {
+		return nil, err
+	}
+
+	// create client
+	nicClient := network.NewInterfacesClientWithBaseURI(baseURI, subscriptionID)
+	return &nicClient, nil
+}
+
+func CreateNewNetworkInterfaceIPConfigurationClientE(subscriptionID string) (*network.InterfaceIPConfigurationsClient, error) {
+	// Validate Azure subscription ID
+	subscriptionID, err := getTargetAzureSubscription(subscriptionID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Lookup environment URI
+	baseURI, err := getEnvironmentEndpointE(ResourceManagerEndpointName)
+	if err != nil {
+		return nil, err
+	}
+
+	// create client
+	ipConfigClient := network.NewInterfaceIPConfigurationsClientWithBaseURI(baseURI, subscriptionID)
+	return &ipConfigClient, nil
 }
 
 // getDefaultEnvironmentName returns either a configured Azure environment name, or the public default

--- a/modules/azure/networkinterface.go
+++ b/modules/azure/networkinterface.go
@@ -118,14 +118,11 @@ func GetNetworkInterfaceConfigurationE(nicName string, nicConfigName string, res
 
 // GetNetworkInterfaceConfigurationClientE creates a new Network Interface Configuration client in the specified Azure Subscription.
 func GetNetworkInterfaceConfigurationClientE(subscriptionID string) (*network.InterfaceIPConfigurationsClient, error) {
-	// Validate Azure Subscription ID
-	subscriptionID, err := getTargetAzureSubscription(subscriptionID)
+	// Create a new client from client factory
+	client, err := CreateNewNetworkInterfaceIPConfigurationClientE(subscriptionID)
 	if err != nil {
 		return nil, err
 	}
-
-	// Get the NIC client
-	client := network.NewInterfaceIPConfigurationsClient(subscriptionID)
 
 	// Create an authorizer
 	authorizer, err := NewAuthorizer()
@@ -134,7 +131,7 @@ func GetNetworkInterfaceConfigurationClientE(subscriptionID string) (*network.In
 	}
 	client.Authorizer = *authorizer
 
-	return &client, nil
+	return client, nil
 }
 
 // GetNetworkInterfaceE gets a Network Interface in the specified Azure Resource Group.
@@ -162,14 +159,11 @@ func GetNetworkInterfaceE(nicName string, resGroupName string, subscriptionID st
 
 // GetNetworkInterfaceClientE creates a new Network Interface client in the specified Azure Subscription.
 func GetNetworkInterfaceClientE(subscriptionID string) (*network.InterfacesClient, error) {
-	// Validate Azure Subscription ID
-	subscriptionID, err := getTargetAzureSubscription(subscriptionID)
+	// Create new NIC client from client factory
+	client, err := CreateNewNetworkInterfacesClientE(subscriptionID)
 	if err != nil {
 		return nil, err
 	}
-
-	// Get the NIC client
-	client := network.NewInterfacesClient(subscriptionID)
 
 	// Create an authorizer
 	authorizer, err := NewAuthorizer()
@@ -178,5 +172,5 @@ func GetNetworkInterfaceClientE(subscriptionID string) (*network.InterfacesClien
 	}
 	client.Authorizer = *authorizer
 
-	return &client, nil
+	return client, nil
 }

--- a/modules/azure/nsg.go
+++ b/modules/azure/nsg.go
@@ -46,13 +46,11 @@ func GetDefaultNsgRulesClient(t *testing.T, subscriptionID string) network.Defau
 // defined on an network security group. Note that the "default" rules are those provided implicitly
 // by the Azure platform.
 func GetDefaultNsgRulesClientE(subscriptionID string) (network.DefaultSecurityRulesClient, error) {
-	// Validate Azure subscription ID
-	subscriptionID, err := getTargetAzureSubscription(subscriptionID)
+	// Get new default client from client factory
+	nsgClient, err := CreateNsgDefaultRulesClientE(subscriptionID)
 	if err != nil {
 		return network.DefaultSecurityRulesClient{}, err
 	}
-
-	nsgClient := network.NewDefaultSecurityRulesClient(subscriptionID)
 
 	// Get an authorizer
 	auth, err := NewAuthorizer()
@@ -61,7 +59,7 @@ func GetDefaultNsgRulesClientE(subscriptionID string) (network.DefaultSecurityRu
 	}
 
 	nsgClient.Authorizer = *auth
-	return nsgClient, nil
+	return *nsgClient, nil
 }
 
 // GetCustomNsgRulesClient returns a rules client which can be used to read the list of *custom* security rules
@@ -78,13 +76,11 @@ func GetCustomNsgRulesClient(t *testing.T, subscriptionID string) network.Securi
 // defined on an network security group. Note that the "custom" rules are those defined by
 // end users.
 func GetCustomNsgRulesClientE(subscriptionID string) (network.SecurityRulesClient, error) {
-	// Validate Azure subscription ID
-	subscriptionID, err := getTargetAzureSubscription(subscriptionID)
+	// Get new custom rules client from client factory
+	nsgClient, err := CreateNsgCustomRulesClientE(subscriptionID)
 	if err != nil {
 		return network.SecurityRulesClient{}, err
 	}
-
-	nsgClient := network.NewSecurityRulesClient(subscriptionID)
 
 	// Get an authorizer
 	auth, err := NewAuthorizer()
@@ -93,7 +89,7 @@ func GetCustomNsgRulesClientE(subscriptionID string) (network.SecurityRulesClien
 	}
 
 	nsgClient.Authorizer = *auth
-	return nsgClient, nil
+	return *nsgClient, nil
 }
 
 // GetAllNSGRules returns an NsgRuleSummaryList instance containing the combined "default" and "custom" rules from a network


### PR DESCRIPTION
This PR updates the network interface and network security group testing modules to support Azure sovereign clouds (Government, Germany, China, Azure Stack). This behavior is controlled by setting the AZURE_ENVIRONMENT environment variable to the appropriate environment name (as covered in `examples/azure/client_factory.md`).

Closes #813 