### PR TITLE
feat(ecr): add get and put lifecycle policy functions

### DIFF
--- a/modules/aws/ecr_test.go
+++ b/modules/aws/ecr_test.go
@@ -26,3 +26,52 @@ func TestEcrRepo(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, ecrRepoName, aws.StringValue(repo2.RepositoryName))
 }
+
+func TestGetEcrRepoLifecyclePolicyError(t *testing.T) {
+	t.Parallel()
+
+	region := GetRandomStableRegion(t, nil, nil)
+	ecrRepoName := fmt.Sprintf("terratest%s", strings.ToLower(random.UniqueId()))
+	repo1, err := CreateECRRepoE(t, region, ecrRepoName)
+	defer DeleteECRRepo(t, region, repo1)
+	require.NoError(t, err)
+
+	assert.Equal(t, ecrRepoName, aws.StringValue(repo1.RepositoryName))
+
+	_, err = GetECRRepoLifecyclePolicyE(t, region, repo1)
+	require.Error(t, err)
+}
+
+func TestCanSetECRRepoLifecyclePolicyWithSingleRule(t *testing.T) {
+	t.Parallel()
+
+	region := GetRandomStableRegion(t, nil, nil)
+	ecrRepoName := fmt.Sprintf("terratest%s", strings.ToLower(random.UniqueId()))
+	repo1, err := CreateECRRepoE(t, region, ecrRepoName)
+	defer DeleteECRRepo(t, region, repo1)
+	require.NoError(t, err)
+
+	lifecyclePolicy := `{
+		"rules": [
+			{
+				"rulePriority": 1,
+				"description": "Expire images older than 14 days",
+				"selection": {
+					"tagStatus": "untagged",
+					"countType": "sinceImagePushed",
+					"countUnit": "days",
+					"countNumber": 14
+				},
+				"action": {
+					"type": "expire"
+				}
+			}
+		]
+	}`
+
+	err = PutECRRepoLifecyclePolicyE(t, region, repo1, lifecyclePolicy)
+	require.NoError(t, err)
+
+	policy := GetECRRepoLifecyclePolicy(t, region, repo1)
+	assert.JSONEq(t, lifecyclePolicy, policy)
+}


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Add supports to Put and Get [ECR Lifecycle Policy](https://docs.aws.amazon.com/AmazonECR/latest/userguide/LifecyclePolicies.html)

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes

<!-- One-line description of the PR that can be included in the final release notes. -->
Added funcs for get and put an ECR Lifecycle Policy

- GetECRRepoLifecyclePolicy
- GetECRRepoLifecyclePolicyE
- PutECRRepoLifecyclePolicy
- PutECRRepoLifecyclePolicyE