### PR TITLE
Add helper for extracting plan struct without logging and without specifying a plan file

### DIFF
--- a/modules/terraform/plan_test.go
+++ b/modules/terraform/plan_test.go
@@ -84,6 +84,22 @@ func TestInitAndPlanWithPlanFile(t *testing.T) {
 	assert.FileExists(t, planFilePath, "Plan file was not saved to expected location:", planFilePath)
 }
 
+func TestInitAndPlanAndShowWithStructNoLogTempPlanFile(t *testing.T) {
+	t.Parallel()
+
+	testFolder, err := files.CopyTerraformFolderToTemp("../../test/fixtures/terraform-basic-configuration", t.Name())
+	require.NoError(t, err)
+
+	options := &Options{
+		TerraformDir: testFolder,
+		Vars: map[string]interface{}{
+			"cnt": 1,
+		},
+	}
+	planStruct := InitAndPlanAndShowWithStructNoLogTempPlanFile(t, options)
+	assert.Equal(t, 1, len(planStruct.ResourceChangesMap))
+}
+
 func TestPlanWithExitCodeWithNoChanges(t *testing.T) {
 	t.Parallel()
 	testFolder, err := files.CopyTerraformFolderToTemp("../../test/fixtures/terraform-no-error", t.Name())


### PR DESCRIPTION
I'm finding myself rewriting versions of this function more often than not, to the point that it probably makes sense to live in terratest.

The point of this function is:

- Avoid logging the planfile json to console. This is a really big log message that is not human readable, and is not very useful for debugging (there are other, easier ways to debug the plan file, such as by introspecting the struct using [delve](https://github.com/go-delve/delve)).

- Avoid having to specify where to store the plan file. After some usage, I realized that I never need the plan file on disk after I get the struct out.