### PR TITLE
[Backwards Incompatible] Use options classes for HttpHelper methods

### DIFF
--- a/modules/docker/stop_test.go
+++ b/modules/docker/stop_test.go
@@ -36,7 +36,7 @@ func TestStop(t *testing.T) {
 	Run(t, "nginx:1.17-alpine", runOpts)
 
 	// verify nginx is running
-	http_helper.HttpGetWithRetryWithCustomValidation(t, testURL, &tls.Config{}, 60, 2*time.Second, verifyNginxIsUp)
+	http_helper.HttpGetWithRetryWithCustomValidation(t, &http_helper.HttpGetOptions{testURL, &tls.Config{}, 10}, 60, 2*time.Second, verifyNginxIsUp)
 
 	// try to stop it now
 	out := Stop(t, []string{name}, &StopOptions{})

--- a/modules/helm/install_test.go
+++ b/modules/helm/install_test.go
@@ -86,7 +86,7 @@ func TestRemoteChartInstall(t *testing.T) {
 		&http_helper.HttpGetOptions{
 			fmt.Sprintf("http://%s", endpoint),
 			&tlsConfig,
-			10
+			10,
 		},
 		30,
 		10*time.Second,

--- a/modules/helm/install_test.go
+++ b/modules/helm/install_test.go
@@ -83,8 +83,11 @@ func TestRemoteChartInstall(t *testing.T) {
 
 	http_helper.HttpGetWithRetryWithCustomValidation(
 		t,
-		fmt.Sprintf("http://%s", endpoint),
-		&tlsConfig,
+		&http_helper.HttpGetOptions{
+			fmt.Sprintf("http://%s", endpoint),
+			&tlsConfig,
+			10
+		},
 		30,
 		10*time.Second,
 		func(statusCode int, body string) bool {

--- a/modules/helm/upgrade_test.go
+++ b/modules/helm/upgrade_test.go
@@ -85,7 +85,7 @@ func TestRemoteChartInstallUpgradeRollback(t *testing.T) {
 		&http_helper.HttpGetOptions{
 			fmt.Sprintf("http://%s", endpoint),
 			&tlsConfig,
-			10
+			10,
 		},
 		30,
 		10*time.Second,

--- a/modules/helm/upgrade_test.go
+++ b/modules/helm/upgrade_test.go
@@ -82,8 +82,11 @@ func TestRemoteChartInstallUpgradeRollback(t *testing.T) {
 
 	http_helper.HttpGetWithRetryWithCustomValidation(
 		t,
-		fmt.Sprintf("http://%s", endpoint),
-		&tlsConfig,
+		&http_helper.HttpGetOptions{
+			fmt.Sprintf("http://%s", endpoint),
+			&tlsConfig,
+			10
+		},
 		30,
 		10*time.Second,
 		func(statusCode int, body string) bool {

--- a/modules/http-helper/continuous.go
+++ b/modules/http-helper/continuous.go
@@ -36,7 +36,7 @@ func ContinuouslyCheckUrl(
 				logger.Logf(t, "Got signal to stop downtime checks for URL %s.\n", url)
 				return
 			case <-time.After(sleepBetweenChecks):
-				statusCode, body, err := HttpGetE(t, url, &tls.Config{})
+				statusCode, body, err := HttpGetE(t, &HttpGetOptions{url, &tls.Config{}, 10})
 				// Non-blocking send, defaulting to logging a warning if there is no channel reader
 				select {
 				case responses <- GetResponse{StatusCode: statusCode, Body: body}:

--- a/modules/http-helper/dummy_server_test.go
+++ b/modules/http-helper/dummy_server_test.go
@@ -21,7 +21,7 @@ func TestRunDummyServer(t *testing.T) {
 	defer shutDownServer(t, listener)
 
 	url := fmt.Sprintf("http://localhost:%d", port)
-	HttpGetWithValidation(t, url, &tls.Config{}, 200, text)
+	HttpGetWithValidation(t, &HttpGetOptions{url, &tls.Config{}, 10}, 200, text)
 }
 
 func TestContinuouslyCheck(t *testing.T) {

--- a/modules/http-helper/http_helper.go
+++ b/modules/http-helper/http_helper.go
@@ -15,17 +15,17 @@ import (
 	"github.com/gruntwork-io/terratest/modules/testing"
 )
 
+type HttpGetOptions struct {
+	Url       string
+	TlsConfig *tls.Config
+	Timeout   int
+}
+
 type HttpDoOptions struct {
 	Method    string
 	Url       string
 	Body      io.Reader
 	Headers   map[string]string
-	TlsConfig *tls.Config
-	Timeout   int
-}
-
-type HttpGetOptions struct {
-	Url       string
 	TlsConfig *tls.Config
 	Timeout   int
 }

--- a/modules/http-helper/http_helper.go
+++ b/modules/http-helper/http_helper.go
@@ -2,6 +2,7 @@
 package http_helper
 
 import (
+	"bytes"
 	"crypto/tls"
 	"fmt"
 	"io"
@@ -24,7 +25,7 @@ type HttpGetOptions struct {
 type HttpDoOptions struct {
 	Method    string
 	Url       string
-	Body      io.Reader
+	Body      []byte
 	Headers   map[string]string
 	TlsConfig *tls.Config
 	Timeout   int
@@ -187,7 +188,7 @@ func HTTPDoE(
 		Transport: tr,
 	}
 
-	req := newRequest(options.Method, options.Url, options.Body, options.Headers)
+	req := newRequest(options.Method, options.Url, bytes.NewReader(options.Body), options.Headers)
 	resp, err := client.Do(req)
 	if err != nil {
 		return -1, "", err

--- a/modules/http-helper/http_helper_test.go
+++ b/modules/http-helper/http_helper_test.go
@@ -25,8 +25,7 @@ func TestOkBody(t *testing.T) {
 	defer ts.Close()
 	url := ts.URL
 	expectedBody := "Hello, Terratest!"
-	body := bytes.NewReader([]byte(expectedBody))
-	statusCode, respBody := HTTPDo(t, &HttpDoOptions{"POST", url, body, nil, nil, 10})
+	statusCode, respBody := HTTPDo(t, &HttpDoOptions{"POST", url, []byte(expectedBody), nil, nil, 10})
 
 	expectedCode := 200
 	if statusCode != expectedCode {
@@ -43,8 +42,7 @@ func TestHTTPDoWithValidation(t *testing.T) {
 	defer ts.Close()
 	url := ts.URL
 	expectedBody := "Hello, Terratest!"
-	body := bytes.NewReader([]byte(expectedBody))
-	HTTPDoWithValidation(t, &HttpDoOptions{"POST", url, body, nil, nil, 10}, 200, expectedBody)
+	HTTPDoWithValidation(t, &HttpDoOptions{"POST", url, []byte(expectedBody), nil, nil, 10}, 200, expectedBody)
 }
 
 func TestHTTPDoWithCustomValidation(t *testing.T) {
@@ -53,13 +51,12 @@ func TestHTTPDoWithCustomValidation(t *testing.T) {
 	defer ts.Close()
 	url := ts.URL
 	expectedBody := "Hello, Terratest!"
-	body := bytes.NewReader([]byte(expectedBody))
 
 	customValidation := func(statusCode int, response string) bool {
 		return statusCode == 200 && response == expectedBody
 	}
 
-	HTTPDoWithCustomValidation(t, &HttpDoOptions{"POST", url, body, nil, nil, 10}, customValidation)
+	HTTPDoWithCustomValidation(t, &HttpDoOptions{"POST", url, []byte(expectedBody), nil, nil, 10}, customValidation)
 }
 
 func TestOkHeaders(t *testing.T) {
@@ -113,10 +110,9 @@ func TestOkWithRetry(t *testing.T) {
 	ts := getTestServerForFunction(retryHandler)
 	defer ts.Close()
 	body := "TEST_CONTENT"
-	bodyBytes := []byte(body)
 	url := ts.URL
 	counter = 3
-	response := HTTPDoWithRetry(t, &HttpDoOptions{"POST", url, bytes.NewReader(bodyBytes), nil, nil, 10}, 200, 10, time.Second)
+	response := HTTPDoWithRetry(t, &HttpDoOptions{"POST", url, []byte(body), nil, nil, 10}, 200, 10, time.Second)
 	require.Equal(t, body, response)
 }
 

--- a/modules/http-helper/http_helper_test.go
+++ b/modules/http-helper/http_helper_test.go
@@ -26,7 +26,7 @@ func TestOkBody(t *testing.T) {
 	url := ts.URL
 	expectedBody := "Hello, Terratest!"
 	body := bytes.NewReader([]byte(expectedBody))
-	statusCode, respBody := HTTPDo(t, "POST", url, body, nil, nil)
+	statusCode, respBody := HTTPDo(t, &HttpOptions{"POST", url, body, nil, nil, 10})
 
 	expectedCode := 200
 	if statusCode != expectedCode {
@@ -44,7 +44,7 @@ func TestHTTPDoWithValidation(t *testing.T) {
 	url := ts.URL
 	expectedBody := "Hello, Terratest!"
 	body := bytes.NewReader([]byte(expectedBody))
-	HTTPDoWithValidation(t, "POST", url, body, nil, 200, expectedBody, nil)
+	HTTPDoWithValidation(t, &HttpOptions{"POST", url, body, nil, nil, 10}, 200, expectedBody)
 }
 
 func TestHTTPDoWithCustomValidation(t *testing.T) {
@@ -59,7 +59,7 @@ func TestHTTPDoWithCustomValidation(t *testing.T) {
 		return statusCode == 200 && response == expectedBody
 	}
 
-	HTTPDoWithCustomValidation(t, "POST", url, body, nil, customValidation, nil)
+	HTTPDoWithCustomValidation(t, &HttpOptions{"POST", url, body, nil, nil, 10}, customValidation)
 }
 
 func TestOkHeaders(t *testing.T) {
@@ -68,7 +68,7 @@ func TestOkHeaders(t *testing.T) {
 	defer ts.Close()
 	url := ts.URL
 	headers := map[string]string{"Authorization": "Bearer 1a2b3c99ff"}
-	statusCode, respBody := HTTPDo(t, "POST", url, nil, headers, nil)
+	statusCode, respBody := HTTPDo(t, &HttpOptions{"POST", url, nil, headers, nil, 10})
 
 	expectedCode := 200
 	if statusCode != expectedCode {
@@ -85,7 +85,7 @@ func TestWrongStatus(t *testing.T) {
 	ts := getTestServerForFunction(wrongStatusHandler)
 	defer ts.Close()
 	url := ts.URL
-	statusCode, _ := HTTPDo(t, "POST", url, nil, nil, nil)
+	statusCode, _ := HTTPDo(t, &HttpOptions{"POST", url, nil, nil, nil, 10})
 
 	expectedCode := 500
 	if statusCode != expectedCode {
@@ -98,7 +98,7 @@ func TestRequestTimeout(t *testing.T) {
 	ts := getTestServerForFunction(sleepingHandler)
 	defer ts.Close()
 	url := ts.URL
-	_, _, err := HTTPDoE(t, "DELETE", url, nil, nil, nil)
+	_, _, err := HTTPDoE(t, &HttpOptions{"DELETE", url, nil, nil, nil, 10})
 
 	if err == nil {
 		t.Error("handler didn't return a timeout error")
@@ -116,7 +116,7 @@ func TestOkWithRetry(t *testing.T) {
 	bodyBytes := []byte(body)
 	url := ts.URL
 	counter = 3
-	response := HTTPDoWithRetry(t, "POST", url, bodyBytes, nil, 200, 10, time.Second, nil)
+	response := HTTPDoWithRetry(t, &HttpOptions{"POST", url, bytes.NewReader(bodyBytes), nil, nil, 10}, 200, 10, time.Second)
 	require.Equal(t, body, response)
 }
 
@@ -126,7 +126,7 @@ func TestErrorWithRetry(t *testing.T) {
 	defer ts.Close()
 	failCounter = 3
 	url := ts.URL
-	_, err := HTTPDoWithRetryE(t, "POST", url, nil, nil, 200, 2, time.Second, nil)
+	_, err := HTTPDoWithRetryE(t, &HttpOptions{"POST", url, nil, nil, nil, 10}, 200, 2, time.Second)
 
 	if err == nil {
 		t.Error("handler didn't return a retry error")

--- a/modules/http-helper/http_helper_test.go
+++ b/modules/http-helper/http_helper_test.go
@@ -26,7 +26,7 @@ func TestOkBody(t *testing.T) {
 	url := ts.URL
 	expectedBody := "Hello, Terratest!"
 	body := bytes.NewReader([]byte(expectedBody))
-	statusCode, respBody := HTTPDo(t, &HttpOptions{"POST", url, body, nil, nil, 10})
+	statusCode, respBody := HTTPDo(t, &HttpDoOptions{"POST", url, body, nil, nil, 10})
 
 	expectedCode := 200
 	if statusCode != expectedCode {
@@ -44,7 +44,7 @@ func TestHTTPDoWithValidation(t *testing.T) {
 	url := ts.URL
 	expectedBody := "Hello, Terratest!"
 	body := bytes.NewReader([]byte(expectedBody))
-	HTTPDoWithValidation(t, &HttpOptions{"POST", url, body, nil, nil, 10}, 200, expectedBody)
+	HTTPDoWithValidation(t, &HttpDoOptions{"POST", url, body, nil, nil, 10}, 200, expectedBody)
 }
 
 func TestHTTPDoWithCustomValidation(t *testing.T) {
@@ -59,7 +59,7 @@ func TestHTTPDoWithCustomValidation(t *testing.T) {
 		return statusCode == 200 && response == expectedBody
 	}
 
-	HTTPDoWithCustomValidation(t, &HttpOptions{"POST", url, body, nil, nil, 10}, customValidation)
+	HTTPDoWithCustomValidation(t, &HttpDoOptions{"POST", url, body, nil, nil, 10}, customValidation)
 }
 
 func TestOkHeaders(t *testing.T) {
@@ -68,7 +68,7 @@ func TestOkHeaders(t *testing.T) {
 	defer ts.Close()
 	url := ts.URL
 	headers := map[string]string{"Authorization": "Bearer 1a2b3c99ff"}
-	statusCode, respBody := HTTPDo(t, &HttpOptions{"POST", url, nil, headers, nil, 10})
+	statusCode, respBody := HTTPDo(t, &HttpDoOptions{"POST", url, nil, headers, nil, 10})
 
 	expectedCode := 200
 	if statusCode != expectedCode {
@@ -85,7 +85,7 @@ func TestWrongStatus(t *testing.T) {
 	ts := getTestServerForFunction(wrongStatusHandler)
 	defer ts.Close()
 	url := ts.URL
-	statusCode, _ := HTTPDo(t, &HttpOptions{"POST", url, nil, nil, nil, 10})
+	statusCode, _ := HTTPDo(t, &HttpDoOptions{"POST", url, nil, nil, nil, 10})
 
 	expectedCode := 500
 	if statusCode != expectedCode {
@@ -98,7 +98,7 @@ func TestRequestTimeout(t *testing.T) {
 	ts := getTestServerForFunction(sleepingHandler)
 	defer ts.Close()
 	url := ts.URL
-	_, _, err := HTTPDoE(t, &HttpOptions{"DELETE", url, nil, nil, nil, 10})
+	_, _, err := HTTPDoE(t, &HttpDoOptions{"DELETE", url, nil, nil, nil, 10})
 
 	if err == nil {
 		t.Error("handler didn't return a timeout error")
@@ -116,7 +116,7 @@ func TestOkWithRetry(t *testing.T) {
 	bodyBytes := []byte(body)
 	url := ts.URL
 	counter = 3
-	response := HTTPDoWithRetry(t, &HttpOptions{"POST", url, bytes.NewReader(bodyBytes), nil, nil, 10}, 200, 10, time.Second)
+	response := HTTPDoWithRetry(t, &HttpDoOptions{"POST", url, bytes.NewReader(bodyBytes), nil, nil, 10}, 200, 10, time.Second)
 	require.Equal(t, body, response)
 }
 
@@ -126,7 +126,7 @@ func TestErrorWithRetry(t *testing.T) {
 	defer ts.Close()
 	failCounter = 3
 	url := ts.URL
-	_, err := HTTPDoWithRetryE(t, &HttpOptions{"POST", url, nil, nil, nil, 10}, 200, 2, time.Second)
+	_, err := HTTPDoWithRetryE(t, &HttpDoOptions{"POST", url, nil, nil, nil, 10}, 200, 2, time.Second)
 
 	if err == nil {
 		t.Error("handler didn't return a retry error")

--- a/modules/k8s/service_test.go
+++ b/modules/k8s/service_test.go
@@ -91,8 +91,11 @@ func TestGetServiceEndpointEReturnsAccessibleEndpointForNodePort(t *testing.T) {
 	// Test up to 5 minutes
 	http_helper.HttpGetWithRetryWithCustomValidation(
 		t,
-		fmt.Sprintf("http://%s", endpoint),
-		&tlsConfig,
+		&http_helper.HttpGetOptions{
+			fmt.Sprintf("http://%s", endpoint),
+			&tlsConfig,
+			10
+		},
 		30,
 		10*time.Second,
 		func(statusCode int, body string) bool {

--- a/modules/k8s/service_test.go
+++ b/modules/k8s/service_test.go
@@ -94,7 +94,7 @@ func TestGetServiceEndpointEReturnsAccessibleEndpointForNodePort(t *testing.T) {
 		&http_helper.HttpGetOptions{
 			fmt.Sprintf("http://%s", endpoint),
 			&tlsConfig,
-			10
+			10,
 		},
 		30,
 		10*time.Second,

--- a/modules/k8s/tunnel_test.go
+++ b/modules/k8s/tunnel_test.go
@@ -40,8 +40,11 @@ func TestTunnelOpensAPortForwardTunnelToPod(t *testing.T) {
 	// Try to access the nginx service on the local port, retrying until we get a good response for up to 5 minutes
 	http_helper.HttpGetWithRetryWithCustomValidation(
 		t,
-		fmt.Sprintf("http://%s", tunnel.Endpoint()),
-		&tlsConfig,
+		&http_helper.HttpGetOptions{
+			fmt.Sprintf("http://%s", tunnel.Endpoint()),
+			&tlsConfig,
+			10
+		},
 		60,
 		5*time.Second,
 		verifyNginxWelcomePage,
@@ -70,8 +73,11 @@ func TestTunnelOpensAPortForwardTunnelToService(t *testing.T) {
 	// Try to access the nginx service on the local port, retrying until we get a good response for up to 5 minutes
 	http_helper.HttpGetWithRetryWithCustomValidation(
 		t,
-		fmt.Sprintf("http://%s", tunnel.Endpoint()),
-		&tlsConfig,
+		&http_helper.HttpGetOptions{
+			fmt.Sprintf("http://%s", tunnel.Endpoint()),
+			&tlsConfig,
+			10
+		},
 		60,
 		5*time.Second,
 		verifyNginxWelcomePage,

--- a/modules/k8s/tunnel_test.go
+++ b/modules/k8s/tunnel_test.go
@@ -43,7 +43,7 @@ func TestTunnelOpensAPortForwardTunnelToPod(t *testing.T) {
 		&http_helper.HttpGetOptions{
 			fmt.Sprintf("http://%s", tunnel.Endpoint()),
 			&tlsConfig,
-			10
+			10,
 		},
 		60,
 		5*time.Second,
@@ -76,7 +76,7 @@ func TestTunnelOpensAPortForwardTunnelToService(t *testing.T) {
 		&http_helper.HttpGetOptions{
 			fmt.Sprintf("http://%s", tunnel.Endpoint()),
 			&tlsConfig,
-			10
+			10,
 		},
 		60,
 		5*time.Second,

--- a/modules/terraform/plan_struct_test.go
+++ b/modules/terraform/plan_struct_test.go
@@ -22,7 +22,7 @@ func TestPlannedValuesMapWithBasicJson(t *testing.T) {
 	t.Parallel()
 
 	// Retrieve test data from the terraform-json project.
-	_, jsonData := http_helper.HttpGet(t, basicJsonUrl, nil)
+	_, jsonData := http_helper.HttpGet(t, &http_helper.HttpGetOptions{basicJsonUrl, nil, 10})
 	plan, err := parsePlanJson(jsonData)
 	require.NoError(t, err)
 
@@ -47,7 +47,7 @@ func TestPlannedValuesMapWithDeepModuleJson(t *testing.T) {
 	t.Parallel()
 
 	// Retrieve test data from the terraform-json project.
-	_, jsonData := http_helper.HttpGet(t, deepModuleJsonUrl, nil)
+	_, jsonData := http_helper.HttpGet(t, &http_helper.HttpGetOptions{deepModuleJsonUrl, nil, 10})
 	plan, err := parsePlanJson(jsonData)
 	require.NoError(t, err)
 
@@ -63,7 +63,7 @@ func TestResourceChangesJson(t *testing.T) {
 	t.Parallel()
 
 	// Retrieve test data from the terraform-json project.
-	_, jsonData := http_helper.HttpGet(t, changesJsonUrl, nil)
+	_, jsonData := http_helper.HttpGet(t, &http_helper.HttpGetOptions{changesJsonUrl, nil, 10})
 	plan, err := parsePlanJson(jsonData)
 	require.NoError(t, err)
 

--- a/test/azure/terraform_azure_aks_example_test.go
+++ b/test/azure/terraform_azure_aks_example_test.go
@@ -89,8 +89,11 @@ func TestTerraformAzureAKSExample(t *testing.T) {
 	// response.
 	http_helper.HttpGetWithRetryWithCustomValidation(
 		t,
-		fmt.Sprintf("http://%s", endpoint),
-		&tlsConfig,
+		&http_helper.HttpGetOptions{
+			fmt.Sprintf("http://%s", endpoint),
+			&tlsConfig,
+			10,
+		},
 		30,
 		10*time.Second,
 		func(statusCode int, body string) bool {

--- a/test/helm_basic_example_integration_test.go
+++ b/test/helm_basic_example_integration_test.go
@@ -91,8 +91,11 @@ func TestHelmBasicExampleDeployment(t *testing.T) {
 	// response.
 	http_helper.HttpGetWithRetryWithCustomValidation(
 		t,
-		fmt.Sprintf("http://%s", endpoint),
-		&tlsConfig,
+		&http_helper.HttpGetOptions{
+			fmt.Sprintf("http://%s", endpoint),
+			&tlsConfig,
+			10,
+		},
 		30,
 		10*time.Second,
 		func(statusCode int, body string) bool {

--- a/test/kubernetes_basic_example_service_check_test.go
+++ b/test/kubernetes_basic_example_service_check_test.go
@@ -65,8 +65,11 @@ func TestKubernetesBasicExampleServiceCheck(t *testing.T) {
 	// response.
 	http_helper.HttpGetWithRetryWithCustomValidation(
 		t,
-		fmt.Sprintf("http://%s", endpoint),
-		&tlsConfig,
+		&http_helper.HttpGetOptions{
+			fmt.Sprintf("http://%s", endpoint),
+			&tlsConfig,
+			10,
+		},
 		30,
 		10*time.Second,
 		func(statusCode int, body string) bool {

--- a/test/kubernetes_hello_world_example_test.go
+++ b/test/kubernetes_hello_world_example_test.go
@@ -33,5 +33,5 @@ func TestKubernetesHelloWorldExample(t *testing.T) {
 	url := fmt.Sprintf("http://%s", k8s.GetServiceEndpoint(t, options, service, 5000))
 
 	// website::tag::5:: Make an HTTP request to the URL and make sure it returns a 200 OK with the body "Hello, World".
-	http_helper.HttpGetWithRetry(t, url, nil, 200, "Hello world!", 30, 3*time.Second)
+	http_helper.HttpGetWithRetry(t, &http_helper.HttpGetOptions{url, nil, 10}, 200, "Hello world!", 30, 3*time.Second)
 }

--- a/test/packer_docker_example_test.go
+++ b/test/packer_docker_example_test.go
@@ -65,5 +65,5 @@ func TestPackerDockerExampleLocal(t *testing.T) {
 	tlsConfig := tls.Config{}
 
 	// website::tag::5::Verify that we get back a 200 OK with the expected text
-	http_helper.HttpGetWithRetry(t, url, &tlsConfig, 200, expectedServerText, maxRetries, timeBetweenRetries)
+	http_helper.HttpGetWithRetry(t, &http_helper.HttpGetOptions{url, &tlsConfig, 10}, 200, expectedServerText, maxRetries, timeBetweenRetries)
 }

--- a/test/terraform_aws_hello_world_example_test.go
+++ b/test/terraform_aws_hello_world_example_test.go
@@ -31,5 +31,5 @@ func TestTerraformAwsHelloWorldExample(t *testing.T) {
 
 	// website::tag::5:: Make an HTTP request to the instance and make sure we get back a 200 OK with the body "Hello, World!"
 	url := fmt.Sprintf("http://%s:8080", publicIp)
-	http_helper.HttpGetWithRetry(t, url, nil, 200, "Hello, World!", 30, 5*time.Second)
+	http_helper.HttpGetWithRetry(t, &http_helper.HttpGetOptions{url, nil, 10}, 200, "Hello, World!", 30, 5*time.Second)
 }

--- a/test/terraform_http_example_test.go
+++ b/test/terraform_http_example_test.go
@@ -65,5 +65,5 @@ func TestTerraformHttpExample(t *testing.T) {
 	timeBetweenRetries := 5 * time.Second
 
 	// Verify that we get back a 200 OK with the expected instanceText
-	http_helper.HttpGetWithRetry(t, instanceURL, &tlsConfig, 200, instanceText, maxRetries, timeBetweenRetries)
+	http_helper.HttpGetWithRetry(t, &http_helper.HttpGetOptions{instanceURL, &tlsConfig, 10}, 200, instanceText, maxRetries, timeBetweenRetries)
 }

--- a/test/terraform_packer_example_test.go
+++ b/test/terraform_packer_example_test.go
@@ -187,5 +187,5 @@ func validateInstanceRunningWebServer(t *testing.T, workingDir string) {
 	timeBetweenRetries := 5 * time.Second
 
 	// Verify that we get back a 200 OK with the expected instanceText
-	http_helper.HttpGetWithRetry(t, instanceURL, &tlsConfig, 200, instanceText, maxRetries, timeBetweenRetries)
+	http_helper.HttpGetWithRetry(t, &http_helper.HttpGetOptions{instanceURL, &tlsConfig, 10}, 200, instanceText, maxRetries, timeBetweenRetries)
 }

--- a/test/terraform_redeploy_example_test.go
+++ b/test/terraform_redeploy_example_test.go
@@ -140,7 +140,7 @@ func validateAsgRunningWebServer(t *testing.T, awsRegion string, workingDir stri
 
 	// Verify that we get back a 200 OK with the expectedText
 	// It can take a few minutes for the ALB to boot up, so retry a few times
-	http_helper.HttpGetWithRetry(t, url, &tlsConfig, 200, expectedText, maxRetries, timeBetweenRetries)
+	http_helper.HttpGetWithRetry(t, &http_helper.HttpGetOptions{url, &tlsConfig, 10}, 200, expectedText, maxRetries, timeBetweenRetries)
 }
 
 // Validate we can deploy an update to the ASG with zero downtime for users accessing the ALB
@@ -166,7 +166,7 @@ func validateAsgRedeploy(t *testing.T, workingDir string) {
 
 	// Check once per second that the ELB returns a proper response to make sure there is no downtime during deployment
 	elbChecks := retry.DoInBackgroundUntilStopped(t, fmt.Sprintf("Check URL %s", url), 1*time.Second, func() {
-		http_helper.HttpGetWithCustomValidation(t, url, &tlsConfig, func(statusCode int, body string) bool {
+		http_helper.HttpGetWithCustomValidation(t, &http_helper.HttpGetOptions{url, &tlsConfig, 10}, func(statusCode int, body string) bool {
 			return statusCode == 200 && (body == originalText || body == newText)
 		})
 	})


### PR DESCRIPTION
This PR adds option classes for the HttpHelper methods so that it can be more easily extended in a backwards compatible way. 

Addresses #902