### PR TITLE
Updated GCP tests to skip zones that can't run N1 instances

### DIFF
--- a/test/gcp/packer_gcp_basic_example_test.go
+++ b/test/gcp/packer_gcp_basic_example_test.go
@@ -32,8 +32,9 @@ func TestPackerGCPBasicExample(t *testing.T) {
 	projectID := gcp.GetGoogleProjectIDFromEnvVar(t)
 
 	// Pick a random GCP zone to test in. This helps ensure your code works in all regions.
-	// On October 22, 2018, GCP launched the asia-east2 region, which promptly failed all our tests, so blacklist asia-east2.
-	zone := gcp.GetRandomZone(t, projectID, nil, nil, []string{"asia-east2"})
+	// zones that don't support n1-standard-1 instances
+	zonesToAvoid := []string{"asia-east2", "southamerica-west1"}
+	zone := gcp.GetRandomZone(t, projectID, nil, nil, zonesToAvoid)
 
 	packerOptions := &packer.Options{
 		// The path to where the Packer template is located

--- a/test/gcp/terraform_gcp_example_test.go
+++ b/test/gcp/terraform_gcp_example_test.go
@@ -109,8 +109,9 @@ func TestSshAccessToComputeInstance(t *testing.T) {
 	// Setup values for our Terraform apply
 	projectID := gcp.GetGoogleProjectIDFromEnvVar(t)
 	randomValidGcpName := gcp.RandomValidGcpName()
-	// On October 22, 2018, GCP launched the asia-east2 region, which promptly failed all our tests, so blacklist asia-east2.
-	zone := gcp.GetRandomZone(t, projectID, nil, nil, []string{"asia-east2"})
+	// zones that don't support n1-standard-1 instances
+	zonesToAvoid := []string{"asia-east2", "southamerica-west1"}
+	zone := gcp.GetRandomZone(t, projectID, nil, nil, zonesToAvoid)
 
 	terraformOptions := &terraform.Options{
 		// The path to where our Terraform code is located


### PR DESCRIPTION
Updated GCP tests to skip zones that can't run N1 instances