### PR TITLE
update job is succeeded to check completions

### DIFF
--- a/modules/k8s/job.go
+++ b/modules/k8s/job.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/gruntwork-io/terratest/modules/logger"
@@ -87,7 +88,12 @@ func WaitUntilJobSucceedE(t testing.TestingT, options *KubectlOptions, jobName s
 	return nil
 }
 
-// IsJobSucceeded returns true if all containers in the job are completed & succeeded
+// IsJobSucceeded returns true when the job status condition "Complete" is true
 func IsJobSucceeded(job *batchv1.Job) bool {
-	return job.Status.Active == 0 && job.Status.Failed == 0
+	for _, condition := range job.Status.Conditions {
+		if condition.Type == batchv1.JobComplete && condition.Status == corev1.ConditionTrue {
+			return true
+		}
+	}
+	return false
 }

--- a/modules/k8s/job.go
+++ b/modules/k8s/job.go
@@ -88,7 +88,8 @@ func WaitUntilJobSucceedE(t testing.TestingT, options *KubectlOptions, jobName s
 	return nil
 }
 
-// IsJobSucceeded returns true when the job status condition "Complete" is true
+// IsJobSucceeded returns true when the job status condition "Complete" is true. This behavior is documented in the kubernetes API reference:
+// https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/job-v1/#JobStatus
 func IsJobSucceeded(job *batchv1.Job) bool {
 	for _, condition := range job.Status.Conditions {
 		if condition.Type == batchv1.JobComplete && condition.Status == corev1.ConditionTrue {

--- a/modules/k8s/job_test.go
+++ b/modules/k8s/job_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/gruntwork-io/terratest/modules/random"
@@ -83,9 +84,12 @@ func TestIsJobSucceeded(t *testing.T) {
 			title: "TestIsJobSucceeded",
 			job: &batchv1.Job{
 				Status: batchv1.JobStatus{
-					Succeeded: 1,
-					Failed:    0,
-					Active:    0,
+					Conditions: []batchv1.JobCondition{
+						batchv1.JobCondition{
+							Type:   batchv1.JobComplete,
+							Status: corev1.ConditionTrue,
+						},
+					},
 				},
 			},
 			expectedResult: true,
@@ -94,9 +98,21 @@ func TestIsJobSucceeded(t *testing.T) {
 			title: "TestIsJobFailed",
 			job: &batchv1.Job{
 				Status: batchv1.JobStatus{
-					Failed:    1,
-					Active:    0,
-					Succeeded: 1,
+					Conditions: []batchv1.JobCondition{
+						batchv1.JobCondition{
+							Type:   batchv1.JobFailed,
+							Status: corev1.ConditionTrue,
+						},
+					},
+				},
+			},
+			expectedResult: false,
+		},
+		{
+			title: "TestIsJobStarting",
+			job: &batchv1.Job{
+				Status: batchv1.JobStatus{
+					Conditions: []batchv1.JobCondition{},
 				},
 			},
 			expectedResult: false,


### PR DESCRIPTION
When checking the job status in `IsJobSucceeded`, it will sometimes return true for jobs that are not complete.

This updates the check in IsJobSucceeded to check the job status conditions for a condition of type "Complete" with status "True".

resolves #992