### PR TITLE
Add ability to reorder var and var-file options

### DIFF
--- a/modules/terraform/format.go
+++ b/modules/terraform/format.go
@@ -56,7 +56,7 @@ func FormatArgs(options *Options, args ...string) []string {
 	terraformArgs = append(terraformArgs, args...)
 
 	if includeVars {
-		if options.SetVarArgsLast {
+		if options.SetVarsAfterVarFiles {
 			terraformArgs = append(terraformArgs, FormatTerraformArgs("-var-file", options.VarFiles)...)
 			terraformArgs = append(terraformArgs, FormatTerraformVarsAsArgs(options.Vars)...)
 		} else {

--- a/modules/terraform/format.go
+++ b/modules/terraform/format.go
@@ -56,8 +56,13 @@ func FormatArgs(options *Options, args ...string) []string {
 	terraformArgs = append(terraformArgs, args...)
 
 	if includeVars {
-		terraformArgs = append(terraformArgs, FormatTerraformVarsAsArgs(options.Vars)...)
-		terraformArgs = append(terraformArgs, FormatTerraformArgs("-var-file", options.VarFiles)...)
+		if options.SetVarArgsLast {
+			terraformArgs = append(terraformArgs, FormatTerraformArgs("-var-file", options.VarFiles)...)
+			terraformArgs = append(terraformArgs, FormatTerraformVarsAsArgs(options.Vars)...)
+		} else {
+			terraformArgs = append(terraformArgs, FormatTerraformVarsAsArgs(options.Vars)...)
+			terraformArgs = append(terraformArgs, FormatTerraformArgs("-var-file", options.VarFiles)...)
+		}
 	}
 
 	terraformArgs = append(terraformArgs, FormatTerraformArgs("-target", options.Targets)...)

--- a/modules/terraform/format_test.go
+++ b/modules/terraform/format_test.go
@@ -295,7 +295,9 @@ func TestFormatSetVarsAfterVarFilesFormatsCorrectly(t *testing.T) {
 		{[]string{"plan"}, map[string]interface{}{"foo": "bar"}, []string{"test.tfvars"}, false, []string{"plan", "-var", "foo=bar", "-var-file", "test.tfvars", "-lock=false"}},
 	}
 
-	for _, testCase := range testCases {
-		assert.Equal(t, testCase.expected, FormatArgs(&Options{SetVarsAfterVarFiles: testCase.setVarsAfterVarFiles, Vars: testCase.vars, VarFiles: testCase.varFiles}, testCase.command...))
+	for idx, testCase := range testCases {
+		checkResultWithRetry(t, 100, testCase.expected, fmt.Sprintf("FormatArgs(%d)", idx), func() interface{} {
+			return FormatArgs(&Options{SetVarsAfterVarFiles: testCase.setVarsAfterVarFiles, Vars: testCase.vars, VarFiles: testCase.varFiles}, testCase.command...)
+		})
 	}
 }

--- a/modules/terraform/format_test.go
+++ b/modules/terraform/format_test.go
@@ -292,6 +292,7 @@ func TestFormatSetVarsAfterVarFilesFormatsCorrectly(t *testing.T) {
 		{[]string{"plan"}, map[string]interface{}{"foo": "bar"}, []string{"test.tfvars"}, true, []string{"plan", "-var-file", "test.tfvars", "-var", "foo=bar", "-lock=false"}},
 		{[]string{"plan"}, map[string]interface{}{"foo": "bar", "hello": "world"}, []string{"test.tfvars"}, true, []string{"plan", "-var-file", "test.tfvars", "-var", "foo=bar", "-var", "hello=world", "-lock=false"}},
 		{[]string{"plan"}, map[string]interface{}{"foo": "bar", "hello": "world"}, []string{"test.tfvars"}, false, []string{"plan", "-var", "foo=bar", "-var", "hello=world", "-var-file", "test.tfvars", "-lock=false"}},
+		{[]string{"plan"}, map[string]interface{}{"foo": "bar"}, []string{"test.tfvars"}, false, []string{"plan", "-var", "foo=bar", "-var-file", "test.tfvars", "-lock=false"}},
 	}
 
 	for _, testCase := range testCases {

--- a/modules/terraform/format_test.go
+++ b/modules/terraform/format_test.go
@@ -295,9 +295,20 @@ func TestFormatSetVarsAfterVarFilesFormatsCorrectly(t *testing.T) {
 		{[]string{"plan"}, map[string]interface{}{"foo": "bar"}, []string{"test.tfvars"}, false, []string{"plan", "-var", "foo=bar", "-var-file", "test.tfvars", "-lock=false"}},
 	}
 
-	for idx, testCase := range testCases {
-		checkResultWithRetry(t, 100, testCase.expected, fmt.Sprintf("FormatArgs(%d)", idx), func() interface{} {
-			return FormatArgs(&Options{SetVarsAfterVarFiles: testCase.setVarsAfterVarFiles, Vars: testCase.vars, VarFiles: testCase.varFiles}, testCase.command...)
-		})
+	for _, testCase := range testCases {
+		result := FormatArgs(&Options{SetVarsAfterVarFiles: testCase.setVarsAfterVarFiles, Vars: testCase.vars, VarFiles: testCase.varFiles}, testCase.command...)
+
+		// Make sure that -var and -var-file options are in the expected order relative to each other
+		// Note that the order of the different -var and -var-file options may change
+		// See this comment for more info: https://github.com/gruntwork-io/terratest/blob/6fb86056797e3e62ebdd9011ba26605e0976a6f8/modules/terraform/format_test.go#L123-L142
+		for idx, arg := range result {
+			if arg == "-var-file" || arg == "-var" {
+				assert.Equal(t, testCase.expected[idx], arg)
+			}
+		}
+
+		// Make sure that the order of other arguments hasn't been incorrectly modified
+		assert.Equal(t, testCase.expected[0], result[0])
+		assert.Equal(t, testCase.expected[len(testCase.expected)-1], result[len(result)-1])
 	}
 }

--- a/modules/terraform/format_test.go
+++ b/modules/terraform/format_test.go
@@ -279,15 +279,15 @@ func TestFormatArgsAppliesLockCorrectly(t *testing.T) {
 	}
 }
 
-func TestFormatSetVarArgsLastFormatsCorrectly(t *testing.T) {
+func TestFormatSetVarsAfterVarFilesFormatsCorrectly(t *testing.T) {
 	t.Parallel()
 
 	testCases := []struct {
-		command        []string
-		vars           map[string]interface{}
-		varFiles       []string
-		setVarArgsLast bool
-		expected       []string
+		command              []string
+		vars                 map[string]interface{}
+		varFiles             []string
+		setVarsAfterVarFiles bool
+		expected             []string
 	}{
 		{[]string{"plan"}, map[string]interface{}{"foo": "bar"}, []string{"test.tfvars"}, true, []string{"plan", "-var-file", "test.tfvars", "-var", "foo=bar", "-lock=false"}},
 		{[]string{"plan"}, map[string]interface{}{"foo": "bar", "hello": "world"}, []string{"test.tfvars"}, true, []string{"plan", "-var-file", "test.tfvars", "-var", "foo=bar", "-var", "hello=world", "-lock=false"}},
@@ -295,6 +295,6 @@ func TestFormatSetVarArgsLastFormatsCorrectly(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		assert.Equal(t, testCase.expected, FormatArgs(&Options{SetVarArgsLast: testCase.setVarArgsLast, Vars: testCase.vars, VarFiles: testCase.varFiles}, testCase.command...))
+		assert.Equal(t, testCase.expected, FormatArgs(&Options{SetVarsAfterVarFiles: testCase.setVarsAfterVarFiles, Vars: testCase.vars, VarFiles: testCase.varFiles}, testCase.command...))
 	}
 }

--- a/modules/terraform/format_test.go
+++ b/modules/terraform/format_test.go
@@ -278,3 +278,23 @@ func TestFormatArgsAppliesLockCorrectly(t *testing.T) {
 		assert.Equal(t, testCase.expected, FormatArgs(&Options{}, testCase.command...))
 	}
 }
+
+func TestFormatSetVarArgsLastFormatsCorrectly(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		command        []string
+		vars           map[string]interface{}
+		varFiles       []string
+		setVarArgsLast bool
+		expected       []string
+	}{
+		{[]string{"plan"}, map[string]interface{}{"foo": "bar"}, []string{"test.tfvars"}, true, []string{"plan", "-var-file", "test.tfvars", "-var", "foo=bar", "-lock=false"}},
+		{[]string{"plan"}, map[string]interface{}{"foo": "bar", "hello": "world"}, []string{"test.tfvars"}, true, []string{"plan", "-var-file", "test.tfvars", "-var", "foo=bar", "-var", "hello=world", "-lock=false"}},
+		{[]string{"plan"}, map[string]interface{}{"foo": "bar", "hello": "world"}, []string{"test.tfvars"}, false, []string{"plan", "-var", "foo=bar", "-var", "hello=world", "-var-file", "test.tfvars", "-lock=false"}},
+	}
+
+	for _, testCase := range testCases {
+		assert.Equal(t, testCase.expected, FormatArgs(&Options{SetVarArgsLast: testCase.setVarArgsLast, Vars: testCase.vars, VarFiles: testCase.varFiles}, testCase.command...))
+	}
+}

--- a/modules/terraform/options.go
+++ b/modules/terraform/options.go
@@ -70,6 +70,7 @@ type Options struct {
 	Parallelism              int                    // Set the parallelism setting for Terraform
 	PlanFilePath             string                 // The path to output a plan file to (for the plan command) or read one from (for the apply command)
 	PluginDir                string                 // The path of downloaded plugins to pass to the terraform init command (-plugin-dir)
+	SetVarArgsLast           bool                   // Pass -var options after -var-file options to Terraform commands
 }
 
 // Clone makes a deep copy of most fields on the Options object and returns it.

--- a/modules/terraform/options.go
+++ b/modules/terraform/options.go
@@ -70,7 +70,7 @@ type Options struct {
 	Parallelism              int                    // Set the parallelism setting for Terraform
 	PlanFilePath             string                 // The path to output a plan file to (for the plan command) or read one from (for the apply command)
 	PluginDir                string                 // The path of downloaded plugins to pass to the terraform init command (-plugin-dir)
-	SetVarArgsLast           bool                   // Pass -var options after -var-file options to Terraform commands
+	SetVarsAfterVarFiles     bool                   // Pass -var options after -var-file options to Terraform commands
 }
 
 // Clone makes a deep copy of most fields on the Options object and returns it.

--- a/modules/terraform/workspace_test.go
+++ b/modules/terraform/workspace_test.go
@@ -1,12 +1,10 @@
 package terraform
 
 import (
-	"errors"
 	"testing"
 
 	"github.com/gruntwork-io/terratest/modules/files"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestWorkspaceNew(t *testing.T) {
@@ -133,100 +131,100 @@ func TestNameMatchesWorkspace(t *testing.T) {
 	}
 }
 
-func TestWorkspaceDeleteE(t *testing.T) {
-	t.Parallel()
+// func TestWorkspaceDeleteE(t *testing.T) {
+// 	t.Parallel()
 
-	// state describes an expected status when a given testCase begins
-	type state struct {
-		workspaces []string
-		current    string
-	}
+// 	// state describes an expected status when a given testCase begins
+// 	type state struct {
+// 		workspaces []string
+// 		current    string
+// 	}
 
-	// testCase describes a named test case with a state, args and expcted results
-	type testCase struct {
-		name              string
-		initialState      state
-		toDeleteWorkspace string
-		expectedCurrent   string
-		expectedError     error
-	}
+// 	// testCase describes a named test case with a state, args and expcted results
+// 	type testCase struct {
+// 		name              string
+// 		initialState      state
+// 		toDeleteWorkspace string
+// 		expectedCurrent   string
+// 		expectedError     error
+// 	}
 
-	testCases := []testCase{
-		{
-			name: "delete another existing workspace and stay on current",
-			initialState: state{
-				workspaces: []string{"staging", "production"},
-				current:    "staging",
-			},
-			toDeleteWorkspace: "production",
-			expectedCurrent:   "staging",
-			expectedError:     nil,
-		},
-		{
-			name: "delete current workspace and switch to a specified",
-			initialState: state{
-				workspaces: []string{"staging", "production"},
-				current:    "production",
-			},
-			toDeleteWorkspace: "production",
-			expectedCurrent:   "default",
-			expectedError:     nil,
-		},
-		{
-			name: "delete a non existing workspace should trigger an error",
-			initialState: state{
-				workspaces: []string{"staging", "production"},
-				current:    "staging",
-			},
-			toDeleteWorkspace: "hellothere",
-			expectedCurrent:   "staging",
-			expectedError:     WorkspaceDoesNotExist("hellothere"),
-		},
-		{
-			name: "delete the default workspace triggers an error",
-			initialState: state{
-				workspaces: []string{"staging", "production"},
-				current:    "staging",
-			},
-			toDeleteWorkspace: "default",
-			expectedCurrent:   "staging",
-			expectedError:     &UnsupportedDefaultWorkspaceDeletion{},
-		},
-	}
+// 	testCases := []testCase{
+// 		{
+// 			name: "delete another existing workspace and stay on current",
+// 			initialState: state{
+// 				workspaces: []string{"staging", "production"},
+// 				current:    "staging",
+// 			},
+// 			toDeleteWorkspace: "production",
+// 			expectedCurrent:   "staging",
+// 			expectedError:     nil,
+// 		},
+// 		{
+// 			name: "delete current workspace and switch to a specified",
+// 			initialState: state{
+// 				workspaces: []string{"staging", "production"},
+// 				current:    "production",
+// 			},
+// 			toDeleteWorkspace: "production",
+// 			expectedCurrent:   "default",
+// 			expectedError:     nil,
+// 		},
+// 		{
+// 			name: "delete a non existing workspace should trigger an error",
+// 			initialState: state{
+// 				workspaces: []string{"staging", "production"},
+// 				current:    "staging",
+// 			},
+// 			toDeleteWorkspace: "hellothere",
+// 			expectedCurrent:   "staging",
+// 			expectedError:     WorkspaceDoesNotExist("hellothere"),
+// 		},
+// 		{
+// 			name: "delete the default workspace triggers an error",
+// 			initialState: state{
+// 				workspaces: []string{"staging", "production"},
+// 				current:    "staging",
+// 			},
+// 			toDeleteWorkspace: "default",
+// 			expectedCurrent:   "staging",
+// 			expectedError:     &UnsupportedDefaultWorkspaceDeletion{},
+// 		},
+// 	}
 
-	for _, testCase := range testCases {
-		testCase := testCase
-		t.Run(testCase.name, func(t *testing.T) {
-			t.Parallel()
-			testFolder, err := files.CopyTerraformFolderToTemp("../../test/fixtures/terraform-workspace", testCase.name)
-			require.NoError(t, err)
+// 	for _, testCase := range testCases {
+// 		testCase := testCase
+// 		t.Run(testCase.name, func(t *testing.T) {
+// 			t.Parallel()
+// 			testFolder, err := files.CopyTerraformFolderToTemp("../../test/fixtures/terraform-workspace", testCase.name)
+// 			require.NoError(t, err)
 
-			options := &Options{
-				TerraformDir: testFolder,
-			}
+// 			options := &Options{
+// 				TerraformDir: testFolder,
+// 			}
 
-			// Set up pre-existing environment based on test case description
-			for _, existingWorkspace := range testCase.initialState.workspaces {
-				_, err = RunTerraformCommandE(t, options, "workspace", "new", existingWorkspace)
-				require.NoError(t, err)
-			}
-			// Switch to the specified workspace
-			_, err = RunTerraformCommandE(t, options, "workspace", "select", testCase.initialState.current)
-			require.NoError(t, err)
+// 			// Set up pre-existing environment based on test case description
+// 			for _, existingWorkspace := range testCase.initialState.workspaces {
+// 				_, err = RunTerraformCommandE(t, options, "workspace", "new", existingWorkspace)
+// 				require.NoError(t, err)
+// 			}
+// 			// Switch to the specified workspace
+// 			_, err = RunTerraformCommandE(t, options, "workspace", "select", testCase.initialState.current)
+// 			require.NoError(t, err)
 
-			// Testing time, wooohoooo
-			gotResult, gotErr := WorkspaceDeleteE(t, options, testCase.toDeleteWorkspace)
+// 			// Testing time, wooohoooo
+// 			gotResult, gotErr := WorkspaceDeleteE(t, options, testCase.toDeleteWorkspace)
 
-			// Check for errors
-			if testCase.expectedError != nil {
-				assert.True(t, errors.As(gotErr, &testCase.expectedError))
-			} else {
-				assert.NoError(t, gotErr)
-				// Check for results
-				assert.Equal(t, testCase.expectedCurrent, gotResult)
-				assert.False(t, isExistingWorkspace(RunTerraformCommand(t, options, "workspace", "list"), testCase.toDeleteWorkspace))
-			}
-		})
+// 			// Check for errors
+// 			if testCase.expectedError != nil {
+// 				assert.True(t, errors.As(gotErr, &testCase.expectedError))
+// 			} else {
+// 				assert.NoError(t, gotErr)
+// 				// Check for results
+// 				assert.Equal(t, testCase.expectedCurrent, gotResult)
+// 				assert.False(t, isExistingWorkspace(RunTerraformCommand(t, options, "workspace", "list"), testCase.toDeleteWorkspace))
+// 			}
+// 		})
 
-	}
-}
+// 	}
+// }

--- a/modules/terraform/workspace_test.go
+++ b/modules/terraform/workspace_test.go
@@ -1,10 +1,12 @@
 package terraform
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/gruntwork-io/terratest/modules/files"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestWorkspaceNew(t *testing.T) {
@@ -131,100 +133,100 @@ func TestNameMatchesWorkspace(t *testing.T) {
 	}
 }
 
-// func TestWorkspaceDeleteE(t *testing.T) {
-// 	t.Parallel()
+func TestWorkspaceDeleteE(t *testing.T) {
+	t.Parallel()
 
-// 	// state describes an expected status when a given testCase begins
-// 	type state struct {
-// 		workspaces []string
-// 		current    string
-// 	}
+	// state describes an expected status when a given testCase begins
+	type state struct {
+		workspaces []string
+		current    string
+	}
 
-// 	// testCase describes a named test case with a state, args and expcted results
-// 	type testCase struct {
-// 		name              string
-// 		initialState      state
-// 		toDeleteWorkspace string
-// 		expectedCurrent   string
-// 		expectedError     error
-// 	}
+	// testCase describes a named test case with a state, args and expcted results
+	type testCase struct {
+		name              string
+		initialState      state
+		toDeleteWorkspace string
+		expectedCurrent   string
+		expectedError     error
+	}
 
-// 	testCases := []testCase{
-// 		{
-// 			name: "delete another existing workspace and stay on current",
-// 			initialState: state{
-// 				workspaces: []string{"staging", "production"},
-// 				current:    "staging",
-// 			},
-// 			toDeleteWorkspace: "production",
-// 			expectedCurrent:   "staging",
-// 			expectedError:     nil,
-// 		},
-// 		{
-// 			name: "delete current workspace and switch to a specified",
-// 			initialState: state{
-// 				workspaces: []string{"staging", "production"},
-// 				current:    "production",
-// 			},
-// 			toDeleteWorkspace: "production",
-// 			expectedCurrent:   "default",
-// 			expectedError:     nil,
-// 		},
-// 		{
-// 			name: "delete a non existing workspace should trigger an error",
-// 			initialState: state{
-// 				workspaces: []string{"staging", "production"},
-// 				current:    "staging",
-// 			},
-// 			toDeleteWorkspace: "hellothere",
-// 			expectedCurrent:   "staging",
-// 			expectedError:     WorkspaceDoesNotExist("hellothere"),
-// 		},
-// 		{
-// 			name: "delete the default workspace triggers an error",
-// 			initialState: state{
-// 				workspaces: []string{"staging", "production"},
-// 				current:    "staging",
-// 			},
-// 			toDeleteWorkspace: "default",
-// 			expectedCurrent:   "staging",
-// 			expectedError:     &UnsupportedDefaultWorkspaceDeletion{},
-// 		},
-// 	}
+	testCases := []testCase{
+		{
+			name: "delete another existing workspace and stay on current",
+			initialState: state{
+				workspaces: []string{"staging", "production"},
+				current:    "staging",
+			},
+			toDeleteWorkspace: "production",
+			expectedCurrent:   "staging",
+			expectedError:     nil,
+		},
+		{
+			name: "delete current workspace and switch to a specified",
+			initialState: state{
+				workspaces: []string{"staging", "production"},
+				current:    "production",
+			},
+			toDeleteWorkspace: "production",
+			expectedCurrent:   "default",
+			expectedError:     nil,
+		},
+		{
+			name: "delete a non existing workspace should trigger an error",
+			initialState: state{
+				workspaces: []string{"staging", "production"},
+				current:    "staging",
+			},
+			toDeleteWorkspace: "hellothere",
+			expectedCurrent:   "staging",
+			expectedError:     WorkspaceDoesNotExist("hellothere"),
+		},
+		{
+			name: "delete the default workspace triggers an error",
+			initialState: state{
+				workspaces: []string{"staging", "production"},
+				current:    "staging",
+			},
+			toDeleteWorkspace: "default",
+			expectedCurrent:   "staging",
+			expectedError:     &UnsupportedDefaultWorkspaceDeletion{},
+		},
+	}
 
-// 	for _, testCase := range testCases {
-// 		testCase := testCase
-// 		t.Run(testCase.name, func(t *testing.T) {
-// 			t.Parallel()
-// 			testFolder, err := files.CopyTerraformFolderToTemp("../../test/fixtures/terraform-workspace", testCase.name)
-// 			require.NoError(t, err)
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			testFolder, err := files.CopyTerraformFolderToTemp("../../test/fixtures/terraform-workspace", testCase.name)
+			require.NoError(t, err)
 
-// 			options := &Options{
-// 				TerraformDir: testFolder,
-// 			}
+			options := &Options{
+				TerraformDir: testFolder,
+			}
 
-// 			// Set up pre-existing environment based on test case description
-// 			for _, existingWorkspace := range testCase.initialState.workspaces {
-// 				_, err = RunTerraformCommandE(t, options, "workspace", "new", existingWorkspace)
-// 				require.NoError(t, err)
-// 			}
-// 			// Switch to the specified workspace
-// 			_, err = RunTerraformCommandE(t, options, "workspace", "select", testCase.initialState.current)
-// 			require.NoError(t, err)
+			// Set up pre-existing environment based on test case description
+			for _, existingWorkspace := range testCase.initialState.workspaces {
+				_, err = RunTerraformCommandE(t, options, "workspace", "new", existingWorkspace)
+				require.NoError(t, err)
+			}
+			// Switch to the specified workspace
+			_, err = RunTerraformCommandE(t, options, "workspace", "select", testCase.initialState.current)
+			require.NoError(t, err)
 
-// 			// Testing time, wooohoooo
-// 			gotResult, gotErr := WorkspaceDeleteE(t, options, testCase.toDeleteWorkspace)
+			// Testing time, wooohoooo
+			gotResult, gotErr := WorkspaceDeleteE(t, options, testCase.toDeleteWorkspace)
 
-// 			// Check for errors
-// 			if testCase.expectedError != nil {
-// 				assert.True(t, errors.As(gotErr, &testCase.expectedError))
-// 			} else {
-// 				assert.NoError(t, gotErr)
-// 				// Check for results
-// 				assert.Equal(t, testCase.expectedCurrent, gotResult)
-// 				assert.False(t, isExistingWorkspace(RunTerraformCommand(t, options, "workspace", "list"), testCase.toDeleteWorkspace))
-// 			}
-// 		})
+			// Check for errors
+			if testCase.expectedError != nil {
+				assert.True(t, errors.As(gotErr, &testCase.expectedError))
+			} else {
+				assert.NoError(t, gotErr)
+				// Check for results
+				assert.Equal(t, testCase.expectedCurrent, gotResult)
+				assert.False(t, isExistingWorkspace(RunTerraformCommand(t, options, "workspace", "list"), testCase.toDeleteWorkspace))
+			}
+		})
 
-// 	}
-// }
+	}
+}


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

This adds a `SetVarsAfterVarFiles` field to the `Options` struct. When set to `true`, `FormatArgs` will place `-var` options after `-var-file` options. When `false`, `FormatArgs` will maintain its current behavior. This is a similar idea to #256.

This will increase terratest's flexibility without introducing a breaking changes 🙂 

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added ability to control order of `-var` and `-var-file` options passed to Terraform

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->
