### PR TITLE
Fix regression bug using run-all in lock commands

### DIFF
--- a/modules/terraform/format.go
+++ b/modules/terraform/format.go
@@ -9,13 +9,15 @@ import (
 	"github.com/gruntwork-io/terratest/modules/collections"
 )
 
+const runAllCmd = "run-all"
+
 // TerraformCommandsWithLockSupport is a list of all the Terraform commands that
 // can obtain locks on Terraform state
 var TerraformCommandsWithLockSupport = []string{
 	"plan",
+	"plan-all",
 	"apply",
 	"apply-all",
-	"run-all",
 	"destroy",
 	"destroy-all",
 	"init",
@@ -39,6 +41,12 @@ var TerraformCommandsWithPlanFileSupport = []string{
 func FormatArgs(options *Options, args ...string) []string {
 	var terraformArgs []string
 	commandType := args[0]
+	// If the user is trying to run with run-all, then we need to make sure the command based args are based on the
+	// actual terraform command. E.g., we want to base the logic on `plan` when `run-all plan` is passed in, not
+	// `run-all`.
+	if commandType == runAllCmd {
+		commandType = args[1]
+	}
 	lockSupported := collections.ListContains(TerraformCommandsWithLockSupport, commandType)
 	planFileSupported := collections.ListContains(TerraformCommandsWithPlanFileSupport, commandType)
 

--- a/modules/terraform/format_test.go
+++ b/modules/terraform/format_test.go
@@ -259,3 +259,22 @@ func TestTryToConvertToGenericMap(t *testing.T) {
 		assert.Equal(t, testCase.expectedIsMap, actualIsMap, "Value: %v", testCase.value)
 	}
 }
+
+func TestFormatArgsAppliesLockCorrectly(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		command  []string
+		expected []string
+	}{
+		{[]string{"plan"}, []string{"plan", "-lock=false"}},
+		{[]string{"validate"}, []string{"validate"}},
+		{[]string{"plan-all"}, []string{"plan-all", "-lock=false"}},
+		{[]string{"run-all", "validate"}, []string{"run-all", "validate"}},
+		{[]string{"run-all", "plan"}, []string{"run-all", "plan", "-lock=false"}},
+	}
+
+	for _, testCase := range testCases {
+		assert.Equal(t, testCase.expected, FormatArgs(&Options{}, testCase.command...))
+	}
+}


### PR DESCRIPTION
Because we were including `run-all` in `TerraformCommandsWithLockSupport`, it was always appending `-lock=false` for any `run-call` command, even if the underlying tf command didn't support it (e.g., `run-all validate`).

This PR fixes that.