### PR TITLE
Get default aws subnet ids 

### DIFF
--- a/modules/aws/vpc.go
+++ b/modules/aws/vpc.go
@@ -205,7 +205,7 @@ func GetDefaultSubnetIDsForVpcE(t testing.TestingT, vpc Vpc) ([]string, error) {
 	}
 
 	for _, subnet := range vpc.Subnets {
-		if subnet.DefaultForAz == true {
+		if subnet.DefaultForAz {
 			subnetIDs = append(subnetIDs, subnet.Id)
 		}
 	}

--- a/modules/aws/vpc.go
+++ b/modules/aws/vpc.go
@@ -24,6 +24,7 @@ type Vpc struct {
 type Subnet struct {
 	Id               string            // The ID of the Subnet
 	AvailabilityZone string            // The Availability Zone the subnet is in
+	DefaultForAz     bool              // If the subnet is default for the Availability Zone
 	Tags             map[string]string // The tags associated with the subnet
 }
 
@@ -34,6 +35,7 @@ const vpcResourceTypeFilterValue = "vpc"
 const subnetResourceTypeFilterValue = "subnet"
 const isDefaultFilterName = "isDefault"
 const isDefaultFilterValue = "true"
+const defaultVPCName = "Default"
 
 // GetDefaultVpc fetches information about the default VPC in the given region.
 func GetDefaultVpc(t testing.TestingT, region string) *Vpc {
@@ -117,7 +119,7 @@ func FindVpcName(vpc *ec2.Vpc) string {
 	}
 
 	if *vpc.IsDefault {
-		return "Default"
+		return defaultVPCName
 	}
 
 	return ""
@@ -149,7 +151,7 @@ func GetSubnetsForVpcE(t testing.TestingT, vpcID string, region string) ([]Subne
 
 	for _, ec2Subnet := range subnetOutput.Subnets {
 		subnetTags := GetTagsForSubnet(t, *ec2Subnet.SubnetId, region)
-		subnet := Subnet{Id: aws.StringValue(ec2Subnet.SubnetId), AvailabilityZone: aws.StringValue(ec2Subnet.AvailabilityZone), Tags: subnetTags}
+		subnet := Subnet{Id: aws.StringValue(ec2Subnet.SubnetId), AvailabilityZone: aws.StringValue(ec2Subnet.AvailabilityZone), DefaultForAz: aws.BoolValue(ec2Subnet.DefaultForAz), Tags: subnetTags}
 		subnets = append(subnets, subnet)
 	}
 
@@ -180,6 +182,34 @@ func GetTagsForVpcE(t testing.TestingT, vpcID string, region string) (map[string
 	}
 
 	return tags, nil
+}
+
+// GetDefaultSubnetIDsForVpc gets the ids of the subnets that are the default subnet for the AvailabilityZone
+func GetDefaultSubnetIDsForVpc(t testing.TestingT, vpc Vpc) []string {
+	subnetIDs, err := GetDefaultSubnetIDsForVpcE(t, vpc)
+	require.NoError(t, err)
+	return subnetIDs
+}
+
+// GetDefaultSubnetIDsForVpcE gets the ids of the subnets that are the default subnet for the AvailabilityZone
+func GetDefaultSubnetIDsForVpcE(t testing.TestingT, vpc Vpc) ([]string, error) {
+	if vpc.Name != defaultVPCName {
+		// You cannot create a default subnet in a nondefault VPC
+		// https://docs.aws.amazon.com/vpc/latest/userguide/default-vpc.html
+		return nil, fmt.Errorf("Only default VPCs have default subnets but VPC with id %s is not default VPC", vpc.Id)
+	}
+	subnetIDs := []string{}
+	numSubnets := len(vpc.Subnets)
+	if numSubnets == 0 {
+		return nil, fmt.Errorf("Expected to find at least one subnet in vpc with ID %s but found zero", vpc.Id)
+	}
+
+	for _, subnet := range vpc.Subnets {
+		if subnet.DefaultForAz == true {
+			subnetIDs = append(subnetIDs, subnet.Id)
+		}
+	}
+	return subnetIDs, nil
 }
 
 // GetTagsForSubnet gets the tags for the specified subnet.

--- a/modules/aws/vpc_test.go
+++ b/modules/aws/vpc_test.go
@@ -76,6 +76,31 @@ func TestIsPublicSubnet(t *testing.T) {
 	assert.True(t, IsPublicSubnet(t, *subnet.SubnetId, region))
 }
 
+func TestGetDefaultSubnetIDsForVpc(t *testing.T) {
+	t.Parallel()
+
+	region := GetRandomStableRegion(t, nil, nil)
+	vpc := GetDefaultVpc(t, region)
+
+	defaultSubnetIDs := GetDefaultSubnetIDsForVpc(t, *vpc)
+	assert.NotEmpty(t, defaultSubnetIDs)
+
+	availabilityZones := []string{}
+	for _, id := range defaultSubnetIDs {
+		for _, subnet := range vpc.Subnets {
+			if id == subnet.Id {
+				availabilityZones = append(availabilityZones, subnet.AvailabilityZone)
+			}
+		}
+	}
+	// only one default subnet is allowed per AZ
+	uniqueAZs := map[string]bool{}
+	for _, az := range availabilityZones {
+		uniqueAZs[az] = true
+	}
+	assert.Equal(t, len(defaultSubnetIDs), len(uniqueAZs))
+}
+
 func TestGetTagsForVpc(t *testing.T) {
 	t.Parallel()
 

--- a/modules/aws/vpc_test.go
+++ b/modules/aws/vpc_test.go
@@ -49,7 +49,7 @@ func TestGetVpcsE(t *testing.T) {
 
 	// the default VPC has by default one subnet per availability zone
 	// https://docs.aws.amazon.com/vpc/latest/userguide/default-vpc.html
-	assert.Equal(t, len(vpcs[0].Subnets), len(azs))
+	assert.True(t, len(vpcs[0].Subnets) >= len(azs))
 }
 
 func TestGetFirstTwoOctets(t *testing.T) {

--- a/modules/aws/vpc_test.go
+++ b/modules/aws/vpc_test.go
@@ -1,6 +1,7 @@
 package aws
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -80,17 +81,29 @@ func TestGetDefaultSubnetIDsForVpc(t *testing.T) {
 	t.Parallel()
 
 	region := GetRandomStableRegion(t, nil, nil)
-	vpc := GetDefaultVpc(t, region)
+	defaultVpcBeforeSubnetCreation := GetDefaultVpc(t, region)
 
-	defaultSubnetIDs := GetDefaultSubnetIDsForVpc(t, *vpc)
+	// Creates a subnet in the default VPC with deferred deletion
+	// and fetches vpc object again
+	subnetName := fmt.Sprintf("%s-subnet", t.Name())
+	subnet := createPrivateSubnetInDefaultVpc(t, defaultVpcBeforeSubnetCreation.Id, subnetName, region)
+	defer deleteSubnet(t, *subnet.SubnetId, region)
+	defaultVpc := GetDefaultVpc(t, region)
+
+	defaultSubnetIDs := GetDefaultSubnetIDsForVpc(t, *defaultVpc)
 	assert.NotEmpty(t, defaultSubnetIDs)
+	// Checks that the amount of default subnets is smaller than
+	// total number of subnets in default vpc
+	assert.True(t, len(defaultSubnetIDs) < len(defaultVpc.Subnets))
 
 	availabilityZones := []string{}
 	for _, id := range defaultSubnetIDs {
+		// check if the recently created subnet does not come up here
+		assert.NotEqual(t, id, subnet.SubnetId)
 		// default subnets are by default public
 		// https://docs.aws.amazon.com/vpc/latest/userguide/default-vpc.html
 		assert.True(t, IsPublicSubnet(t, id, region))
-		for _, subnet := range vpc.Subnets {
+		for _, subnet := range defaultVpc.Subnets {
 			if id == subnet.Id {
 				availabilityZones = append(availabilityZones, subnet.AvailabilityZone)
 			}
@@ -204,6 +217,38 @@ func createSubnet(t *testing.T, vpcId string, routeTableId string, region string
 	require.NoError(t, err)
 
 	return *createSubnetOutput.Subnet
+}
+
+func createPrivateSubnetInDefaultVpc(t *testing.T, vpcId string, subnetName string, region string) ec2.Subnet {
+	ec2Client := NewEc2Client(t, region)
+
+	createSubnetOutput, err := ec2Client.CreateSubnet(&ec2.CreateSubnetInput{
+		CidrBlock: aws.String("172.31.172.0/24"),
+		VpcId:     aws.String(vpcId),
+		TagSpecifications: []*ec2.TagSpecification{
+			{
+				ResourceType: aws.String("subnet"),
+				Tags: []*ec2.Tag{
+					{
+						Key:   aws.String("Name"),
+						Value: aws.String(subnetName),
+					},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	return *createSubnetOutput.Subnet
+}
+
+func deleteSubnet(t *testing.T, subnetId string, region string) {
+	ec2Client := NewEc2Client(t, region)
+
+	_, err := ec2Client.DeleteSubnet(&ec2.DeleteSubnetInput{
+		SubnetId: aws.String(subnetId),
+	})
+	require.NoError(t, err)
 }
 
 func createVpc(t *testing.T, region string) ec2.Vpc {

--- a/modules/aws/vpc_test.go
+++ b/modules/aws/vpc_test.go
@@ -87,6 +87,9 @@ func TestGetDefaultSubnetIDsForVpc(t *testing.T) {
 
 	availabilityZones := []string{}
 	for _, id := range defaultSubnetIDs {
+		// default subnets are by default public
+		// https://docs.aws.amazon.com/vpc/latest/userguide/default-vpc.html
+		assert.True(t, IsPublicSubnet(t, id, region))
 		for _, subnet := range vpc.Subnets {
 			if id == subnet.Id {
 				availabilityZones = append(availabilityZones, subnet.AvailabilityZone)


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Resolves #1130.

The VPC object obtained when running aws.GetDefaultVpc includes all subnets in the default VPC, and not just the default subnets. This is a problem because often this is used with the intention to get the default subnets in a region, as by default the default VPC has a default subnet in each availability zone. However, there are occasions where more subnets are created in the default VPC causing unintended effects.

For example: 
* [cloud nuke tests create subnet in default VPC](https://github.com/gruntwork-io/cloud-nuke/blob/a696846eadb65719badc5bc56706a9c8a9b91292/aws/eks_utils_for_test.go#L188)
* [terratest test `TestGetVpcsE` sometimes fails due to unmatching AZ & subnet number](https://app.circleci.com/pipelines/github/gruntwork-io/terratest/993/workflows/ad532d40-0119-4302-978e-7693ba31b5f5/jobs/7638/tests)
* [terraform-aws-asg tests sometimes fail because the ELB cannot be attached to a list of subnets that has more than one subnet in the same AZ](https://github.com/gruntwork-io/terraform-aws-asg/issues/151)

This PR 
* adds `aws.GetDefaultSubnetIDsForVpc` to retrieve default subnet ids
* updates `aws.IsPublicSubnet` to check implicit association with the main route table in VPC when the subnet does not have any explicitly associated route tables
* and fixes the `TestGetVpcsE` test to check for greater or equal number of subnets and availability zones instead of equal. 

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes 

* Added `aws.GetDefaultSubnetIDsForVpc` to retrieve default subnet ids
* Updated `aws.IsPublicSubnet` to check implicit association with the main route table in VPC when the subnet does not have any explicitly associated route tables


