### PR TITLE
Add one more character to the commit SHA

### DIFF
--- a/modules/git/git_test.go
+++ b/modules/git/git_test.go
@@ -53,7 +53,7 @@ func testGetCurrentRefReturnsLightTagValue(t *testing.T) {
 
 	name := GetCurrentGitRef(t)
 
-	assert.Equal(t, "v0.0.1-1-g58d3ea8", name)
+	assert.Equal(t, "v0.0.1-1-g58d3ea8f", name)
 }
 
 func TestGitRefChecks(t *testing.T) {


### PR DESCRIPTION
@yorinasub17 and I found that the `GetCurrentRefReturnsLightTagValue` test was failing because the number of abbreviated characters in a commit SHA returned by bit has changed due to the number of objects in the repo. This behavior is [documented in this comment](https://github.com/git/git/commit/e6c587c733b4634030b353f4024794b08bc86892). This PR fixes that by simply adding the expected character. 