### PR TITLE
Bump docker base images

### DIFF
--- a/test-docker-images/gruntwork-amazon-linux-test/Dockerfile
+++ b/test-docker-images/gruntwork-amazon-linux-test/Dockerfile
@@ -1,5 +1,5 @@
 # TODO: Is it worth referencing a specific tag instead of latest?
-FROM amazonlinux:2017.12
+FROM amazonlinux:2
 
 # Reduce Docker image size per https://blog.replicated.com/refactoring-a-dockerfile-for-image-size/
 # - perl-Digest-SHA: installs shasum

--- a/test-docker-images/gruntwork-amazon-linux-test/Dockerfile
+++ b/test-docker-images/gruntwork-amazon-linux-test/Dockerfile
@@ -13,21 +13,16 @@ RUN yum update -y && \
         sudo \
         tar \
         vim \
+        python3 \
+        pip3 \
         wget && \
         yum clean all && rm -rf /var/cache/yum
 
-# Installing pip with yum doesn't actually put it in the PATH, so we use easy_install instead. Pip will now be placed
-# in /usr/local/bin, but amazonlinux's sudo uses a sanitzed PATH that does not include /usr/local/bin, so we symlink pip.
-# The last line upgrades pip to the latest version.
-RUN curl https://bootstrap.pypa.io/ez_setup.py | sudo /usr/bin/python && \
-    easy_install pip && \
-    pip install --upgrade pip
-
-# Install the AWSCLI (which apparently does not come pre-bundled with Amazon Linux!)
-RUN pip install awscli --upgrade
+# Upgrade pip and install awscli
+RUN pip3 install --upgrade pip && pip3 install awscli
 
 # Ideally, we'd install the latest version of Docker to avoid a conflict between the Docker client in this container
 # and the Docker API on your local host, but installing the latest version of Docker yields the error "Requires:
 # container-selinux >= 2.9", whch indicates that a newer Linux kernel version is required than what comes with Amazon Linux.
 # So we settle for the Amazon Linux supported version for now.
-RUN yum install -y docker
+RUN amazon-linux-extras install docker

--- a/test-docker-images/gruntwork-amazon-linux-test/README.md
+++ b/test-docker-images/gruntwork-amazon-linux-test/README.md
@@ -9,6 +9,5 @@ but it doesn't exist by default in Docker `amazonlinux:latest`.
 This Docker image should publicly accessible via Docker Hub at https://hub.docker.com/r/gruntwork/amazonlinux-test/. To build and
 upload it:
 
-1. `docker build -t gruntwork/amazon-linux-test:2017.12 .`
-1. `docker push gruntwork/amazon-linux-test:2017.12`
-
+1. `docker build -t gruntwork/amazon-linux-test:2 .`
+1. `docker push gruntwork/amazon-linux-test:2`

--- a/test-docker-images/gruntwork-ubuntu-test/Dockerfile
+++ b/test-docker-images/gruntwork-ubuntu-test/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 # Reduce Docker image size per https://blog.replicated.com/refactoring-a-dockerfile-for-image-size/
 # - dnsutils: Install handy DNS checking tools like dig

--- a/test-docker-images/gruntwork-ubuntu-test/Dockerfile
+++ b/test-docker-images/gruntwork-ubuntu-test/Dockerfile
@@ -4,10 +4,9 @@ FROM ubuntu:20.04
 # - dnsutils: Install handy DNS checking tools like dig
 # - libcrypt-hcesha-perl: Install shasum
 # - software-properties-common: Install add-apt-repository
-RUN DEBIAN_FRONTEND=noninteractive \
-    apt-get update && \
-    apt-get upgrade -y && \
-    apt-get install --no-install-recommends -y \
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get upgrade -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
         gpg-agent \
         apt-transport-https \
         ca-certificates \
@@ -15,8 +14,8 @@ RUN DEBIAN_FRONTEND=noninteractive \
         dnsutils \
         jq \
         libcrypt-hcesha-perl \
-        python \
-        python-pip \
+        python3 \
+        python3-pip \
         rsyslog \
         software-properties-common \
         sudo \
@@ -24,15 +23,15 @@ RUN DEBIAN_FRONTEND=noninteractive \
         wget && \
         rm -rf /var/lib/apt/lists/*
 
-# Install the AWS CLI per https://docs.aws.amazon.com/cli/latest/userguide/installing.html. The last line upgrades pip
-# to the latest version. Note that we need to remove python-pip before we can use the updated pip, as pip does not
-# automatically remove the ubuntu managed pip. We also need to refresh the cached pip path in the current bash session so
+# Install the AWS CLI per https://docs.aws.amazon.com/cli/latest/userguide/installing.html. The last line upgrades pip3
+# to the latest version. Note that we need to remove python3-pip before we can use the updated pip3, as pip3 does not
+# automatically remove the ubuntu managed pip3. We also need to refresh the cached pip3 path in the current bash session so
 # that it picks up the new pip.
-RUN pip install --upgrade setuptools && \
-    pip install --upgrade pip && \
-    apt-get remove -y python-pip python-pip-whl && \
-    hash pip && \
-    pip install awscli --upgrade
+RUN pip3 install --upgrade setuptools && \
+    pip3 install --upgrade pip && \
+    apt-get remove -y python3-pip && \
+    hash pip3 && \
+    pip3 install awscli --upgrade
 
 # Install the latest version of Docker, Consumer Edition
 RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - && \

--- a/test-docker-images/gruntwork-ubuntu-test/README.md
+++ b/test-docker-images/gruntwork-ubuntu-test/README.md
@@ -1,14 +1,13 @@
 # Gruntwork Ubuntu-Test Docker Image
 
-The purpose of this Docker image is to provide a pre-built Ubuntu 18.04 Docker image that has most of the libraries
-we would expect to be installed on the Ubuntu 18.04 AMI that would run in AWS. For example, we'd expect `curl` in AWS,
-but it doesn't exist by default in Docker `ubuntu:18.04`.
+The purpose of this Docker image is to provide a pre-built Ubuntu 20.04 Docker image that has most of the libraries
+we would expect to be installed on the Ubuntu 20.04 AMI that would run in AWS. For example, we'd expect `curl` in AWS,
+but it doesn't exist by default in Docker `ubuntu:20.04`.
 
 ### Building and Pushing a New Docker Image to Docker Hub
 
 This Docker image should publicly accessible via Docker Hub at https://hub.docker.com/r/gruntwork/ubuntu-test/. To build and
 upload it:
 
-1. `docker build -t gruntwork/ubuntu-test:18.04 .`
-1. `docker push gruntwork/ubuntu-test:18.04`
-
+1. `docker build -t gruntwork/ubuntu-test:20.04 .`
+1. `docker push gruntwork/ubuntu-test:20.04`


### PR DESCRIPTION
Amazon linux: 2017.12 => 2
Ubuntu: 18.04 => 20.04