### PR TITLE
Add new function to allow explicitly using in-cluster auth

### DIFF
--- a/modules/k8s/kubectl_options.go
+++ b/modules/k8s/kubectl_options.go
@@ -6,10 +6,11 @@ import (
 
 // KubectlOptions represents common options necessary to specify for all Kubectl calls
 type KubectlOptions struct {
-	ContextName string
-	ConfigPath  string
-	Namespace   string
-	Env         map[string]string
+	ContextName   string
+	ConfigPath    string
+	Namespace     string
+	Env           map[string]string
+	InClusterAuth bool
 }
 
 // NewKubectlOptions will return a pointer to new instance of KubectlOptions with the configured options
@@ -19,6 +20,13 @@ func NewKubectlOptions(contextName string, configPath string, namespace string) 
 		ConfigPath:  configPath,
 		Namespace:   namespace,
 		Env:         map[string]string{},
+	}
+}
+
+// NewKubectlOptionsWithInClusterAuth will return a pointer to a new instance of KubectlOptions with the InClusterAuth field set to true
+func NewKubectlOptionsWithInClusterAuth() *KubectlOptions {
+	return &KubectlOptions{
+		InClusterAuth: true,
 	}
 }
 


### PR DESCRIPTION
Related to #753. 

This PR builds off of the work done in https://github.com/gruntwork-io/terratest/pull/760.

I took @yorinasub17's advice and implemented a new function `NewKubectlOptionsWithInClusterAuth` to make it a bit more straightforward for users to explicitly implement in-cluster authentication.

I also kept the initial fallback implementation to maintain backwards compatibility. 

Thanks for reviewing!