### PR TITLE
Don't run validate tests in parallel

### DIFF
--- a/modules/test-structure/test_structure.go
+++ b/modules/test-structure/test_structure.go
@@ -116,8 +116,6 @@ func ValidateAllTerraformModules(t *go_test.T, opts *ValidationOptions) {
 	for _, dir := range dirsToValidate {
 		dir := dir
 		t.Run(strings.TrimLeft(dir, "/"), func(t *go_test.T) {
-			t.Parallel()
-
 			// Determine the absolute path to the git repository root
 			cwd, cwdErr := os.Getwd()
 			require.NoError(t, cwdErr)


### PR DESCRIPTION
Terraform validate spins up lots of providers, each of which is CPU and memory hungry. Running these in parallel currently exhausts even beefy machines, consuming over 7GB of ram and pegging all CPUs. 

Removing the call to `parallel` resolves the problem locally, which I was able to repro prior to removal. 