### PR TITLE
add `pod.Status.{Reason,Message}` to `PodNotAvailable` error

### DIFF
--- a/modules/k8s/errors.go
+++ b/modules/k8s/errors.go
@@ -68,7 +68,7 @@ type PodNotAvailable struct {
 
 // Error is a simple function to return a formatted error message as a string
 func (err PodNotAvailable) Error() string {
-	return fmt.Sprintf("Pod %s is not available", err.pod.Name)
+	return fmt.Sprintf("Pod %s is not available, reason: %s, message: %s", err.pod.Name, err.pod.Status.Reason, err.pod.Status.Message)
 }
 
 // NewPodNotAvailableError returnes a PodNotAvailable struct when Kubernetes deems a pod is not available


### PR DESCRIPTION

Signed-off-by: Charly Molter <charly.molter@konghq.com>

<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

When writing tests using terratest it's useful to figure why a pod
failed to start.

For example we use heavily terratest in our e2e suite. Some tests
are flaky for many possible reasons at the moment we have to switch to using:
`WaitUntilPodAvailableE` and use the error to get the pod status.

Fix #1222

<!-- Description of the changes introduced by this PR. -->

Add extra info in the error message.

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs. -- No docs for this
- [ ] Run the relevant tests successfully, including pre-commit checks. -- Trying to figure out how to do this
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

Added context to `PodNotAvailable` error to make troubleshooting easier.

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->
