### PR TITLE
Call build --platform when only requesting a single cross platform image

### DIFF
--- a/modules/docker/build_test.go
+++ b/modules/docker/build_test.go
@@ -42,6 +42,23 @@ func TestBuildMultiArch(t *testing.T) {
 	require.Contains(t, out, text)
 }
 
+func TestBuildCrossPlatform(t *testing.T) {
+	t.Parallel()
+
+	tag := "gruntwork-io/test-image:v1"
+	text := "Hello, World!"
+
+	options := &BuildOptions{
+		Tags:          []string{tag},
+		BuildArgs:     []string{fmt.Sprintf("text=%s", text)},
+		Architectures: []string{"linux/arm64"},
+	}
+
+	Build(t, "../../test/fixtures/docker", options)
+	out := Run(t, tag, &RunOptions{Remove: true})
+	require.Contains(t, out, text)
+}
+
 func TestBuildWithTarget(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Improve multiarchitecture support by avoiding the need for `buildx` if building a single architecture image, but cross platform. `docker build` has native support for creating a single architecture cross platform image in the `--platform` option.