### PR TITLE
[AZURE] Fix Azure ACI example image reference

### DIFF
--- a/examples/azure/terraform-azure-aci-example/main.tf
+++ b/examples/azure/terraform-azure-aci-example/main.tf
@@ -37,7 +37,7 @@ resource "azurerm_container_group" "aci" {
 
   container {
     name   = "hello-world"
-    image  = "microsoft/aci-helloworld:latest"
+    image  = "mcr.microsoft.com/azuredocs/aci-helloworld:latest"
     cpu    = "0.5"
     memory = "1.5"
 


### PR DESCRIPTION
This PR updates the Azure container instance example to use the aci-helloworld image in [Microsoft container Registry](https://github.com/microsoft/ContainerRegistry) 

[CI](https://github.com/HadwaAbdelhalem/terratest/runs/3705424016?check_suite_focus=true)

fixes #997 
closes #997 