### PR TITLE
[Azure] Updated VNet/Subnet module to use sovereign client factory (aztfmod)

### DIFF
--- a/modules/azure/client_factory.go
+++ b/modules/azure/client_factory.go
@@ -18,6 +18,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-07-01/compute"
 	"github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2019-11-01/containerservice"
 	kvmng "github.com/Azure/azure-sdk-for-go/services/keyvault/mgmt/2016-10-01/keyvault"
+	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2019-09-01/network"
 	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2019-06-01/subscriptions"
 	autorestAzure "github.com/Azure/go-autorest/autorest/azure"
 )
@@ -157,6 +158,46 @@ func CreateKeyVaultManagementClientE(subscriptionID string) (*kvmng.VaultsClient
 	vaultClient := kvmng.NewVaultsClientWithBaseURI(baseURI, subscriptionID)
 
 	return &vaultClient, nil
+}
+
+// CreateNewSubnetClientE returns a Subnet client instance configured with the
+// correct BaseURI depending on the Azure environment that is currently setup (or "Public", if none is setup).
+func CreateNewSubnetClientE(subscriptionID string) (*network.SubnetsClient, error) {
+	// Validate Azure subscription ID
+	subscriptionID, err := getTargetAzureSubscription(subscriptionID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Lookup environment URI
+	baseURI, err := getEnvironmentEndpointE(ResourceManagerEndpointName)
+	if err != nil {
+		return nil, err
+	}
+
+	// create client
+	subnetClient := network.NewSubnetsClientWithBaseURI(baseURI, subscriptionID)
+	return &subnetClient, nil
+}
+
+// CreateNewVirtualNetworkClientE returns a Virtual Network client instance configured with the
+// correct BaseURI depending on the Azure environment that is currently setup (or "Public", if none is setup).
+func CreateNewVirtualNetworkClientE(subscriptionID string) (*network.VirtualNetworksClient, error) {
+	// Validate Azure subscription ID
+	subscriptionID, err := getTargetAzureSubscription(subscriptionID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Lookup environment URI
+	baseURI, err := getEnvironmentEndpointE(ResourceManagerEndpointName)
+	if err != nil {
+		return nil, err
+	}
+
+	// create client
+	vnetClient := network.NewVirtualNetworksClientWithBaseURI(baseURI, subscriptionID)
+	return &vnetClient, nil
 }
 
 // GetKeyVaultURISuffixE returns the proper KeyVault URI suffix for the configured Azure environment.

--- a/modules/azure/virtualnetwork.go
+++ b/modules/azure/virtualnetwork.go
@@ -162,14 +162,11 @@ func GetSubnetE(subnetName string, vnetName string, resGroupName string, subscri
 
 // GetSubnetClientE creates a subnet client.
 func GetSubnetClientE(subscriptionID string) (*network.SubnetsClient, error) {
-	// Validate Azure subscription ID
-	subscriptionID, err := getTargetAzureSubscription(subscriptionID)
+	// Create a new Subnet client from client factory
+	client, err := CreateNewSubnetClientE(subscriptionID)
 	if err != nil {
 		return nil, err
 	}
-
-	// Get the Subnet client
-	client := network.NewSubnetsClient(subscriptionID)
 
 	// Create an authorizer
 	authorizer, err := NewAuthorizer()
@@ -178,7 +175,7 @@ func GetSubnetClientE(subscriptionID string) (*network.SubnetsClient, error) {
 	}
 	client.Authorizer = *authorizer
 
-	return &client, nil
+	return client, nil
 }
 
 // GetVirtualNetworkE gets Virtual Network in the specified Azure Resource Group.
@@ -205,14 +202,11 @@ func GetVirtualNetworkE(vnetName string, resGroupName string, subscriptionID str
 
 // GetVirtualNetworksClientE creates a virtual network client in the specified Azure Subscription.
 func GetVirtualNetworksClientE(subscriptionID string) (*network.VirtualNetworksClient, error) {
-	// Validate Azure subscription ID
-	subscriptionID, err := getTargetAzureSubscription(subscriptionID)
+	// Create a new Virtual Network client from client factory
+	client, err := CreateNewVirtualNetworkClientE(subscriptionID)
 	if err != nil {
 		return nil, err
 	}
-
-	// Get the Virtual Network client
-	client := network.NewVirtualNetworksClient(subscriptionID)
 
 	// Create an authorizer
 	authorizer, err := NewAuthorizer()
@@ -221,5 +215,5 @@ func GetVirtualNetworksClientE(subscriptionID string) (*network.VirtualNetworksC
 	}
 	client.Authorizer = *authorizer
 
-	return &client, nil
+	return client, nil
 }


### PR DESCRIPTION
This PR updates the virtual network modules to support Azure sovereign clouds (Government, Germany, China, Azure Stack). This behavior is controlled by setting the AZURE_ENVIRONMENT environment variable to the appropriate environment name (as covered in examples/azure/client_factory.md).

Closes #832 

cc @rguthriemsft