### PR TITLE
Add function to invoke a lambda using an invocation type of "DryRun"

### DIFF
--- a/test/terraform_aws_lambda_example_test.go
+++ b/test/terraform_aws_lambda_example_test.go
@@ -119,8 +119,9 @@ func TestTerraformAwsLambdaWithParamsExample(t *testing.T) {
 	}
 	out, err := aws.InvokeFunctionWithParamsE(t, awsRegion, functionName, input)
 
-	// No error in the invocation as Lambda was found and executed.
-	require.Nil(t, err)
+	// The Lambda executed, but should have failed.
+	require.NotNil(t, err)
+	assert.Contains(t, err.Error(), "Unhandled")
 	assert.Equal(t, int(*out.StatusCode), 200)
 
 	// Make sure the function-specific error comes back
@@ -135,9 +136,7 @@ func TestTerraformAwsLambdaWithParamsExample(t *testing.T) {
 	}
 	out, err = aws.InvokeFunctionWithParamsE(t, awsRegion, functionName, input)
 	require.NotNil(t, err)
-	msg := "LambdaOptions.InvocationType, if specified, must either be \"RequestResponse\" or \"DryRun\""
-	assert.Contains(t, err.Error(), msg)
-	assert.Contains(t, *out.FunctionError, msg)
+	assert.Contains(t, err.Error(), "LambdaOptions.InvocationType, if specified, must either be \"RequestResponse\" or \"DryRun\"")
 }
 
 type ExampleFunctionPayload struct {

--- a/test/terraform_aws_lambda_example_test.go
+++ b/test/terraform_aws_lambda_example_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/service/lambda"
 	"github.com/gruntwork-io/terratest/modules/aws"
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/gruntwork-io/terratest/modules/terraform"
@@ -102,7 +101,7 @@ func TestTerraformAwsLambdaWithParamsExample(t *testing.T) {
 	// Call InvokeFunctionWithParms with an InvocationType of "DryRun".
 	// A "DryRun" invocation does not execute the function, so the example
 	// test function will not be checking the payload.
-	invocationType := lambda.InvocationTypeDryRun
+	var invocationType aws.InvocationTypeOption = aws.InvocationTypeDryRun
 	input := &aws.LambdaOptions{InvocationType: &invocationType}
 	out := aws.InvokeFunctionWithParams(t, awsRegion, functionName, input)
 
@@ -113,7 +112,7 @@ func TestTerraformAwsLambdaWithParamsExample(t *testing.T) {
 
 	// Invoke the function, this time causing the Lambda to error and
 	// capturing the error.
-	invocationType = lambda.InvocationTypeRequestResponse
+	invocationType = aws.InvocationTypeRequestResponse
 	input = &aws.LambdaOptions{
 		InvocationType: &invocationType,
 		Payload:        ExampleFunctionPayload{ShouldFail: true, Echo: "hi!"},

--- a/test/terraform_aws_lambda_example_test.go
+++ b/test/terraform_aws_lambda_example_test.go
@@ -60,6 +60,14 @@ func TestTerraformAwsLambdaExample(t *testing.T) {
 
 	// Make sure the function-specific error comes back
 	assert.Contains(t, string(functionError.Payload), "Failed to handle")
+
+	// Conduct a "DryRun" invocation to confirm that the user has
+	// permission to invoke the function.  A "DryRun" invocation does
+	// not execute the function, so the example test function will not
+	// be checking the payload.
+	statusCode, err := aws.InvokeDryRunE(t, awsRegion, functionName, ExampleFunctionPayload{ShouldFail: true, Echo: "bye!"})
+	require.NoError(t, err)
+	assert.Equal(t, statusCode, 204)
 }
 
 type ExampleFunctionPayload struct {


### PR DESCRIPTION
Provides the functionality to invoke a Lambda with an InvocationType of "DryRun".  This functionality provides a simple verification of a Lambda's installation.

This functionality was implemented through the new function `InvokeDryRunE()`, which returns a status code and an error.  I debated about the return values, but a status code and error seemed consistent with the return values from the AWS SDK.  When the the AWS SDK `Invoke()` is called with a invocation type of DryRun, `StatusCode` is the only field in the returned `InvokeOutput` struct that has a value, even when there is an error.  A `StatusCode` value of 204 indicates the DryRun was successful and further details are then found in the returned error:

>  // The HTTP status code is in the 200 range for a successful request. For the
    // RequestResponse invocation type, this status code is 200. For the Event invocation
    // type, this status code is 202. For the DryRun invocation type, the status
    // code is 204.
 StatusCode *int64 `location:"statusCode" type:"integer"`

I also debated whether there was a value to creating a `InvokeDryRun()` (no "E" at the end) version of the function to simply return the status code and no error.  I assumed if the dry run failed, the error was needed, so `InvokeDryRun()` wouldn't have much utility.

And I debated adding a test of an error condition.  The dry run can determine whether the user or role has permission to execute the Lambda, which would be more involved to set up.  I could specify a bad function name, but that's not really the point of a dry run invocation.

This pull request is a bit of a trial balloon to determine just what you'd like to see for this added functionality.

Issue:  [#802](https://github.com/gruntwork-io/terratest/issues/802) 
Test results:  https://gist.github.com/kbalk/fbb68f156d391eacf4d330b7870e1401