### PR TITLE
Always include namespace flag in helm

### DIFF
--- a/modules/helm/cmd.go
+++ b/modules/helm/cmd.go
@@ -65,6 +65,7 @@ func RunHelmCommandAndGetStdOutE(t testing.TestingT, options *Options, cmd strin
 func prepareHelmCommand(t testing.TestingT, options *Options, cmd string, additionalArgs ...string) shell.Command {
 	args := []string{cmd}
 	args = getCommonArgs(options, args...)
+	args = append(args, getNamespaceArgs(options)...)
 	args = append(args, additionalArgs...)
 
 	helmCmd := shell.Command{

--- a/modules/helm/delete.go
+++ b/modules/helm/delete.go
@@ -23,7 +23,6 @@ func DeleteE(t testing.TestingT, options *Options, releaseName string, purge boo
 			args = append(args, deleteArgs...)
 		}
 	}
-	args = append(args, getNamespaceArgs(options)...)
 	args = append(args, releaseName)
 	_, err := RunHelmCommandAndGetOutputE(t, options, "delete", args...)
 	return err

--- a/modules/helm/install.go
+++ b/modules/helm/install.go
@@ -37,7 +37,6 @@ func InstallE(t testing.TestingT, options *Options, chart string, releaseName st
 			args = append(args, installArgs...)
 		}
 	}
-	args = append(args, getNamespaceArgs(options)...)
 	if options.Version != "" {
 		args = append(args, "--version", options.Version)
 	}

--- a/modules/helm/rollback.go
+++ b/modules/helm/rollback.go
@@ -20,7 +20,6 @@ func RollbackE(t testing.TestingT, options *Options, releaseName string, revisio
 			args = append(args, rollbackArgs...)
 		}
 	}
-	args = append(args, getNamespaceArgs(options)...)
 	args = append(args, releaseName)
 	if revision != "" {
 		args = append(args, revision)

--- a/modules/helm/upgrade.go
+++ b/modules/helm/upgrade.go
@@ -34,7 +34,6 @@ func UpgradeE(t testing.TestingT, options *Options, chart string, releaseName st
 			args = append(args, upgradeArgs...)
 		}
 	}
-	args = append(args, getNamespaceArgs(options)...)
 	args, err = getValuesArgsE(t, options, args...)
 	if err != nil {
 		return err


### PR DESCRIPTION
Fixes https://github.com/gruntwork-io/terratest/issues/937

In helm 3, namespace flag is a global option so we can always include it.