### PR TITLE
Fix broken Terraform example

### DIFF
--- a/examples/terraform-basic-example/main.tf
+++ b/examples/terraform-basic-example/main.tf
@@ -15,21 +15,13 @@ terraform {
 # See test/terraform_aws_example.go for how to write automated tests for this code.
 # ---------------------------------------------------------------------------------------------------------------------
 
-data "template_file" "example" {
-  template = var.example
-}
-
-data "template_file" "example2" {
-  template = var.example2
-}
-
 resource "local_file" "example" {
-  content  = "${data.template_file.example.rendered} + ${data.template_file.example2.rendered}"
+  content  = "${var.example} + ${var.example2}"
   filename = "example.txt"
 }
 
 resource "local_file" "example2" {
-  content  = data.template_file.example2.rendered
+  content  = var.example2
   filename = "example2.txt"
 }
 

--- a/examples/terraform-basic-example/outputs.tf
+++ b/examples/terraform-basic-example/outputs.tf
@@ -1,9 +1,9 @@
 output "example" {
-  value = data.template_file.example.rendered
+  value = var.example
 }
 
 output "example2" {
-  value = data.template_file.example2.rendered
+  value = var.example2
 }
 
 output "example_list" {


### PR DESCRIPTION
The previous version of this code failed with Terraform 0.12+ on an M1 Mac with the following error:

> Error: Incompatible provider version
> 
> Provider registry.terraform.io/hashicorp/template v2.2.0 does not have a
> package available for your current platform, darwin_arm64.
> 
> Provider releases are separate from Terraform CLI releases, so not all
> providers are available for all platforms. Other versions of this provider
> may have different platforms supported.

The issue is that the `template_file` resource is now deprecated and no download exists for darwin_amd64 for this provider.

I considered using the now current `templatefile` function, but we don't have any files from which we're reading templates in this example, so I used the more idiomatic variable interpolation.