### PR TITLE
[Azure] Fixing Azure CI workflow to pin to Terraform 15.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,8 @@ name: ci-workflow
     # target_pr: pr number on the source repo (e.g. 14, 25, etc.)
 
 on:
+  push:
+    branches: master
   workflow_dispatch:
     inputs:
       repo:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
           export ARM_SKIP_PROVIDER_REGISTRATION=${{ github.event.inputs.skip_provider_registration }}
 
           # run the unit tests under the `azure` subfolder
-          go test ./azure/* -v -timeout 120m
+          go test ./azure/* -v -timeout 90m
       - name: run go test for azure
         id: azure_test
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,8 @@ jobs:
     steps:
       - uses: hashicorp/setup-terraform@v1
         with:
-          terraform_version: 0.14.9    
+          terraform_version: 0.14.9  
+          terraform_wrapper: false  
       - name: checkout to repo
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
     steps:
       - uses: hashicorp/setup-terraform@v1
         with:
-          terraform_version: 0.14.9  
+          terraform_version: 0.15.1
           terraform_wrapper: false  
       - name: checkout to repo
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
           export ARM_SKIP_PROVIDER_REGISTRATION=${{ github.event.inputs.skip_provider_registration }}
 
           # run the unit tests under the `azure` subfolder
-          go test ./azure/* -v -timeout 90m
+          go test ./azure/* -v -timeout 120m
       - name: run go test for azure
         id: azure_test
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,9 @@ jobs:
   ci-job:
     runs-on: [ubuntu-latest]
     steps:
+      - uses: hashicorp/setup-terraform@v1
+        with:
+          terraform_version: 0.14.9    
       - name: checkout to repo
         uses: actions/checkout@v2
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@ terraform.tfvars
 *.tfstate*
 .terragrunt
 .terragrunt-cache
-
+.terraform.lock.hcl
 # IDE files
 .idea
 .vscode

--- a/examples/azure/terraform-azure-aks-example/output.tf
+++ b/examples/azure/terraform-azure-aks-example/output.tf
@@ -19,7 +19,8 @@ output "cluster_password" {
 }
 
 output "kube_config" {
-  value = azurerm_kubernetes_cluster.k8s.kube_config_raw
+  value     = azurerm_kubernetes_cluster.k8s.kube_config_raw
+  sensitive = true
 }
 
 output "host" {

--- a/examples/azure/terraform-azure-aks-example/output.tf
+++ b/examples/azure/terraform-azure-aks-example/output.tf
@@ -19,7 +19,7 @@ output "cluster_password" {
 }
 
 output "kube_config" {
-  value = nonsensitive(azurerm_kubernetes_cluster.k8s.kube_config_raw)
+  value = azurerm_kubernetes_cluster.k8s.kube_config_raw
 }
 
 output "host" {

--- a/examples/azure/terraform-azure-aks-example/output.tf
+++ b/examples/azure/terraform-azure-aks-example/output.tf
@@ -19,8 +19,7 @@ output "cluster_password" {
 }
 
 output "kube_config" {
-  value     = azurerm_kubernetes_cluster.k8s.kube_config_raw
-  sensitive = true
+  value     = nonsensitive(azurerm_kubernetes_cluster.k8s.kube_config_raw)
 }
 
 output "host" {

--- a/examples/azure/terraform-azure-aks-example/output.tf
+++ b/examples/azure/terraform-azure-aks-example/output.tf
@@ -19,7 +19,7 @@ output "cluster_password" {
 }
 
 output "kube_config" {
-  value     = nonsensitive(azurerm_kubernetes_cluster.k8s.kube_config_raw)
+  value = nonsensitive(azurerm_kubernetes_cluster.k8s.kube_config_raw)
 }
 
 output "host" {

--- a/examples/azure/terraform-azure-cosmosdb-example/outputs.tf
+++ b/examples/azure/terraform-azure-cosmosdb-example/outputs.tf
@@ -11,5 +11,6 @@ output "endpoint" {
 }
 
 output "primary_key" {
-  value = azurerm_cosmosdb_account.test.primary_key
+  value     = azurerm_cosmosdb_account.test.primary_key
+  sensitive = true
 }

--- a/examples/azure/terraform-azure-cosmosdb-example/outputs.tf
+++ b/examples/azure/terraform-azure-cosmosdb-example/outputs.tf
@@ -11,5 +11,5 @@ output "endpoint" {
 }
 
 output "primary_key" {
-  value = nonsensitive(azurerm_cosmosdb_account.test.primary_key)
+  value = azurerm_cosmosdb_account.test.primary_key
 }

--- a/examples/azure/terraform-azure-cosmosdb-example/outputs.tf
+++ b/examples/azure/terraform-azure-cosmosdb-example/outputs.tf
@@ -11,6 +11,5 @@ output "endpoint" {
 }
 
 output "primary_key" {
-  value     = azurerm_cosmosdb_account.test.primary_key
-  sensitive = true
+  value     = nonsensitive(azurerm_cosmosdb_account.test.primary_key)
 }

--- a/examples/azure/terraform-azure-cosmosdb-example/outputs.tf
+++ b/examples/azure/terraform-azure-cosmosdb-example/outputs.tf
@@ -11,5 +11,5 @@ output "endpoint" {
 }
 
 output "primary_key" {
-  value     = nonsensitive(azurerm_cosmosdb_account.test.primary_key)
+  value = nonsensitive(azurerm_cosmosdb_account.test.primary_key)
 }

--- a/examples/azure/terraform-azure-vm-example/outputs.tf
+++ b/examples/azure/terraform-azure-vm-example/outputs.tf
@@ -40,7 +40,7 @@ output "virtual_network_name" {
 }
 
 output "vm_admin_username" {
-  value = azurerm_virtual_machine.vm_example.os_profile[*].admin_username
+  value = nonsensitive(azurerm_virtual_machine.vm_example.os_profile[*].admin_username)
 }
 
 output "vm_image_sku" {

--- a/examples/azure/terraform-azure-vm-example/outputs.tf
+++ b/examples/azure/terraform-azure-vm-example/outputs.tf
@@ -40,8 +40,7 @@ output "virtual_network_name" {
 }
 
 output "vm_admin_username" {
-  value     = azurerm_virtual_machine.vm_example.os_profile[*].admin_username
-  sensitive = true
+  value     = nonsensitive(azurerm_virtual_machine.vm_example.os_profile[*].admin_username)
 }
 
 output "vm_image_sku" {

--- a/examples/azure/terraform-azure-vm-example/outputs.tf
+++ b/examples/azure/terraform-azure-vm-example/outputs.tf
@@ -40,7 +40,7 @@ output "virtual_network_name" {
 }
 
 output "vm_admin_username" {
-  value = nonsensitive(azurerm_virtual_machine.vm_example.os_profile[*].admin_username)
+  value = azurerm_virtual_machine.vm_example.os_profile[*].admin_username
 }
 
 output "vm_image_sku" {

--- a/examples/azure/terraform-azure-vm-example/outputs.tf
+++ b/examples/azure/terraform-azure-vm-example/outputs.tf
@@ -40,7 +40,8 @@ output "virtual_network_name" {
 }
 
 output "vm_admin_username" {
-  value = azurerm_virtual_machine.vm_example.os_profile[*].admin_username
+  value     = azurerm_virtual_machine.vm_example.os_profile[*].admin_username
+  sensitive = true
 }
 
 output "vm_image_sku" {

--- a/examples/azure/terraform-azure-vm-example/outputs.tf
+++ b/examples/azure/terraform-azure-vm-example/outputs.tf
@@ -40,7 +40,7 @@ output "virtual_network_name" {
 }
 
 output "vm_admin_username" {
-  value     = nonsensitive(azurerm_virtual_machine.vm_example.os_profile[*].admin_username)
+  value = nonsensitive(azurerm_virtual_machine.vm_example.os_profile[*].admin_username)
 }
 
 output "vm_image_sku" {


### PR DESCRIPTION
Closes #881 881

This PR includes changes to support Terraform 0.15.1 . As part of the 0.15.x update to Terraform there are changes are sensitive values that require them to be explicitly marked as  sensitive. In addition, 0.15.0 has a bug with sensitive outputs that causes a panic and the tests failing.

This changes pins the workflow to Terraform 0.15.1 and also adds the sensitive flag to modules that need it.