### PR TITLE
Increase precedence of variable supplied by -var over -var-file

### DIFF
--- a/modules/terraform/format.go
+++ b/modules/terraform/format.go
@@ -56,8 +56,8 @@ func FormatArgs(options *Options, args ...string) []string {
 	terraformArgs = append(terraformArgs, args...)
 
 	if includeVars {
-		terraformArgs = append(terraformArgs, FormatTerraformVarsAsArgs(options.Vars)...)
 		terraformArgs = append(terraformArgs, FormatTerraformArgs("-var-file", options.VarFiles)...)
+		terraformArgs = append(terraformArgs, FormatTerraformVarsAsArgs(options.Vars)...)
 	}
 
 	terraformArgs = append(terraformArgs, FormatTerraformArgs("-target", options.Targets)...)


### PR DESCRIPTION

<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description
Currenty terraform decides prcedence of variable based on their order. Having -var at higher precedence allows us to edit some of the variables quickly for testing etc.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->
