### PR TITLE
VPC pagination

### DIFF
--- a/modules/aws/vpc_test.go
+++ b/modules/aws/vpc_test.go
@@ -50,6 +50,7 @@ func TestGetVpcsE(t *testing.T) {
 	// the default VPC has by default one subnet per availability zone
 	// https://docs.aws.amazon.com/vpc/latest/userguide/default-vpc.html
 	assert.Equal(t, len(vpcs[0].Subnets), len(azs))
+	assert.NotEmpty(t, vpcs[0].Subnets[0].CidrBlock)
 }
 
 func TestGetFirstTwoOctets(t *testing.T) {


### PR DESCRIPTION
Included changes:
  * Updated `GetSubnetsForVpcE` to load paginated VPC results
  * Added `CidrBlock` to response list of Subnets - this will help to get a better view on allocated blocks and avoid hardcoded [values](https://github.com/gruntwork-io/cloud-nuke/blob/master/aws/eks_utils_for_test.go#L216)