### PR TITLE
add support for providing a dest folder for tf copy

### DIFF
--- a/modules/files/files.go
+++ b/modules/files/files.go
@@ -56,7 +56,8 @@ func CopyTerraformFolderToTemp(folderPath string, tempFolderPrefix string) (stri
 		return true
 	}
 
-	destFolder, err := CopyFolderToTemp(folderPath, tempFolderPrefix, filter)
+	destRootFolder := os.TempDir()
+	destFolder, err := CopyFolderToDest(folderPath, destRootFolder, tempFolderPrefix, filter)
 	if err != nil {
 		return "", err
 	}
@@ -98,7 +99,8 @@ func CopyTerragruntFolderToTemp(folderPath string, tempFolderPrefix string) (str
 		return !PathContainsHiddenFileOrFolder(path) && !PathContainsTerraformState(path)
 	}
 
-	destFolder, err := CopyFolderToTemp(folderPath, tempFolderPrefix, filter)
+	destRootFolder := os.TempDir()
+	destFolder, err := CopyFolderToDest(folderPath, destRootFolder, tempFolderPrefix, filter)
 	if err != nil {
 		return "", err
 	}
@@ -116,41 +118,6 @@ func CopyTerragruntFolderToDest(folderPath string, destRootFolder string, tempFo
 
 	destFolder, err := CopyFolderToDest(folderPath, destRootFolder, tempFolderPrefix, filter)
 	if err != nil {
-		return "", err
-	}
-
-	return destFolder, nil
-}
-
-// CopyFolderToTemp creates a copy of the given folder and all its filtered contents in a temp folder
-// with a unique name and the given prefix.
-func CopyFolderToTemp(folderPath string, tempFolderPrefix string, filter func(path string) bool) (string, error) {
-	exists, err := FileExistsE(folderPath)
-	if err != nil {
-		return "", err
-	}
-	if !exists {
-		return "", DirNotFoundError{Directory: folderPath}
-	}
-
-	tmpDir, err := ioutil.TempDir("", tempFolderPrefix)
-	if err != nil {
-		return "", err
-	}
-
-	// Inside of the temp folder, we create a subfolder that preserves the name of the folder we're copying from.
-	absFolderPath, err := filepath.Abs(folderPath)
-	if err != nil {
-		return "", err
-	}
-	folderName := filepath.Base(absFolderPath)
-	destFolder := filepath.Join(tmpDir, folderName)
-
-	if err := os.MkdirAll(destFolder, 0777); err != nil {
-		return "", err
-	}
-
-	if err := CopyFolderContentsWithFilter(folderPath, destFolder, filter); err != nil {
 		return "", err
 	}
 

--- a/modules/files/files_test.go
+++ b/modules/files/files_test.go
@@ -80,11 +80,11 @@ func TestCopyFolderToDest(t *testing.T) {
 		return !PathContainsHiddenFileOrFolder(path) && !PathContainsTerraformState(path)
 	}
 
-	folder, err := CopyFolderToDest(destFolder, "/not/a/real/path", tempFolderPrefix, filter)
+	folder, err := CopyFolderToDest("/not/a/real/path", destFolder, tempFolderPrefix, filter)
 	require.Error(t, err)
 	assert.False(t, FileExists(folder))
 
-	folder, err = CopyFolderToDest(destFolder, tmpDir, tempFolderPrefix, filter)
+	folder, err = CopyFolderToDest(tmpDir, destFolder, tempFolderPrefix, filter)
 	assert.DirExists(t, folder)
 	assert.NoError(t, err)
 }
@@ -189,7 +189,7 @@ func TestCopyTerraformFolderToDest(t *testing.T) {
 	expectedDir := filepath.Join(copyFolderContentsFixtureRoot, "no-hidden-files-no-terraform-files")
 	destFolder := os.TempDir()
 
-	tmpDir, err := CopyTerraformFolderToDest(destFolder, originalDir, "TestCopyTerraformFolderToTemp")
+	tmpDir, err := CopyTerraformFolderToDest(originalDir, destFolder, "TestCopyTerraformFolderToTemp")
 	require.NoError(t, err)
 
 	requireDirectoriesEqual(t, expectedDir, tmpDir)
@@ -202,6 +202,19 @@ func TestCopyTerragruntFolderToTemp(t *testing.T) {
 	expectedDir := filepath.Join(copyFolderContentsFixtureRoot, "no-state-files")
 
 	tmpDir, err := CopyTerragruntFolderToTemp(originalDir, t.Name())
+	require.NoError(t, err)
+
+	requireDirectoriesEqual(t, expectedDir, tmpDir)
+}
+
+func TestCopyTerragruntFolderToDest(t *testing.T) {
+	t.Parallel()
+
+	originalDir := filepath.Join(copyFolderContentsFixtureRoot, "terragrunt-files")
+	expectedDir := filepath.Join(copyFolderContentsFixtureRoot, "no-state-files")
+	destFolder := os.TempDir()
+
+	tmpDir, err := CopyTerragruntFolderToDest(originalDir, destFolder, t.Name())
 	require.NoError(t, err)
 
 	requireDirectoriesEqual(t, expectedDir, tmpDir)

--- a/modules/files/files_test.go
+++ b/modules/files/files_test.go
@@ -48,26 +48,6 @@ func TestIsExistingDir(t *testing.T) {
 	assert.True(t, IsExistingDir(currentFileDir))
 }
 
-func TestCopyFolderToTemp(t *testing.T) {
-	t.Parallel()
-
-	tempFolderPrefix := "someprefix"
-	tmpDir, err := ioutil.TempDir("", "TestCopyFolderContents")
-	require.NoError(t, err)
-
-	filter := func(path string) bool {
-		return !PathContainsHiddenFileOrFolder(path) && !PathContainsTerraformState(path)
-	}
-
-	folder, err := CopyFolderToTemp("/not/a/real/path", tempFolderPrefix, filter)
-	require.Error(t, err)
-	assert.False(t, FileExists(folder))
-
-	folder, err = CopyFolderToTemp(tmpDir, tempFolderPrefix, filter)
-	assert.DirExists(t, folder)
-	assert.NoError(t, err)
-}
-
 func TestCopyFolderToDest(t *testing.T) {
 	t.Parallel()
 

--- a/modules/test-structure/test_structure.go
+++ b/modules/test-structure/test_structure.go
@@ -97,6 +97,64 @@ func CopyTerraformFolderToTemp(t testing.TestingT, rootFolder string, terraformM
 	return tmpTestFolder
 }
 
+// CopyTerraformFolderToDest copies the given root folder to a randomly-named temp folder and return the path to the
+// given terraform modules folder within the new temp root folder. This is useful when running multiple tests in
+// parallel against the same set of Terraform files to ensure the tests don't overwrite each other's .terraform working
+// directory and terraform.tfstate files. To ensure relative paths work, we copy over the entire root folder to a temp
+// folder, and then return the path within that temp folder to the given terraform module dir, which is where the actual
+// test will be running.
+// For example, suppose you had the target terraform folder you want to test in "/examples/terraform-aws-example"
+// relative to the repo root. If your tests reside in the "/test" relative to the root, then you will use this as
+// follows:
+//
+//       // Destination for the copy of the files.  In this example we are using the Azure Dev Ops variable
+//       // for the folder that is cleaned after each pipeline job.
+//       destRootFolder := os.Getenv("AGENT_TEMPDIRECTORY")
+//
+//       // Root folder where terraform files should be (relative to the test folder)
+//       rootFolder := ".."
+//
+//       // Relative path to terraform module being tested from the root folder
+//       terraformFolderRelativeToRoot := "examples/terraform-aws-example"
+//
+//       // Copy the terraform folder to a temp folder
+//       tempTestFolder := test_structure.CopyTerraformFolderToTemp(t, destRootFolder, rootFolder, terraformFolderRelativeToRoot)
+//
+//       // Make sure to use the temp test folder in the terraform options
+//       terraformOptions := &terraform.Options{
+//       		TerraformDir: tempTestFolder,
+//       }
+//
+// Note that if any of the SKIP_<stage> environment variables is set, we assume this is a test in the local dev where
+// there are no other concurrent tests running and we want to be able to cache test data between test stages, so in that
+// case, we do NOT copy anything to a temp folder, and return the path to the original terraform module folder instead.
+func CopyTerraformFolderToDest(t testing.TestingT, destRootFolder string, rootFolder string, terraformModuleFolder string) string {
+	if SkipStageEnvVarSet() {
+		logger.Logf(t, "A SKIP_XXX environment variable is set. Using original examples folder rather than a temp folder so we can cache data between stages for faster local testing.")
+		return filepath.Join(rootFolder, terraformModuleFolder)
+	}
+
+	fullTerraformModuleFolder := filepath.Join(rootFolder, terraformModuleFolder)
+
+	exists, err := files.FileExistsE(fullTerraformModuleFolder)
+	require.NoError(t, err)
+	if !exists {
+		t.Fatal(files.DirNotFoundError{Directory: fullTerraformModuleFolder})
+	}
+
+	tmpRootFolder, err := files.CopyTerraformFolderToDest(destRootFolder, rootFolder, cleanName(t.Name()))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tmpTestFolder := filepath.Join(tmpRootFolder, terraformModuleFolder)
+
+	// Log temp folder so we can see it
+	logger.Logf(t, "Copied terraform folder %s to %s", fullTerraformModuleFolder, tmpTestFolder)
+
+	return tmpTestFolder
+}
+
 func cleanName(originalName string) string {
 	parts := strings.Split(originalName, "/")
 	return parts[len(parts)-1]

--- a/modules/test-structure/test_structure.go
+++ b/modules/test-structure/test_structure.go
@@ -128,7 +128,7 @@ func CopyTerraformFolderToTemp(t testing.TestingT, rootFolder string, terraformM
 // Note that if any of the SKIP_<stage> environment variables is set, we assume this is a test in the local dev where
 // there are no other concurrent tests running and we want to be able to cache test data between test stages, so in that
 // case, we do NOT copy anything to a temp folder, and return the path to the original terraform module folder instead.
-func CopyTerraformFolderToDest(t testing.TestingT, destRootFolder string, rootFolder string, terraformModuleFolder string) string {
+func CopyTerraformFolderToDest(t testing.TestingT, rootFolder string, terraformModuleFolder string, destRootFolder string) string {
 	if SkipStageEnvVarSet() {
 		logger.Logf(t, "A SKIP_XXX environment variable is set. Using original examples folder rather than a temp folder so we can cache data between stages for faster local testing.")
 		return filepath.Join(rootFolder, terraformModuleFolder)
@@ -142,7 +142,7 @@ func CopyTerraformFolderToDest(t testing.TestingT, destRootFolder string, rootFo
 		t.Fatal(files.DirNotFoundError{Directory: fullTerraformModuleFolder})
 	}
 
-	tmpRootFolder, err := files.CopyTerraformFolderToDest(destRootFolder, rootFolder, cleanName(t.Name()))
+	tmpRootFolder, err := files.CopyTerraformFolderToDest(rootFolder, cleanName(t.Name()), destRootFolder)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Adds a new function similar to CopyTerraformFolderToTemp called CopyTerraformFolderToDest that allows providing a destination folder other than temp.  This is useful when running on a build agent where a failure in the tests occurs and files are abandoned in the temp folder.  With large provider downloads across multiple tests this can cause space issues.