### PR TITLE
feat: extend aws/cloudwatch with CloudWatch client

### DIFF
--- a/modules/aws/cloudwatch.go
+++ b/modules/aws/cloudwatch.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/cloudwatch"
 	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
 	"github.com/gruntwork-io/terratest/modules/testing"
 )
@@ -55,4 +56,22 @@ func NewCloudWatchLogsClientE(t testing.TestingT, region string) (*cloudwatchlog
 		return nil, err
 	}
 	return cloudwatchlogs.New(sess), nil
+}
+
+// NewCloudWatchClient creates a new CloudWatch client.
+func NewCloudWatchClient(t testing.TestingT, region string) *cloudwatch.CloudWatch {
+	client, err := NewCloudWatchClientE(t, region)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return client
+}
+
+// NewCloudWatchClientE creates a new CloudWatch client.
+func NewCloudWatchClientE(t testing.TestingT, region string) (*cloudwatch.CloudWatch, error) {
+	sess, err := NewAuthenticatedSession(region)
+	if err != nil {
+		return nil, err
+	}
+	return cloudwatch.New(sess), nil
 }

--- a/modules/aws/cloudwatch.go
+++ b/modules/aws/cloudwatch.go
@@ -5,14 +5,13 @@ import (
 	"github.com/aws/aws-sdk-go/service/cloudwatch"
 	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
 	"github.com/gruntwork-io/terratest/modules/testing"
+	"github.com/stretchr/testify/require"
 )
 
 // GetCloudWatchLogEntries returns the CloudWatch log messages in the given region for the given log stream and log group.
 func GetCloudWatchLogEntries(t testing.TestingT, awsRegion string, logStreamName string, logGroupName string) []string {
 	out, err := GetCloudWatchLogEntriesE(t, awsRegion, logStreamName, logGroupName)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	return out
 }
 
@@ -43,9 +42,7 @@ func GetCloudWatchLogEntriesE(t testing.TestingT, awsRegion string, logStreamNam
 // NewCloudWatchLogsClient creates a new CloudWatch Logs client.
 func NewCloudWatchLogsClient(t testing.TestingT, region string) *cloudwatchlogs.CloudWatchLogs {
 	client, err := NewCloudWatchLogsClientE(t, region)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	return client
 }
 
@@ -61,9 +58,7 @@ func NewCloudWatchLogsClientE(t testing.TestingT, region string) (*cloudwatchlog
 // NewCloudWatchClient creates a new CloudWatch client.
 func NewCloudWatchClient(t testing.TestingT, region string) *cloudwatch.CloudWatch {
 	client, err := NewCloudWatchClientE(t, region)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	return client
 }
 

--- a/modules/aws/cloudwatch_test.go
+++ b/modules/aws/cloudwatch_test.go
@@ -1,0 +1,24 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewCloudWatchClient(t *testing.T) {
+	t.Parallel()
+
+	region := GetRandomStableRegion(t, nil, nil)
+	client := NewCloudWatchClient(t, region)
+	assert.NotEmpty(t, client)
+}
+func TestNewCloudWatchClientE(t *testing.T) {
+	t.Parallel()
+
+	region := GetRandomStableRegion(t, nil, nil)
+	client, err := NewCloudWatchClientE(t, region)
+	require.NoError(t, err)
+	assert.NotEmpty(t, client)
+}


### PR DESCRIPTION
# Summary
This adds the ability to get a CloudWatch client that can be used to manage alarms, metrics and dashboards.

The code was originally created by @whage as part of #229. This adds the automated tests.

# Test results
```bash
go test -v -run TestNewCloudWatchClient
=== RUN   TestNewCloudWatchClient
=== PAUSE TestNewCloudWatchClient
=== RUN   TestNewCloudWatchClientE
=== PAUSE TestNewCloudWatchClientE
=== CONT  TestNewCloudWatchClient
=== CONT  TestNewCloudWatchClientE
TestNewCloudWatchClient 2021-07-27T15:08:59-04:00 region.go:92: Using region ap-south-1
TestNewCloudWatchClientE 2021-07-27T15:08:59-04:00 region.go:92: Using region eu-west-1
--- PASS: TestNewCloudWatchClient (0.00s)
--- PASS: TestNewCloudWatchClientE (0.00s)
PASS
ok      github.com/gruntwork-io/terratest/modules/aws   0.144s
```

# Related issues
Closes #229 
Closes #958 