### PR TITLE
updated keyvault ref from 2016 to 2019, verified sovereign support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,8 @@ name: ci-workflow
     # target_pr: pr number on the source repo (e.g. 14, 25, etc.)
 
 on:
+  push:
+    branches: master
   workflow_dispatch:
     inputs:
       repo:

--- a/modules/azure/client_factory.go
+++ b/modules/azure/client_factory.go
@@ -17,7 +17,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/profiles/preview/cosmos-db/mgmt/documentdb"
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-07-01/compute"
 	"github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2019-11-01/containerservice"
-	kvmng "github.com/Azure/azure-sdk-for-go/services/keyvault/mgmt/2016-10-01/keyvault"
+	kvmng "github.com/Azure/azure-sdk-for-go/services/keyvault/mgmt/2019-09-01/keyvault"
 	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2019-06-01/subscriptions"
 	autorestAzure "github.com/Azure/go-autorest/autorest/azure"
 )

--- a/modules/azure/keyvault.go
+++ b/modules/azure/keyvault.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	kvauth "github.com/Azure/azure-sdk-for-go/services/keyvault/auth"
-	kvmng "github.com/Azure/azure-sdk-for-go/services/keyvault/mgmt/2016-10-01/keyvault"
+	kvmng "github.com/Azure/azure-sdk-for-go/services/keyvault/mgmt/2019-09-01/keyvault"
 	"github.com/Azure/azure-sdk-for-go/services/keyvault/v7.0/keyvault"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/stretchr/testify/require"


### PR DESCRIPTION
* updated keyvault reference from 2016 version to newer 2019 version
* verified that client_factory.go has CreateKeyVaultManagementClientE() method that looks up env URI
* verified that keyvault.go has GetKeyVaultE() method that calls GetKeyVaultManagementClientE() which returns a vaultClient object (rather than a reference)