### PR TITLE
feat(opa): Export downloadPolicyE function

### DIFF
--- a/modules/opa/download_policy.go
+++ b/modules/opa/download_policy.go
@@ -18,10 +18,10 @@ var (
 	policyDirCache sync.Map
 )
 
-// downloadPolicyE takes in a rule path written in go-getter syntax and downloads it to a temporary directory so that it
+// DownloadPolicyE takes in a rule path written in go-getter syntax and downloads it to a temporary directory so that it
 // can be passed to opa. The temporary directory that is used is cached based on the go-getter base path, and reused
 // across calls.
-// For example, if you call downloadPolicyE with the go-getter URL multiple times:
+// For example, if you call DownloadPolicyE with the go-getter URL multiple times:
 //   git::https://github.com/gruntwork-io/terratest.git//policies/foo.rego?ref=master
 // The first time the gruntwork-io/terratest repo will be downloaded to a new temp directory. All subsequent calls will
 // reuse that first temporary dir where the repo was cloned. This is preserved even if a different subdir is requested
@@ -29,7 +29,7 @@ var (
 // Note that the query parameters are always included in the base URL. This means that if you use a different ref (e.g.,
 // git::https://github.com/gruntwork-io/terratest.git//examples/bar.rego?ref=v0.39.3), then that will be cloned to a new
 // temporary directory rather than the cached dir.
-func downloadPolicyE(t testing.TestingT, rulePath string) (string, error) {
+func DownloadPolicyE(t testing.TestingT, rulePath string) (string, error) {
 	cwd, err := os.Getwd()
 	if err != nil {
 		return "", err

--- a/modules/opa/download_policy_test.go
+++ b/modules/opa/download_policy_test.go
@@ -15,17 +15,17 @@ import (
 	"github.com/gruntwork-io/terratest/modules/git"
 )
 
-// Test to make sure the downloadPolicyE function returns a local path without processing it.
+// Test to make sure the DownloadPolicyE function returns a local path without processing it.
 func TestDownloadPolicyReturnsLocalPath(t *testing.T) {
 	t.Parallel()
 
 	localPath := "../../examples/terraform-opa-example/policy/enforce_source.rego"
-	path, err := downloadPolicyE(t, localPath)
+	path, err := DownloadPolicyE(t, localPath)
 	require.NoError(t, err)
 	assert.Equal(t, localPath, path)
 }
 
-// Test to make sure the downloadPolicyE function returns a remote path to a temporary directory.
+// Test to make sure the DownloadPolicyE function returns a remote path to a temporary directory.
 func TestDownloadPolicyDownloadsRemote(t *testing.T) {
 	t.Parallel()
 
@@ -46,7 +46,7 @@ func TestDownloadPolicyDownloadsRemote(t *testing.T) {
 		assert.NoError(t, os.RemoveAll(downloadPath))
 	}()
 
-	path, err := downloadPolicyE(t, remotePath)
+	path, err := DownloadPolicyE(t, remotePath)
 	require.NoError(t, err)
 
 	absPath, err := filepath.Abs(localPath)
@@ -60,7 +60,7 @@ func TestDownloadPolicyDownloadsRemote(t *testing.T) {
 	assert.Equal(t, localContents, remoteContents)
 }
 
-// Test to make sure the downloadPolicyE function uses the cache if it has already downloaded an existing base path.
+// Test to make sure the DownloadPolicyE function uses the cache if it has already downloaded an existing base path.
 func TestDownloadPolicyReusesCachedDir(t *testing.T) {
 	t.Parallel()
 
@@ -81,7 +81,7 @@ func TestDownloadPolicyReusesCachedDir(t *testing.T) {
 		assert.NoError(t, os.RemoveAll(downloadPath))
 	}()
 
-	path, err := downloadPolicyE(t, remotePath)
+	path, err := DownloadPolicyE(t, remotePath)
 	require.NoError(t, err)
 	files.FileExists(path)
 
@@ -90,12 +90,12 @@ func TestDownloadPolicyReusesCachedDir(t *testing.T) {
 	downloadPath := downloadPathRaw.(string)
 
 	// make sure the second call is exactly equal to the first call
-	newPath, err := downloadPolicyE(t, remotePath)
+	newPath, err := DownloadPolicyE(t, remotePath)
 	require.NoError(t, err)
 	assert.Equal(t, path, newPath)
 
 	// Also make sure the cache is reused for alternative sub dirs.
-	newAltPath, err := downloadPolicyE(t, remotePathAltSubPath)
+	newAltPath, err := DownloadPolicyE(t, remotePathAltSubPath)
 	require.NoError(t, err)
 	assert.True(t, strings.HasPrefix(path, downloadPath))
 	assert.True(t, strings.HasPrefix(newAltPath, downloadPath))

--- a/modules/opa/eval.go
+++ b/modules/opa/eval.go
@@ -58,7 +58,7 @@ func Eval(t testing.TestingT, options *EvalOptions, jsonFilePaths []string, resu
 //     opa eval -i $JSONFile -d $RulePath $ResultQuery
 // This will asynchronously run OPA on each file concurrently using goroutines.
 func EvalE(t testing.TestingT, options *EvalOptions, jsonFilePaths []string, resultQuery string) error {
-	downloadedPolicyPath, err := downloadPolicyE(t, options.RulePath)
+	downloadedPolicyPath, err := DownloadPolicyE(t, options.RulePath)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Export downloadPolicyE function

We're using conftest so the opa module is almost what we want, but not
quite. Instead we'd like to use this function in our tests to download
our conftest rego policies from a remote URL. In order to do that, this
needs to be an exported function.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [N/A] Update the docs.
- [X] Run the relevant tests successfully, including pre-commit checks.
- [X] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [X] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Export `DownloadPolicyE` function.