### PR TITLE
GCP tests fixes

### DIFF
--- a/examples/terraform-gcp-example/main.tf
+++ b/examples/terraform-gcp-example/main.tf
@@ -23,7 +23,7 @@ resource "google_compute_instance" "example" {
 
   boot_disk {
     initialize_params {
-      image = "ubuntu-os-cloud/ubuntu-1604-lts"
+      image = "ubuntu-os-cloud/ubuntu-2004-lts"
     }
   }
 

--- a/examples/terraform-gcp-ig-example/main.tf
+++ b/examples/terraform-gcp-ig-example/main.tf
@@ -47,7 +47,7 @@ resource "google_compute_instance_template" "example" {
   disk {
     boot         = true
     auto_delete  = true
-    source_image = "ubuntu-os-cloud/ubuntu-1604-lts"
+    source_image = "ubuntu-os-cloud/ubuntu-2004-lts"
   }
 
   network_interface {

--- a/modules/gcp/compute_test.go
+++ b/modules/gcp/compute_test.go
@@ -27,7 +27,7 @@ func TestGetPublicIpOfInstance(t *testing.T) {
 
 	instanceName := RandomValidGcpName()
 	projectID := GetGoogleProjectIDFromEnvVar(t)
-	zone := GetRandomZone(t, projectID, nil, nil, nil)
+	zone := GetRandomZone(t, projectID, nil, nil, []string{"southamerica-west1"})
 
 	createComputeInstance(t, projectID, zone, instanceName)
 	defer deleteComputeInstance(t, projectID, zone, instanceName)


### PR DESCRIPTION
Noticed that GCP tests started to fail with errors like:
```
TestTerraformGcpInstanceGroupExample 2022-02-13T15:01:51Z retry.go:99: Returning due to fatal error: FatalError{Underlying: error while running command: exit status 1; ╷
│ Error: Error resolving image name 'ubuntu-os-cloud/ubuntu-1604-lts': Could not find image or family ubuntu-os-cloud/ubuntu-1604-lts
```
or

```
TestImportSSHKeyOSLogin 2022-02-13T20:14:34Z oslogin.go:101: Getting login profile for user circleci@terratest-214610.iam.gserviceaccount.com
    compute_test.go:205: Error launching new Compute Instance: googleapi: Error 400: Invalid value for field 'resource.machineType': 'zones/southamerica-west1-a/machineTypes/f1-micro'. Machine type with name 'f1-micro' does not exist in zone 'southamerica-west1-a'., invalid
```

Looks like ubuntu-1604 image is only in as "ubuntu-pro" with additional costs

https://user-images.githubusercontent.com/10694338/153772991-edb90b91-bcba-4c3e-9ee5-f969b4296ac2.png

Updated tests to use `ubuntu-2004-lts` image, removed region `southamerica-west1` from tests since can't be deployed `f1-micro` instances there.
