### PR TITLE
Fix broken validate call for azure example

### DIFF
--- a/examples/azure/terraform-azure-frontdoor-example/main.tf
+++ b/examples/azure/terraform-azure-frontdoor-example/main.tf
@@ -27,9 +27,12 @@ resource "azurerm_resource_group" "rg" {
 # ---------------------------------------------------------------------------------------------------------------------
 
 resource "azurerm_frontdoor" "frontdoor" {
-  name                                         = "terratest-afd-${var.postfix}"
-  resource_group_name                          = azurerm_resource_group.rg.name
-  enforce_backend_pools_certificate_name_check = false
+  name                = "terratest-afd-${var.postfix}"
+  resource_group_name = azurerm_resource_group.rg.name
+
+  backend_pool_settings {
+    enforce_backend_pools_certificate_name_check = false
+  }
 
   routing_rule {
     name               = "terratestRoutingRule1"


### PR DESCRIPTION
This Azure example was failing the validate test due to a backward incompatibility update in the azure provider for the `azurerm_frontdoor` resource.

cc @HadwaAbdelhalem 