### PR TITLE
Install goimports with go install

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,7 +119,7 @@ jobs:
       - run:
           name: run precommit
           command: |
-            go get golang.org/x/tools/cmd/goimports
+            go install golang.org/x/tools/cmd/goimports@latest
             # Install the latest minor version for v2
             pip install pre-commit~=2.9
             pre-commit install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,6 +136,8 @@ jobs:
             # environment so it pulls in what it needs.
             go mod tidy
 
+            go install github.com/mitchellh/gox@latest
+
             GO_ENABLED=0 build-go-binaries \
               --parallel "$BIN_BUILD_PARALLELISM" \
               --app-name terratest_log_parser \


### PR DESCRIPTION
`go get` for `goimports` no longer works in our CI environment, so switch to using `go install`. Same with `gox`, which still works but emits a warning.