### PR TITLE
Implement ValidateAllTerraformModules function

### DIFF
--- a/modules/terraform/validate.go
+++ b/modules/terraform/validate.go
@@ -1,20 +1,25 @@
 package terraform
 
 import (
+	go_test "testing"
+
 	"github.com/gruntwork-io/terratest/modules/testing"
 	"github.com/stretchr/testify/require"
 )
 
 // Automatically finds all folders specified in RootDir that contain .tf files and runs InitAndValidate in all of them
 // Excludes any folders specified in the ExcludeDirs slice
-func ValidateAllTerraformModules(t testing.TestingT, opts ValidationOptions) error {
+func ValidateAllTerraformModules(t *go_test.T, opts ValidationOptions) error {
 	dirsToValidate, readErr := readModuleAndExampleSubDirs(opts)
 	if readErr != nil {
 		return readErr
 	}
 	for _, dir := range dirsToValidate {
-		tfOpts := &Options{TerraformDir: dir}
-		InitAndValidate(t, tfOpts)
+		t.Run(dir, func(t *go_test.T) {
+			t.Parallel()
+			tfOpts := &Options{TerraformDir: dir}
+			InitAndValidate(t, tfOpts)
+		})
 	}
 	return nil
 }

--- a/modules/terraform/validate.go
+++ b/modules/terraform/validate.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// ValidateAllTerraformModules rutomatically finds all folders specified in RootDir that contain .tf files and runs
+// ValidateAllTerraformModules automatically finds all folders specified in RootDir that contain .tf files and runs
 // InitAndValidate in all of them.
 // Filters down to only those paths passed in ValidationOptions.IncludeDirs, if passed.
 // Excludes any folders specified in the ValidationOptions.ExcludeDirs. IncludeDirs will take precedence over ExcludeDirs

--- a/modules/terraform/validate.go
+++ b/modules/terraform/validate.go
@@ -15,7 +15,7 @@ import (
 // Use the NewValidationOptions method to pass relative paths for either of these options to have the full paths built
 // Note that go_test is an alias to Golang's native testing package created to avoid naming conflicts with Terratest's
 // own testing package. We are using the native testing.T here because Terratest's testing.T struct does not implement Run
-func ValidateAllTerraformModules(t *go_test.T, opts ValidationOptions) {
+func ValidateAllTerraformModules(t *go_test.T, opts *ValidationOptions) {
 	dirsToValidate, readErr := FindTerraformModulePathsInRootE(opts)
 	require.NoError(t, readErr)
 

--- a/modules/terraform/validate.go
+++ b/modules/terraform/validate.go
@@ -2,6 +2,7 @@ package terraform
 
 import (
 	// We alias Golang's native testing package to go_test to avoid naming conflicts with terratest's own testing module
+
 	go_test "testing"
 
 	"github.com/gruntwork-io/terratest/modules/testing"

--- a/modules/terraform/validate.go
+++ b/modules/terraform/validate.go
@@ -5,6 +5,20 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// Automatically finds all folders specified in RootDir that contain .tf files and runs InitAndValidate in all of them
+// Excludes any folders specified in the ExcludeDirs slice
+func ValidateAllTerraformModules(t testing.TestingT, opts ValidationOptions) error {
+	dirsToValidate, readErr := readModuleAndExampleSubDirs(opts)
+	if readErr != nil {
+		return readErr
+	}
+	for _, dir := range dirsToValidate {
+		tfOpts := &Options{TerraformDir: dir}
+		InitAndValidate(t, tfOpts)
+	}
+	return nil
+}
+
 // Validate calls terraform validate and returns stdout/stderr.
 func Validate(t testing.TestingT, options *Options) string {
 	out, err := ValidateE(t, options)

--- a/modules/terraform/validate.go
+++ b/modules/terraform/validate.go
@@ -14,7 +14,7 @@ import (
 // Excludes any folders specified in the ValidationOptions.ExcludeDirs. IncludeDirs will take precedence over ExcludeDirs
 // Use the NewValidationOptions method to pass relative paths for either of these options to have the full paths built
 // Note that go_test is an alias to Golang's native testing package created to avoid naming conflicts with Terratest's
-// own testing package
+// own testing package. We are using the native testing.T here because Terratest's testing.T struct does not implement run
 func ValidateAllTerraformModules(t *go_test.T, opts ValidationOptions) {
 	dirsToValidate, readErr := FindTerraformModulePathsInRootE(opts)
 	require.NoError(t, readErr)

--- a/modules/terraform/validate.go
+++ b/modules/terraform/validate.go
@@ -1,19 +1,24 @@
 package terraform
 
 import (
+	// We alias Golang's native testing package to go_test to avoid naming conflicts with terratest's own testing module
 	go_test "testing"
 
 	"github.com/gruntwork-io/terratest/modules/testing"
 	"github.com/stretchr/testify/require"
 )
 
-// Automatically finds all folders specified in RootDir that contain .tf files and runs InitAndValidate in all of them
-// Excludes any folders specified in the ExcludeDirs slice
-func ValidateAllTerraformModules(t *go_test.T, opts ValidationOptions) error {
+// ValidateAllTerraformModules rutomatically finds all folders specified in RootDir that contain .tf files and runs
+// InitAndValidate in all of them.
+// Filters down to only those paths passed in ValidationOptions.IncludeDirs, if passed.
+// Excludes any folders specified in the ValidationOptions.ExcludeDirs. IncludeDirs will take precedence over ExcludeDirs
+// Use the NewValidationOptions method to pass relative paths for either of these options to have the full paths built
+// Note that go_test is an alias to Golang's native testing package created to avoid naming conflicts with Terratest's
+// own testing package
+func ValidateAllTerraformModules(t *go_test.T, opts ValidationOptions) {
 	dirsToValidate, readErr := FindTerraformModulePathsInRootE(opts)
-	if readErr != nil {
-		return readErr
-	}
+	require.NoError(t, readErr)
+
 	for _, dir := range dirsToValidate {
 		dir := dir
 		t.Run(dir, func(t *go_test.T) {
@@ -22,7 +27,6 @@ func ValidateAllTerraformModules(t *go_test.T, opts ValidationOptions) error {
 			InitAndValidate(t, tfOpts)
 		})
 	}
-	return nil
 }
 
 // Validate calls terraform validate and returns stdout/stderr.

--- a/modules/terraform/validate.go
+++ b/modules/terraform/validate.go
@@ -10,7 +10,7 @@ import (
 // Automatically finds all folders specified in RootDir that contain .tf files and runs InitAndValidate in all of them
 // Excludes any folders specified in the ExcludeDirs slice
 func ValidateAllTerraformModules(t *go_test.T, opts ValidationOptions) error {
-	dirsToValidate, readErr := readModuleAndExampleSubDirs(opts)
+	dirsToValidate, readErr := ReadModuleAndExampleSubDirs(opts)
 	if readErr != nil {
 		return readErr
 	}

--- a/modules/terraform/validate.go
+++ b/modules/terraform/validate.go
@@ -14,7 +14,7 @@ import (
 // Excludes any folders specified in the ValidationOptions.ExcludeDirs. IncludeDirs will take precedence over ExcludeDirs
 // Use the NewValidationOptions method to pass relative paths for either of these options to have the full paths built
 // Note that go_test is an alias to Golang's native testing package created to avoid naming conflicts with Terratest's
-// own testing package. We are using the native testing.T here because Terratest's testing.T struct does not implement run
+// own testing package. We are using the native testing.T here because Terratest's testing.T struct does not implement Run
 func ValidateAllTerraformModules(t *go_test.T, opts ValidationOptions) {
 	dirsToValidate, readErr := FindTerraformModulePathsInRootE(opts)
 	require.NoError(t, readErr)

--- a/modules/terraform/validate.go
+++ b/modules/terraform/validate.go
@@ -10,11 +10,12 @@ import (
 // Automatically finds all folders specified in RootDir that contain .tf files and runs InitAndValidate in all of them
 // Excludes any folders specified in the ExcludeDirs slice
 func ValidateAllTerraformModules(t *go_test.T, opts ValidationOptions) error {
-	dirsToValidate, readErr := ReadModuleAndExampleSubDirs(opts)
+	dirsToValidate, readErr := FindTerraformModulePathsInRootE(opts)
 	if readErr != nil {
 		return readErr
 	}
 	for _, dir := range dirsToValidate {
+		dir := dir
 		t.Run(dir, func(t *go_test.T) {
 			t.Parallel()
 			tfOpts := &Options{TerraformDir: dir}

--- a/modules/terraform/validate_struct.go
+++ b/modules/terraform/validate_struct.go
@@ -19,7 +19,7 @@ type ValidationOptions struct {
 	// Note that while the struct requires full paths, you can pass relative paths to the NewValidationOptions function
 	// which will build the full paths based on the supplied RootDir
 	IncludeDirs []string
-	// If you want to explicitly exclude certain sub directories, add them as paths relative to RootDir. For example, if the
+	// If you want to explicitly exclude certain sub directories of RootDir, add the absolute paths here. For example, if the
 	// RootDir is /home/project and you want to include everything EXCEPT /home/project/modules, add
 	// /home/project/modules to this slice. Note that ExcludeDirs is only considered when IncludeDirs is not passed
 	// Note that while the struct requires full paths, you can pass relative paths to the NewValidationOptions function

--- a/modules/terraform/validate_struct.go
+++ b/modules/terraform/validate_struct.go
@@ -29,7 +29,7 @@ type ValidationOptions struct {
 
 // NewValidationOptions returns a ValidationOptions struct, with override-able sane defaults. Note that the
 // ValidationOptions's fields IncludeDirs and ExcludeDirs must be absolute paths, but this method will accept relative paths
-// and build the full paths when instantiating the ValidationOptions struct,  making it the preferred means of configuring
+// and build the absolute paths when instantiating the ValidationOptions struct,  making it the preferred means of configuring
 // ValidationOptions.
 //
 // For example, if your RootDir is /home/project/ and you want to exclude "modules" and "test" you need

--- a/modules/terraform/validate_struct.go
+++ b/modules/terraform/validate_struct.go
@@ -68,7 +68,7 @@ func buildFullPathsFromRelative(rootDir string, relativePaths []string) []string
 }
 
 // FindTerraformModulePathsInRootE returns a slice strings representing the filepaths for all valid Terraform modules
-// in both the "modules" directory and "examples" directories in the project root, if they exist.
+// in the given RootDir, subject to the include / exclude filters.
 func FindTerraformModulePathsInRootE(opts ValidationOptions) ([]string, error) {
 	// Find all Terraform files from the configured RootDir
 	pattern := fmt.Sprintf("%s/**/*.tf", opts.RootDir)

--- a/modules/terraform/validate_struct.go
+++ b/modules/terraform/validate_struct.go
@@ -83,10 +83,9 @@ func ReadModuleAndExampleSubDirs(opts ValidationOptions) ([]string, error) {
 	return collections.ListSubtract(terraformModuleCandidates, opts.ExcludeDirs), nil
 }
 
-// filterTerraformModulesFromDirs accepts a slice of fs.DirEntry representing subDirectories
-// (under "modules" or "examples"), for instance, returning only those that contain a main.tf file in their root. This
-// is useful for filtering out any sub directories that might ship alongside Terraform modules, but actually be
-// Terraform modules themselves
+// IsTerraformModuleDirectory accepts a slice of string paths representing sub directories (under "modules" or "examples"),
+// for instance, returning true for any.tf files. This is useful for filtering out any sub directories that might ship
+// alongside Terraform modules, but not actually be Terraform modules themselves
 func IsTerraformModuleDirectory(path string) (bool, error) {
 	files, err := os.ReadDir(path)
 	if err != nil {

--- a/modules/terraform/validate_struct.go
+++ b/modules/terraform/validate_struct.go
@@ -1,0 +1,62 @@
+package terraform
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+
+	"github.com/gruntwork-io/terratest/modules/collections"
+)
+
+type ValidationOptions struct {
+	RootDir     string
+	ExcludeDirs []string
+}
+
+// readModuleAndExampleSubDirs returns a slice strings representing the filepaths for all valid Terraform modules
+// in both the "modules" directory and "examples" directories in the project root, if they exist.
+func readModuleAndExampleSubDirs(opts ValidationOptions) ([]string, error) {
+	if opts.RootDir == "" {
+		return nil, errors.New("RootDir must be defined in ValidationOptions passed to ValidateAllTerraformModules")
+	}
+	var validationCandidates []string
+	// We want to run InitAndValidate on all valid subdirectories of both the modules and examples dirs
+	modulesDir := filepath.Join(opts.RootDir, "modules")
+	examplesDir := filepath.Join(opts.RootDir, "examples")
+
+	moduleSubDirs, readModulesErr := os.ReadDir(modulesDir)
+	if readModulesErr != nil {
+		return nil, readModulesErr
+	}
+	exampleSubDirs, readExamplesErr := os.ReadDir(examplesDir)
+	if readExamplesErr != nil {
+		return nil, readExamplesErr
+	}
+
+	for _, m := range filterTerraformModulesFromDirs(modulesDir, moduleSubDirs) {
+		validationCandidates = append(validationCandidates, m)
+	}
+
+	for _, e := range filterTerraformModulesFromDirs(examplesDir, exampleSubDirs) {
+		validationCandidates = append(validationCandidates, e)
+	}
+
+	// Filter out any filepaths that were explicitly included in opts.ExcludeDirs
+	return collections.ListSubtract(validationCandidates, opts.ExcludeDirs), nil
+}
+
+// filterTerraformModulesFromDirs accepts a slice of fs.DirEntry representing subDirectories
+// (under "modules" or "examples"), for instance, returning only those that contain a main.tf file in their root. This
+// is useful for filtering out any sub directories that might ship alongside Terraform modules, but actually be
+// Terraform modules themselves
+func filterTerraformModulesFromDirs(rootDir string, subDirs []fs.DirEntry) []string {
+	var validTerraformModules []string
+	for _, m := range subDirs {
+		maybeMainTf := filepath.Join(rootDir, m.Name(), "main.tf")
+		if _, err := os.Stat(maybeMainTf); err == nil {
+			validTerraformModules = append(validTerraformModules, filepath.Join(rootDir, m.Name()))
+		}
+	}
+	return validTerraformModules
+}

--- a/modules/terraform/validate_struct.go
+++ b/modules/terraform/validate_struct.go
@@ -35,15 +35,15 @@ type ValidationOptions struct {
 // For example, if your RootDir is /home/project/ and you want to exclude "modules" and "test" you need
 // only pass the relative paths in your excludeDirs slice like so:
 // opts, err := NewValidationOptions("/home/project", []string{}, []string{"modules", "test"})
-func NewValidationOptions(rootDir string, includeDirs, excludeDirs []string) (ValidationOptions, error) {
-	vo := ValidationOptions{
+func NewValidationOptions(rootDir string, includeDirs, excludeDirs []string) (*ValidationOptions, error) {
+	vo := &ValidationOptions{
 		RootDir:     "",
 		IncludeDirs: []string{},
 		ExcludeDirs: []string{},
 	}
 
 	if rootDir == "" {
-		return vo, ValidationUndefinedRootDirErr{}
+		return nil, ValidationUndefinedRootDirErr{}
 	}
 
 	vo.RootDir = rootDir
@@ -69,7 +69,7 @@ func buildFullPathsFromRelative(rootDir string, relativePaths []string) []string
 
 // FindTerraformModulePathsInRootE returns a slice strings representing the filepaths for all valid Terraform modules
 // in the given RootDir, subject to the include / exclude filters.
-func FindTerraformModulePathsInRootE(opts ValidationOptions) ([]string, error) {
+func FindTerraformModulePathsInRootE(opts *ValidationOptions) ([]string, error) {
 	// Find all Terraform files from the configured RootDir
 	pattern := fmt.Sprintf("%s/**/*.tf", opts.RootDir)
 	matches, err := zglob.Glob(pattern)

--- a/modules/terraform/validate_struct.go
+++ b/modules/terraform/validate_struct.go
@@ -1,7 +1,6 @@
 package terraform
 
 import (
-	"errors"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -14,11 +13,17 @@ type ValidationOptions struct {
 	ExcludeDirs []string
 }
 
+type ValidationUndefinedRootDirErr struct{}
+
+func (e ValidationUndefinedRootDirErr) Error() string {
+	return "RootDir must be defined in ValidationOptions passed to ValidateAllTerraformModules"
+}
+
 // readModuleAndExampleSubDirs returns a slice strings representing the filepaths for all valid Terraform modules
 // in both the "modules" directory and "examples" directories in the project root, if they exist.
 func readModuleAndExampleSubDirs(opts ValidationOptions) ([]string, error) {
 	if opts.RootDir == "" {
-		return nil, errors.New("RootDir must be defined in ValidationOptions passed to ValidateAllTerraformModules")
+		return nil, ValidationUndefinedRootDirErr{}
 	}
 	var validationCandidates []string
 	// We want to run InitAndValidate on all valid subdirectories of both the modules and examples dirs

--- a/modules/terraform/validate_struct.go
+++ b/modules/terraform/validate_struct.go
@@ -27,7 +27,14 @@ type ValidationOptions struct {
 	ExcludeDirs []string
 }
 
-// NewValidationOptions returns a ValidationOptions struct, with override-able sane defaults
+// NewValidationOptions returns a ValidationOptions struct, with override-able sane defaults. Note that the
+// ValidationOptions's fields IncludeDirs and ExcludeDirs must be full paths, but this method will accept relative paths
+// and build the full paths when instantiating the ValidationOptions struct,  making it the preferred means of configuring
+// ValidationOptions.
+//
+// For example, if your RootDir is /home/project/ and you want to exclude "modules" and "test" you need
+// only pass the relative paths in your excludeDirs slice like so:
+// opts, err := NewValidationOptions("/home/project", []string{}, []string{"modules", "test"})
 func NewValidationOptions(rootDir string, includeDirs, excludeDirs []string) (ValidationOptions, error) {
 	vo := ValidationOptions{
 		RootDir:     "",

--- a/modules/terraform/validate_struct.go
+++ b/modules/terraform/validate_struct.go
@@ -60,7 +60,7 @@ func buildFullPathsFromRelative(rootDir string, relativePaths []string) []string
 	return fullPaths
 }
 
-// readModuleAndExampleSubDirs returns a slice strings representing the filepaths for all valid Terraform modules
+// FindTerraformModulePathsInRootE returns a slice strings representing the filepaths for all valid Terraform modules
 // in both the "modules" directory and "examples" directories in the project root, if they exist.
 func FindTerraformModulePathsInRootE(opts ValidationOptions) ([]string, error) {
 	// Find all Terraform files from the configured RootDir

--- a/modules/terraform/validate_struct.go
+++ b/modules/terraform/validate_struct.go
@@ -91,13 +91,16 @@ func FindTerraformModulePathsInRootE(opts ValidationOptions) ([]string, error) {
 		terraformDirs = append(terraformDirs, dir)
 	}
 
-	// If opts.IncludeDirs is specified, it takes precedence over opts.ExcludeDirs
 	if len(opts.IncludeDirs) > 0 {
-		return collections.ListIntersection(terraformDirs, opts.IncludeDirs), nil
+		terraformDirs = collections.ListIntersection(terraformDirs, opts.IncludeDirs)
+	}
+
+	if len(opts.ExcludeDirs) > 0 {
+		terraformDirs = collections.ListSubtract(terraformDirs, opts.ExcludeDirs)
 	}
 
 	// Filter out any filepaths that were explicitly included in opts.ExcludeDirs
-	return collections.ListSubtract(terraformDirs, opts.ExcludeDirs), nil
+	return terraformDirs, nil
 }
 
 // Custom error types

--- a/modules/terraform/validate_struct.go
+++ b/modules/terraform/validate_struct.go
@@ -1,7 +1,6 @@
 package terraform
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 
@@ -75,7 +74,7 @@ func ReadModuleAndExampleSubDirs(opts ValidationOptions) ([]string, error) {
 			return nil
 		})
 		if err != nil {
-			fmt.Println(err)
+			return terraformModuleCandidates, err
 		}
 	}
 

--- a/modules/terraform/validate_struct.go
+++ b/modules/terraform/validate_struct.go
@@ -61,8 +61,13 @@ func NewValidationOptions(rootDir string, includeDirs, excludeDirs []string) (*V
 
 func buildFullPathsFromRelative(rootDir string, relativePaths []string) []string {
 	var fullPaths []string
-	for _, relativePath := range relativePaths {
-		fullPaths = append(fullPaths, filepath.Join(rootDir, relativePath))
+	for _, maybeRelativePath := range relativePaths {
+		// If the relativePath is already an absolute path, don't modify it
+		if filepath.IsAbs(maybeRelativePath) {
+			fullPaths = append(fullPaths, maybeRelativePath)
+		} else {
+			fullPaths = append(fullPaths, filepath.Join(rootDir, maybeRelativePath))
+		}
 	}
 	return fullPaths
 }

--- a/modules/terraform/validate_struct.go
+++ b/modules/terraform/validate_struct.go
@@ -2,7 +2,6 @@ package terraform
 
 import (
 	"fmt"
-	"os"
 	"path"
 	"path/filepath"
 
@@ -92,22 +91,6 @@ func FindTerraformModulePathsInRootE(opts ValidationOptions) ([]string, error) {
 
 	// Filter out any filepaths that were explicitly included in opts.ExcludeDirs
 	return collections.ListSubtract(terraformDirs, opts.ExcludeDirs), nil
-}
-
-// IsTerraformModuleDirectory accepts a slice of string paths representing sub directories (under "modules" or "examples"),
-// for instance, returning true for any.tf files. This is useful for filtering out any sub directories that might ship
-// alongside Terraform modules, but not actually be Terraform modules themselves
-func IsTerraformModuleDirectory(path string) (bool, error) {
-	files, err := os.ReadDir(path)
-	if err != nil {
-		return false, err
-	}
-	for _, f := range files {
-		if filepath.Ext(filepath.Join(path, f.Name())) == ".tf" {
-			return true, nil
-		}
-	}
-	return false, nil
 }
 
 // Custom error types

--- a/modules/terraform/validate_struct.go
+++ b/modules/terraform/validate_struct.go
@@ -50,12 +50,6 @@ func NewValidationOptions(rootDir string, targetSubDirs, excludeDirs []string) (
 	return vo, nil
 }
 
-type ValidationUndefinedRootDirErr struct{}
-
-func (e ValidationUndefinedRootDirErr) Error() string {
-	return "RootDir must be defined in ValidationOptions passed to ValidateAllTerraformModules"
-}
-
 // readModuleAndExampleSubDirs returns a slice strings representing the filepaths for all valid Terraform modules
 // in both the "modules" directory and "examples" directories in the project root, if they exist.
 func ReadModuleAndExampleSubDirs(opts ValidationOptions) ([]string, error) {
@@ -96,4 +90,13 @@ func IsTerraformModuleDirectory(path string) (bool, error) {
 		}
 	}
 	return false, nil
+}
+
+// Custom error types
+
+// ValidationUndefinedRootDirErr is returned when NewValidationOptions is called without a RootDir argument
+type ValidationUndefinedRootDirErr struct{}
+
+func (e ValidationUndefinedRootDirErr) Error() string {
+	return "RootDir must be defined in ValidationOptions passed to ValidateAllTerraformModules"
 }

--- a/modules/terraform/validate_struct.go
+++ b/modules/terraform/validate_struct.go
@@ -14,7 +14,7 @@ type ValidationOptions struct {
 	// If you provide RootDir and do not pass entries in either IncludeDirs or ExcludeDirs, then all Terraform directories
 	// From the RootDir, recursively, will be validated
 	RootDir string
-	// If you only want to include certain sub directories, add them as paths relative to RootDir. For example, if the
+	// If you only want to include certain sub directories of RootDir, add the absolute paths here. For example, if the
 	// RootDir is /home/project and you want to only include /home/project/examples, add /home/project/examples here
 	// Note that while the struct requires full paths, you can pass relative paths to the NewValidationOptions function
 	// which will build the full paths based on the supplied RootDir

--- a/modules/terraform/validate_struct.go
+++ b/modules/terraform/validate_struct.go
@@ -16,13 +16,15 @@ type ValidationOptions struct {
 	// From the RootDir, recursively, will be validated
 	RootDir string
 	// If you only want to include certain sub directories, add them as paths relative to RootDir. For example, if the
-	// RootDir is /home/project and you want to only include /home/project/examples, add "examples" to this slice
-	// IncludeDirs takes precedence over ExcludeDirs, meaning that if you provide both IncludeDirs and ExcludeDirs, only
-	// IncludeDirs will be honored
+	// RootDir is /home/project and you want to only include /home/project/examples, add /home/project/examples here
+	// Note that while the struct requires full paths, you can pass relative paths to the NewValidationOptions function
+	// which will build the full paths based on the supplied RootDir
 	IncludeDirs []string
 	// If you want to explicitly exclude certain sub directories, add them as paths relative to RootDir. For example, if the
-	// RootDir is /home/project and you want to include everything EXCEPT /home/project/modules, add "modules"
-	// to this slice. Note that ExcludeDirs is only considered when IncludeDirs is not passed
+	// RootDir is /home/project and you want to include everything EXCEPT /home/project/modules, add
+	// /home/project/modules to this slice. Note that ExcludeDirs is only considered when IncludeDirs is not passed
+	// Note that while the struct requires full paths, you can pass relative paths to the NewValidationOptions function
+	// which will build the full paths based on the supplied RootDir
 	ExcludeDirs []string
 }
 

--- a/modules/terraform/validate_struct.go
+++ b/modules/terraform/validate_struct.go
@@ -28,7 +28,7 @@ type ValidationOptions struct {
 }
 
 // NewValidationOptions returns a ValidationOptions struct, with override-able sane defaults. Note that the
-// ValidationOptions's fields IncludeDirs and ExcludeDirs must be full paths, but this method will accept relative paths
+// ValidationOptions's fields IncludeDirs and ExcludeDirs must be absolute paths, but this method will accept relative paths
 // and build the full paths when instantiating the ValidationOptions struct,  making it the preferred means of configuring
 // ValidationOptions.
 //

--- a/modules/terraform/validate_struct.go
+++ b/modules/terraform/validate_struct.go
@@ -5,6 +5,7 @@ import (
 	"path"
 	"path/filepath"
 
+	go_commons_collections "github.com/gruntwork-io/go-commons/collections"
 	"github.com/gruntwork-io/terratest/modules/collections"
 	"github.com/mattn/go-zglob"
 )
@@ -90,19 +91,16 @@ func FindTerraformModulePathsInRootE(opts *ValidationOptions) ([]string, error) 
 		return matches, err
 	}
 	// Keep a unique set of the base dirs that contain Terraform files
-	terraformDirSet := make(map[string]bool)
+	terraformDirSet := make(map[string]string)
 	for _, match := range matches {
 		// The glob match returns all full paths to every .tf file, whereas we're only interested in their root
 		// directories for the purposes of running Terraform validate
 		rootDir := path.Dir(match)
-		terraformDirSet[rootDir] = true
+		terraformDirSet[rootDir] = "exists"
 	}
 
-	// Return the unique slice of Terraform directories found starting at opts.RootDir
-	terraformDirs := make([]string, 0, len(terraformDirSet))
-	for dir := range terraformDirSet {
-		terraformDirs = append(terraformDirs, dir)
-	}
+	// Retrieve just the unique paths to each Terraform module directory from the map we're using as a set
+	terraformDirs := go_commons_collections.Keys(terraformDirSet)
 
 	if len(opts.IncludeDirs) > 0 {
 		terraformDirs = collections.ListIntersection(terraformDirs, opts.IncludeDirs)
@@ -117,6 +115,7 @@ func FindTerraformModulePathsInRootE(opts *ValidationOptions) ([]string, error) 
 }
 
 // Custom error types
+
 // ValidationAbsolutePathErr is returned when NewValidationOptions was unable to convert a non-absolute RootDir to
 // an absolute path
 type ValidationAbsolutePathErr struct {

--- a/modules/terraform/validate_test.go
+++ b/modules/terraform/validate_test.go
@@ -98,3 +98,31 @@ func TestFindTerraformModulePathsInRootEWithResultsExclusion(t *testing.T) {
 		assert.True(t, collections.ListContains(subDirsWithoutExclusions, filepath.Join(projectRootDir, exclusion)))
 	}
 }
+
+// TestValidateAllTerraformModulesSucceedsOnValidTerraform points at a simple text fixture Terraform module that is
+// known to be valid
+func TestValidateAllTerraformModulesSucceedsOnValidTerraform(t *testing.T) {
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+
+	// Use the test fixtures directory as the RootDir for ValidationOptions
+	projectRootDir := filepath.Join(cwd, "../../test/fixtures")
+
+	opts, optsErr := NewValidationOptions(projectRootDir, []string{"terraform-validation-valid"}, []string{})
+	require.NoError(t, optsErr)
+
+	ValidateAllTerraformModules(t, opts)
+}
+
+// This test calls ValidateAllTerraformModules on the Terratest root directory
+func TestValidateAllTerraformModulesOnTerratest(t *testing.T) {
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+
+	projectRootDir := filepath.Join(cwd, "../..")
+
+	opts, optsErr := NewValidationOptions(projectRootDir, []string{}, []string{})
+	require.NoError(t, optsErr)
+
+	ValidateAllTerraformModules(t, opts)
+}

--- a/modules/terraform/validate_test.go
+++ b/modules/terraform/validate_test.go
@@ -60,7 +60,7 @@ func TestReadModuleAndExampleSubDirsExamples(t *testing.T) {
 
 	subDirs, err := readModuleAndExampleSubDirs(opts)
 	require.NoError(t, err)
-	// There are many valid Terraform modules in the root/examples directory of the Terratest project, so we should get back 0 results
+	// There are many valid Terraform modules in the root/examples directory of the Terratest project, so we should get back many results
 	require.Greater(t, len(subDirs), 0)
 }
 

--- a/modules/terraform/validate_test.go
+++ b/modules/terraform/validate_test.go
@@ -45,14 +45,14 @@ func TestNewValidationOptionsRejectsEmptyRootDir(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestReadModuleAndExampleSubDirsExamples(t *testing.T) {
+func TestFindTerraformModulePathsInRootEExamples(t *testing.T) {
 	cwd, cwdErr := os.Getwd()
 	require.NoError(t, cwdErr)
 
 	opts, optsErr := NewValidationOptions(filepath.Join(cwd, "../../"), []string{}, []string{})
 	require.NoError(t, optsErr)
 
-	subDirs, err := ReadModuleAndExampleSubDirs(opts)
+	subDirs, err := FindTerraformModulePathsInRootE(opts)
 	require.NoError(t, err)
 	// There are many valid Terraform modules in the root/examples directory of the Terratest project, so we should get back many results
 	require.Greater(t, len(subDirs), 0)
@@ -62,36 +62,36 @@ func TestReadModuleAndExampleSubDirsExamples(t *testing.T) {
 // and ensuring at the end that they do not appear in the returned slice of sub directories to validate
 // Then, re-run the function with no exclusions and ensure the excluded paths ARE returned in the result set when no
 // exclusions are passed
-func TestReadModuleAndExampleSubDirsWithResultsExclusion(t *testing.T) {
+func TestFindTerraformModulePathsInRootEWithResultsExclusion(t *testing.T) {
 
 	cwd, cwdErr := os.Getwd()
 	require.NoError(t, cwdErr)
 
 	projectRootDir := filepath.Join(cwd, "../..")
 
-	// First, call the ReadModuleAndExampleSubDirs method with several exclusions
+	// First, call the FindTerraformModulePathsInRootE method with several exclusions
 	exclusions := []string{
 		filepath.Join("test", "fixtures", "terraform-output"),
 		filepath.Join("test", "fixtures", "terraform-output-map"),
 	}
 
-	opts, optsErr := NewValidationOptions(projectRootDir, []string{"test/fixtures"}, exclusions)
+	opts, optsErr := NewValidationOptions(projectRootDir, []string{}, exclusions)
 	require.NoError(t, optsErr)
 
-	subDirs, err := ReadModuleAndExampleSubDirs(opts)
+	subDirs, err := FindTerraformModulePathsInRootE(opts)
 	require.NoError(t, err)
 	require.Greater(t, len(subDirs), 0)
-	// Ensure none of the excluded paths were returned by ReadModuleAndExampleSubDirs
+	// Ensure none of the excluded paths were returned by FindTerraformModulePathsInRootE
 	for _, exclusion := range exclusions {
 		assert.False(t, collections.ListContains(subDirs, filepath.Join(projectRootDir, exclusion)))
 	}
 
 	// Next, call the same function but this time without exclusions and ensure that the excluded paths
 	// exist in the non-excluded result set
-	optsWithoutExclusions, optswoErr := NewValidationOptions(projectRootDir, []string{"examples", "test/fixtures"}, []string{})
+	optsWithoutExclusions, optswoErr := NewValidationOptions(projectRootDir, []string{}, []string{})
 	require.NoError(t, optswoErr)
 
-	subDirsWithoutExclusions, woExErr := ReadModuleAndExampleSubDirs(optsWithoutExclusions)
+	subDirsWithoutExclusions, woExErr := FindTerraformModulePathsInRootE(optsWithoutExclusions)
 	require.NoError(t, woExErr)
 	require.Greater(t, len(subDirsWithoutExclusions), 0)
 	for _, exclusion := range exclusions {

--- a/modules/terraform/validate_test.go
+++ b/modules/terraform/validate_test.go
@@ -58,7 +58,7 @@ func TestReadModuleAndExampleSubDirsExamples(t *testing.T) {
 	require.Greater(t, len(subDirs), 0)
 }
 
-// Verify ExcludeDirs is working properly, by explicitly passing a list of two modules and two examples to exclude
+// Verify ExcludeDirs is working properly, by explicitly passing a list of two test fixture modules to exclude
 // and ensuring at the end that they do not appear in the returned slice of sub directories to validate
 // Then, re-run the function with no exclusions and ensure the excluded paths ARE returned in the result set when no
 // exclusions are passed
@@ -73,11 +73,9 @@ func TestReadModuleAndExampleSubDirsWithResultsExclusion(t *testing.T) {
 	exclusions := []string{
 		filepath.Join("test", "fixtures", "terraform-output"),
 		filepath.Join("test", "fixtures", "terraform-output-map"),
-		filepath.Join("examples", "terraform-packer-example"),
-		filepath.Join("examples", "terraform-hello-world-example"),
 	}
 
-	opts, optsErr := NewValidationOptions(projectRootDir, []string{"examples", "test/fixtures"}, exclusions)
+	opts, optsErr := NewValidationOptions(projectRootDir, []string{"test/fixtures"}, exclusions)
 	require.NoError(t, optsErr)
 
 	subDirs, err := ReadModuleAndExampleSubDirs(opts)

--- a/modules/terraform/validate_test.go
+++ b/modules/terraform/validate_test.go
@@ -121,7 +121,7 @@ func TestValidateAllTerraformModulesOnTerratest(t *testing.T) {
 
 	projectRootDir := filepath.Join(cwd, "../..")
 
-	opts, optsErr := NewValidationOptions(projectRootDir, []string{}, []string{})
+	opts, optsErr := NewValidationOptions(projectRootDir, []string{}, []string{"test/fixtures/terraform-with-plan-error", "examples/terraform-backend-example"})
 	require.NoError(t, optsErr)
 
 	ValidateAllTerraformModules(t, opts)

--- a/modules/terraform/validate_test.go
+++ b/modules/terraform/validate_test.go
@@ -1,8 +1,11 @@
 package terraform
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
+	"github.com/gruntwork-io/terratest/modules/collections"
 	"github.com/gruntwork-io/terratest/modules/files"
 	"github.com/stretchr/testify/require"
 )
@@ -34,4 +37,58 @@ func TestInitAndValidateWithError(t *testing.T) {
 	out, err := InitAndValidateE(t, options)
 	require.Error(t, err)
 	require.Contains(t, out, "Reference to undeclared input variable")
+}
+
+func TestReadModuleAndExampleSubDirsRejectsEmptyOpts(t *testing.T) {
+	opts := ValidationOptions{
+		RootDir:     "",
+		ExcludeDirs: []string{},
+	}
+
+	_, err := readModuleAndExampleSubDirs(opts)
+	require.Error(t, err)
+}
+
+func TestReadModuleAndExampleSubDirsExamples(t *testing.T) {
+	cwd, cwdErr := os.Getwd()
+	require.NoError(t, cwdErr)
+
+	opts := ValidationOptions{
+		RootDir:     filepath.Join(cwd, "../../"),
+		ExcludeDirs: []string{},
+	}
+
+	subDirs, err := readModuleAndExampleSubDirs(opts)
+	require.NoError(t, err)
+	// There are many valid Terraform modules in the root/examples directory of the Terratest project, so we should get back 0 results
+	require.Greater(t, len(subDirs), 0)
+}
+
+// Verify ExcludeDirs is working properly, by explicitly passing a list of two modules and two examples to exclude
+// and ensuring at the end that they do not appear in the returned slice of sub directories to validate
+func TestReadModuleAndExampleSubDirsWithResultsExclusion(t *testing.T) {
+
+	cwd, cwdErr := os.Getwd()
+	require.NoError(t, cwdErr)
+
+	projectRootDir := filepath.Join(cwd, "../..")
+
+	exclusions := []string{
+		filepath.Join(projectRootDir, "retry"),
+		filepath.Join(projectRootDir, "ssh"),
+		filepath.Join(projectRootDir, "terraform-packer-example"),
+		filepath.Join(projectRootDir, "terraform-hello-world-example"),
+	}
+
+	opts := ValidationOptions{
+		RootDir:     projectRootDir,
+		ExcludeDirs: exclusions,
+	}
+
+	subDirs, err := readModuleAndExampleSubDirs(opts)
+	require.NoError(t, err)
+	require.Greater(t, len(subDirs), 0)
+	for _, exclusion := range exclusions {
+		require.False(t, collections.ListContains(subDirs, exclusion))
+	}
 }

--- a/test/fixtures/terraform-validation-valid/main.tf
+++ b/test/fixtures/terraform-validation-valid/main.tf
@@ -1,0 +1,12 @@
+# This is a test resource that echoes the message specified by var.message
+resource "null_resource" "greet" {
+  count = 5
+
+  triggers = {
+    run_always = timestamp()
+  }
+
+  provisioner "local-exec" {
+    command = "echo ${var.message}"
+  }
+}

--- a/test/fixtures/terraform-validation-valid/outputs.tf
+++ b/test/fixtures/terraform-validation-valid/outputs.tf
@@ -1,0 +1,3 @@
+output "message" {
+  value = var.message
+}

--- a/test/fixtures/terraform-validation-valid/vars.tf
+++ b/test/fixtures/terraform-validation-valid/vars.tf
@@ -1,0 +1,4 @@
+variable "message" {
+  type    = string
+  default = "Hello, World"
+}


### PR DESCRIPTION
- We need an easy way to generate a single test that runs validate
- It should always expand to catch all examples and modules

Relates to https://github.com/gruntwork-io/prototypes/pull/175