### PR TITLE
Implement a helper funciton to check minimum binary versions.

### DIFF
--- a/modules/version-checker/errors.go
+++ b/modules/version-checker/errors.go
@@ -1,0 +1,10 @@
+package version_checker
+
+// VersionMismatchErr is an error to indicate version mismatch.
+type VersionMismatchErr struct {
+	errorMessage string
+}
+
+func (r *VersionMismatchErr) Error() string {
+	return r.errorMessage
+}

--- a/modules/version-checker/version_checker.go
+++ b/modules/version-checker/version_checker.go
@@ -2,11 +2,12 @@ package version_checker
 
 import (
 	"fmt"
+	"regexp"
+
 	"github.com/gruntwork-io/terratest/modules/shell"
 	"github.com/gruntwork-io/terratest/modules/testing"
 	"github.com/hashicorp/go-version"
 	"github.com/stretchr/testify/require"
-	"regexp"
 )
 
 // VersionCheckerBinary is an enum for supported version checking.

--- a/modules/version-checker/version_checker.go
+++ b/modules/version-checker/version_checker.go
@@ -4,12 +4,23 @@ import (
 	"fmt"
 	"github.com/gruntwork-io/terratest/modules/shell"
 	"github.com/gruntwork-io/terratest/modules/testing"
+	"github.com/hashicorp/go-version"
 	"github.com/stretchr/testify/require"
 	"regexp"
-	"strconv"
-	"strings"
 )
 
+// VersionMismatchErr is an error to indicate version mismatch.
+type VersionMismatchErr struct {
+	expectedVersion string
+	actualVersion   string
+}
+
+func (r *VersionMismatchErr) Error() string {
+	return fmt.Sprintf("found version mismatch {%s} when "+
+		"expecting min version of {%s}", r.expectedVersion, r.actualVersion)
+}
+
+// VersionCheckerBinary is an enum for supported version checking.
 type VersionCheckerBinary int
 
 // List of binaries supported for version checking.
@@ -20,65 +31,63 @@ const (
 )
 
 const (
-	// VersionRegexMatcher is a regex used to extract version string from shell command output.
-	VersionRegexMatcher = "\\d+(\\.\\d+)+"
-	// DefaultVersionArg is a default arg to pass in to get version output from shell command.
-	DefaultVersionArg = "--version"
+	// versionRegexMatcher is a regex used to extract version string from shell command output.
+	versionRegexMatcher = `\d+(\.\d+)+`
+	// defaultVersionArg is a default arg to pass in to get version output from shell command.
+	defaultVersionArg = "--version"
 )
 
 type CheckVersionParams struct {
-	binary          VersionCheckerBinary
-	expectedVersion string
-	workingDir      string
+	Binary          VersionCheckerBinary
+	ExpectedVersion string
+	WorkingDir      string
 }
 
-// CheckVersionE checks whether the given binary version is greater or equal
+// CheckVersionE checks whether the given Binary version is greater than or equal
 // to the given expected version.
 func CheckVersionE(
 	t testing.TestingT,
 	params CheckVersionParams) error {
 
-	err := validateParams(params)
+	if err := validateParams(params); err != nil {
+		return err
+	}
+
+	binaryVersion, err := getVersionWithShellCommand(t, params)
 	if err != nil {
 		return err
 	}
 
-	version, err := getVersionWithShellCommand(t, params)
-	if err != nil {
+	if err := checkMinimumBinaryVersion(binaryVersion, params.ExpectedVersion); err != nil {
 		return err
 	}
 
-	return validateBinaryVersionGreaterOrEqual(version, params.expectedVersion)
+	return nil
 }
 
-// CheckVersion checks whether the given binary version is greater or equal to the
+// CheckVersion checks whether the given Binary version is greater than or equal to the
 // given expected version and fail if it's not.
 func CheckVersion(
 	t testing.TestingT,
 	params CheckVersionParams) {
-	err := CheckVersionE(t, params)
-	require.NoError(t, err)
+	require.NoError(t, CheckVersionE(t, params))
 }
 
 // Validate whether the given params contains valid data to check version.
 func validateParams(params CheckVersionParams) error {
 	// Check for empty parameters
-	if len(params.expectedVersion) == 0 {
-		return fmt.Errorf("empty expectedVersion found")
-	} else if len(params.workingDir) == 0 {
-		return fmt.Errorf("empty workingDir found")
-	} else if params.binary < 0 {
-		return fmt.Errorf("empty binary found")
+	if params.ExpectedVersion == "" {
+		return fmt.Errorf("set ExpectedVersion in params")
+	} else if params.WorkingDir == "" {
+		return fmt.Errorf("set WorkingDir in params")
+	} else if params.Binary < 0 {
+		return fmt.Errorf("set Binary in params")
 	}
 
 	// Check the format of the expected version.
-	match, err := regexp.MatchString(VersionRegexMatcher, params.expectedVersion)
-	if err != nil {
+	if _, err := version.NewVersion(params.ExpectedVersion); err != nil {
 		return fmt.Errorf(
-			"unexpected regex matcher compilation failure: %w", err)
-	} else if !match {
-		return fmt.Errorf(
-			"invalid expected version format found {%s}", params.expectedVersion)
+			"invalid version format found {%s}", params.ExpectedVersion)
 	}
 
 	return nil
@@ -86,10 +95,11 @@ func validateParams(params CheckVersionParams) error {
 
 // getVersionWithShellCommand get version by running a shell command.
 func getVersionWithShellCommand(t testing.TestingT, params CheckVersionParams) (string, error) {
-	// Set appropriate binary, versionArg and extract version function
+	// Set appropriate Binary, versionArg and extract version function
 	// based on the given parameters.
-	var binaryName, versionArg = "", DefaultVersionArg
-	switch params.binary {
+	var binaryName = ""
+	var versionArg = defaultVersionArg
+	switch params.Binary {
 	case Docker:
 		binaryName = "docker"
 	case Packer:
@@ -97,93 +107,67 @@ func getVersionWithShellCommand(t testing.TestingT, params CheckVersionParams) (
 	case Terraform:
 		binaryName = "terraform"
 	default:
-		t.Fatalf("unsupported binary for checking versions.")
+		t.Fatalf("unsupported Binary for checking versions {%s}.", params.Binary)
 	}
 
 	// Run a shell command to get the version string.
 	output, err := shell.RunCommandAndGetOutputE(t, shell.Command{
 		Command:    binaryName,
 		Args:       []string{versionArg},
-		WorkingDir: params.workingDir,
+		WorkingDir: params.WorkingDir,
 		Env:        map[string]string{},
 	})
 	if err != nil {
-		return "", fmt.Errorf("failed to run shell command for binaray {%s} "+
+		return "", fmt.Errorf("failed to run shell command for Binary {%s} "+
 			"w/ version args {%s}: %w", binaryName, versionArg, err)
 	}
 
-	version, err := extractVersionFromShellCommandOutput(output)
+	versionStr, err := extractVersionFromShellCommandOutput(output)
 	if err != nil {
 		return "", fmt.Errorf("failed to extract version from shell "+
 			"command output {%s}: %w", output, err)
 	}
 
-	return version, nil
+	return versionStr, nil
 }
 
 // extractVersionFromShellCommandOutput extracts version with regex string matching
 // from the given shell command output string.
 func extractVersionFromShellCommandOutput(output string) (string, error) {
-	regexMatcher, err := regexp.Compile(VersionRegexMatcher)
-	if err != nil {
-		return "", fmt.Errorf("unexpected regex compilation error: %w", err)
-	}
-
-	version := regexMatcher.FindString(output)
-	if len(version) == 0 {
+	regexMatcher := regexp.MustCompile(versionRegexMatcher)
+	versionStr := regexMatcher.FindString(output)
+	if versionStr == "" {
 		return "", fmt.Errorf("failed to find version using regex matcher")
 	}
 
-	return version, nil
+	return versionStr, nil
 }
 
-// validateBinaryVersionGreaterOrEqual asserts that the first version is greater
-// than or equal to the second version.
+// checkMinimumBinaryVersion checks whether the given version is greater
+// than or equal to the given minimum version.
 //
-//    validateBinaryVersionGreaterOrEqual(t, 1.0.31, 1.0.27) - no error
-//    validateBinaryVersionGreaterOrEqual(t, 1.0.10, 1.0.27) - error
-//    validateBinaryVersionGreaterOrEqual(t, 1.0, 1.0.10) - error
-func validateBinaryVersionGreaterOrEqual(versionStr1 string, versionStr2 string) error {
-	if len(versionStr1) == 0 {
-		return fmt.Errorf("empty versionStr1 found")
-	} else if len(versionStr2) == 0 {
-		return fmt.Errorf("empty versionStr2 found")
+// It returns Error for ill-formatted version string and VersionMismatchErr for
+// minimum version check failure.
+//
+//    checkMinimumBinaryVersion(t, 1.0.31, 1.0.27) - no error
+//    checkMinimumBinaryVersion(t, 1.0.10, 1.0.27) - error
+//    checkMinimumBinaryVersion(t, 1.0, 1.0.10) - error
+func checkMinimumBinaryVersion(actualVersionStr string, minimumVersionStr string) error {
+	version1, err := version.NewVersion(actualVersionStr)
+	if err != nil {
+		return fmt.Errorf("invalid version format found for actualVersionStr: %s", actualVersionStr)
 	}
 
-	var versionNums1 = strings.Split(versionStr1, ".")
-	var versionNums2 = strings.Split(versionStr2, ".")
-	v1Length, v2Length := len(versionNums1), len(versionNums2)
-
-	length := v1Length
-	if v2Length < v1Length {
-		length = v2Length
+	version2, err := version.NewVersion(minimumVersionStr)
+	if err != nil {
+		return fmt.Errorf("invalid version format found for minimumVersionStr: %s", minimumVersionStr)
 	}
 
-	for i := 0; i < length; i++ {
-		v1, err := strconv.Atoi(versionNums1[i])
-		if err != nil {
-			return fmt.Errorf("invalid format version found {%s}", versionStr1)
+	if version1.LessThan(version2) {
+		return &VersionMismatchErr{
+			expectedVersion: minimumVersionStr,
+			actualVersion:   actualVersionStr,
 		}
-
-		v2, err := strconv.Atoi(versionNums2[i])
-		if err != nil {
-			return fmt.Errorf("invalid format version found {%s}", versionStr2)
-		}
-
-		if v1 < v2 {
-			return fmt.Errorf("binary version {%s} is smaller than {%s}",
-				versionStr1, versionStr2)
-		} else if v1 > v2 {
-			// version1 is higher than version2
-			return nil
-		}
-	}
-
-	// Final check to make sure the length of the version1 is
-	// greater or equal than version2. (e.g., 1.0.12 vs. 1.0)
-	if v1Length < v2Length {
-		return fmt.Errorf("binary version {%s} is smaller than {%s}",
-			versionStr1, versionStr2)
 	}
 
 	return nil

--- a/modules/version-checker/version_checker.go
+++ b/modules/version-checker/version_checker.go
@@ -65,16 +65,17 @@ func CheckVersionE(
 		return err
 	}
 
+	var versionConstraint string
 	switch params.VersionCheckerType {
 	case MinimumVersion:
-		err = checkMinimumVersion(binaryVersion, params.MinimumVersion)
+		versionConstraint = ">" + params.MinimumVersion
 	case VersionConstraint:
-		err = checkVersionConstraint(binaryVersion, params.VersionConstraint)
+		versionConstraint = params.VersionConstraint
 	default:
 		return fmt.Errorf("unsupported version checker type {%d}", params.VersionCheckerType)
 	}
 
-	return err
+	return checkVersionConstraint(binaryVersion, versionConstraint)
 }
 
 // CheckVersion checks whether the given Binary version is greater than or equal to the
@@ -169,34 +170,6 @@ func extractVersionFromShellCommandOutput(output string) (string, error) {
 	}
 
 	return versionStr, nil
-}
-
-// checkMinimumVersion checks whether the given version is greater
-// than or equal to the given minimum version.
-//
-//    checkMinimumVersion(t, 1.0.31, 1.0.27) - no error
-//    checkMinimumVersion(t, 1.0.10, 1.0.27) - error
-//    checkMinimumVersion(t, 1.0, 1.0.10) - error
-func checkMinimumVersion(actualVersionStr string, minimumVersionStr string) error {
-	actualVersion, err := version.NewVersion(actualVersionStr)
-	if err != nil {
-		return fmt.Errorf("invalid version format found for actualVersionStr: %s", actualVersionStr)
-	}
-
-	minimumVersion, err := version.NewVersion(minimumVersionStr)
-	if err != nil {
-		return fmt.Errorf("invalid version format found for minimumVersionStr: %s", minimumVersionStr)
-	}
-
-	if actualVersion.LessThan(minimumVersion) {
-		return &VersionMismatchErr{
-			errorMessage: fmt.Sprintf("actual version {%s} is less than the "+
-				"minimum version required {%s}", actualVersionStr, minimumVersionStr),
-		}
-	}
-
-	return nil
-
 }
 
 // checkVersionConstraint checks whether the given version pass the version constraint.

--- a/modules/version-checker/version_checker.go
+++ b/modules/version-checker/version_checker.go
@@ -1,0 +1,190 @@
+package version_checker
+
+import (
+	"fmt"
+	"github.com/gruntwork-io/terratest/modules/shell"
+	"github.com/gruntwork-io/terratest/modules/testing"
+	"github.com/stretchr/testify/require"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+type VersionCheckerBinary int
+
+// List of binaries supported for version checking.
+const (
+	Docker VersionCheckerBinary = iota
+	Terraform
+	Packer
+)
+
+const (
+	// VersionRegexMatcher is a regex used to extract version string from shell command output.
+	VersionRegexMatcher = "\\d+(\\.\\d+)+"
+	// DefaultVersionArg is a default arg to pass in to get version output from shell command.
+	DefaultVersionArg = "--version"
+)
+
+type CheckVersionParams struct {
+	binary          VersionCheckerBinary
+	expectedVersion string
+	workingDir      string
+}
+
+// CheckVersionE checks whether the given binary version is greater or equal
+// to the given expected version.
+func CheckVersionE(
+	t testing.TestingT,
+	params CheckVersionParams) error {
+
+	err := validateParams(params)
+	if err != nil {
+		return err
+	}
+
+	version, err := getVersionWithShellCommand(t, params)
+	if err != nil {
+		return err
+	}
+
+	return validateBinaryVersionGreaterOrEqual(version, params.expectedVersion)
+}
+
+// CheckVersion checks whether the given binary version is greater or equal to the
+// given expected version and fail if it's not.
+func CheckVersion(
+	t testing.TestingT,
+	params CheckVersionParams) {
+	err := CheckVersionE(t, params)
+	require.NoError(t, err)
+}
+
+// Validate whether the given params contains valid data to check version.
+func validateParams(params CheckVersionParams) error {
+	// Check for empty parameters
+	if len(params.expectedVersion) == 0 {
+		return fmt.Errorf("empty expectedVersion found")
+	} else if len(params.workingDir) == 0 {
+		return fmt.Errorf("empty workingDir found")
+	} else if params.binary < 0 {
+		return fmt.Errorf("empty binary found")
+	}
+
+	// Check the format of the expected version.
+	match, err := regexp.MatchString(VersionRegexMatcher, params.expectedVersion)
+	if err != nil {
+		return fmt.Errorf(
+			"unexpected regex matcher compilation failure: %w", err)
+	} else if !match {
+		return fmt.Errorf(
+			"invalid expected version format found {%s}", params.expectedVersion)
+	}
+
+	return nil
+}
+
+// getVersionWithShellCommand get version by running a shell command.
+func getVersionWithShellCommand(t testing.TestingT, params CheckVersionParams) (string, error) {
+	// Set appropriate binary, versionArg and extract version function
+	// based on the given parameters.
+	var binaryName, versionArg = "", DefaultVersionArg
+	switch params.binary {
+	case Docker:
+		binaryName = "docker"
+	case Packer:
+		binaryName = "packer"
+	case Terraform:
+		binaryName = "terraform"
+	default:
+		t.Fatalf("unsupported binary for checking versions.")
+	}
+
+	// Run a shell command to get the version string.
+	output, err := shell.RunCommandAndGetOutputE(t, shell.Command{
+		Command:    binaryName,
+		Args:       []string{versionArg},
+		WorkingDir: params.workingDir,
+		Env:        map[string]string{},
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to run shell command for binaray {%s} "+
+			"w/ version args {%s}: %w", binaryName, versionArg, err)
+	}
+
+	version, err := extractVersionFromShellCommandOutput(output)
+	if err != nil {
+		return "", fmt.Errorf("failed to extract version from shell "+
+			"command output {%s}: %w", output, err)
+	}
+
+	return version, nil
+}
+
+// extractVersionFromShellCommandOutput extracts version with regex string matching
+// from the given shell command output string.
+func extractVersionFromShellCommandOutput(output string) (string, error) {
+	regexMatcher, err := regexp.Compile(VersionRegexMatcher)
+	if err != nil {
+		return "", fmt.Errorf("unexpected regex compilation error: %w", err)
+	}
+
+	version := regexMatcher.FindString(output)
+	if len(version) == 0 {
+		return "", fmt.Errorf("failed to find version using regex matcher")
+	}
+
+	return version, nil
+}
+
+// validateBinaryVersionGreaterOrEqual asserts that the first version is greater
+// than or equal to the second version.
+//
+//    validateBinaryVersionGreaterOrEqual(t, 1.0.31, 1.0.27) - no error
+//    validateBinaryVersionGreaterOrEqual(t, 1.0.10, 1.0.27) - error
+//    validateBinaryVersionGreaterOrEqual(t, 1.0, 1.0.10) - error
+func validateBinaryVersionGreaterOrEqual(versionStr1 string, versionStr2 string) error {
+	if len(versionStr1) == 0 {
+		return fmt.Errorf("empty versionStr1 found")
+	} else if len(versionStr2) == 0 {
+		return fmt.Errorf("empty versionStr2 found")
+	}
+
+	var versionNums1 = strings.Split(versionStr1, ".")
+	var versionNums2 = strings.Split(versionStr2, ".")
+	v1Length, v2Length := len(versionNums1), len(versionNums2)
+
+	length := v1Length
+	if v2Length < v1Length {
+		length = v2Length
+	}
+
+	for i := 0; i < length; i++ {
+		v1, err := strconv.Atoi(versionNums1[i])
+		if err != nil {
+			return fmt.Errorf("invalid format version found {%s}", versionStr1)
+		}
+
+		v2, err := strconv.Atoi(versionNums2[i])
+		if err != nil {
+			return fmt.Errorf("invalid format version found {%s}", versionStr2)
+		}
+
+		if v1 < v2 {
+			return fmt.Errorf("binary version {%s} is smaller than {%s}",
+				versionStr1, versionStr2)
+		} else if v1 > v2 {
+			// version1 is higher than version2
+			return nil
+		}
+	}
+
+	// Final check to make sure the length of the version1 is
+	// greater or equal than version2. (e.g., 1.0.12 vs. 1.0)
+	if v1Length < v2Length {
+		return fmt.Errorf("binary version {%s} is smaller than {%s}",
+			versionStr1, versionStr2)
+	}
+
+	return nil
+}

--- a/modules/version-checker/version_checker.go
+++ b/modules/version-checker/version_checker.go
@@ -19,14 +19,6 @@ const (
 	Packer
 )
 
-// VersionCheckerType is an enum for different type of version checking available.
-type VersionCheckerType int
-
-const (
-	MinimumVersion VersionCheckerType = iota
-	VersionConstraint
-)
-
 const (
 	// versionRegexMatcher is a regex used to extract version string from shell command output.
 	versionRegexMatcher = `\d+(\.\d+)+`
@@ -39,10 +31,6 @@ type CheckVersionParams struct {
 	BinaryPath string
 	// Binary is the name of the binary you want to check the version for.
 	Binary VersionCheckerBinary
-	// VersionCheckerType to specify different ways to enforce certain version on binary.
-	VersionCheckerType VersionCheckerType
-	// MinimumVersion is a string literal containing a minimum version (e.g., 1.2.1)
-	MinimumVersion string
 	// VersionConstraint is a string literal containing one or more conditions, which are separated by commas.
 	// More information here:https://www.terraform.io/language/expressions/version-constraints
 	VersionConstraint string
@@ -65,17 +53,7 @@ func CheckVersionE(
 		return err
 	}
 
-	var versionConstraint string
-	switch params.VersionCheckerType {
-	case MinimumVersion:
-		versionConstraint = ">" + params.MinimumVersion
-	case VersionConstraint:
-		versionConstraint = params.VersionConstraint
-	default:
-		return fmt.Errorf("unsupported version checker type {%d}", params.VersionCheckerType)
-	}
-
-	return checkVersionConstraint(binaryVersion, versionConstraint)
+	return checkVersionConstraint(binaryVersion, params.VersionConstraint)
 }
 
 // CheckVersion checks whether the given Binary version is greater than or equal to the
@@ -91,16 +69,8 @@ func validateParams(params CheckVersionParams) error {
 	// Check for empty parameters
 	if params.WorkingDir == "" {
 		return fmt.Errorf("set WorkingDir in params")
-	} else if params.VersionCheckerType == MinimumVersion && params.MinimumVersion == "" {
-		return fmt.Errorf("set MinimumVersion in params")
-	} else if params.VersionCheckerType == VersionConstraint && params.VersionConstraint == "" {
+	} else if params.VersionConstraint == "" {
 		return fmt.Errorf("set VersionConstraint in params")
-	}
-
-	// Check the format of the expected version.
-	if _, err := version.NewVersion(params.MinimumVersion); params.MinimumVersion != "" && err != nil {
-		return fmt.Errorf(
-			"invalid minimum version format found {%s}", params.MinimumVersion)
 	}
 
 	// Check the format of the version constraint if present.

--- a/modules/version-checker/version_checker_test.go
+++ b/modules/version-checker/version_checker_test.go
@@ -1,8 +1,9 @@
 package version_checker
 
 import (
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestParamValidation(t *testing.T) {

--- a/modules/version-checker/version_checker_test.go
+++ b/modules/version-checker/version_checker_test.go
@@ -1,0 +1,112 @@
+package version_checker
+
+import (
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestParamValidation(t *testing.T) {
+	t.Parallel()
+
+	// empty params
+	err := validateParams(CheckVersionParams{})
+	require.EqualError(t, err, "empty expectedVersion found")
+
+	// invalid binary
+	err = validateParams(CheckVersionParams{
+		binary:          -1,
+		expectedVersion: "1.2",
+		workingDir:      ".",
+	})
+	require.EqualError(t, err, "empty binary found")
+
+	// invalid working Dir
+	err = validateParams(CheckVersionParams{
+		binary:          Docker,
+		expectedVersion: "1.2",
+		workingDir:      "",
+	})
+	require.EqualError(t, err, "empty workingDir found")
+
+	// invalid expected version
+	err = validateParams(CheckVersionParams{
+		binary:          Docker,
+		expectedVersion: "abc",
+		workingDir:      ".",
+	})
+	require.EqualError(t, err, "invalid expected version format found {abc}")
+
+	// valid params
+	err = validateParams(CheckVersionParams{
+		binary:          Docker,
+		expectedVersion: "1.2.3",
+		workingDir:      ".",
+	})
+	require.NoError(t, err)
+}
+
+func TestExtractVersionFromShellCommandOutput(t *testing.T) {
+	t.Parallel()
+
+	// empty output
+	_, err := extractVersionFromShellCommandOutput("")
+	require.EqualError(t, err, "failed to find version using regex matcher")
+
+	// invalid version output from shell command
+	_, err = extractVersionFromShellCommandOutput("invalid output")
+	require.EqualError(t, err, "failed to find version using regex matcher")
+}
+
+func TestValidateBinaryVersionGreaterOrEqual(t *testing.T) {
+	t.Parallel()
+
+	// empty versionStr1
+	err := validateBinaryVersionGreaterOrEqual("", "")
+	require.EqualError(t, err, "empty versionStr1 found")
+
+	// empty versionStr2
+	err = validateBinaryVersionGreaterOrEqual("1.2.3", "")
+	require.EqualError(t, err, "empty versionStr2 found")
+
+	// invalid format versionStr1
+	err = validateBinaryVersionGreaterOrEqual("abc", "1.2.3")
+	require.EqualError(t, err, "invalid format version found {abc}")
+
+	// invalid format versionStr2
+	err = validateBinaryVersionGreaterOrEqual("1.2.3", "abc")
+	require.EqualError(t, err, "invalid format version found {abc}")
+
+	// versionStr1 > versionStr2
+	err = validateBinaryVersionGreaterOrEqual("1.2.3", "1.2.2")
+	require.NoError(t, err)
+
+	// versionStr1 = versionStr2
+	err = validateBinaryVersionGreaterOrEqual("1.2.3", "1.2.3")
+	require.NoError(t, err)
+
+	// versionStr1 < versionStr2
+	err = validateBinaryVersionGreaterOrEqual("1.2.3", "1.2.4")
+	require.EqualError(t, err, "binary version {1.2.3} is smaller than {1.2.4}")
+
+	// mismatching version length: versionStr1 > versionStr2
+	err = validateBinaryVersionGreaterOrEqual("1.2", "1.2.4")
+	require.EqualError(t, err, "binary version {1.2} is smaller than {1.2.4}")
+
+	// mismatching version length: versionStr1 < versionStr2
+	err = validateBinaryVersionGreaterOrEqual("1.2.4", "1.2")
+	require.NoError(t, err)
+}
+
+func TestCheckVersionSanityCheck(t *testing.T) {
+	t.Parallel()
+
+	// Note: with the current implementation of running shell command, it's not easy to
+	// mock the output of running a shell command. So we assume a certain binary is installed in the working
+	// directory and it's greater than 0.
+	err := CheckVersionE(t, CheckVersionParams{
+		binary:          Terraform,
+		expectedVersion: "0.0.1",
+		workingDir:      ".",
+	})
+	require.NoError(t, err)
+}

--- a/modules/version-checker/version_checker_test.go
+++ b/modules/version-checker/version_checker_test.go
@@ -1,7 +1,6 @@
 package version_checker
 
 import (
-	"fmt"
 	"github.com/stretchr/testify/require"
 	"testing"
 )
@@ -10,47 +9,70 @@ func TestParamValidation(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
+		name                 string
 		param                CheckVersionParams
 		containError         bool
 		expectedErrorMessage string
 	}{
 		{
+			name:                 "Empty Params",
 			param:                CheckVersionParams{},
-			containError:         true,
-			expectedErrorMessage: "set ExpectedVersion in params",
-		},
-		{
-			param: CheckVersionParams{
-				Binary:          -1,
-				ExpectedVersion: "1.2",
-				WorkingDir:      ".",
-			},
-			containError:         true,
-			expectedErrorMessage: "set Binary in params",
-		},
-		{
-			param: CheckVersionParams{
-				Binary:          Docker,
-				ExpectedVersion: "1.2",
-				WorkingDir:      "",
-			},
 			containError:         true,
 			expectedErrorMessage: "set WorkingDir in params",
 		},
 		{
+			name: "Missing MinimumVersion",
 			param: CheckVersionParams{
-				Binary:          Docker,
-				ExpectedVersion: "abc",
-				WorkingDir:      ".",
+				VersionCheckerType: MinimumVersion,
+				Binary:             Docker,
+				VersionConstraint:  "",
+				MinimumVersion:     "",
+				WorkingDir:         ".",
 			},
 			containError:         true,
-			expectedErrorMessage: "invalid version format found {abc}",
+			expectedErrorMessage: "set MinimumVersion in params",
 		},
 		{
+			name: "Missing VersionConstraint",
 			param: CheckVersionParams{
-				Binary:          Docker,
-				ExpectedVersion: "1.2.3",
-				WorkingDir:      ".",
+				VersionCheckerType: VersionConstraint,
+				Binary:             Docker,
+				VersionConstraint:  "",
+				MinimumVersion:     "",
+				WorkingDir:         ".",
+			},
+			containError:         true,
+			expectedErrorMessage: "set VersionConstraint in params",
+		},
+		{
+			name: "Invalid Minimum Version Format",
+			param: CheckVersionParams{
+				VersionCheckerType: MinimumVersion,
+				Binary:             Docker,
+				MinimumVersion:     "abc",
+				WorkingDir:         ".",
+			},
+			containError:         true,
+			expectedErrorMessage: "invalid minimum version format found {abc}",
+		},
+		{
+			name: "Invalid Version Constraint Format",
+			param: CheckVersionParams{
+				VersionCheckerType: VersionConstraint,
+				Binary:             Docker,
+				VersionConstraint:  "abc",
+				WorkingDir:         ".",
+			},
+			containError:         true,
+			expectedErrorMessage: "invalid version constraint format found {abc}",
+		},
+		{
+			name: "Success",
+			param: CheckVersionParams{
+				VersionCheckerType: MinimumVersion,
+				Binary:             Docker,
+				MinimumVersion:     "1.2.3",
+				WorkingDir:         ".",
 			},
 			containError:         false,
 			expectedErrorMessage: "",
@@ -59,11 +81,10 @@ func TestParamValidation(t *testing.T) {
 
 	for _, tc := range tests {
 		err := validateParams(tc.param)
-		testCaseContextStr := fmt.Sprintf("test case w/ param: %v", tc.param)
 		if tc.containError {
-			require.EqualError(t, err, tc.expectedErrorMessage, testCaseContextStr)
+			require.EqualError(t, err, tc.expectedErrorMessage, tc.name)
 		} else {
-			require.NoError(t, err, testCaseContextStr)
+			require.NoError(t, err, tc.name)
 		}
 	}
 }
@@ -72,64 +93,176 @@ func TestExtractVersionFromShellCommandOutput(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
+		name                 string
 		outputStr            string
 		expectedVersionStr   string
 		containError         bool
 		expectedErrorMessage string
 	}{
-		{outputStr: "version is 1.2.3", expectedVersionStr: "1.2.3", containError: false,
-			expectedErrorMessage: ""},
-		{outputStr: "version is v1.0.0", expectedVersionStr: "1.0.0", containError: false,
-			expectedErrorMessage: ""},
-		{outputStr: "version is v1.0", expectedVersionStr: "1.0", containError: false,
-			expectedErrorMessage: ""},
-		{outputStr: "version is vabc", expectedVersionStr: "", containError: true,
-			expectedErrorMessage: "failed to find version using regex matcher"},
-		{outputStr: "", expectedVersionStr: "", containError: true,
-			expectedErrorMessage: "failed to find version using regex matcher"},
+		{
+			name:                 "Stand-alone version string",
+			outputStr:            "version is 1.2.3",
+			expectedVersionStr:   "1.2.3",
+			containError:         false,
+			expectedErrorMessage: "",
+		},
+		{
+			name:                 "version string with v prefix",
+			outputStr:            "version is v1.0.0",
+			expectedVersionStr:   "1.0.0",
+			containError:         false,
+			expectedErrorMessage: "",
+		},
+		{
+			name:                 "2 digit version string",
+			outputStr:            "version is v1.0",
+			expectedVersionStr:   "1.0",
+			containError:         false,
+			expectedErrorMessage: "",
+		},
+		{
+			name:                 "invalid output string",
+			outputStr:            "version is vabc",
+			expectedVersionStr:   "",
+			containError:         true,
+			expectedErrorMessage: "failed to find version using regex matcher",
+		},
+		{
+			name:                 "empty output string",
+			outputStr:            "",
+			expectedVersionStr:   "",
+			containError:         true,
+			expectedErrorMessage: "failed to find version using regex matcher",
+		},
 	}
 
 	for _, tc := range tests {
 		versionStr, err := extractVersionFromShellCommandOutput(tc.outputStr)
-		testCaseContextStr := fmt.Sprintf("test case w/ outputStr: %s", tc.outputStr)
 		if tc.containError {
-			require.EqualError(t, err, tc.expectedErrorMessage, testCaseContextStr)
+			require.EqualError(t, err, tc.expectedErrorMessage, tc.name)
 		} else {
-			require.NoError(t, err, testCaseContextStr)
-			require.Equal(t, tc.expectedVersionStr, versionStr, testCaseContextStr)
+			require.NoError(t, err, tc.name)
+			require.Equal(t, tc.expectedVersionStr, versionStr, tc.name)
 		}
 	}
 }
 
-func TestValidateBinaryVersionGreaterOrEqual(t *testing.T) {
+func TestCheckMimnimumVersion(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
+		name                 string
 		actualVersionStr     string
 		minimumVersionStr    string
 		containError         bool
 		expectedErrorMessage string
 	}{
-		{actualVersionStr: "", minimumVersionStr: "1.2.3", containError: true,
-			expectedErrorMessage: "invalid version format found for actualVersionStr: "},
-		{actualVersionStr: "1.2.3", minimumVersionStr: "", containError: true,
-			expectedErrorMessage: "invalid version format found for minimumVersionStr: "},
-		{actualVersionStr: "1.2.3", minimumVersionStr: "1.2.3", containError: false,
-			expectedErrorMessage: ""},
-		{actualVersionStr: "1.2.4", minimumVersionStr: "1.2.3", containError: false,
-			expectedErrorMessage: ""},
-		{actualVersionStr: "1.2", minimumVersionStr: "1.2.3", containError: true,
-			expectedErrorMessage: "found version mismatch {1.2.3} when expecting min version of {1.2}"},
+		{
+			name:                 "invalid actualVersionStr",
+			actualVersionStr:     "",
+			minimumVersionStr:    "1.2.3",
+			containError:         true,
+			expectedErrorMessage: "invalid version format found for actualVersionStr: ",
+		},
+		{
+			name:                 "invalid minimumVersionStr",
+			actualVersionStr:     "1.2.3",
+			minimumVersionStr:    "",
+			containError:         true,
+			expectedErrorMessage: "invalid version format found for minimumVersionStr: ",
+		},
+		{
+			name:                 "same version as minimum version",
+			actualVersionStr:     "1.2.3",
+			minimumVersionStr:    "1.2.3",
+			containError:         false,
+			expectedErrorMessage: "",
+		},
+		{
+			name:                 "higher version as minimum version",
+			actualVersionStr:     "1.2.4",
+			minimumVersionStr:    "1.2.3",
+			containError:         false,
+			expectedErrorMessage: "",
+		},
+		{
+			name:                 "lower version as minimum version",
+			actualVersionStr:     "1.2.2",
+			minimumVersionStr:    "1.2.3",
+			containError:         true,
+			expectedErrorMessage: "actual version {1.2.2} is less than the minimum version required {1.2.3}",
+		},
 	}
 
 	for _, tc := range tests {
-		err := checkMinimumBinaryVersion(tc.actualVersionStr, tc.minimumVersionStr)
-		testCaseContextStr := fmt.Sprintf("test case w/ actualVersionStr: %s, expectedVersionstr: %s",
-			tc.actualVersionStr, tc.minimumVersionStr)
+		err := checkMinimumVersion(tc.actualVersionStr, tc.minimumVersionStr)
 		if tc.containError {
-			require.EqualError(t, err, tc.expectedErrorMessage, testCaseContextStr)
+			require.EqualError(t, err, tc.expectedErrorMessage, tc.name)
 		} else {
-			require.NoError(t, err, testCaseContextStr)
+			require.NoError(t, err, tc.name)
+		}
+	}
+}
+
+func TestCheckVersionConstraint(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                 string
+		actualVersionStr     string
+		versionConstraint    string
+		containError         bool
+		expectedErrorMessage string
+	}{
+		{
+			name:                 "invalid actualVersionStr",
+			actualVersionStr:     "",
+			versionConstraint:    "1.2.3",
+			containError:         true,
+			expectedErrorMessage: "invalid version format found for actualVersionStr: ",
+		},
+		{
+			name:                 "invalid versionConstraint",
+			actualVersionStr:     "1.2.3",
+			versionConstraint:    "",
+			containError:         true,
+			expectedErrorMessage: "invalid version format found for versionConstraint: ",
+		},
+		{
+			name:                 "pass version constraint",
+			actualVersionStr:     "1.2.3",
+			versionConstraint:    "1.2.3",
+			containError:         false,
+			expectedErrorMessage: "",
+		},
+		{
+			name:                 "fail version constraint",
+			actualVersionStr:     "1.2.3",
+			versionConstraint:    "1.2.4",
+			containError:         true,
+			expectedErrorMessage: "actual version {1.2.3} failed the version constraint {1.2.4}",
+		},
+		{
+			name:                 "special syntax version constraint",
+			actualVersionStr:     "1.0.5",
+			versionConstraint:    "~> 1.0.4",
+			containError:         false,
+			expectedErrorMessage: "",
+		},
+		{
+			name:                 "version constraint w/ operators",
+			actualVersionStr:     "1.2.7",
+			versionConstraint:    ">= 1.2.0, < 2.0.0",
+			containError:         false,
+			expectedErrorMessage: ""},
+	}
+
+	for _, tc := range tests {
+		err := checkVersionConstraint(tc.actualVersionStr, tc.versionConstraint)
+		if tc.containError {
+			require.EqualError(t, err, tc.expectedErrorMessage, tc.name)
+		} else {
+			require.NoError(t, err, tc.name)
 		}
 	}
 }
@@ -141,9 +274,10 @@ func TestCheckVersionSanityCheck(t *testing.T) {
 	// mock the output of running a shell command. So we assume a certain Binary is installed in the working
 	// directory and it's greater than 0.
 	err := CheckVersionE(t, CheckVersionParams{
-		Binary:          Terraform,
-		ExpectedVersion: "0.0.1",
-		WorkingDir:      ".",
+		VersionCheckerType: MinimumVersion,
+		Binary:             Terraform,
+		MinimumVersion:     "0.0.1",
+		WorkingDir:         ".",
 	})
 	require.NoError(t, err)
 }

--- a/modules/version-checker/version_checker_test.go
+++ b/modules/version-checker/version_checker_test.go
@@ -21,47 +21,21 @@ func TestParamValidation(t *testing.T) {
 			expectedErrorMessage: "set WorkingDir in params",
 		},
 		{
-			name: "Missing MinimumVersion",
-			param: CheckVersionParams{
-				VersionCheckerType: MinimumVersion,
-				Binary:             Docker,
-				VersionConstraint:  "",
-				MinimumVersion:     "",
-				WorkingDir:         ".",
-			},
-			containError:         true,
-			expectedErrorMessage: "set MinimumVersion in params",
-		},
-		{
 			name: "Missing VersionConstraint",
 			param: CheckVersionParams{
-				VersionCheckerType: VersionConstraint,
-				Binary:             Docker,
-				VersionConstraint:  "",
-				MinimumVersion:     "",
-				WorkingDir:         ".",
+				Binary:            Docker,
+				VersionConstraint: "",
+				WorkingDir:        ".",
 			},
 			containError:         true,
 			expectedErrorMessage: "set VersionConstraint in params",
 		},
 		{
-			name: "Invalid Minimum Version Format",
-			param: CheckVersionParams{
-				VersionCheckerType: MinimumVersion,
-				Binary:             Docker,
-				MinimumVersion:     "abc",
-				WorkingDir:         ".",
-			},
-			containError:         true,
-			expectedErrorMessage: "invalid minimum version format found {abc}",
-		},
-		{
 			name: "Invalid Version Constraint Format",
 			param: CheckVersionParams{
-				VersionCheckerType: VersionConstraint,
-				Binary:             Docker,
-				VersionConstraint:  "abc",
-				WorkingDir:         ".",
+				Binary:            Docker,
+				VersionConstraint: "abc",
+				WorkingDir:        ".",
 			},
 			containError:         true,
 			expectedErrorMessage: "invalid version constraint format found {abc}",
@@ -69,10 +43,9 @@ func TestParamValidation(t *testing.T) {
 		{
 			name: "Success",
 			param: CheckVersionParams{
-				VersionCheckerType: MinimumVersion,
-				Binary:             Docker,
-				MinimumVersion:     "1.2.3",
-				WorkingDir:         ".",
+				Binary:            Docker,
+				VersionConstraint: ">1.2.3",
+				WorkingDir:        ".",
 			},
 			containError:         false,
 			expectedErrorMessage: "",
@@ -220,24 +193,21 @@ func TestCheckVersionEndToEnd(t *testing.T) {
 		param CheckVersionParams
 	}{
 		{name: "Docker", param: CheckVersionParams{
-			Binary:             Docker,
-			VersionCheckerType: MinimumVersion,
-			MinimumVersion:     "0.0.1",
-			WorkingDir:         ".",
+			Binary:            Docker,
+			VersionConstraint: ">= 0.0.1",
+			WorkingDir:        ".",
 		}},
 		{name: "Terraform", param: CheckVersionParams{
-			BinaryPath:         "",
-			Binary:             Terraform,
-			VersionCheckerType: VersionConstraint,
-			VersionConstraint:  ">= 0.0.1",
-			WorkingDir:         ".",
+			BinaryPath:        "",
+			Binary:            Terraform,
+			VersionConstraint: ">= 0.0.1",
+			WorkingDir:        ".",
 		}},
 		{name: "Packer", param: CheckVersionParams{
-			BinaryPath:         "/usr/local/bin/packer",
-			Binary:             Packer,
-			VersionCheckerType: MinimumVersion,
-			MinimumVersion:     "0.0.1",
-			WorkingDir:         ".",
+			BinaryPath:        "/usr/local/bin/packer",
+			Binary:            Packer,
+			VersionConstraint: ">= 0.0.1",
+			WorkingDir:        ".",
 		}},
 	}
 


### PR DESCRIPTION
The overall approach is to run a shell command to extract version string: 
* run a shell command (e.g., `docker --version`) 
* use regex string matcher to extract the exact version string

Right now, it only supports `docker`, `packer`, and `terraform` and the caller need to ensure that those binary exists in the working directory. If we want to support other binaries in the future that potentially has different ways to extract the version string, we can branch it out in the main method e.g., :

```
version, err
switch binary: 
case Docker, Packer, Terrafor: 
  version, err = getVersionWithShellCommand(t, params)
case ...:
  version, err = getVersionX(t, params)

// other remaining code
```

TODO: explore ways to mock `shell.RunCommandAndGetOutputE` so we can test handling different potential output from the shell command end to end. 

Fixes #566 