### PR TITLE
Add common list of regions to avoid in GCP tests

### DIFF
--- a/modules/gcp/compute_test.go
+++ b/modules/gcp/compute_test.go
@@ -22,12 +22,15 @@ const DEFAULT_MACHINE_TYPE = "f1-micro"
 const DEFAULT_IMAGE_FAMILY_PROJECT_NAME = "ubuntu-os-cloud"
 const DEFAULT_IMAGE_FAMILY_NAME = "family/ubuntu-1804-lts"
 
+// Regions that don't support running f1-micro instances
+var RegionsToAvoid = []string{"asia-east2", "southamerica-west1", "europe-west8"}
+
 func TestGetPublicIpOfInstance(t *testing.T) {
 	t.Parallel()
 
 	instanceName := RandomValidGcpName()
 	projectID := GetGoogleProjectIDFromEnvVar(t)
-	zone := GetRandomZone(t, projectID, nil, nil, []string{"southamerica-west1"})
+	zone := GetRandomZone(t, projectID, nil, nil, RegionsToAvoid)
 
 	createComputeInstance(t, projectID, zone, instanceName)
 	defer deleteComputeInstance(t, projectID, zone, instanceName)
@@ -74,8 +77,7 @@ func TestGetAndSetLabels(t *testing.T) {
 	instanceName := RandomValidGcpName()
 	projectID := GetGoogleProjectIDFromEnvVar(t)
 
-	// On October 22, 2018, GCP launched the asia-east2 region, which promptly failed all our tests, so blacklist asia-east2.
-	zone := GetRandomZone(t, projectID, nil, nil, []string{"asia-east2"})
+	zone := GetRandomZone(t, projectID, nil, nil, RegionsToAvoid)
 
 	createComputeInstance(t, projectID, zone, instanceName)
 	defer deleteComputeInstance(t, projectID, zone, instanceName)
@@ -111,9 +113,7 @@ func TestGetAndSetMetadata(t *testing.T) {
 	projectID := GetGoogleProjectIDFromEnvVar(t)
 	instanceName := RandomValidGcpName()
 
-	// The following zones do not have f1-micro instances available, so we avoid them
-	zonesToAvoid := []string{"asia-east2", "southamerica-west1"}
-	zone := GetRandomZone(t, projectID, nil, nil, zonesToAvoid)
+	zone := GetRandomZone(t, projectID, nil, nil, RegionsToAvoid)
 
 	// Create a new Compute Instance
 	createComputeInstance(t, projectID, zone, instanceName)

--- a/test/gcp/packer_gcp_basic_example_test.go
+++ b/test/gcp/packer_gcp_basic_example_test.go
@@ -22,6 +22,9 @@ var DefaultRetryablePackerErrors = map[string]string{
 }
 var DefaultTimeBetweenPackerRetries = 15 * time.Second
 
+// Regions that don't support n1-standard-1 instances
+var RegionsToAvoid = []string{"asia-east2", "southamerica-west1", "europe-west8"}
+
 const DefaultMaxPackerRetries = 3
 
 // An example of how to test the Packer template in examples/packer-basic-example using Terratest.
@@ -32,9 +35,7 @@ func TestPackerGCPBasicExample(t *testing.T) {
 	projectID := gcp.GetGoogleProjectIDFromEnvVar(t)
 
 	// Pick a random GCP zone to test in. This helps ensure your code works in all regions.
-	// zones that don't support n1-standard-1 instances
-	zonesToAvoid := []string{"asia-east2", "southamerica-west1"}
-	zone := gcp.GetRandomZone(t, projectID, nil, nil, zonesToAvoid)
+	zone := gcp.GetRandomZone(t, projectID, nil, nil, RegionsToAvoid)
 
 	packerOptions := &packer.Options{
 		// The path to where the Packer template is located

--- a/test/gcp/terraform_gcp_example_test.go
+++ b/test/gcp/terraform_gcp_example_test.go
@@ -109,9 +109,7 @@ func TestSshAccessToComputeInstance(t *testing.T) {
 	// Setup values for our Terraform apply
 	projectID := gcp.GetGoogleProjectIDFromEnvVar(t)
 	randomValidGcpName := gcp.RandomValidGcpName()
-	// zones that don't support n1-standard-1 instances
-	zonesToAvoid := []string{"asia-east2", "southamerica-west1"}
-	zone := gcp.GetRandomZone(t, projectID, nil, nil, zonesToAvoid)
+	zone := gcp.GetRandomZone(t, projectID, nil, nil, RegionsToAvoid)
 
 	terraformOptions := &terraform.Options{
 		// The path to where our Terraform code is located

--- a/test/gcp/terraform_gcp_ig_example_test.go
+++ b/test/gcp/terraform_gcp_ig_example_test.go
@@ -24,8 +24,7 @@ func TestTerraformGcpInstanceGroupExample(t *testing.T) {
 	// Setup values for our Terraform apply
 	projectId := gcp.GetGoogleProjectIDFromEnvVar(t)
 
-	// On October 22, 2018, GCP launched the asia-east2 region, which promptly failed all our tests, so blacklist asia-east2.
-	region := gcp.GetRandomRegion(t, projectId, nil, []string{"asia-east2"})
+	region := gcp.GetRandomRegion(t, projectId, nil, RegionsToAvoid)
 
 	randomValidGcpName := gcp.RandomValidGcpName()
 	clusterSize := 3


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Extracted a common list of GCP regions that can't run f1-micro and n1-standard-1 instances, re-used created list in GCP tests.

Fixes #1132

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->
