### PR TITLE
fix for handling -no-color and -var options

### DIFF
--- a/modules/terraform/apply_test.go
+++ b/modules/terraform/apply_test.go
@@ -1,6 +1,7 @@
 package terraform
 
 import (
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -200,4 +201,29 @@ func TestTgApplyUseLockNoError(t *testing.T) {
 	require.Contains(t, out, "Hello, World")
 	// make sure -lock CLI option is passed down correctly
 	require.Contains(t, out, "-lock=true")
+}
+
+func TestApplyWithPlanFile(t *testing.T) {
+	t.Parallel()
+
+	testFolder, err := files.CopyTerraformFolderToTemp("../../test/fixtures/terraform-basic-configuration", t.Name())
+	require.NoError(t, err)
+	planFilePath := filepath.Join(testFolder, "plan.out")
+
+	options := &Options{
+		TerraformDir: testFolder,
+		Vars: map[string]interface{}{
+			"cnt": 1,
+		},
+		NoColor:      true,
+		PlanFilePath: planFilePath,
+	}
+	_, err = InitAndPlanE(t, options)
+	require.NoError(t, err)
+	require.FileExists(t, planFilePath, "Plan file was not saved to expected location:", planFilePath)
+
+	out, err := ApplyE(t, options)
+	require.NoError(t, err)
+	require.Contains(t, out, "1 added, 0 changed, 0 destroyed.")
+	require.NotRegexp(t, `\[\d*m`, out, "Output should not contain color escape codes")
 }

--- a/modules/terraform/cmd.go
+++ b/modules/terraform/cmd.go
@@ -32,10 +32,6 @@ var commandsWithParallelism = []string{
 
 // GetCommonOptions extracts commons terraform options
 func GetCommonOptions(options *Options, args ...string) (*Options, []string) {
-	if options.NoColor && !collections.ListContains(args, "-no-color") {
-		args = append(args, "-no-color")
-	}
-
 	if options.TerraformBinary == "" {
 		options.TerraformBinary = "terraform"
 	}

--- a/modules/terraform/format.go
+++ b/modules/terraform/format.go
@@ -50,10 +50,21 @@ func FormatArgs(options *Options, args ...string) []string {
 	lockSupported := collections.ListContains(TerraformCommandsWithLockSupport, commandType)
 	planFileSupported := collections.ListContains(TerraformCommandsWithPlanFileSupport, commandType)
 
+	// Include -var and -var-file flags unless we're running 'apply' with a plan file
+	includeVars := !(commandType == "apply" && len(options.PlanFilePath) > 0)
+
 	terraformArgs = append(terraformArgs, args...)
-	terraformArgs = append(terraformArgs, FormatTerraformVarsAsArgs(options.Vars)...)
-	terraformArgs = append(terraformArgs, FormatTerraformArgs("-var-file", options.VarFiles)...)
+
+	if includeVars {
+		terraformArgs = append(terraformArgs, FormatTerraformVarsAsArgs(options.Vars)...)
+		terraformArgs = append(terraformArgs, FormatTerraformArgs("-var-file", options.VarFiles)...)
+	}
+
 	terraformArgs = append(terraformArgs, FormatTerraformArgs("-target", options.Targets)...)
+
+	if options.NoColor {
+		terraformArgs = append(terraformArgs, "-no-color")
+	}
 
 	if lockSupported {
 		// If command supports locking, handle lock arguments


### PR DESCRIPTION
This PR fixes a few things:

- `terraform apply` expects `plan file` to be presented as the last
argument, currently `-no-color` option is added after the plan file in the argument/options order. 
- when `terraform apply` is provided with a plan file, we should not pass
`-var` and `-var-file` options anymore. it is a violation.