### PR TITLE
add k8s.GetKubernetesClusterVersion to get cluster version

### DIFF
--- a/modules/k8s/version.go
+++ b/modules/k8s/version.go
@@ -3,7 +3,7 @@ package k8s
 import "github.com/gruntwork-io/terratest/modules/testing"
 
 // GetKubernetesClusterVersion returns the Kubernetes cluster version.
-func GetKubernetesClusterVersion(t testing.TestingT) (string, error) {
+func GetKubernetesClusterVersionE(t testing.TestingT) (string, error) {
 	clientset, err := GetKubernetesClientE(t)
 	if err != nil {
 		return "", err

--- a/modules/k8s/version.go
+++ b/modules/k8s/version.go
@@ -4,7 +4,19 @@ import "github.com/gruntwork-io/terratest/modules/testing"
 
 // GetKubernetesClusterVersion returns the Kubernetes cluster version.
 func GetKubernetesClusterVersionE(t testing.TestingT) (string, error) {
-	clientset, err := GetKubernetesClientE(t)
+	kubeConfigPath, err := GetKubeConfigPathE(t)
+	if err != nil {
+		return "", err
+	}
+
+	options := NewKubectlOptions("", kubeConfigPath, "default")
+
+	return GetKubernetesClusterVersionWithOptionsE(t, options)
+}
+
+// GetKubernetesClusterVersion returns the Kubernetes cluster version given a configured KubectlOptions object.
+func GetKubernetesClusterVersionWithOptionsE(t testing.TestingT, kubectlOptions *KubectlOptions) (string, error) {
+	clientset, err := GetKubernetesClientFromOptionsE(t, kubectlOptions)
 	if err != nil {
 		return "", err
 	}

--- a/modules/k8s/version.go
+++ b/modules/k8s/version.go
@@ -1,0 +1,18 @@
+package k8s
+
+import "github.com/gruntwork-io/terratest/modules/testing"
+
+// GetKubernetesClusterVersion returns the Kubernetes cluster version.
+func GetKubernetesClusterVersion(t testing.TestingT) (string, error) {
+	clientset, err := GetKubernetesClientE(t)
+	if err != nil {
+		return "", err
+	}
+
+	versionInfo, err := clientset.DiscoveryClient.ServerVersion()
+	if err != nil {
+		return "", err
+	}
+
+	return versionInfo.String(), nil
+}

--- a/modules/k8s/version_test.go
+++ b/modules/k8s/version_test.go
@@ -1,0 +1,32 @@
+// +build kubeall kubernetes
+
+// NOTE: we have build tags to differentiate kubernetes tests from non-kubernetes tests. This is done because minikube
+// is heavy and can interfere with docker related tests in terratest. Specifically, many of the tests start to fail with
+// `connection refused` errors from `minikube`. To avoid overloading the system, we run the kubernetes tests and helm
+// tests separately from the others. This may not be necessary if you have a sufficiently powerful machine.  We
+// recommend at least 4 cores and 16GB of RAM if you want to run all the tests together.
+
+package k8s
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetKubernetesClusterVersionE(t *testing.T) {
+	t.Parallel()
+
+	kubernetesClusterVersion, err := GetKubernetesClusterVersionE(t)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, kubernetesClusterVersion)
+}
+
+func TestGetKubernetesClusterVersionWithOptionsE(t *testing.T) {
+	t.Parallel()
+
+	options := NewKubectlOptions("", "", "")
+	kubernetesClusterVersion, err := GetKubernetesClusterVersionWithOptionsE(t, options)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, kubernetesClusterVersion)
+}


### PR DESCRIPTION
I found myself checking cluster version often so I wrote a helper function to do so. This also satisfy the requirements of this [issue](https://github.com/gruntwork-io/terratest/issues/758).

PR adds a function that returns Kubernetes cluster version.

I'm not sure how to write unit tests for code the depend on [Kubernetes client](https://github.com/gruntwork-io/terratest/blob/adca4a84bcddefbb7d6453fb8bd17da25f2ecd04/modules/k8s/client.go#L16), any pointers are greatly appreciated.