### PR TITLE
Added `GetTagsForSubnet()` (and `Tags` property to `Subnet` struct) into `aws` module (Resolves #1004)

### DIFF
--- a/modules/aws/vpc.go
+++ b/modules/aws/vpc.go
@@ -31,6 +31,9 @@ var vpcIDFilterName = "vpc-id"
 var vpcResourceIdFilterName = "resource-id"
 var vpcResourceTypeFilterName = "resource-type"
 var vpcResourceTypeFilterValue = "vpc"
+var subnetResourceIdFilterName = "resource-id"
+var subnetResourceTypeFilterName = "resource-type"
+var subnetResourceTypeFilterValue = "subnet"
 var isDefaultFilterName = "isDefault"
 var isDefaultFilterValue = "true"
 
@@ -170,6 +173,32 @@ func GetTagsForVpcE(t testing.TestingT, vpcID string, region string) (map[string
 	vpcResourceTypeFilter := ec2.Filter{Name: &vpcResourceTypeFilterName, Values: []*string{&vpcResourceTypeFilterValue}}
 	vpcResourceIdFilter := ec2.Filter{Name: &vpcResourceIdFilterName, Values: []*string{&vpcID}}
 	tagsOutput, err := client.DescribeTags(&ec2.DescribeTagsInput{Filters: []*ec2.Filter{&vpcResourceTypeFilter, &vpcResourceIdFilter}})
+	require.NoError(t, err)
+
+	tags := map[string]string{}
+	for _, tag := range tagsOutput.Tags {
+		tags[aws.StringValue(tag.Key)] = aws.StringValue(tag.Value)
+	}
+
+	return tags, nil
+}
+
+// GetTagsForSubnet gets the tags for the specified subnet.
+func GetTagsForSubnet(t testing.TestingT, subnetId string, region string) map[string]string {
+	tags, err := GetTagsForSubnetE(t, subnetId, region)
+	require.NoError(t, err)
+
+	return tags
+}
+
+// GetTagsForSubnetE gets the tags for the specified subnet.
+func GetTagsForSubnetE(t testing.TestingT, subnetId string, region string) (map[string]string, error) {
+	client, err := NewEc2ClientE(t, region)
+	require.NoError(t, err)
+
+	subnetResourceTypeFilter := ec2.Filter{Name: &subnetResourceTypeFilterName, Values: []*string{&subnetResourceTypeFilterValue}}
+	subnetResourceIdFilter := ec2.Filter{Name: &subnetResourceIdFilterName, Values: []*string{&subnetId}}
+	tagsOutput, err := client.DescribeTags(&ec2.DescribeTagsInput{Filters: []*ec2.Filter{&subnetResourceTypeFilter, &subnetResourceIdFilter}})
 	require.NoError(t, err)
 
 	tags := map[string]string{}

--- a/modules/aws/vpc.go
+++ b/modules/aws/vpc.go
@@ -150,7 +150,9 @@ func GetSubnetsForVpcE(t testing.TestingT, vpcID string, region string) ([]Subne
 	subnets := []Subnet{}
 
 	for _, ec2Subnet := range subnetOutput.Subnets {
-		subnet := Subnet{Id: aws.StringValue(ec2Subnet.SubnetId), AvailabilityZone: aws.StringValue(ec2Subnet.AvailabilityZone)}
+
+		subnetTags := GetTagsForSubnet(t, *ec2Subnet.SubnetId, region)
+		subnet := Subnet{Id: aws.StringValue(ec2Subnet.SubnetId), AvailabilityZone: aws.StringValue(ec2Subnet.AvailabilityZone), Tags: subnetTags}
 		subnets = append(subnets, subnet)
 	}
 

--- a/modules/aws/vpc.go
+++ b/modules/aws/vpc.go
@@ -22,8 +22,9 @@ type Vpc struct {
 
 // Subnet is a subnet in an availability zone.
 type Subnet struct {
-	Id               string // The ID of the Subnet
-	AvailabilityZone string // The Availability Zone the subnet is in
+	Id               string            // The ID of the Subnet
+	AvailabilityZone string            // The Availability Zone the subnet is in
+	Tags             map[string]string // The tags associated with the subnet
 }
 
 var vpcIDFilterName = "vpc-id"


### PR DESCRIPTION
Made some changes to implement `GetTagsForSubnet()` function and `Tags` to resolve #1004 (to provide support for obtaining `Tags` from `Subnet`.

- Added `GetTagsForSubnet()` function
- Added test for above `GetTagsForSubnet()` function
- Added `Tags` property into `Subnet` struct
- Updated `GetSubnetsForVpcE()` to populate `Tags` property in `Subnet` struct 

I've tried to make these changes in line with those made in a similar change for AWS, VPC Tags (#1000).