### PR TITLE
Replace *testing.T with testing.TestingT (#908)

### DIFF
--- a/modules/terraform/options.go
+++ b/modules/terraform/options.go
@@ -1,11 +1,11 @@
 package terraform
 
 import (
-	"testing"
 	"time"
 
 	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/ssh"
+	"github.com/gruntwork-io/terratest/modules/testing"
 	"github.com/jinzhu/copier"
 	"github.com/stretchr/testify/require"
 )
@@ -86,7 +86,7 @@ func (options *Options) Clone() (*Options, error) {
 // for retryable errors. The included retryable errors are typical errors that most terraform modules encounter during
 // testing, and are known to self resolve upon retrying.
 // This will fail the test if there are any errors in the cloning process.
-func WithDefaultRetryableErrors(t *testing.T, originalOptions *Options) *Options {
+func WithDefaultRetryableErrors(t testing.TestingT, originalOptions *Options) *Options {
 	newOptions, err := originalOptions.Clone()
 	require.NoError(t, err)
 


### PR DESCRIPTION
The `WithDefaultRetryableErrors` function now takes a testing.TestingT
argument instead of *testing.T to allow for anything that implements the
testing.TestingT interface to be used. This allows for GinkgoT() to be
used in tests utilizing the ginkgo testing framework.

Test output for all terraform tests is available here: https://gist.github.com/cbascom/81d2c6659beace706072329594e7068c

There is a test failure unrelated to my changes. I have terraform v0.15.4 installed locally. The current terratest is not compatible with that terraform version since the `planWithNoChangesRegexp` used by the `GetResourceCountE` function looks for `No changes\. Infrastructure is up-to-date\.` instead of `(\033\[32m)?No changes\.(\033\[0m\033\[1m)? Your infrastructure matches the configuration\.` which is output by my terraform version.

I didn't see how you handle compatibility with different terraform versions so I didn't include this update in this PR, but let me know how you want to handle that. I can submit a new issue for that if necessary.