### PR TITLE
Added 'Tags' and supporting functions to VPC struct

### DIFF
--- a/modules/aws/vpc.go
+++ b/modules/aws/vpc.go
@@ -156,25 +156,20 @@ func GetSubnetsForVpcE(t testing.TestingT, vpcID string, region string) ([]Subne
 // GetTagsForVpc gets the tags for the specified VPC.
 func GetTagsForVpc(t testing.TestingT, vpcID string, region string) map[string]string {
 	tags, err := GetTagsForVpcE(t, vpcID, region)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+
 	return tags
 }
 
 // GetTagsForVpcE gets the tags for the specified VPC.
 func GetTagsForVpcE(t testing.TestingT, vpcID string, region string) (map[string]string, error) {
 	client, err := NewEc2ClientE(t, region)
-	if err != nil {
-		return nil, err
-	}
+	require.NoError(t, err)
 
 	vpcResourceTypeFilter := ec2.Filter{Name: &vpcResourceTypeFilterName, Values: []*string{&vpcResourceTypeFilterValue}}
 	vpcResourceIdFilter := ec2.Filter{Name: &vpcResourceIdFilterName, Values: []*string{&vpcID}}
 	tagsOutput, err := client.DescribeTags(&ec2.DescribeTagsInput{Filters: []*ec2.Filter{&vpcResourceTypeFilter, &vpcResourceIdFilter}})
-	if err != nil {
-		return nil, err
-	}
+	require.NoError(t, err)
 
 	tags := map[string]string{}
 	for _, tag := range tagsOutput.Tags {

--- a/modules/aws/vpc.go
+++ b/modules/aws/vpc.go
@@ -27,6 +27,9 @@ type Subnet struct {
 }
 
 var vpcIDFilterName = "vpc-id"
+var vpcResourceIdFilterName = "resource-id"
+var vpcResourceTypeFilterName = "resource-type"
+var vpcResourceTypeFilterValue = "vpc"
 var isDefaultFilterName = "isDefault"
 var isDefaultFilterValue = "true"
 
@@ -166,8 +169,9 @@ func GetTagsForVpcE(t testing.TestingT, vpcID string, region string) (map[string
 		return nil, err
 	}
 
-	vpcIDFilter := ec2.Filter{Name: &vpcIDFilterName, Values: []*string{&vpcID}}
-	tagsOutput, err := client.DescribeTags(&ec2.DescribeTagsInput{Filters: []*ec2.Filter{&vpcIDFilter}})
+	vpcResourceTypeFilter := ec2.Filter{Name: &vpcResourceTypeFilterName, Values: []*string{&vpcResourceTypeFilterValue}}
+	vpcResourceIdFilter := ec2.Filter{Name: &vpcResourceIdFilterName, Values: []*string{&vpcID}}
+	tagsOutput, err := client.DescribeTags(&ec2.DescribeTagsInput{Filters: []*ec2.Filter{&vpcResourceTypeFilter, &vpcResourceIdFilter}})
 	if err != nil {
 		return nil, err
 	}

--- a/modules/aws/vpc.go
+++ b/modules/aws/vpc.go
@@ -184,29 +184,6 @@ func GetTagsForVpcE(t testing.TestingT, vpcID string, region string) (map[string
 	return tags, nil
 }
 
-// GetTagValueForVpc gets the value of the tag for the specified VPC tag.
-func GetTagValueForVpc(t testing.TestingT, vpcID string, region string, tagKey string) string {
-	tagValue, err := GetTagValueForVpcE(t, vpcID, region, tagKey)
-	if err != nil {
-		t.Fatal(err)
-	}
-	return tagValue
-}
-
-// GetTagValueForVpcE gets the value of the tag for the specified VPC tag.
-func GetTagValueForVpcE(t testing.TestingT, vpcID string, region string, tagKey string) (string, error) {
-	tags, err := GetTagsForVpcE(t, vpcID, region)
-	if err != nil {
-		return "", err
-	}
-
-	if tagValue, tagExists := tags[tagKey]; tagExists {
-		return tagValue, nil
-	} else {
-		return "", fmt.Errorf("VPC does not have any Tag with a key of %s", tagKey)
-	}
-}
-
 // IsPublicSubnet returns True if the subnet identified by the given id in the provided region is public.
 func IsPublicSubnet(t testing.TestingT, subnetId string, region string) bool {
 	isPublic, err := IsPublicSubnetE(t, subnetId, region)

--- a/modules/aws/vpc.go
+++ b/modules/aws/vpc.go
@@ -180,6 +180,29 @@ func GetTagsForVpcE(t testing.TestingT, vpcID string, region string) (map[string
 	return tags, nil
 }
 
+// GetTagValueForVpc gets the value of the tag for the specified VPC tag.
+func GetTagValueForVpc(t testing.TestingT, vpcID string, region string, tagKey string) string {
+	tagValue, err := GetTagValueForVpcE(t, vpcID, region, tagKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return tagValue
+}
+
+// GetTagValueForVpcE gets the value of the tag for the specified VPC tag.
+func GetTagValueForVpcE(t testing.TestingT, vpcID string, region string, tagKey string) (string, error) {
+	tags, err := GetTagsForVpcE(t, vpcID, region)
+	if err != nil {
+		return "", err
+	}
+
+	if tagValue, tagExists := tags[tagKey]; tagExists {
+		return tagValue, nil
+	} else {
+		return "", fmt.Errorf("VPC does not have any Tag with a key of %s", tagKey)
+	}
+}
+
 // IsPublicSubnet returns True if the subnet identified by the given id in the provided region is public.
 func IsPublicSubnet(t testing.TestingT, subnetId string, region string) bool {
 	isPublic, err := IsPublicSubnetE(t, subnetId, region)

--- a/modules/aws/vpc.go
+++ b/modules/aws/vpc.go
@@ -14,9 +14,10 @@ import (
 
 // Vpc is an Amazon Virtual Private Cloud.
 type Vpc struct {
-	Id      string   // The ID of the VPC
-	Name    string   // The name of the VPC
-	Subnets []Subnet // A list of subnets in the VPC
+	Id      string            // The ID of the VPC
+	Name    string            // The name of the VPC
+	Subnets []Subnet          // A list of subnets in the VPC
+	Tags    map[string]string // The tags associated with the VPC
 }
 
 // Subnet is a subnet in an availability zone.
@@ -89,7 +90,13 @@ func GetVpcsE(t testing.TestingT, filters []*ec2.Filter, region string) ([]*Vpc,
 		if err != nil {
 			return nil, err
 		}
-		retVal[i] = &Vpc{Id: aws.StringValue(vpc.VpcId), Name: FindVpcName(vpc), Subnets: subnets}
+
+		tags, err := GetTagsForVpcE(t, aws.StringValue(vpc.VpcId), region)
+		if err != nil {
+			return nil, err
+		}
+
+		retVal[i] = &Vpc{Id: aws.StringValue(vpc.VpcId), Name: FindVpcName(vpc), Subnets: subnets, Tags: tags}
 	}
 
 	return retVal, nil
@@ -141,6 +148,36 @@ func GetSubnetsForVpcE(t testing.TestingT, vpcID string, region string) ([]Subne
 	}
 
 	return subnets, nil
+}
+
+// GetTagsForVpc gets the tags for the specified VPC.
+func GetTagsForVpc(t testing.TestingT, vpcID string, region string) map[string]string {
+	tags, err := GetTagsForVpcE(t, vpcID, region)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return tags
+}
+
+// GetTagsForVpcE gets the tags for the specified VPC.
+func GetTagsForVpcE(t testing.TestingT, vpcID string, region string) (map[string]string, error) {
+	client, err := NewEc2ClientE(t, region)
+	if err != nil {
+		return nil, err
+	}
+
+	vpcIDFilter := ec2.Filter{Name: &vpcIDFilterName, Values: []*string{&vpcID}}
+	tagsOutput, err := client.DescribeTags(&ec2.DescribeTagsInput{Filters: []*ec2.Filter{&vpcIDFilter}})
+	if err != nil {
+		return nil, err
+	}
+
+	tags := map[string]string{}
+	for _, tag := range tagsOutput.Tags {
+		tags[aws.StringValue(tag.Key)] = aws.StringValue(tag.Value)
+	}
+
+	return tags, nil
 }
 
 // IsPublicSubnet returns True if the subnet identified by the given id in the provided region is public.

--- a/modules/aws/vpc_test.go
+++ b/modules/aws/vpc_test.go
@@ -76,6 +76,54 @@ func TestIsPublicSubnet(t *testing.T) {
 	assert.True(t, IsPublicSubnet(t, *subnet.SubnetId, region))
 }
 
+func TestGetTagsForVpc(t *testing.T) {
+	t.Parallel()
+
+	region := GetRandomStableRegion(t, nil, nil)
+	vpc := createVpc(t, region)
+	defer deleteVpc(t, *vpc.VpcId, region)
+
+	noTags := GetTagsForVpc(t, *vpc.VpcId, region)
+	assert.True(t, len(vpc.Tags) == 0)
+	assert.True(t, len(noTags) == 0)
+
+	testTags := make(map[string]string)
+	testTags["TagKey1"] = "TagValue1"
+	testTags["TagKey2"] = "TagValue2"
+
+	AddTagsToResource(t, region, *vpc.VpcId, testTags)
+	vpcWithTags := GetVpcById(t, *vpc.VpcId, region)
+	tags := GetTagsForVpc(t, *vpc.VpcId, region)
+
+	assert.True(t, len(vpcWithTags.Tags) == len(testTags))
+	assert.True(t, len(tags) == len(testTags))
+}
+
+func TestGetTagValueForVpcE(t *testing.T) {
+	t.Parallel()
+
+	region := GetRandomStableRegion(t, nil, nil)
+	vpc := createVpc(t, region)
+	defer deleteVpc(t, *vpc.VpcId, region)
+
+	assert.True(t, len(vpc.Tags) == 0)
+	_, err1 := GetTagValueForVpcE(t, *vpc.VpcId, region, "NotPresentTagKey1")
+	assert.Error(t, err1)
+
+	testTags := make(map[string]string)
+	testTags["TagKey1"] = "TagValue1"
+
+	AddTagsToResource(t, region, *vpc.VpcId, testTags)
+	vpcWithTags := GetVpcById(t, *vpc.VpcId, region)
+	assert.True(t, len(vpcWithTags.Tags) == len(testTags))
+
+	_, err2 := GetTagValueForVpcE(t, *vpc.VpcId, region, "TagKey1")
+	assert.NoError(t, err2)
+
+	_, err3 := GetTagValueForVpcE(t, *vpc.VpcId, region, "NotPresentTagKey1")
+	assert.Error(t, err3)
+}
+
 func createPublicRoute(t *testing.T, vpcId string, routeTableId string, region string) {
 	ec2Client := NewEc2Client(t, region)
 

--- a/modules/aws/vpc_test.go
+++ b/modules/aws/vpc_test.go
@@ -99,52 +99,6 @@ func TestGetTagsForVpc(t *testing.T) {
 	assert.True(t, len(tags) == len(testTags))
 }
 
-func TestGetTagValueForVpc(t *testing.T) {
-	t.Parallel()
-
-	region := GetRandomStableRegion(t, nil, nil)
-	vpc := createVpc(t, region)
-	defer deleteVpc(t, *vpc.VpcId, region)
-
-	assert.True(t, len(vpc.Tags) == 0)
-
-	testTags := make(map[string]string)
-	testTags["TagKey1"] = "TagValue1"
-	testTags["TagKey2"] = "TagValue2"
-
-	AddTagsToResource(t, region, *vpc.VpcId, testTags)
-	vpcWithTags := GetVpcById(t, *vpc.VpcId, region)
-	assert.True(t, len(vpcWithTags.Tags) == len(testTags))
-
-	assert.True(t, GetTagValueForVpc(t, *vpc.VpcId, region, "TagKey1") == "TagValue1")
-	assert.True(t, GetTagValueForVpc(t, *vpc.VpcId, region, "TagKey2") == "TagValue2")
-}
-
-func TestGetTagValueForVpcE(t *testing.T) {
-	t.Parallel()
-
-	region := GetRandomStableRegion(t, nil, nil)
-	vpc := createVpc(t, region)
-	defer deleteVpc(t, *vpc.VpcId, region)
-
-	assert.True(t, len(vpc.Tags) == 0)
-	_, err1 := GetTagValueForVpcE(t, *vpc.VpcId, region, "NotPresentTagKey1")
-	assert.Error(t, err1)
-
-	testTags := make(map[string]string)
-	testTags["TagKey1"] = "TagValue1"
-
-	AddTagsToResource(t, region, *vpc.VpcId, testTags)
-	vpcWithTags := GetVpcById(t, *vpc.VpcId, region)
-	assert.True(t, len(vpcWithTags.Tags) == len(testTags))
-
-	_, err2 := GetTagValueForVpcE(t, *vpc.VpcId, region, "TagKey1")
-	assert.NoError(t, err2)
-
-	_, err3 := GetTagValueForVpcE(t, *vpc.VpcId, region, "NotPresentTagKey1")
-	assert.Error(t, err3)
-}
-
 func createPublicRoute(t *testing.T, vpcId string, routeTableId string, region string) {
 	ec2Client := NewEc2Client(t, region)
 

--- a/modules/aws/vpc_test.go
+++ b/modules/aws/vpc_test.go
@@ -99,6 +99,27 @@ func TestGetTagsForVpc(t *testing.T) {
 	assert.True(t, len(tags) == len(testTags))
 }
 
+func TestGetTagValueForVpc(t *testing.T) {
+	t.Parallel()
+
+	region := GetRandomStableRegion(t, nil, nil)
+	vpc := createVpc(t, region)
+	defer deleteVpc(t, *vpc.VpcId, region)
+
+	assert.True(t, len(vpc.Tags) == 0)
+
+	testTags := make(map[string]string)
+	testTags["TagKey1"] = "TagValue1"
+	testTags["TagKey2"] = "TagValue2"
+
+	AddTagsToResource(t, region, *vpc.VpcId, testTags)
+	vpcWithTags := GetVpcById(t, *vpc.VpcId, region)
+	assert.True(t, len(vpcWithTags.Tags) == len(testTags))
+
+	assert.True(t, GetTagValueForVpc(t, *vpc.VpcId, region, "TagKey1") == "TagValue1")
+	assert.True(t, GetTagValueForVpc(t, *vpc.VpcId, region, "TagKey2") == "TagValue2")
+}
+
 func TestGetTagValueForVpcE(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Updated `vpc.go.` and `vpc_test.go` to include support for `Tags` to resolve #995 (just for `VPC`, not `Subnet`):
* `Vpc` struct now has additional, `Tags` property
* Added additional `GetTagsForVpc()` and  `GetTagsForVpcE()` functions (to obtain tags for VPC)
* Added additional `GetTagValueForVpc()` and  `GetTagValueForVpcE()` functions (to obtain tag value for VPC tag)
* Tests added for `GetTagsForVpc()` and `GetTagValueForVpc()`.
* Test added for `GetTagValueForVpcE()` to assert error where no tag of specific key exists


## Test Evidence

![image](https://user-images.githubusercontent.com/28236991/134811836-8415ec47-4591-4252-9218-1bf259f8c1cb.png)
