### PR TITLE
Include project name into docker-compose options

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,4 @@
+repos:
 - repo: https://github.com/gruntwork-io/pre-commit
   rev: v0.1.10
   hooks:

--- a/modules/docker/docker_compose_test.go
+++ b/modules/docker/docker_compose_test.go
@@ -25,3 +25,40 @@ func TestDockerComposeWithBuildKit(t *testing.T) {
 
 	require.Contains(t, out, testToken)
 }
+
+func TestDockerComposeWithCustomProjectName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		options  *Options
+		expected string
+	}{
+		{
+			name: "Testing ",
+			options: &Options{
+				WorkingDir: "../../test/fixtures/docker-compose-with-custom-project-name",
+			},
+			expected: "testdockercomposewithcustomprojectname",
+		},
+		{
+			name: "Testing",
+			options: &Options{
+				WorkingDir:  "../../test/fixtures/docker-compose-with-custom-project-name",
+				ProjectName: "testingProjectName",
+			},
+			expected: "testingprojectname",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Log(test.name)
+
+			output := RunDockerCompose(t, test.options, "up", "-d")
+			defer RunDockerCompose(t, test.options, "down", "--remove-orphans", "--timeout", "2")
+
+			require.Contains(t, output, test.expected)
+		})
+	}
+}

--- a/modules/docker/inspect.go
+++ b/modules/docker/inspect.go
@@ -187,14 +187,15 @@ func transformContainer(t *testing.T, container inspectOutput) (*ContainerInspec
 }
 
 // transformContainerPorts converts Docker's ports from the following json into a more testable format
-// {
-//   "80/tcp": [
-//     {
-// 	     "HostIp": ""
-//       "HostPort": "8080"
-//     }
-//   ]
-// }
+//
+//	{
+//	  "80/tcp": [
+//	    {
+//		     "HostIp": ""
+//	      "HostPort": "8080"
+//	    }
+//	  ]
+//	}
 func transformContainerPorts(container inspectOutput) ([]Port, error) {
 	var ports []Port
 

--- a/test/fixtures/docker-compose-with-custom-project-name/docker-compose.yml
+++ b/test/fixtures/docker-compose-with-custom-project-name/docker-compose.yml
@@ -1,0 +1,4 @@
+services:
+  test-docker-image:
+    image: busybox
+    # command: sh -c "while true; do { echo -e 'HTTP/1.1 200 OK\r\n'; echo 'testing service'; } | nc -l -p  8080; done"

--- a/test/fixtures/docker-compose-with-custom-project-name/docker-compose.yml
+++ b/test/fixtures/docker-compose-with-custom-project-name/docker-compose.yml
@@ -1,4 +1,3 @@
 services:
   test-docker-image:
     image: busybox
-    # command: sh -c "while true; do { echo -e 'HTTP/1.1 200 OK\r\n'; echo 'testing service'; } | nc -l -p  8080; done"


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description
That PR is an enhancement for the docker-compose test suite. A new attribute has been included, on docker-compose options, that allows customizing the project name on docker-compose.

When the options attribute does not provide the project name, `strings.ToLower(t.Name())` is used as the default value.

<!-- Description of the changes introduced by this PR. -->

## TODOs
Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [n/a] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide. (n/a)

## Release Notes (draft)
<!-- One-line description of the PR that can be included in the final release notes. -->
New attribute included on docker-compose options. It is named `ProjectName` and allows to customize the project name when docker-compose is executed.

