### PR TITLE
feat: add new LocalStack AWS session via env var

### DIFF
--- a/modules/aws/auth.go
+++ b/modules/aws/auth.go
@@ -33,7 +33,7 @@ func NewAuthenticatedSession(region string) (*session.Session, error) {
 func NewAuthenticatedSessionFromDefaultCredentials(region string) (*session.Session, error) {
 	awsConfig := aws.NewConfig().WithRegion(region)
 
-	if loaclStackUrl, ok := os.LookupEnv(LocalStackEnvVar); ok {
+	if localStackUrl, ok := os.LookupEnv(LocalStackEnvVar); ok {
 		awsAccessKeyId := "test"
 		awsSecretAccessKey := "test"
 
@@ -45,7 +45,7 @@ func NewAuthenticatedSessionFromDefaultCredentials(region string) (*session.Sess
 			awsSecretAccessKey = AWS_SECRET_ACCESS_KEY
 		}
 
-		awsConfig = awsConfig.WithEndpoint(loaclStackUrl).WithDisableSSL(true).WithCredentials(credentials.NewStaticCredentials(awsAccessKeyId, awsSecretAccessKey, ""))
+		awsConfig = awsConfig.WithEndpoint(localStackUrl).WithDisableSSL(true).WithCredentials(credentials.NewStaticCredentials(awsAccessKeyId, awsSecretAccessKey, ""))
 	}
 
 	sessionOptions := session.Options{

--- a/modules/aws/auth.go
+++ b/modules/aws/auth.go
@@ -30,6 +30,7 @@ func NewAuthenticatedSession(region string) (*session.Session, error) {
 }
 
 // NewAuthenticatedSessionFromDefaultCredentials gets an AWS Session, checking that the user has credentials properly configured in their environment.
+// if TERRATEST_LOCALSTACK environment variable is set, uses LocalStack Endpoint and Credentials.
 func NewAuthenticatedSessionFromDefaultCredentials(region string) (*session.Session, error) {
 	awsConfig := aws.NewConfig().WithRegion(region)
 

--- a/modules/aws/auth.go
+++ b/modules/aws/auth.go
@@ -81,27 +81,6 @@ func NewAuthenticatedSessionFromRole(region string, roleARN string) (*session.Se
 	return sess, nil
 }
 
-// NewAuthenticatedLocalStackSession returns a new LocalStack AWS Session.
-func NewAuthenticatedLocalStackSession(region string, url string) (*session.Session, error) {
-	awsConfig := aws.NewConfig().WithRegion(region).WithEndpoint(url).WithDisableSSL(true).WithCredentials(credentials.NewStaticCredentials("test", "test", ""))
-
-	sessionOptions := session.Options{
-		Config:            *awsConfig,
-		SharedConfigState: session.SharedConfigEnable,
-	}
-
-	sess, err := session.NewSessionWithOptions(sessionOptions)
-	if err != nil {
-		return nil, err
-	}
-
-	if _, err = sess.Config.Credentials.Get(); err != nil {
-		return nil, CredentialsError{UnderlyingErr: err}
-	}
-
-	return sess, nil
-}
-
 // CreateAwsSessionFromRole returns a new AWS session after assuming the role
 // whose ARN is provided in roleARN.
 func CreateAwsSessionFromRole(region string, roleARN string) (*session.Session, error) {


### PR DESCRIPTION
## Description

### Issues related
-  [Assert failing if you are using local configuration for testing (i.e: localstack locally) #494](https://github.com/gruntwork-io/terratest/issues/494)
- [No valid credential sources found for AWS Provider when running terratest in github actions #453](https://github.com/gruntwork-io/terratest/issues/453)

### Pull Requests related
- [Add aws custom configuration support for local testing (i.e: localstack use) #495](https://github.com/gruntwork-io/terratest/pull/495)

This adds a new create session that points to the URL specified in the env variable `TERRATEST_LOCALSTACK`. Since we don't need any credentials with LocalStack, we assume some random credentials and use the rest of Terratest. This was inspired by @ffernandezcast PR and the comments in it. This should be a much simpler approach and much more maintainable, which was one of the questions made by @brikis98  

### Usage
define the env var `TERRATEST_LOCALSTACK`
```
TERRATEST_LOCALSTACK=http://localhost:4566
```

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [X] Update the docs.
- [X] Run the relevant tests successfully, including pre-commit checks.
- [X] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [X] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Added support for custom AWS Endpoint.