### PR TITLE
Handle new plan output in 1.2.0

### DIFF
--- a/modules/gcp/compute_test.go
+++ b/modules/gcp/compute_test.go
@@ -23,7 +23,7 @@ const DEFAULT_IMAGE_FAMILY_PROJECT_NAME = "ubuntu-os-cloud"
 const DEFAULT_IMAGE_FAMILY_NAME = "family/ubuntu-1804-lts"
 
 // Regions that don't support running f1-micro instances
-var RegionsToAvoid = []string{"asia-east2", "southamerica-west1", "europe-west8"}
+var RegionsToAvoid = []string{"asia-east2", "southamerica-west1", "europe-west8", "europe-southwest1"}
 
 func TestGetPublicIpOfInstance(t *testing.T) {
 	t.Parallel()

--- a/modules/k8s/job_test.go
+++ b/modules/k8s/job_test.go
@@ -145,7 +145,7 @@ spec:
     spec:
       containers:
       - name: pi
-        image: perl
+        image: "perl:5.34.1"
         command: ["perl",  "-Mbignum=bpi", "-wle", "print bpi(2000)"]
       restartPolicy: Never
   backoffLimit: 4

--- a/modules/terraform/count.go
+++ b/modules/terraform/count.go
@@ -18,10 +18,11 @@ type ResourceCount struct {
 
 // Regular expressions for terraform commands stdout pattern matching.
 const (
-	applyRegexp             = `Apply complete! Resources: (\d+) added, (\d+) changed, (\d+) destroyed\.`
-	destroyRegexp           = `Destroy complete! Resources: (\d+) destroyed\.`
-	planWithChangesRegexp   = `(\033\[1m)?Plan:(\033\[0m)? (\d+) to add, (\d+) to change, (\d+) to destroy\.`
-	planWithNoChangesRegexp = `No changes\. (Infrastructure is up-to-date)|(Your infrastructure matches the configuration)\.`
+	applyRegexp                  = `Apply complete! Resources: (\d+) added, (\d+) changed, (\d+) destroyed\.`
+	destroyRegexp                = `Destroy complete! Resources: (\d+) destroyed\.`
+	planWithChangesRegexp        = `(\033\[1m)?Plan:(\033\[0m)? (\d+) to add, (\d+) to change, (\d+) to destroy\.`
+	planWithNoChangesRegexp      = `No changes\. (Infrastructure is up-to-date)|(Your infrastructure matches the configuration)\.`
+	planWithNoInfraChangesRegexp = `You can apply this plan.*without changing any real infrastructure`
 )
 
 const getResourceCountErrMessage = "Can't parse Terraform output"
@@ -48,6 +49,7 @@ func GetResourceCountE(t testing.TestingT, cmdout string) (*ResourceCount, error
 		{destroyRegexp, -1, -1, 1},
 		{planWithChangesRegexp, 3, 4, 5},
 		{planWithNoChangesRegexp, -1, -1, -1},
+		{planWithNoInfraChangesRegexp, -1, -1, -1},
 	}
 
 	for _, tc := range terraformCommandPatterns {

--- a/modules/terraform/count.go
+++ b/modules/terraform/count.go
@@ -22,7 +22,7 @@ const (
 	destroyRegexp                = `Destroy complete! Resources: (\d+) destroyed\.`
 	planWithChangesRegexp        = `(\033\[1m)?Plan:(\033\[0m)? (\d+) to add, (\d+) to change, (\d+) to destroy\.`
 	planWithNoChangesRegexp      = `No changes\. (Infrastructure is up-to-date)|(Your infrastructure matches the configuration)\.`
-	planWithNoInfraChangesRegexp = `You can apply this plan.*without changing any real infrastructure`
+	planWithNoInfraChangesRegexp = `You can apply this plan[.\n]*without changing any real infrastructure`
 )
 
 const getResourceCountErrMessage = "Can't parse Terraform output"

--- a/modules/terraform/count.go
+++ b/modules/terraform/count.go
@@ -18,11 +18,13 @@ type ResourceCount struct {
 
 // Regular expressions for terraform commands stdout pattern matching.
 const (
-	applyRegexp                  = `Apply complete! Resources: (\d+) added, (\d+) changed, (\d+) destroyed\.`
-	destroyRegexp                = `Destroy complete! Resources: (\d+) destroyed\.`
-	planWithChangesRegexp        = `(\033\[1m)?Plan:(\033\[0m)? (\d+) to add, (\d+) to change, (\d+) to destroy\.`
-	planWithNoChangesRegexp      = `No changes\. (Infrastructure is up-to-date)|(Your infrastructure matches the configuration)\.`
-	planWithNoInfraChangesRegexp = `You can apply this plan[.\n]*without changing any real infrastructure`
+	applyRegexp             = `Apply complete! Resources: (\d+) added, (\d+) changed, (\d+) destroyed\.`
+	destroyRegexp           = `Destroy complete! Resources: (\d+) destroyed\.`
+	planWithChangesRegexp   = `(\033\[1m)?Plan:(\033\[0m)? (\d+) to add, (\d+) to change, (\d+) to destroy\.`
+	planWithNoChangesRegexp = `No changes\. (Infrastructure is up-to-date)|(Your infrastructure matches the configuration)\.`
+
+	// '.' doesn't match newline by default in go. We must instruct the regex to match it with the 's' flag.
+	planWithNoInfraChangesRegexp = `(?s)You can apply this plan.+without changing any real infrastructure`
 )
 
 const getResourceCountErrMessage = "Can't parse Terraform output"

--- a/test/gcp/packer_gcp_basic_example_test.go
+++ b/test/gcp/packer_gcp_basic_example_test.go
@@ -23,7 +23,7 @@ var DefaultRetryablePackerErrors = map[string]string{
 var DefaultTimeBetweenPackerRetries = 15 * time.Second
 
 // Regions that don't support n1-standard-1 instances
-var RegionsToAvoid = []string{"asia-east2", "southamerica-west1", "europe-west8"}
+var RegionsToAvoid = []string{"asia-east2", "southamerica-west1", "europe-west8", "europe-southwest1"}
 
 const DefaultMaxPackerRetries = 3
 


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

There was a new case I observed in terraform 1.2 that `GetResourceCount` doesn't handle. This PR updates the routine to consider this new case in the Regex.

As a bonus, this fixes the following two test failures:

- `kubernetes_test` started failing due to a regression in the latest perl container image that causes the bigint pi call to fail. This is addressed by locking the container to some known working version.
- `gcp_test` was still failing due to region incompatibilities, so added that new region to the list of regions to avoid.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Updated `terraform.GetResourceCount` to handle new output case in terraform 1.2.0, which occurs when there are only output changes but no real change to the underlying infrastructure.
