### PR TITLE
Postgres 13.1 rolled off available list

### DIFF
--- a/modules/aws/rds_test.go
+++ b/modules/aws/rds_test.go
@@ -30,7 +30,7 @@ func TestGetRecommendedRdsInstanceTypeHappyPath(t *testing.T) {
 			name:                  "EU region, postgres, 2nd offering available based on region",
 			region:                "eu-north-1",
 			databaseEngine:        "postgres",
-			databaseEngineVersion: "13.1",
+			databaseEngineVersion: "13.5",
 			instanceTypes:         []string{"db.t2.micro", "db.m5.large"},
 			expected:              "db.m5.large",
 		},


### PR DESCRIPTION
Fixes the broken build on `master`.

See attached screenshot for available PG versions:

<img width="597" alt="Screen Shot 2022-03-07 at 7 31 25 PM" src="https://user-images.githubusercontent.com/430092/157147990-a85e1cb4-7a20-4220-beb5-e8145d71340e.png">
