### PR TITLE
Implement GetPodLogs

### DIFF
--- a/examples/kubernetes-basic-example/podinfo-daemonset.yml
+++ b/examples/kubernetes-basic-example/podinfo-daemonset.yml
@@ -1,0 +1,19 @@
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: podinfo-deamonset
+spec:
+  selector:
+    matchLabels:
+      app: podinfo
+  template:
+    metadata:
+      labels:
+        app: podinfo
+    spec:
+      containers:
+      - name: podinfo
+        image: ghcr.io/stefanprodan/podinfo:6.3.0
+        ports:
+        - containerPort: 9898

--- a/modules/k8s/pod.go
+++ b/modules/k8s/pod.go
@@ -149,7 +149,18 @@ func IsPodAvailable(pod *corev1.Pod) bool {
 	return pod.Status.Phase == corev1.PodRunning
 }
 
+// GetPodLogsE returns the logs of a Pod at the time when the function was called. If the Pod is not running an Error is returned.
+func GetPodLogsE(t testing.TestingT, options *KubectlOptions, pod *corev1.Pod) (string, error) {
+	output, err := RunKubectlAndGetOutputE(t, options, "logs", pod.Name)
+	if err != nil {
+		return "", err
+	}
+	return output, nil
+}
+
 // GetPodLogsE returns the logs of a Pod at the time when the function was called.
 func GetPodLogs(t testing.TestingT, options *KubectlOptions, pod *corev1.Pod) string {
-	return ""
+	logs, err := GetPodLogsE(t, options, pod)
+	require.NoError(t, err)
+	return logs
 }

--- a/modules/k8s/pod.go
+++ b/modules/k8s/pod.go
@@ -148,3 +148,8 @@ func IsPodAvailable(pod *corev1.Pod) bool {
 	}
 	return pod.Status.Phase == corev1.PodRunning
 }
+
+// GetPodLogsE returns the logs of a Pod at the time when the function was called.
+func GetPodLogs(t testing.TestingT, options *KubectlOptions, pod *corev1.Pod) string {
+	return ""
+}

--- a/modules/k8s/pod.go
+++ b/modules/k8s/pod.go
@@ -149,18 +149,27 @@ func IsPodAvailable(pod *corev1.Pod) bool {
 	return pod.Status.Phase == corev1.PodRunning
 }
 
-// GetPodLogsE returns the logs of a Pod at the time when the function was called. If the Pod is not running an Error is returned.
-func GetPodLogsE(t testing.TestingT, options *KubectlOptions, pod *corev1.Pod) (string, error) {
-	output, err := RunKubectlAndGetOutputE(t, options, "logs", pod.Name)
+// GetPodLogsE returns the logs of a Pod at the time when the function was called. Pass container name if there are more containers in the Pod or set to "" if there is only one.
+// If the Pod is not running an Error is returned.
+// If the provided containerName is not the name of a container in the Pod an Error is returned.
+func GetPodLogsE(t testing.TestingT, options *KubectlOptions, pod *corev1.Pod, containerName string) (string, error) {
+	var output string
+	var err error
+	if containerName == "" {
+		output, err = RunKubectlAndGetOutputE(t, options, "logs", pod.Name)
+	} else {
+		output, err = RunKubectlAndGetOutputE(t, options, "logs", pod.Name, fmt.Sprintf("-c%s", containerName))
+	}
+
 	if err != nil {
 		return "", err
 	}
 	return output, nil
 }
 
-// GetPodLogsE returns the logs of a Pod at the time when the function was called.
-func GetPodLogs(t testing.TestingT, options *KubectlOptions, pod *corev1.Pod) string {
-	logs, err := GetPodLogsE(t, options, pod)
+// GetPodLogsE returns the logs of a Pod at the time when the function was called.  Pass container name if there are more containers in the Pod or set to "" if there is only one.
+func GetPodLogs(t testing.TestingT, options *KubectlOptions, pod *corev1.Pod, containerName string) string {
+	logs, err := GetPodLogsE(t, options, pod, containerName)
 	require.NoError(t, err)
 	return logs
 }

--- a/test/kubernetes_basic_example_logs_test.go
+++ b/test/kubernetes_basic_example_logs_test.go
@@ -1,3 +1,6 @@
+//go:build kubeall || kubernetes
+// +build kubeall kubernetes
+
 // NOTE: we have build tags to differentiate kubernetes tests from non-kubernetes tests. This is done because minikube
 // is heavy and can interfere with docker related tests in terratest. Specifically, many of the tests start to fail with
 // `connection refused` errors from `minikube`. To avoid overloading the system, we run the kubernetes tests and helm

--- a/test/kubernetes_basic_example_logs_test.go
+++ b/test/kubernetes_basic_example_logs_test.go
@@ -1,0 +1,82 @@
+//go:build kubeall || kubernetes
+// +build kubeall kubernetes
+
+// NOTE: we have build tags to differentiate kubernetes tests from non-kubernetes tests. This is done because minikube
+// is heavy and can interfere with docker related tests in terratest. Specifically, many of the tests start to fail with
+// `connection refused` errors from `minikube`. To avoid overloading the system, we run the kubernetes tests and helm
+// tests separately from the others. This may not be necessary if you have a sufficiently powerful machine.  We
+// recommend at least 4 cores and 16GB of RAM if you want to run all the tests together.
+
+package test
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gruntwork-io/terratest/modules/k8s"
+	"github.com/gruntwork-io/terratest/modules/random"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// An example of how to do more expanded verification of the Kubernetes resource config in examples/kubernetes-basic-example using Terratest.
+func TestKubernetesBasicExampleServiceCheck(t *testing.T) {
+	t.Parallel()
+
+	// Path to the Kubernetes resource config we will test
+	kubeResourcePath, err := filepath.Abs("../examples/kubernetes-basic-example/podinfo-daemonset.yml")
+	require.NoError(t, err)
+
+	// To ensure we can reuse the resource config on the same cluster to test different scenarios, we setup a unique
+	// namespace for the resources for this test.
+	// Note that namespaces must be lowercase.
+	namespaceName := strings.ToLower(random.UniqueId())
+
+	// Setup the kubectl config and context. Here we choose to use the defaults, which is:
+	// - HOME/.kube/config for the kubectl config file
+	// - Current context of the kubectl config file
+	options := k8s.NewKubectlOptions("", "", namespaceName)
+
+	k8s.CreateNamespace(t, options, namespaceName)
+	// ... and make sure to delete the namespace at the end of the test
+	defer k8s.DeleteNamespace(t, options, namespaceName)
+
+	// At the end of the test, run `kubectl delete -f RESOURCE_CONFIG` to clean up any resources that were created.
+	defer k8s.KubectlDelete(t, options, kubeResourcePath)
+
+	// This will run `kubectl apply -f RESOURCE_CONFIG` and fail the test if there are any errors
+	k8s.KubectlApply(t, options, kubeResourcePath)
+
+	// Wait for at least 1 Pod to be ready from the DaemonSet
+	retries := 10
+	sleep := time.Second * 1
+	for i := 1; i < retries; i++ {
+		podsReady := k8s.GetDaemonSet(t, options, "podinfo-deamonset").Status.NumberReady
+		if podsReady > 0 {
+			break
+		}
+		time.Sleep(sleep)
+	}
+
+	// listOptions are used to select the pods with label app=podinfo
+	listOptions := new(metav1.ListOptions)
+	listOptions.LabelSelector = "app=podinfo"
+
+	// Get a list of Pods. The pods are not guaranteed to be in running state.
+	pods := k8s.ListPods(t, options, *listOptions)
+
+	// Check that we did not timeout waiting for the Pod of the DaemonSet to be ready
+	require.Greater(t, len(pods), 0)
+
+	pod := pods[0]
+
+	// Wait fot the pod to be started and ready
+	k8s.WaitUntilPodAvailable(t, options, pod.Name, 5, 10*time.Second)
+
+	logs := k8s.GetPodLogs(t, options, &pod)
+
+	require.Contains(t, logs, "Starting podinfo")
+}


### PR DESCRIPTION
Implement GetPodLogs

## Description

Fixes #1206 

Implements a function to get the logs of a running Pod.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs. - **Not needed**
- [x] Run the relevant tests successfully, including pre-commit checks. - **Screenshots attached**
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes

<!-- One-line description of the PR that can be included in the final release notes. -->
Added[X] / Removed / Updated.

GetPodLogs returns the logs of a running Pod as a string.

### Migration Guide  - **Not needed**

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

### Documentated test run
First commit - Function returns an empty string, we expect the test to fail.
![image](https://user-images.githubusercontent.com/22328547/213862681-225c93b6-0750-403f-b293-b0892d515dad.png)
![image](https://user-images.githubusercontent.com/22328547/213862691-02b285c3-737b-4814-82a9-bda7a355da0d.png)
Second commit - Functionality implemented, test pass.
![image](https://user-images.githubusercontent.com/22328547/213862723-89839bfc-dc21-4df4-9890-73a9c0288fed.png)
![image](https://user-images.githubusercontent.com/22328547/213862734-6756f507-15e1-436b-b196-2eed6ab3144c.png)

