### PR TITLE
Include .terraform.lock.hcl in CopyTerraformFolderToDest

### DIFF
--- a/modules/files/files.go
+++ b/modules/files/files.go
@@ -43,12 +43,12 @@ func IsExistingDir(path string) bool {
 // This is useful when running multiple tests in parallel against the same set of Terraform files to ensure the
 // tests don't overwrite each other's .terraform working directory and terraform.tfstate files. This method returns
 // the path to the dest folder with the copied contents. Hidden files and folders (with the exception of the `.terraform-version` files used
-// by the [tfenv tool](https://github.com/tfutils/tfenv)), Terraform state files, and terraform.tfvars files are not copied to this temp folder,
-// as you typically don't want them interfering with your tests.
+// by the [tfenv tool](https://github.com/tfutils/tfenv) and `.terraform.lock.hcl` used by Terraform to lock providers versions), Terraform state
+// files, and terraform.tfvars files are not copied to this temp folder, as you typically don't want them interfering with your tests.
 // This method is useful when running through a build tool so the files are copied to a destination that is cleaned on each run of the pipeline.
 func CopyTerraformFolderToDest(folderPath string, destRootFolder string, tempFolderPrefix string) (string, error) {
 	filter := func(path string) bool {
-		if PathIsTerraformVersionFile(path) {
+		if PathIsTerraformVersionFile(path) || PathIsTerraformLockFile(path) {
 			return true
 		}
 		if PathContainsHiddenFileOrFolder(path) || PathContainsTerraformStateOrVars(path) {
@@ -209,6 +209,11 @@ func PathContainsHiddenFileOrFolder(path string) bool {
 // PathIsTerraformVersionFile returns true if the given path is the special '.terraform-version' file used by the [tfenv](https://github.com/tfutils/tfenv) tool.
 func PathIsTerraformVersionFile(path string) bool {
 	return filepath.Base(path) == ".terraform-version"
+}
+
+// PathIsTerraformLockFile return true if the given path is the special '.terraform.lock.hcl' file used by Terraform to lock providers versions
+func PathIsTerraformLockFile(path string) bool {
+	return filepath.Base(path) == ".terraform.lock.hcl"
 }
 
 // CopyFile copies a file from source to destination.


### PR DESCRIPTION
This commit adds in the filter from the function
CopyTerragruntFolderToDest an exclusion exception for the lock file.

The `.terraform.lock.hcl` used by Terraform to lock the versions of
the providers is not included during the copy. It can bring weird
behaviors when the copy is skipped (check the function
test_structure.CopyTerraformFolderToDest) where version 1.1 of a
provider would be used in the example folder but might be updated during
the `terraform init` due to the copy without the lock file. The lock
file should be included within the copy to keep the same providers'
versions.

Fix: #1116

I ran the test from the `modules/files`. Here is the output:

```
Test completed without error, however due to a limitation in GNU diff < 3.3.0, directories have not been compared for equivalency.
PASS
ok      github.com/gruntwork-io/terratest/modules/files 0.005s
```
I try to run the tests from the `modules/terraform`, but a lot of them fail 
(they fail as well from master) and don't seem to be related to my changes.