### PR TITLE
Add function to retrieve the git repo root dir

### DIFF
--- a/modules/git/git.go
+++ b/modules/git/git.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/gruntwork-io/terratest/modules/testing"
+	"github.com/stretchr/testify/require"
 )
 
 // GetCurrentBranchName retrieves the current branch name or
@@ -89,6 +90,23 @@ func GetCurrentGitRefE(t testing.TestingT) (string, error) {
 // to the commit exact tag value.
 func GetTagE(t testing.TestingT) (string, error) {
 	cmd := exec.Command("git", "describe", "--tags")
+	bytes, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(bytes)), nil
+}
+
+// GetRepoRoot retrieves the path to the root directory of the repo. This fails the test if there is an error.
+func GetRepoRoot(t testing.TestingT) string {
+	out, err := GetRepoRootE(t)
+	require.NoError(t, err)
+	return out
+}
+
+// GetRepoRootE retrieves the path to the root directory of the repo.
+func GetRepoRootE(t testing.TestingT) (string, error) {
+	cmd := exec.Command("git", "rev-parse", "--show-toplevel")
 	bytes, err := cmd.Output()
 	if err != nil {
 		return "", err

--- a/modules/git/git_test.go
+++ b/modules/git/git_test.go
@@ -77,3 +77,15 @@ func TestGitRefChecks(t *testing.T) {
 	t.Run("GetCurrentRefReturnsTagValue", testGetCurrentRefReturnsTagValue)
 	t.Run("GetCurrentRefReturnsLightTagValue", testGetCurrentRefReturnsLightTagValue)
 }
+
+func TestGetRepoRoot(t *testing.T) {
+	t.Parallel()
+
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+	expectedRepoRoot, err := filepath.Abs(filepath.Join(cwd, "..", ".."))
+	require.NoError(t, err)
+
+	repoRoot := GetRepoRoot(t)
+	assert.Equal(t, expectedRepoRoot, repoRoot)
+}


### PR DESCRIPTION
This adds a helper function that returns the absolute path to the root dir of the git repository, assuming the test is running within a git repo.