### PR TITLE
Handle maps in clone

### DIFF
--- a/modules/terraform/options.go
+++ b/modules/terraform/options.go
@@ -81,6 +81,24 @@ func (options *Options) Clone() (*Options, error) {
 	if err := copier.Copy(newOptions, options); err != nil {
 		return nil, err
 	}
+	// copier does not deep copy maps, so we have to do it manually.
+	newOptions.EnvVars = make(map[string]string)
+	for key, val := range options.EnvVars {
+		newOptions.EnvVars[key] = val
+	}
+	newOptions.Vars = make(map[string]interface{})
+	for key, val := range options.Vars {
+		newOptions.Vars[key] = val
+	}
+	newOptions.BackendConfig = make(map[string]interface{})
+	for key, val := range options.BackendConfig {
+		newOptions.BackendConfig[key] = val
+	}
+	newOptions.RetryableTerraformErrors = make(map[string]string)
+	for key, val := range options.RetryableTerraformErrors {
+		newOptions.RetryableTerraformErrors[key] = val
+	}
+
 	return newOptions, nil
 }
 

--- a/modules/terraform/options_test.go
+++ b/modules/terraform/options_test.go
@@ -1,0 +1,43 @@
+package terraform
+
+import (
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/random"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOptionsCloneDeepClonesEnvVars(t *testing.T) {
+	t.Parallel()
+
+	unique := random.UniqueId()
+	original := Options{
+		EnvVars: map[string]string{
+			"unique":   unique,
+			"original": unique,
+		},
+	}
+	copied, err := original.Clone()
+	require.NoError(t, err)
+	copied.EnvVars["unique"] = "nullified"
+	assert.Equal(t, unique, original.EnvVars["unique"])
+	assert.Equal(t, unique, copied.EnvVars["original"])
+}
+
+func TestOptionsCloneDeepClonesVars(t *testing.T) {
+	t.Parallel()
+
+	unique := random.UniqueId()
+	original := Options{
+		Vars: map[string]interface{}{
+			"unique":   unique,
+			"original": unique,
+		},
+	}
+	copied, err := original.Clone()
+	require.NoError(t, err)
+	copied.Vars["unique"] = "nullified"
+	assert.Equal(t, unique, original.Vars["unique"])
+	assert.Equal(t, unique, copied.Vars["original"])
+}


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes a bug in the  `Clone` function of the `terraform.Options` struct where `map` objects were not being deep cloned, causing side effects.
<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
- Fixed a bug in the  `Clone` function of the `terraform.Options` struct where `map` objects were not being deep cloned, causing side effects.