### PR TITLE
#1160 Specify -var-file before -var

### DIFF
--- a/modules/terraform/format.go
+++ b/modules/terraform/format.go
@@ -56,8 +56,8 @@ func FormatArgs(options *Options, args ...string) []string {
 	terraformArgs = append(terraformArgs, args...)
 
 	if includeVars {
-		terraformArgs = append(terraformArgs, FormatTerraformVarsAsArgs(options.Vars)...)
 		terraformArgs = append(terraformArgs, FormatTerraformArgs("-var-file", options.VarFiles)...)
+		terraformArgs = append(terraformArgs, FormatTerraformVarsAsArgs(options.Vars)...)
 	}
 
 	terraformArgs = append(terraformArgs, FormatTerraformArgs("-target", options.Targets)...)

--- a/modules/terraform/format_test.go
+++ b/modules/terraform/format_test.go
@@ -278,3 +278,24 @@ func TestFormatArgsAppliesLockCorrectly(t *testing.T) {
 		assert.Equal(t, testCase.expected, FormatArgs(&Options{}, testCase.command...))
 	}
 }
+
+func TestFormatArgsAppliesVarsFilesAndVarsCorrectly(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		varFile  []string
+		vars     map[string]interface{}
+		expected []string
+	}{
+		{[]string{}, map[string]interface{}{"foo": "bar"}, []string{"apply", "-var", "foo=bar", "-lock=false"}},
+		{[]string{"var_file.tfvars"}, map[string]interface{}{}, []string{"apply", "-var-file", "var_file.tfvars", "-lock=false"}},
+		{[]string{"var_file.tfvars"}, map[string]interface{}{"foo": "bar"}, []string{"apply", "-var-file", "var_file.tfvars", "-var", "foo=bar", "-lock=false"}},
+	}
+
+	for _, testCase := range testCases {
+		assert.Equal(t, testCase.expected, FormatArgs(&Options{
+			VarFiles: testCase.varFile,
+			Vars:     testCase.vars,
+		}, "apply"))
+	}
+}


### PR DESCRIPTION
## Description

Fixes #1160 .

Specify -var-file before -var parameters for Terraform. This allows to override variable values from var file.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Specify -var-file before -var parameters for Terraform.
