### PR TITLE
test: use `T.TempDir` to create temporary test directory

### DIFF
--- a/modules/files/files_test.go
+++ b/modules/files/files_test.go
@@ -2,7 +2,6 @@ package files
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -53,8 +52,7 @@ func TestCopyFolderToDest(t *testing.T) {
 
 	tempFolderPrefix := "someprefix"
 	destFolder := os.TempDir()
-	tmpDir, err := ioutil.TempDir("", "TestCopyFolderContents")
-	require.NoError(t, err)
+	tmpDir := t.TempDir()
 
 	filter := func(path string) bool {
 		return !PathContainsHiddenFileOrFolder(path) && !PathContainsTerraformState(path)
@@ -74,10 +72,9 @@ func TestCopyFolderContents(t *testing.T) {
 
 	originalDir := filepath.Join(copyFolderContentsFixtureRoot, "original")
 	expectedDir := filepath.Join(copyFolderContentsFixtureRoot, "full-copy")
-	tmpDir, err := ioutil.TempDir("", "TestCopyFolderContents")
-	require.NoError(t, err)
+	tmpDir := t.TempDir()
 
-	err = CopyFolderContents(originalDir, tmpDir)
+	err := CopyFolderContents(originalDir, tmpDir)
 	require.NoError(t, err)
 
 	requireDirectoriesEqual(t, expectedDir, tmpDir)
@@ -88,10 +85,9 @@ func TestCopyFolderContentsWithHiddenFilesFilter(t *testing.T) {
 
 	originalDir := filepath.Join(copyFolderContentsFixtureRoot, "original")
 	expectedDir := filepath.Join(copyFolderContentsFixtureRoot, "no-hidden-files")
-	tmpDir, err := ioutil.TempDir("", "TestCopyFolderContentsWithFilter")
-	require.NoError(t, err)
+	tmpDir := t.TempDir()
 
-	err = CopyFolderContentsWithFilter(originalDir, tmpDir, func(path string) bool {
+	err := CopyFolderContentsWithFilter(originalDir, tmpDir, func(path string) bool {
 		return !PathContainsHiddenFileOrFolder(path)
 	})
 	require.NoError(t, err)
@@ -105,10 +101,9 @@ func TestCopyFolderContentsWithSymLinks(t *testing.T) {
 
 	originalDir := filepath.Join(copyFolderContentsFixtureRoot, "symlinks")
 	expectedDir := filepath.Join(copyFolderContentsFixtureRoot, "symlinks")
-	tmpDir, err := ioutil.TempDir("", "TestCopyFolderContentsWithFilter")
-	require.NoError(t, err)
+	tmpDir := t.TempDir()
 
-	err = CopyFolderContentsWithFilter(originalDir, tmpDir, func(path string) bool {
+	err := CopyFolderContentsWithFilter(originalDir, tmpDir, func(path string) bool {
 		return !PathContainsHiddenFileOrFolder(path)
 	})
 	require.NoError(t, err)
@@ -134,10 +129,9 @@ func TestCopyFolderContentsWithBrokenSymLinks(t *testing.T) {
 
 	// Test copying folder
 	originalDir := filepath.Join(copyFolderContentsFixtureRoot, "symlinks-broken")
-	tmpDir, err := ioutil.TempDir("", "TestCopyFolderContentsWithFilter")
-	require.NoError(t, err)
+	tmpDir := t.TempDir()
 
-	err = CopyFolderContentsWithFilter(originalDir, tmpDir, func(path string) bool {
+	err := CopyFolderContentsWithFilter(originalDir, tmpDir, func(path string) bool {
 		return !PathContainsHiddenFileOrFolder(path)
 	})
 	require.NoError(t, err)

--- a/modules/git/git_test.go
+++ b/modules/git/git_test.go
@@ -1,7 +1,6 @@
 package git
 
 import (
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -59,13 +58,11 @@ func testGetCurrentRefReturnsLightTagValue(t *testing.T) {
 func TestGitRefChecks(t *testing.T) {
 	t.Parallel()
 
-	tmpdir, err := ioutil.TempDir("", "")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 	gitWorkDir := filepath.Join(tmpdir, "terratest")
 
 	url := "https://github.com/gruntwork-io/terratest.git"
-	err = exec.Command("git", "clone", url, gitWorkDir).Run()
+	err := exec.Command("git", "clone", url, gitWorkDir).Run()
 	require.NoError(t, err)
 
 	err = os.Chdir(gitWorkDir)

--- a/modules/logger/parser/helpers_for_test.go
+++ b/modules/logger/parser/helpers_for_test.go
@@ -3,7 +3,6 @@ package parser
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"strings"
 	"testing"
 	"time"
@@ -32,12 +31,4 @@ func (formatter *LogTestFormatter) Format(entry *logrus.Entry) ([]byte, error) {
 	)
 	b.WriteString(outStr)
 	return b.Bytes(), nil
-}
-
-func getTempDir(t *testing.T) string {
-	dir, err := ioutil.TempDir("", t.Name())
-	if err != nil {
-		t.Fatal(err)
-	}
-	return dir
 }

--- a/modules/logger/parser/integration_test.go
+++ b/modules/logger/parser/integration_test.go
@@ -43,8 +43,7 @@ func openFile(t *testing.T, filename string) *os.File {
 
 func testExample(t *testing.T, example string) {
 	logger := NewTestLogger(t)
-	dir := getTempDir(t)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	logFileName := fmt.Sprintf("./fixtures/%s_example.log", example)
 	expectedOutputDirName := fmt.Sprintf("./fixtures/%s_example_expected", example)
 	file := openFile(t, logFileName)

--- a/modules/logger/parser/store_test.go
+++ b/modules/logger/parser/store_test.go
@@ -12,10 +12,9 @@ import (
 )
 
 func createLogWriter(t *testing.T) LogWriter {
-	dir := getTempDir(t)
 	logWriter := LogWriter{
 		lookup:    make(map[string]*os.File),
-		outputDir: dir,
+		outputDir: t.TempDir(),
 	}
 	return logWriter
 }
@@ -23,8 +22,7 @@ func createLogWriter(t *testing.T) LogWriter {
 func TestEnsureDirectoryExistsCreatesDirectory(t *testing.T) {
 	t.Parallel()
 
-	dir := getTempDir(t)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	logger := NewTestLogger(t)
 	tmpd := filepath.Join(dir, "tmpdir")
@@ -36,8 +34,7 @@ func TestEnsureDirectoryExistsCreatesDirectory(t *testing.T) {
 func TestEnsureDirectoryExistsHandlesExistingDirectory(t *testing.T) {
 	t.Parallel()
 
-	dir := getTempDir(t)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	logger := NewTestLogger(t)
 	assert.True(t, files.IsDir(dir))
@@ -49,7 +46,6 @@ func TestGetOrCreateFileCreatesNewFile(t *testing.T) {
 	t.Parallel()
 
 	logWriter := createLogWriter(t)
-	defer os.RemoveAll(logWriter.outputDir)
 
 	logger := NewTestLogger(t)
 	testFileName := filepath.Join(logWriter.outputDir, t.Name()+".log")
@@ -65,7 +61,6 @@ func TestGetOrCreateFileCreatesNewFileIfTestNameHasDir(t *testing.T) {
 	t.Parallel()
 
 	logWriter := createLogWriter(t)
-	defer os.RemoveAll(logWriter.outputDir)
 
 	logger := NewTestLogger(t)
 	dirName := filepath.Join(logWriter.outputDir, "TestMain")
@@ -84,7 +79,6 @@ func TestGetOrCreateChannelReturnsExistingFileHandle(t *testing.T) {
 	t.Parallel()
 
 	logWriter := createLogWriter(t)
-	defer os.RemoveAll(logWriter.outputDir)
 
 	testName := t.Name()
 	logger := NewTestLogger(t)
@@ -105,7 +99,6 @@ func TestCloseFilesClosesAll(t *testing.T) {
 	t.Parallel()
 
 	logWriter := createLogWriter(t)
-	defer os.RemoveAll(logWriter.outputDir)
 
 	logger := NewTestLogger(t)
 	testName := t.Name()
@@ -134,7 +127,6 @@ func TestWriteLogWritesToCorrectLogFile(t *testing.T) {
 	t.Parallel()
 
 	logWriter := createLogWriter(t)
-	defer os.RemoveAll(logWriter.outputDir)
 
 	logger := NewTestLogger(t)
 	testName := t.Name()
@@ -173,7 +165,6 @@ func TestWriteLogCreatesLogFileIfNotExists(t *testing.T) {
 	t.Parallel()
 
 	logWriter := createLogWriter(t)
-	defer os.RemoveAll(logWriter.outputDir)
 
 	logger := NewTestLogger(t)
 	testName := t.Name()

--- a/modules/terraform/init_test.go
+++ b/modules/terraform/init_test.go
@@ -1,7 +1,6 @@
 package terraform
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -14,10 +13,7 @@ import (
 func TestInitBackendConfig(t *testing.T) {
 	t.Parallel()
 
-	stateDirectory, err := ioutil.TempDir("", t.Name())
-	if err != nil {
-		t.Fatal(err)
-	}
+	stateDirectory := t.TempDir()
 
 	remoteStateFile := filepath.Join(stateDirectory, "backend.tfstate")
 
@@ -41,9 +37,7 @@ func TestInitBackendConfig(t *testing.T) {
 func TestInitPluginDir(t *testing.T) {
 	t.Parallel()
 
-	testingDir, err := ioutil.TempDir("", t.Name())
-	require.NoError(t, err)
-	defer os.RemoveAll(testingDir)
+	testingDir := t.TempDir()
 
 	terraformFixture := "../../test/fixtures/terraform-basic-configuration"
 
@@ -86,9 +80,7 @@ func TestInitPluginDir(t *testing.T) {
 func TestInitReconfigureBackend(t *testing.T) {
 	t.Parallel()
 
-	stateDirectory, err := ioutil.TempDir("", t.Name())
-	require.NoError(t, err)
-	defer os.RemoveAll(stateDirectory)
+	stateDirectory := t.TempDir()
 
 	testFolder, err := files.CopyTerraformFolderToTemp("../../test/fixtures/terraform-backend", t.Name())
 	require.NoError(t, err)
@@ -116,9 +108,7 @@ func TestInitReconfigureBackend(t *testing.T) {
 func TestInitBackendMigration(t *testing.T) {
 	t.Parallel()
 
-	stateDirectory, err := ioutil.TempDir("", t.Name())
-	require.NoError(t, err)
-	defer os.RemoveAll(stateDirectory)
+	stateDirectory := t.TempDir()
 
 	testFolder, err := files.CopyTerraformFolderToTemp("../../test/fixtures/terraform-backend", t.Name())
 	require.NoError(t, err)

--- a/modules/test-structure/save_test_data_test.go
+++ b/modules/test-structure/save_test_data_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/gruntwork-io/terratest/modules/k8s"
 	"github.com/gruntwork-io/terratest/modules/terraform"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 type testData struct {
@@ -96,10 +95,7 @@ func TestIsEmptyJson(t *testing.T) {
 func TestSaveAndLoadTerraformOptions(t *testing.T) {
 	t.Parallel()
 
-	tmpFolder, err := ioutil.TempDir("", "save-and-load-terratest-options")
-	if err != nil {
-		t.Fatalf("Failed to create temp dir: %v", err)
-	}
+	tmpFolder := t.TempDir()
 
 	expectedData := &terraform.Options{
 		TerraformDir: "/abc/def/ghi",
@@ -114,10 +110,7 @@ func TestSaveAndLoadTerraformOptions(t *testing.T) {
 func TestSaveAndLoadAmiId(t *testing.T) {
 	t.Parallel()
 
-	tmpFolder, err := ioutil.TempDir("", "save-and-load-ami-id")
-	if err != nil {
-		t.Fatalf("Failed to create temp dir: %v", err)
-	}
+	tmpFolder := t.TempDir()
 
 	expectedData := "ami-abcd1234"
 	SaveAmiId(t, tmpFolder, expectedData)
@@ -129,10 +122,7 @@ func TestSaveAndLoadAmiId(t *testing.T) {
 func TestSaveAndLoadArtifactID(t *testing.T) {
 	t.Parallel()
 
-	tmpFolder, err := ioutil.TempDir("", "save-and-load-artifact-id")
-	if err != nil {
-		t.Fatalf("Failed to create temp dir: %v", err)
-	}
+	tmpFolder := t.TempDir()
 
 	expectedData := "terratest-packer-example-2018-08-08t15-35-19z"
 	SaveArtifactID(t, tmpFolder, expectedData)
@@ -144,10 +134,7 @@ func TestSaveAndLoadArtifactID(t *testing.T) {
 func TestSaveAndLoadNamedStrings(t *testing.T) {
 	t.Parallel()
 
-	tmpFolder, err := ioutil.TempDir("", "save-and-load-named-strings")
-	if err != nil {
-		t.Fatalf("Failed to create temp dir: %v", err)
-	}
+	tmpFolder := t.TempDir()
 
 	name1 := "test-ami"
 	expectedData1 := "ami-abcd1234"
@@ -180,10 +167,7 @@ func TestSaveAndLoadNamedStrings(t *testing.T) {
 func TestSaveDuplicateTestData(t *testing.T) {
 	t.Parallel()
 
-	tmpFolder, err := ioutil.TempDir("", "save-and-load-duplicate-test-data")
-	if err != nil {
-		t.Fatalf("Failed to create temp dir: %v", err)
-	}
+	tmpFolder := t.TempDir()
 
 	name := "hello-world"
 	val1 := "hello world"
@@ -200,10 +184,7 @@ func TestSaveDuplicateTestData(t *testing.T) {
 func TestSaveAndLoadNamedInts(t *testing.T) {
 	t.Parallel()
 
-	tmpFolder, err := ioutil.TempDir("", "save-and-load-named-ints")
-	if err != nil {
-		t.Fatalf("Failed to create temp dir: %v", err)
-	}
+	tmpFolder := t.TempDir()
 
 	name1 := "test-int1"
 	expectedData1 := 23842834
@@ -224,8 +205,7 @@ func TestSaveAndLoadNamedInts(t *testing.T) {
 func TestSaveAndLoadKubectlOptions(t *testing.T) {
 	t.Parallel()
 
-	tmpFolder, err := ioutil.TempDir("", "save-and-load-kubectl-options")
-	require.NoError(t, err)
+	tmpFolder := t.TempDir()
 
 	expectedData := &k8s.KubectlOptions{
 		ContextName: "terratest-context",


### PR DESCRIPTION
A small testing enhancement.

We can use the `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete. 

Reference: https://pkg.go.dev/testing#T.TempDir