### PR TITLE
Continue searching when we get a deleted bucket

### DIFF
--- a/modules/aws/s3.go
+++ b/modules/aws/s3.go
@@ -37,6 +37,9 @@ func FindS3BucketWithTagE(t testing.TestingT, awsRegion string, key string, valu
 		tagResponse, err := s3Client.GetBucketTagging(&s3.GetBucketTaggingInput{Bucket: bucket.Name})
 
 		if err != nil {
+			if strings.Contains(err.Error(), "NoSuchBucket") {
+				continue
+			}
 			if !strings.Contains(err.Error(), "AuthorizationHeaderMalformed") &&
 				!strings.Contains(err.Error(), "BucketRegionError") &&
 				!strings.Contains(err.Error(), "NoSuchTagSet") {

--- a/modules/aws/s3.go
+++ b/modules/aws/s3.go
@@ -38,6 +38,10 @@ func FindS3BucketWithTagE(t testing.TestingT, awsRegion string, key string, valu
 
 		if err != nil {
 			if strings.Contains(err.Error(), "NoSuchBucket") {
+				// Occasionally, the ListBuckets call will return a bucket that has been deleted by S3
+				// but hasn't yet been actually removed from the backend. Listing tags on that bucket
+				// will return this error. If the bucket has been deleted, it can't be the one to find,
+				// so just ignore this error, and keep checking the other buckets.
 				continue
 			}
 			if !strings.Contains(err.Error(), "AuthorizationHeaderMalformed") &&


### PR DESCRIPTION
Check to see if the error we get is "NoSuchBucket"
Sometimes, ListBuckets will return buckets that have been deleted, but haven't actually been removed yet. This causes GetBucketTagging to return NoSuchBucket, and the function to return without checking any remaining buckets (which could be the one we actually want).
If we get "NoSuchBucket", just continue. A bucket that has been deleted can't be the one we are looking for (at least, it wouldn't be useful if it was). 

Fixes #928 

I'm not quite sure how to test this, as it it a transient error related to how S3 is working behind the scenes. It happened to me once in several days of use, but the issue persisted for an hour or more. The "phantom" bucket was gone the next morning.