### PR TITLE
feat(k8s): introduce several retry functions to deal w/ flaky apis

### DIFF
--- a/modules/k8s/kubectl.go
+++ b/modules/k8s/kubectl.go
@@ -4,9 +4,11 @@ import (
 	"io/ioutil"
 	"net/url"
 	"os"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/gruntwork-io/terratest/modules/retry"
 	"github.com/gruntwork-io/terratest/modules/shell"
 	"github.com/gruntwork-io/terratest/modules/testing"
 )
@@ -19,6 +21,26 @@ func RunKubectl(t testing.TestingT, options *KubectlOptions, args ...string) {
 // RunKubectlE will call kubectl using the provided options and args.
 func RunKubectlE(t testing.TestingT, options *KubectlOptions, args ...string) error {
 	_, err := RunKubectlAndGetOutputE(t, options, args...)
+	return err
+}
+
+// RunKubectlWithRetry will call kubectl using the provided options and args, failing the test after errors have been retried.
+func RunKubectlWithRetry(t testing.TestingT, options *KubectlOptions, retries int, sleepBetweenRetries time.Duration, args ...string) {
+	err := RunKubectlWithRetryE(t, options, retries, sleepBetweenRetries, args...)
+	require.NoError(t, err)
+}
+
+// RunKubectlWithRetryE will call kubectl using the provided options and args, reytring on error.
+func RunKubectlWithRetryE(t testing.TestingT, options *KubectlOptions, retries int, sleepBetweenRetries time.Duration, args ...string) error {
+	_, err := retry.DoWithRetryE(
+		t,
+		"",
+		retries,
+		sleepBetweenRetries,
+		func() (string, error) {
+			return "", RunKubectlE(t, options, args...)
+		},
+	)
 	return err
 }
 
@@ -42,6 +64,29 @@ func RunKubectlAndGetOutputE(t testing.TestingT, options *KubectlOptions, args .
 		Env:     options.Env,
 	}
 	return shell.RunCommandAndGetOutputE(t, command)
+}
+
+// RunKubectlAndGetOutputWithRetry will call kubectl using the provided options and args, returning the output of stdout and
+// stderr, failing the test after errors have been retried.
+func RunKubectlAndGetOutputWithRetry(t testing.TestingT, options *KubectlOptions, retries int, sleepBetweenRetries time.Duration, args ...string) string {
+	output, err := RunKubectlAndGetOutputWithRetryE(t, options, retries, sleepBetweenRetries, args...)
+	require.NoError(t, err)
+	return output
+}
+
+// RunKubectlAndGetOutputWithRetryE will call kubectl using the provided options and args, returning the output of stdout and
+// stderr, reytring on error.
+func RunKubectlAndGetOutputWithRetryE(t testing.TestingT, options *KubectlOptions, retries int, sleepBetweenRetries time.Duration, args ...string) (string, error) {
+	output, err := retry.DoWithRetryE(
+		t,
+		"",
+		retries,
+		sleepBetweenRetries,
+		func() (string, error) {
+			return RunKubectlAndGetOutputE(t, options, args...)
+		},
+	)
+	return output, err
 }
 
 // KubectlDelete will take in a file path and delete it from the cluster targeted by KubectlOptions. If there are any
@@ -120,6 +165,28 @@ func KubectlApplyFromStringE(t testing.TestingT, options *KubectlOptions, config
 	}
 	defer os.Remove(tmpfile)
 	return KubectlApplyE(t, options, tmpfile)
+}
+
+// KubectlApplyFromStringWithRetry will take in a kubernetes resource config as a string and apply it on the cluster specified
+// by the provided kubectl options. The test fails after errors have been retried.
+func KubectlApplyFromStringWithRetry(t testing.TestingT, options *KubectlOptions, retries int, sleepBetweenRetries time.Duration, configData string) {
+	err := KubectlApplyFromStringWithRetryE(t, options, retries, sleepBetweenRetries, configData)
+	require.NoError(t, err)
+}
+
+// KubectlApplyFromStringWithRetryE will take in a kubernetes resource config as a string and apply it on the cluster specified
+// by the provided kubectl options. Errors are retried.
+func KubectlApplyFromStringWithRetryE(t testing.TestingT, options *KubectlOptions, retries int, sleepBetweenRetries time.Duration, configData string) error {
+	_, err := retry.DoWithRetryE(
+		t,
+		"",
+		retries,
+		sleepBetweenRetries,
+		func() (string, error) {
+			return "", KubectlApplyFromStringE(t, options, configData)
+		},
+	)
+	return err
 }
 
 // StoreConfigToTempFile will store the provided config data to a temporary file created on the os and return the


### PR DESCRIPTION
## Description

To deal with flaky kube-apiservers we wrote several retry functions. Related issue: https://github.com/aws/containers-roadmap/issues/1810#issuecomment-1236812689

I am unsure whether these functions will be considered, but it was little effort to make a PR.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Added k8s functions: `RunKubectlWithRetry`, `RunKubectlWithRetryE`, `RunKubectlAndGetOutputWithRetry`, `RunKubectlAndGetOutputWithRetryE`, `KubectlApplyFromStringWithRetry`, `KubectlApplyFromStringWithRetryE`

### Migration Guide

N/A