### PR TITLE
Additional description for module helm.Options - .logger.Discard

### DIFF
--- a/modules/helm/options.go
+++ b/modules/helm/options.go
@@ -14,6 +14,6 @@ type Options struct {
 	HomePath       string              // The path to the helm home to use when calling out to helm. Empty string means use default ($HOME/.helm).
 	EnvVars        map[string]string   // Environment variables to set when running helm
 	Version        string              // Version of chart
-	Logger         *logger.Logger      // Set a non-default logger that should be used. See the logger package for more info.
+	Logger         *logger.Logger      // Set a non-default logger that should be used. See the logger package for more info. Use logger.Discard to not print the output while executing the command.
 	ExtraArgs      map[string][]string // Extra arguments to pass to the helm install/upgrade/rollback/delete command. The key signals the command (e.g., install) while the values are the extra arguments to pass through.
 }


### PR DESCRIPTION
Hello team.
This description will be helpful for engineers who are working with Helm.
I've spent a few hours looking for the solution to avoid logging while running tests inside the CI.

Example of use:

Import the logging module:
```go
import (
    "github.com/gruntwork-io/terratest/modules/logger"
)
```

Then inside your function append the options with log parameters:
```go
    options := &helm.Options{
        SetValues: map[string]string{
            "global.nameOverride": "test",
        },
        Logger: logger.Discard, // <- this line will disable console logging for the helm templates and will print only errors and PASS results.
    }
```
