### PR TITLE
Add HttpHelper methods that accept options structs

### DIFF
--- a/modules/http-helper/http_helper.go
+++ b/modules/http-helper/http_helper.go
@@ -16,6 +16,12 @@ import (
 	"github.com/gruntwork-io/terratest/modules/testing"
 )
 
+type HttpGetOptions struct {
+	Url       string
+	TlsConfig *tls.Config
+	Timeout   int
+}
+
 // HttpGet performs an HTTP GET, with an optional pointer to a custom TLS configuration, on the given URL and
 // return the HTTP status code and body. If there's any error, fail the test.
 func HttpGet(t testing.TestingT, url string, tlsConfig *tls.Config) (int, string) {

--- a/modules/http-helper/http_helper.go
+++ b/modules/http-helper/http_helper.go
@@ -78,7 +78,14 @@ func HttpGetWithOptionsE(t testing.TestingT, options HttpGetOptions) (int, strin
 // HttpGetWithValidation performs an HTTP GET on the given URL and verify that you get back the expected status code and body. If either
 // doesn't match, fail the test.
 func HttpGetWithValidation(t testing.TestingT, url string, tlsConfig *tls.Config, expectedStatusCode int, expectedBody string) {
-	err := HttpGetWithValidationE(t, url, tlsConfig, expectedStatusCode, expectedBody)
+	options := HttpGetOptions{Url: url, TlsConfig: tlsConfig, Timeout: 10}
+	HttpGetWithValidationWithOptions(t, options, expectedStatusCode, expectedBody)
+}
+
+// HttpGetWithValidationWithOptions performs an HTTP GET on the given URL and verify that you get back the expected status code and body. If either
+// doesn't match, fail the test.
+func HttpGetWithValidationWithOptions(t testing.TestingT, options HttpGetOptions, expectedStatusCode int, expectedBody string) {
+	err := HttpGetWithValidationWithOptionsE(t, options, expectedStatusCode, expectedBody)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -87,7 +94,14 @@ func HttpGetWithValidation(t testing.TestingT, url string, tlsConfig *tls.Config
 // HttpGetWithValidationE performs an HTTP GET on the given URL and verify that you get back the expected status code and body. If either
 // doesn't match, return an error.
 func HttpGetWithValidationE(t testing.TestingT, url string, tlsConfig *tls.Config, expectedStatusCode int, expectedBody string) error {
-	return HttpGetWithCustomValidationE(t, url, tlsConfig, func(statusCode int, body string) bool {
+	options := HttpGetOptions{Url: url, TlsConfig: tlsConfig, Timeout: 10}
+	return HttpGetWithValidationWithOptionsE(t, options, expectedStatusCode, expectedBody)
+}
+
+// HttpGetWithValidationWithOptionsE performs an HTTP GET on the given URL and verify that you get back the expected status code and body. If either
+// doesn't match, return an error.
+func HttpGetWithValidationWithOptionsE(t testing.TestingT, options HttpGetOptions, expectedStatusCode int, expectedBody string) error {
+	return HttpGetWithCustomValidationWithOptionsE(t, options, func(statusCode int, body string) bool {
 		return statusCode == expectedStatusCode && body == expectedBody
 	})
 }

--- a/modules/http-helper/http_helper.go
+++ b/modules/http-helper/http_helper.go
@@ -22,6 +22,15 @@ type HttpGetOptions struct {
 	Timeout   int
 }
 
+type HttpDoOptions struct {
+	Method    string
+	Url       string
+	Body      []byte
+	Headers   map[string]string
+	TlsConfig *tls.Config
+	Timeout   int
+}
+
 // HttpGet performs an HTTP GET, with an optional pointer to a custom TLS configuration, on the given URL and
 // return the HTTP status code and body. If there's any error, fail the test.
 func HttpGet(t testing.TestingT, url string, tlsConfig *tls.Config) (int, string) {

--- a/modules/http-helper/http_helper.go
+++ b/modules/http-helper/http_helper.go
@@ -413,7 +413,21 @@ func HTTPDoWithValidationE(t testing.TestingT, method string, url string, body i
 // HTTPDoWithCustomValidation performs the given HTTP method on the given URL and validate the returned status code and
 // body using the given function.
 func HTTPDoWithCustomValidation(t testing.TestingT, method string, url string, body io.Reader, headers map[string]string, validateResponse func(int, string) bool, tlsConfig *tls.Config) {
-	err := HTTPDoWithCustomValidationE(t, method, url, body, headers, validateResponse, tlsConfig)
+	options := HttpDoOptions{
+		Method:    method,
+		Url:       url,
+		Body:      body,
+		Headers:   headers,
+		TlsConfig: tlsConfig,
+		Timeout:   10}
+
+	HTTPDoWithCustomValidationWithOptions(t, options, validateResponse)
+}
+
+// HTTPDoWithCustomValidationWithOptions performs the given HTTP method on the given URL and validate the returned status code and
+// body using the given function.
+func HTTPDoWithCustomValidationWithOptions(t testing.TestingT, options HttpDoOptions, validateResponse func(int, string) bool) {
+	err := HTTPDoWithCustomValidationWithOptionsE(t, options, validateResponse)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -422,14 +436,28 @@ func HTTPDoWithCustomValidation(t testing.TestingT, method string, url string, b
 // HTTPDoWithCustomValidationE performs the given HTTP method on the given URL and validate the returned status code and
 // body using the given function.
 func HTTPDoWithCustomValidationE(t testing.TestingT, method string, url string, body io.Reader, headers map[string]string, validateResponse func(int, string) bool, tlsConfig *tls.Config) error {
-	statusCode, respBody, err := HTTPDoE(t, method, url, body, headers, tlsConfig)
+	options := HttpDoOptions{
+		Method:    method,
+		Url:       url,
+		Body:      body,
+		Headers:   headers,
+		TlsConfig: tlsConfig,
+		Timeout:   10}
+
+	return HTTPDoWithCustomValidationWithOptionsE(t, options, validateResponse)
+}
+
+// HTTPDoWithCustomValidationWithOptionsE performs the given HTTP method on the given URL and validate the returned status code and
+// body using the given function.
+func HTTPDoWithCustomValidationWithOptionsE(t testing.TestingT, options HttpDoOptions, validateResponse func(int, string) bool) error {
+	statusCode, respBody, err := HTTPDoWithOptionsE(t, options)
 
 	if err != nil {
 		return err
 	}
 
 	if !validateResponse(statusCode, respBody) {
-		return ValidationFunctionFailed{Url: url, Status: statusCode, Body: respBody}
+		return ValidationFunctionFailed{Url: options.Url, Status: statusCode, Body: respBody}
 	}
 
 	return nil

--- a/modules/http-helper/http_helper.go
+++ b/modules/http-helper/http_helper.go
@@ -396,7 +396,21 @@ func HTTPDoWithValidationRetryE(
 // HTTPDoWithValidation performs the given HTTP method on the given URL and verify that you get back the expected status
 // code and body. If either doesn't match, fail the test.
 func HTTPDoWithValidation(t testing.TestingT, method string, url string, body io.Reader, headers map[string]string, expectedStatusCode int, expectedBody string, tlsConfig *tls.Config) {
-	err := HTTPDoWithValidationE(t, method, url, body, headers, expectedStatusCode, expectedBody, tlsConfig)
+	options := HttpDoOptions{
+		Method:    method,
+		Url:       url,
+		Body:      body,
+		Headers:   headers,
+		TlsConfig: tlsConfig,
+		Timeout:   10}
+
+	HTTPDoWithValidationWithOptions(t, options, expectedStatusCode, expectedBody)
+}
+
+// HTTPDoWithValidationWithOptions performs the given HTTP method on the given URL and verify that you get back the expected status
+// code and body. If either doesn't match, fail the test.
+func HTTPDoWithValidationWithOptions(t testing.TestingT, options HttpDoOptions, expectedStatusCode int, expectedBody string) {
+	err := HTTPDoWithValidationWithOptionsE(t, options, expectedStatusCode, expectedBody)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -405,9 +419,23 @@ func HTTPDoWithValidation(t testing.TestingT, method string, url string, body io
 // HTTPDoWithValidationE performs the given HTTP method on the given URL and verify that you get back the expected status
 // code and body. If either doesn't match, return an error.
 func HTTPDoWithValidationE(t testing.TestingT, method string, url string, body io.Reader, headers map[string]string, expectedStatusCode int, expectedBody string, tlsConfig *tls.Config) error {
-	return HTTPDoWithCustomValidationE(t, method, url, body, headers, func(statusCode int, body string) bool {
+	options := HttpDoOptions{
+		Method:    method,
+		Url:       url,
+		Body:      body,
+		Headers:   headers,
+		TlsConfig: tlsConfig,
+		Timeout:   10}
+
+	return HTTPDoWithValidationWithOptionsE(t, options, expectedStatusCode, expectedBody)
+}
+
+// HTTPDoWithValidationWithOptionsE performs the given HTTP method on the given URL and verify that you get back the expected status
+// code and body. If either doesn't match, return an error.
+func HTTPDoWithValidationWithOptionsE(t testing.TestingT, options HttpDoOptions, expectedStatusCode int, expectedBody string) error {
+	return HTTPDoWithCustomValidationWithOptionsE(t, options, func(statusCode int, body string) bool {
 		return statusCode == expectedStatusCode && body == expectedBody
-	}, tlsConfig)
+	})
 }
 
 // HTTPDoWithCustomValidation performs the given HTTP method on the given URL and validate the returned status code and

--- a/modules/http-helper/http_helper.go
+++ b/modules/http-helper/http_helper.go
@@ -175,7 +175,14 @@ func HttpGetWithRetryWithOptionsE(t testing.TestingT, options HttpGetOptions, ex
 // HttpGetWithRetryWithCustomValidation repeatedly performs an HTTP GET on the given URL until the given validation function returns true or max retries
 // has been exceeded.
 func HttpGetWithRetryWithCustomValidation(t testing.TestingT, url string, tlsConfig *tls.Config, retries int, sleepBetweenRetries time.Duration, validateResponse func(int, string) bool) {
-	err := HttpGetWithRetryWithCustomValidationE(t, url, tlsConfig, retries, sleepBetweenRetries, validateResponse)
+	options := HttpGetOptions{Url: url, TlsConfig: tlsConfig, Timeout: 10}
+	HttpGetWithRetryWithCustomValidationWithOptions(t, options, retries, sleepBetweenRetries, validateResponse)
+}
+
+// HttpGetWithRetryWithCustomValidationWithOptions repeatedly performs an HTTP GET on the given URL until the given validation function returns true or max retries
+// has been exceeded.
+func HttpGetWithRetryWithCustomValidationWithOptions(t testing.TestingT, options HttpGetOptions, retries int, sleepBetweenRetries time.Duration, validateResponse func(int, string) bool) {
+	err := HttpGetWithRetryWithCustomValidationWithOptionsE(t, options, retries, sleepBetweenRetries, validateResponse)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -184,8 +191,15 @@ func HttpGetWithRetryWithCustomValidation(t testing.TestingT, url string, tlsCon
 // HttpGetWithRetryWithCustomValidationE repeatedly performs an HTTP GET on the given URL until the given validation function returns true or max retries
 // has been exceeded.
 func HttpGetWithRetryWithCustomValidationE(t testing.TestingT, url string, tlsConfig *tls.Config, retries int, sleepBetweenRetries time.Duration, validateResponse func(int, string) bool) error {
-	_, err := retry.DoWithRetryE(t, fmt.Sprintf("HTTP GET to URL %s", url), retries, sleepBetweenRetries, func() (string, error) {
-		return "", HttpGetWithCustomValidationE(t, url, tlsConfig, validateResponse)
+	options := HttpGetOptions{Url: url, TlsConfig: tlsConfig, Timeout: 10}
+	return HttpGetWithRetryWithCustomValidationWithOptionsE(t, options, retries, sleepBetweenRetries, validateResponse)
+}
+
+// HttpGetWithRetryWithCustomValidationWithOptionsE repeatedly performs an HTTP GET on the given URL until the given validation function returns true or max retries
+// has been exceeded.
+func HttpGetWithRetryWithCustomValidationWithOptionsE(t testing.TestingT, options HttpGetOptions, retries int, sleepBetweenRetries time.Duration, validateResponse func(int, string) bool) error {
+	_, err := retry.DoWithRetryE(t, fmt.Sprintf("HTTP GET to URL %s", options.Url), retries, sleepBetweenRetries, func() (string, error) {
+		return "", HttpGetWithCustomValidationWithOptionsE(t, options, validateResponse)
 	})
 
 	return err

--- a/modules/http-helper/http_helper.go
+++ b/modules/http-helper/http_helper.go
@@ -347,9 +347,13 @@ func HTTPDoWithRetryWithOptionsE(
 	t testing.TestingT, options HttpDoOptions, expectedStatus int,
 	retries int, sleepBetweenRetries time.Duration,
 ) (string, error) {
-	// The request body is closed after a request is complete. options.
+	// The request body is closed after a request is complete.
 	// Extract the underlying data and cache it so we can reuse for retried requests
 	data, err := io.ReadAll(options.Body)
+	if err != nil {
+		return "", err
+	}
+
 	options.Body = nil
 
 	out, err := retry.DoWithRetryE(

--- a/modules/http-helper/http_helper.go
+++ b/modules/http-helper/http_helper.go
@@ -142,7 +142,14 @@ func HttpGetWithCustomValidationWithOptionsE(t testing.TestingT, options HttpGet
 // HttpGetWithRetry repeatedly performs an HTTP GET on the given URL until the given status code and body are returned or until max
 // retries has been exceeded.
 func HttpGetWithRetry(t testing.TestingT, url string, tlsConfig *tls.Config, expectedStatus int, expectedBody string, retries int, sleepBetweenRetries time.Duration) {
-	err := HttpGetWithRetryE(t, url, tlsConfig, expectedStatus, expectedBody, retries, sleepBetweenRetries)
+	options := HttpGetOptions{Url: url, TlsConfig: tlsConfig, Timeout: 10}
+	HttpGetWithRetryWithOptions(t, options, expectedStatus, expectedBody, retries, sleepBetweenRetries)
+}
+
+// HttpGetWithRetryWithOptions repeatedly performs an HTTP GET on the given URL until the given status code and body are returned or until max
+// retries has been exceeded.
+func HttpGetWithRetryWithOptions(t testing.TestingT, options HttpGetOptions, expectedStatus int, expectedBody string, retries int, sleepBetweenRetries time.Duration) {
+	err := HttpGetWithRetryWithOptionsE(t, options, expectedStatus, expectedBody, retries, sleepBetweenRetries)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -151,8 +158,15 @@ func HttpGetWithRetry(t testing.TestingT, url string, tlsConfig *tls.Config, exp
 // HttpGetWithRetryE repeatedly performs an HTTP GET on the given URL until the given status code and body are returned or until max
 // retries has been exceeded.
 func HttpGetWithRetryE(t testing.TestingT, url string, tlsConfig *tls.Config, expectedStatus int, expectedBody string, retries int, sleepBetweenRetries time.Duration) error {
-	_, err := retry.DoWithRetryE(t, fmt.Sprintf("HTTP GET to URL %s", url), retries, sleepBetweenRetries, func() (string, error) {
-		return "", HttpGetWithValidationE(t, url, tlsConfig, expectedStatus, expectedBody)
+	options := HttpGetOptions{Url: url, TlsConfig: tlsConfig, Timeout: 10}
+	return HttpGetWithRetryWithOptionsE(t, options, expectedStatus, expectedBody, retries, sleepBetweenRetries)
+}
+
+// HttpGetWithRetryWithOptionsE repeatedly performs an HTTP GET on the given URL until the given status code and body are returned or until max
+// retries has been exceeded.
+func HttpGetWithRetryWithOptionsE(t testing.TestingT, options HttpGetOptions, expectedStatus int, expectedBody string, retries int, sleepBetweenRetries time.Duration) error {
+	_, err := retry.DoWithRetryE(t, fmt.Sprintf("HTTP GET to URL %s", options.Url), retries, sleepBetweenRetries, func() (string, error) {
+		return "", HttpGetWithValidationWithOptionsE(t, options, expectedStatus, expectedBody)
 	})
 
 	return err

--- a/modules/http-helper/http_helper.go
+++ b/modules/http-helper/http_helper.go
@@ -94,7 +94,12 @@ func HttpGetWithValidationE(t testing.TestingT, url string, tlsConfig *tls.Confi
 
 // HttpGetWithCustomValidation performs an HTTP GET on the given URL and validate the returned status code and body using the given function.
 func HttpGetWithCustomValidation(t testing.TestingT, url string, tlsConfig *tls.Config, validateResponse func(int, string) bool) {
-	err := HttpGetWithCustomValidationE(t, url, tlsConfig, validateResponse)
+	HttpGetWithCustomValidationWithOptions(t, HttpGetOptions{Url: url, TlsConfig: tlsConfig, Timeout: 10}, validateResponse)
+}
+
+// HttpGetWithCustomValidationWithOptions performs an HTTP GET on the given URL and validate the returned status code and body using the given function.
+func HttpGetWithCustomValidationWithOptions(t testing.TestingT, options HttpGetOptions, validateResponse func(int, string) bool) {
+	err := HttpGetWithCustomValidationWithOptionsE(t, options, validateResponse)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -102,14 +107,19 @@ func HttpGetWithCustomValidation(t testing.TestingT, url string, tlsConfig *tls.
 
 // HttpGetWithCustomValidationE performs an HTTP GET on the given URL and validate the returned status code and body using the given function.
 func HttpGetWithCustomValidationE(t testing.TestingT, url string, tlsConfig *tls.Config, validateResponse func(int, string) bool) error {
-	statusCode, body, err := HttpGetE(t, url, tlsConfig)
+	return HttpGetWithCustomValidationWithOptionsE(t, HttpGetOptions{Url: url, TlsConfig: tlsConfig, Timeout: 10}, validateResponse)
+}
+
+// HttpGetWithCustomValidationWithOptionsE performs an HTTP GET on the given URL and validate the returned status code and body using the given function.
+func HttpGetWithCustomValidationWithOptionsE(t testing.TestingT, options HttpGetOptions, validateResponse func(int, string) bool) error {
+	statusCode, body, err := HttpGetWithOptionsE(t, options)
 
 	if err != nil {
 		return err
 	}
 
 	if !validateResponse(statusCode, body) {
-		return ValidationFunctionFailed{Url: url, Status: statusCode, Body: body}
+		return ValidationFunctionFailed{Url: options.Url, Status: statusCode, Body: body}
 	}
 
 	return nil


### PR DESCRIPTION
This PR adds option classes for the HttpHelper methods so that it can be more easily extended in a backwards compatible way.

Addresses https://github.com/gruntwork-io/terratest/issues/902