### PR TITLE
Use networkingv1 instead of extensionsv1beta1

### DIFF
--- a/modules/k8s/errors.go
+++ b/modules/k8s/errors.go
@@ -4,13 +4,13 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
-	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
+	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // IngressNotAvailable is returned when a Kubernetes service is not yet available to accept traffic.
 type IngressNotAvailable struct {
-	ingress *extensionsv1beta1.Ingress
+	ingress *networkingv1.Ingress
 }
 
 // Error is a simple function to return a formatted error message as a string

--- a/modules/k8s/errors.go
+++ b/modules/k8s/errors.go
@@ -5,6 +5,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
+	networkingv1beta1 "k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -15,6 +16,16 @@ type IngressNotAvailable struct {
 
 // Error is a simple function to return a formatted error message as a string
 func (err IngressNotAvailable) Error() string {
+	return fmt.Sprintf("Ingress %s is not available", err.ingress.Name)
+}
+
+// IngressNotAvailableV1Beta1 is returned when a Kubernetes service is not yet available to accept traffic.
+type IngressNotAvailableV1Beta1 struct {
+	ingress *networkingv1beta1.Ingress
+}
+
+// Error is a simple function to return a formatted error message as a string
+func (err IngressNotAvailableV1Beta1) Error() string {
 	return fmt.Sprintf("Ingress %s is not available", err.ingress.Name)
 }
 

--- a/modules/k8s/ingress.go
+++ b/modules/k8s/ingress.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	networkingv1 "k8s.io/api/networking/v1"
+	networkingv1beta1 "k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/gruntwork-io/terratest/modules/logger"
@@ -75,6 +76,78 @@ func WaitUntilIngressAvailable(t testing.TestingT, options *KubectlOptions, ingr
 			}
 			if !IsIngressAvailable(ingress) {
 				return "", IngressNotAvailable{ingress: ingress}
+			}
+			return "Ingress is now available", nil
+		},
+	)
+	logger.Logf(t, message)
+}
+
+// ListIngressesV1Beta1 will look for Ingress resources in the given namespace that match the given filters and return
+// them, using networking.k8s.io/v1beta1 API. This will fail the test if there is an error.
+func ListIngressesV1Beta1(t testing.TestingT, options *KubectlOptions, filters metav1.ListOptions) []networkingv1beta1.Ingress {
+	ingresses, err := ListIngressesV1Beta1E(t, options, filters)
+	require.NoError(t, err)
+	return ingresses
+}
+
+// ListIngressesV1Beta1E will look for Ingress resources in the given namespace that match the given filters and return
+// them, using networking.k8s.io/v1beta1 API.
+func ListIngressesV1Beta1E(t testing.TestingT, options *KubectlOptions, filters metav1.ListOptions) ([]networkingv1beta1.Ingress, error) {
+	clientset, err := GetKubernetesClientFromOptionsE(t, options)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := clientset.NetworkingV1beta1().Ingresses(options.Namespace).List(context.Background(), filters)
+	if err != nil {
+		return nil, err
+	}
+	return resp.Items, nil
+
+}
+
+// GetIngressV1Beta1 returns a Kubernetes Ingress resource in the provided namespace with the given name, using
+// networking.k8s.io/v1beta1 API. This will fail the test if there is an error.
+func GetIngressV1Beta1(t testing.TestingT, options *KubectlOptions, ingressName string) *networkingv1beta1.Ingress {
+	ingress, err := GetIngressV1Beta1E(t, options, ingressName)
+	require.NoError(t, err)
+	return ingress
+}
+
+// GetIngressV1Beta1E returns a Kubernetes Ingress resource in the provided namespace with the given name, using
+// networking.k8s.io/v1beta1.
+func GetIngressV1Beta1E(t testing.TestingT, options *KubectlOptions, ingressName string) (*networkingv1beta1.Ingress, error) {
+	clientset, err := GetKubernetesClientFromOptionsE(t, options)
+	if err != nil {
+		return nil, err
+	}
+	return clientset.NetworkingV1beta1().Ingresses(options.Namespace).Get(context.Background(), ingressName, metav1.GetOptions{})
+}
+
+// IsIngressAvailableV1Beta1 returns true if the Ingress endpoint is provisioned and available, using
+// networking.k8s.io/v1beta1 API.
+func IsIngressAvailableV1Beta1(ingress *networkingv1beta1.Ingress) bool {
+	// Ingress is ready if it has at least one endpoint
+	endpoints := ingress.Status.LoadBalancer.Ingress
+	return len(endpoints) > 0
+}
+
+// WaitUntilIngressAvailableV1Beta1 waits until the Ingress resource has an endpoint provisioned for it, using
+// networking.k8s.io/v1beta1 API.
+func WaitUntilIngressAvailableV1Beta1(t testing.TestingT, options *KubectlOptions, ingressName string, retries int, sleepBetweenRetries time.Duration) {
+	statusMsg := fmt.Sprintf("Wait for ingress %s to be provisioned.", ingressName)
+	message := retry.DoWithRetry(
+		t,
+		statusMsg,
+		retries,
+		sleepBetweenRetries,
+		func() (string, error) {
+			ingress, err := GetIngressV1Beta1E(t, options, ingressName)
+			if err != nil {
+				return "", err
+			}
+			if !IsIngressAvailableV1Beta1(ingress) {
+				return "", IngressNotAvailableV1Beta1{ingress: ingress}
 			}
 			return "Ingress is now available", nil
 		},

--- a/modules/k8s/ingress.go
+++ b/modules/k8s/ingress.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
+	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/gruntwork-io/terratest/modules/logger"
@@ -16,19 +16,19 @@ import (
 
 // ListIngresses will look for Ingress resources in the given namespace that match the given filters and return them.
 // This will fail the test if there is an error.
-func ListIngresses(t testing.TestingT, options *KubectlOptions, filters metav1.ListOptions) []extensionsv1beta1.Ingress {
+func ListIngresses(t testing.TestingT, options *KubectlOptions, filters metav1.ListOptions) []networkingv1.Ingress {
 	ingresses, err := ListIngressesE(t, options, filters)
 	require.NoError(t, err)
 	return ingresses
 }
 
 // ListIngressesE will look for Ingress resources in the given namespace that match the given filters and return them.
-func ListIngressesE(t testing.TestingT, options *KubectlOptions, filters metav1.ListOptions) ([]extensionsv1beta1.Ingress, error) {
+func ListIngressesE(t testing.TestingT, options *KubectlOptions, filters metav1.ListOptions) ([]networkingv1.Ingress, error) {
 	clientset, err := GetKubernetesClientFromOptionsE(t, options)
 	if err != nil {
 		return nil, err
 	}
-	resp, err := clientset.ExtensionsV1beta1().Ingresses(options.Namespace).List(context.Background(), filters)
+	resp, err := clientset.NetworkingV1().Ingresses(options.Namespace).List(context.Background(), filters)
 	if err != nil {
 		return nil, err
 	}
@@ -38,23 +38,23 @@ func ListIngressesE(t testing.TestingT, options *KubectlOptions, filters metav1.
 
 // GetIngress returns a Kubernetes Ingress resource in the provided namespace with the given name. This will fail the
 // test if there is an error.
-func GetIngress(t testing.TestingT, options *KubectlOptions, ingressName string) *extensionsv1beta1.Ingress {
+func GetIngress(t testing.TestingT, options *KubectlOptions, ingressName string) *networkingv1.Ingress {
 	ingress, err := GetIngressE(t, options, ingressName)
 	require.NoError(t, err)
 	return ingress
 }
 
 // GetIngressE returns a Kubernetes Ingress resource in the provided namespace with the given name.
-func GetIngressE(t testing.TestingT, options *KubectlOptions, ingressName string) (*extensionsv1beta1.Ingress, error) {
+func GetIngressE(t testing.TestingT, options *KubectlOptions, ingressName string) (*networkingv1.Ingress, error) {
 	clientset, err := GetKubernetesClientFromOptionsE(t, options)
 	if err != nil {
 		return nil, err
 	}
-	return clientset.ExtensionsV1beta1().Ingresses(options.Namespace).Get(context.Background(), ingressName, metav1.GetOptions{})
+	return clientset.NetworkingV1().Ingresses(options.Namespace).Get(context.Background(), ingressName, metav1.GetOptions{})
 }
 
 // IsIngressAvailable returns true if the Ingress endpoint is provisioned and available.
-func IsIngressAvailable(ingress *extensionsv1beta1.Ingress) bool {
+func IsIngressAvailable(ingress *networkingv1.Ingress) bool {
 	// Ingress is ready if it has at least one endpoint
 	endpoints := ingress.Status.LoadBalancer.Ingress
 	return len(endpoints) > 0

--- a/modules/k8s/ingress_test.go
+++ b/modules/k8s/ingress_test.go
@@ -26,7 +26,7 @@ func TestGetIngressEReturnsErrorForNonExistantIngress(t *testing.T) {
 	t.Parallel()
 
 	options := NewKubectlOptions("", "", "default")
-	_, err := GetIngressE(t, options, "i-dont-exist")
+	_, err := GetIngressV1Beta1E(t, options, "i-dont-exist")
 	require.Error(t, err)
 }
 
@@ -39,7 +39,7 @@ func TestGetIngressEReturnsCorrectIngressInCorrectNamespace(t *testing.T) {
 	KubectlApplyFromString(t, options, configData)
 	defer KubectlDeleteFromString(t, options, configData)
 
-	service := GetIngress(t, options, "nginx-service-ingress")
+	service := GetIngressV1Beta1(t, options, "nginx-service-ingress")
 	require.Equal(t, service.Name, "nginx-service-ingress")
 	require.Equal(t, service.Namespace, uniqueID)
 }
@@ -53,7 +53,7 @@ func TestListIngressesReturnsCorrectIngressInCorrectNamespace(t *testing.T) {
 	KubectlApplyFromString(t, options, configData)
 	defer KubectlDeleteFromString(t, options, configData)
 
-	ingresses := ListIngresses(t, options, metav1.ListOptions{})
+	ingresses := ListIngressesV1Beta1(t, options, metav1.ListOptions{})
 	require.Equal(t, len(ingresses), 1)
 
 	ingress := ingresses[0]
@@ -70,7 +70,7 @@ func TestWaitUntilIngressAvailableReturnsSuccessfully(t *testing.T) {
 	KubectlApplyFromString(t, options, configData)
 	defer KubectlDeleteFromString(t, options, configData)
 
-	WaitUntilIngressAvailable(t, options, ExampleIngressName, 60, 5*time.Second)
+	WaitUntilIngressAvailableV1Beta1(t, options, ExampleIngressName, 60, 5*time.Second)
 }
 
 const EXAMPLE_INGRESS_DEPLOYMENT_YAML_TEMPLATE = `---


### PR DESCRIPTION
Fixes https://github.com/gruntwork-io/terratest/issues/840

NOTE: due to the way the k8s APIs are designed, we have no choice but to duplicate the functions to support the separate API versions.