### PR TITLE
Allow for ExtraArgs in Helm Module for AddRepo

### DIFF
--- a/modules/helm/options.go
+++ b/modules/helm/options.go
@@ -15,5 +15,5 @@ type Options struct {
 	EnvVars        map[string]string   // Environment variables to set when running helm
 	Version        string              // Version of chart
 	Logger         *logger.Logger      // Set a non-default logger that should be used. See the logger package for more info. Use logger.Discard to not print the output while executing the command.
-	ExtraArgs      map[string][]string // Extra arguments to pass to the helm install/upgrade/rollback/delete command. The key signals the command (e.g., install) while the values are the extra arguments to pass through.
+	ExtraArgs      map[string][]string // Extra arguments to pass to the helm install/upgrade/rollback/delete and helm repo add commands. The key signals the command (e.g., install) while the values are the extra arguments to pass through.
 }

--- a/modules/helm/repo.go
+++ b/modules/helm/repo.go
@@ -14,7 +14,16 @@ func AddRepo(t testing.TestingT, options *Options, repoName string, repoURL stri
 
 // AddRepoE will setup the provided helm repository to the local helm client configuration.
 func AddRepoE(t testing.TestingT, options *Options, repoName string, repoURL string) error {
-	_, err := RunHelmCommandAndGetOutputE(t, options, "repo", "add", repoName, repoURL)
+	// Set required args
+	args := []string{"add", repoName, repoURL}
+
+	// Append helm repo add ExtraArgs if available
+	if options.ExtraArgs != nil {
+		if repoAddArgs, ok := options.ExtraArgs["repoAdd"]; ok {
+			args = append(args, repoAddArgs...)
+		}
+	}
+	_, err := RunHelmCommandAndGetOutputE(t, options, "repo", args...)
 	return err
 }
 


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes #1165.

This enables users to pass extra arguments to the addRepo function in the helm module. An example would include passing username/password credentials to authenticate against a private repository.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [n/a] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added the ability to pass in ExtraArgs to the helm addRepo function. 

