### PR TITLE
Should not need to call terraform get

### DIFF
--- a/modules/terraform/apply.go
+++ b/modules/terraform/apply.go
@@ -24,10 +24,6 @@ func InitAndApplyE(t testing.TestingT, options *Options) (string, error) {
 		return "", err
 	}
 
-	if _, err := GetE(t, options); err != nil {
-		return "", err
-	}
-
 	return ApplyE(t, options)
 }
 

--- a/modules/terraform/plan.go
+++ b/modules/terraform/plan.go
@@ -21,10 +21,6 @@ func InitAndPlanE(t testing.TestingT, options *Options) (string, error) {
 		return "", err
 	}
 
-	if _, err := GetE(t, options); err != nil {
-		return "", err
-	}
-
 	return PlanE(t, options)
 }
 

--- a/modules/terraform/validate.go
+++ b/modules/terraform/validate.go
@@ -31,9 +31,5 @@ func InitAndValidateE(t testing.TestingT, options *Options) (string, error) {
 		return "", err
 	}
 
-	if _, err := GetE(t, options); err != nil {
-		return "", err
-	}
-
 	return ValidateE(t, options)
 }


### PR DESCRIPTION
Fixes https://github.com/gruntwork-io/terratest/issues/877

We should not have to make a call to `GetE`, as `InitE` should be sufficient to handle all the necessary initialization procedures.