### PR TITLE
Add support for reading S3 bucket ownership controls

### DIFF
--- a/modules/aws/s3.go
+++ b/modules/aws/s3.go
@@ -62,6 +62,33 @@ func FindS3BucketWithTagE(t testing.TestingT, awsRegion string, key string, valu
 	return "", nil
 }
 
+func GetS3BucketOwnershipControls(t testing.TestingT, awsRegion, bucket string) []string {
+	rules, err := GetS3BucketOwnershipControlsE(t, awsRegion, bucket)
+	require.NoError(t, err)
+
+	return rules
+}
+
+func GetS3BucketOwnershipControlsE(t testing.TestingT, awsRegion, bucket string) ([]string, error) {
+	s3Client, err := NewS3ClientE(t, awsRegion)
+	if err != nil {
+		return nil, err
+	}
+
+	out, err := s3Client.GetBucketOwnershipControls(&s3.GetBucketOwnershipControlsInput{
+		Bucket: &bucket,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	rules := make([]string, len(out.OwnershipControls.Rules))
+	for i, rule := range out.OwnershipControls.Rules {
+		rules[i] = *rule.ObjectOwnership
+	}
+	return rules, nil
+}
+
 // GetS3BucketTags fetches the given bucket's tags and returns them as a string map of strings.
 func GetS3BucketTags(t testing.TestingT, awsRegion string, bucket string) map[string]string {
 	tags, err := GetS3BucketTagsE(t, awsRegion, bucket)

--- a/modules/aws/s3_test.go
+++ b/modules/aws/s3_test.go
@@ -163,6 +163,12 @@ func TestGetS3BucketOwnershipControls(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// if no ownership controls are set, an error is thrown
+	controls, err := GetS3BucketOwnershipControlsE(t, region, s3BucketName)
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "OwnershipControlsNotFoundError")
+	assert.Equal(t, 0, len(controls))
+
 	_, err = s3Client.PutBucketOwnershipControls(&s3.PutBucketOwnershipControlsInput{
 		Bucket: &s3BucketName,
 		OwnershipControls: &s3.OwnershipControls{
@@ -173,7 +179,7 @@ func TestGetS3BucketOwnershipControls(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	controls := GetS3BucketOwnershipControls(t, region, s3BucketName)
+	controls = GetS3BucketOwnershipControls(t, region, s3BucketName)
 	assert.Equal(t, 1, len(controls))
 	assert.Equal(t, "BucketOwnerEnforced", controls[0])
 }


### PR DESCRIPTION
This resolves #1081

Open question on code style: the AWS library and other Terratest `Get` implementations all return an error if their check doesn't exist (e.g. no ownership controls set returns an error, not an empty array.)  I've kept this behavior for consistency sake