### PR TITLE
Add option to do terraform init without initializing backend

### DIFF
--- a/modules/terraform/init.go
+++ b/modules/terraform/init.go
@@ -28,6 +28,10 @@ func InitE(t testing.TestingT, options *Options) (string, error) {
 		args = append(args, "-migrate-state", "-force-copy")
 	}
 
+	if options.NoBackend {
+		args = append(args, "-backend=false")
+	}
+
 	args = append(args, FormatTerraformBackendConfigAsArgs(options.BackendConfig)...)
 	args = append(args, FormatTerraformPluginDirAsArgs(options.PluginDir)...)
 	return RunTerraformCommandE(t, options, args...)

--- a/modules/terraform/options.go
+++ b/modules/terraform/options.go
@@ -70,6 +70,7 @@ type Options struct {
 	Parallelism              int                    // Set the parallelism setting for Terraform
 	PlanFilePath             string                 // The path to output a plan file to (for the plan command) or read one from (for the apply command)
 	PluginDir                string                 // The path of downloaded plugins to pass to the terraform init command (-plugin-dir)
+	NoBackend                bool                   // If true, pass "-backend=false" to the terraform init command
 }
 
 // Clone makes a deep copy of most fields on the Options object and returns it.


### PR DESCRIPTION
I see this was raised before, as issue #318, but as it's a thing I would very much like to have, I've gone ahead and written the patch. This is simply an additional field for the Options structure that allows for passing "-backend=false" for terraform init.