### PR TITLE
Azure LoadBalancer module : remove wrong Expand Query param

### DIFF
--- a/modules/azure/loadbalancer.go
+++ b/modules/azure/loadbalancer.go
@@ -173,7 +173,7 @@ func GetLoadBalancerE(loadBalancerName string, resourceGroupName string, subscri
 	}
 
 	// Get the Load Balancer
-	lb, err := client.Get(context.Background(), resourceGroupName, loadBalancerName, subscriptionID)
+	lb, err := client.Get(context.Background(), resourceGroupName, loadBalancerName, "")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Fixes #1091 

[Link](https://github.com/HadwaAbdelhalem/terratest/runs/5744318368?check_suite_focus=true) to PR code branch CI. The failures are mostly due to quote limits on my subscription and AzureLoadBalancer related tests passed