### PR TITLE
#1045 Fixed port forwarding to pod

### DIFF
--- a/modules/k8s/tunnel.go
+++ b/modules/k8s/tunnel.go
@@ -199,7 +199,7 @@ func (tunnel *Tunnel) ForwardPortE(t testing.TestingT) error {
 			}
 		}
 		if !portFound {
-			return errors.New(fmt.Sprintf("Target port %d not found in service %s definition", targetPort, tunnel.resourceName))
+			return errors.New(fmt.Sprintf("Target port %d not found in service %s definition.", targetPort, tunnel.resourceName))
 		}
 	}
 


### PR DESCRIPTION
Updated logic for target port determination in case of port-forwarding to service and target port on the pod is different.

Test result:
```
--- PASS: TestTunnelOpensAPortForwardTunnelToPod (9.87s)
--- PASS: TestTunnelOpensAPortForwardTunnelToService (12.82s)
--- PASS: TestTunnelOpensAPortForwardTunnelToServiceDifferentPodPort (18.11s)
```

Closes: https://github.com/gruntwork-io/terratest/issues/1045
