### PR TITLE
fix: adjust "Host" via http helper

### DIFF
--- a/modules/http-helper/http_helper.go
+++ b/modules/http-helper/http_helper.go
@@ -300,7 +300,12 @@ func newRequest(method string, url string, body io.Reader, headers map[string]st
 		return nil
 	}
 	for k, v := range headers {
-		req.Header.Add(k, v)
+		switch k {
+		case "Host":
+			req.Host = v
+		default:
+			req.Header.Add(k, v)
+		}
 	}
 	return req
 }


### PR DESCRIPTION
I would like to do this:

```golang
headers := map[string]string{"Host" : "gloo-running-7xhydj.foobar"}
code, result := http_helper.HTTPDo(t, "GET", "http://randomelb.elb.ap-southeast-2.amazonaws.com/", nil, headers, nil)

```