### PR TITLE
feat(init): Add arg to execute terraform init with -no-color option

### DIFF
--- a/modules/terraform/init.go
+++ b/modules/terraform/init.go
@@ -27,6 +27,10 @@ func InitE(t testing.TestingT, options *Options) (string, error) {
 	if options.MigrateState {
 		args = append(args, "-migrate-state", "-force-copy")
 	}
+	// Append no-color option if specified
+	if options.NoColor {
+		args = append(args, "-no-color")
+	}
 
 	args = append(args, FormatTerraformBackendConfigAsArgs(options.BackendConfig)...)
 	args = append(args, FormatTerraformPluginDirAsArgs(options.PluginDir)...)


### PR DESCRIPTION
## Description

Allow passing the `-no-color` option to the `terraform init` command.

```bash
-no-color If specified, output won't contain any color.
```

(There's no related Issue)

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [X] Update the docs.
- [X] Run the relevant tests successfully, including pre-commit checks.
- [X] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [X] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Added arg to execute terraform init with -no-color option.

### Migration Guide

This change is backward compatible.
