### PR TITLE
Update f1-micro to e2-micro instance

### DIFF
--- a/examples/terraform-gcp-example/variables.tf
+++ b/examples/terraform-gcp-example/variables.tf
@@ -30,7 +30,7 @@ variable "instance_name" {
 variable "machine_type" {
   description = "The Machine Type to use for the Cloud Instance."
   type        = string
-  default     = "f1-micro"
+  default     = "e2-micro"
 }
 
 variable "zone" {

--- a/examples/terraform-gcp-hello-world-example/main.tf
+++ b/examples/terraform-gcp-hello-world-example/main.tf
@@ -12,7 +12,7 @@ provider "google" {
 # website::tag::1:: Deploy a cloud instance
 resource "google_compute_instance" "example" {
   name         = var.instance_name
-  machine_type = "f1-micro"
+  machine_type = "e2-micro"
   zone         = "us-east1-b"
 
   # website::tag::2:: Run Ubuntu 18.04 on the instace

--- a/examples/terraform-gcp-ig-example/variables.tf
+++ b/examples/terraform-gcp-ig-example/variables.tf
@@ -42,6 +42,6 @@ variable "cluster_size" {
 variable "machine_type" {
   description = "The Machine Type to use for the Compute Instances."
   type        = string
-  default     = "f1-micro"
+  default     = "e2-micro"
 }
 

--- a/modules/gcp/compute_test.go
+++ b/modules/gcp/compute_test.go
@@ -17,7 +17,7 @@ import (
 	"google.golang.org/api/compute/v1"
 )
 
-const DEFAULT_MACHINE_TYPE = "f1-micro"
+const DEFAULT_MACHINE_TYPE = "e2-micro"
 const DEFAULT_IMAGE_FAMILY_PROJECT_NAME = "ubuntu-os-cloud"
 const DEFAULT_IMAGE_FAMILY_NAME = "family/ubuntu-1804-lts"
 


### PR DESCRIPTION
I just got an email from GCP stating that the f1-micro is being retired from free tier access and needs to be updated to e2-micro. This PR makes that change.