### PR TITLE
[terraform] add init options -reconfigure and -migrate-state 

### DIFF
--- a/modules/terraform/init.go
+++ b/modules/terraform/init.go
@@ -18,6 +18,16 @@ func Init(t testing.TestingT, options *Options) string {
 // InitE calls terraform init and return stdout/stderr.
 func InitE(t testing.TestingT, options *Options) (string, error) {
 	args := []string{"init", fmt.Sprintf("-upgrade=%t", options.Upgrade)}
+
+	// Append reconfigure option if specified
+	if options.Reconfigure {
+		args = append(args, "-reconfigure")
+	}
+	// Append combination of migrate-state and force-copy to suppress answer prompt
+	if options.MigrateState {
+		args = append(args, "-migrate-state", "-force-copy")
+	}
+
 	args = append(args, FormatTerraformBackendConfigAsArgs(options.BackendConfig)...)
 	args = append(args, FormatTerraformPluginDirAsArgs(options.PluginDir)...)
 	return RunTerraformCommandE(t, options, args...)

--- a/modules/terraform/init_test.go
+++ b/modules/terraform/init_test.go
@@ -87,21 +87,17 @@ func TestInitReconfigureBackend(t *testing.T) {
 	t.Parallel()
 
 	stateDirectory, err := ioutil.TempDir("", t.Name())
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer os.RemoveAll(stateDirectory)
 
 	testFolder, err := files.CopyTerraformFolderToTemp("../../test/fixtures/terraform-backend", t.Name())
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer os.RemoveAll(testFolder)
 
 	options := &Options{
 		TerraformDir: testFolder,
 		BackendConfig: map[string]interface{}{
-			"path": filepath.Join(stateDirectory, "backend.tfstate"),
+			"path":          filepath.Join(stateDirectory, "backend.tfstate"),
 			"workspace_dir": "current",
 		},
 	}
@@ -121,21 +117,17 @@ func TestInitBackendMigration(t *testing.T) {
 	t.Parallel()
 
 	stateDirectory, err := ioutil.TempDir("", t.Name())
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer os.RemoveAll(stateDirectory)
 
 	testFolder, err := files.CopyTerraformFolderToTemp("../../test/fixtures/terraform-backend", t.Name())
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer os.RemoveAll(testFolder)
 
 	options := &Options{
 		TerraformDir: testFolder,
 		BackendConfig: map[string]interface{}{
-			"path": filepath.Join(stateDirectory, "backend.tfstate"),
+			"path":          filepath.Join(stateDirectory, "backend.tfstate"),
 			"workspace_dir": "current",
 		},
 	}

--- a/modules/terraform/options.go
+++ b/modules/terraform/options.go
@@ -60,6 +60,8 @@ type Options struct {
 	MaxRetries               int                    // Maximum number of times to retry errors matching RetryableTerraformErrors
 	TimeBetweenRetries       time.Duration          // The amount of time to wait between retries
 	Upgrade                  bool                   // Whether the -upgrade flag of the terraform init command should be set to true or not
+	Reconfigure              bool                   // Set the -reconfigure flag to the terraform init command
+	MigrateState             bool                   // Set the -migrate-state and -force-copy (suppress 'yes' answer prompt) flag to the terraform init command
 	NoColor                  bool                   // Whether the -no-color flag will be set for any Terraform command or not
 	SshAgent                 *ssh.SshAgent          // Overrides local SSH agent with the given in-process agent
 	NoStderr                 bool                   // Disable stderr redirection


### PR DESCRIPTION
As mentioned in https://github.com/gruntwork-io/terratest/issues/839 it's may a good idea to have terraform init options `-reconfigure` and `-migrate-state` configurable.  

This PR will add:
- Additional terraform.options `Reconfigure` and `MigrateState`
- MigrateState does also enable `-force-copy` to suppress the prompt for confirmation (similar to `-auto-approve`)
- Tests for both options `TestInitReconfigureBackend` and `TestInitBackendMigration`
- Options directly appended in `InitE` func due to the fact this options only used by terraform init and do not require any parameters which would require specific formatting

Reference to terraform documentation:
https://www.terraform.io/docs/cli/commands/init.html#backend-initialization