### PR TITLE
Security upgrade to 2.6.8-stretch

### DIFF
--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.6.2-stretch
+FROM ruby:2.6.8-stretch
 MAINTAINER Gruntwork <info@gruntwork.io>
 
 # This project requires bundler 2, but the docker image comes with bundler 1 so we need to upgrade


### PR DESCRIPTION
Hi Maintainers,
recommend upgrading to ruby:2.6.8-stretch, and lowering the number of security issues attached to the .2 image