### PR TITLE
expand azure resource group module

### DIFF
--- a/modules/azure/resourcegroup_test.go
+++ b/modules/azure/resourcegroup_test.go
@@ -22,3 +22,13 @@ func TestResourceGroupExists(t *testing.T) {
 	_, err := ResourceGroupExistsE(resourceGroupName, "")
 	require.Error(t, err)
 }
+
+func TestGetAResourceGroup(t *testing.T) {
+	t.Parallel()
+
+	resGroupName := ""
+	subscriptionID := ""
+
+	_, err := GetAResourceGroup(t, resGroupName, subscriptionID)
+	require.Error(t, err)
+}

--- a/modules/azure/resourcegroup_test.go
+++ b/modules/azure/resourcegroup_test.go
@@ -26,8 +26,8 @@ func TestResourceGroupExists(t *testing.T) {
 func TestGetAResourceGroup(t *testing.T) {
 	t.Parallel()
 
-	resGroupName := ""
+	resourceGroupName := "fakeResourceGroupName"
 
-	_, err := GetAResourceGroup(t, resGroupName, "")
+	_, err := GetAResourceGroupE(resourceGroupName, "")
 	require.Error(t, err)
 }

--- a/modules/azure/resourcegroup_test.go
+++ b/modules/azure/resourcegroup_test.go
@@ -27,8 +27,7 @@ func TestGetAResourceGroup(t *testing.T) {
 	t.Parallel()
 
 	resGroupName := ""
-	subscriptionID := ""
 
-	_, err := GetAResourceGroup(t, resGroupName, subscriptionID)
+	_, err := GetAResourceGroup(t, resGroupName, "")
 	require.Error(t, err)
 }


### PR DESCRIPTION
The current implementation of get resource group in terratest doesn't return the object itself. This change will change the module to

return a resource group object helper
add helper to list resource groups by tags helper

closes #911 