### PR TITLE
#1233 Failing tests fixes

### DIFF
--- a/modules/gcp/compute_test.go
+++ b/modules/gcp/compute_test.go
@@ -23,7 +23,7 @@ const DEFAULT_IMAGE_FAMILY_PROJECT_NAME = "ubuntu-os-cloud"
 const DEFAULT_IMAGE_FAMILY_NAME = "family/ubuntu-1804-lts"
 
 // Regions that don't support running f1-micro instances
-var RegionsToAvoid = []string{"asia-east2", "southamerica-west1", "europe-west8", "europe-southwest1"}
+var RegionsToAvoid = []string{"asia-east2", "southamerica-west1", "europe-west8", "europe-southwest1", "us-east5-a"}
 
 func TestGetPublicIpOfInstance(t *testing.T) {
 	t.Parallel()

--- a/modules/gcp/compute_test.go
+++ b/modules/gcp/compute_test.go
@@ -22,15 +22,15 @@ const DEFAULT_MACHINE_TYPE = "f1-micro"
 const DEFAULT_IMAGE_FAMILY_PROJECT_NAME = "ubuntu-os-cloud"
 const DEFAULT_IMAGE_FAMILY_NAME = "family/ubuntu-1804-lts"
 
-// Regions that don't support running f1-micro instances
-var RegionsToAvoid = []string{"asia-east2", "southamerica-west1", "europe-west8", "europe-southwest1", "us-east5-a"}
+// Zones that support running f1-micro instances
+var ZonesThatSupportF1Micro = []string{"us-central1-a", "us-east1-b", "us-west1-a", "europe-north1-a", "europe-west1-b", "europe-central2-a"}
 
 func TestGetPublicIpOfInstance(t *testing.T) {
 	t.Parallel()
 
 	instanceName := RandomValidGcpName()
 	projectID := GetGoogleProjectIDFromEnvVar(t)
-	zone := GetRandomZone(t, projectID, nil, nil, RegionsToAvoid)
+	zone := GetRandomZone(t, projectID, ZonesThatSupportF1Micro, nil, nil)
 
 	createComputeInstance(t, projectID, zone, instanceName)
 	defer deleteComputeInstance(t, projectID, zone, instanceName)
@@ -77,7 +77,7 @@ func TestGetAndSetLabels(t *testing.T) {
 	instanceName := RandomValidGcpName()
 	projectID := GetGoogleProjectIDFromEnvVar(t)
 
-	zone := GetRandomZone(t, projectID, nil, nil, RegionsToAvoid)
+	zone := GetRandomZone(t, projectID, ZonesThatSupportF1Micro, nil, nil)
 
 	createComputeInstance(t, projectID, zone, instanceName)
 	defer deleteComputeInstance(t, projectID, zone, instanceName)
@@ -113,7 +113,7 @@ func TestGetAndSetMetadata(t *testing.T) {
 	projectID := GetGoogleProjectIDFromEnvVar(t)
 	instanceName := RandomValidGcpName()
 
-	zone := GetRandomZone(t, projectID, nil, nil, RegionsToAvoid)
+	zone := GetRandomZone(t, projectID, ZonesThatSupportF1Micro, nil, nil)
 
 	// Create a new Compute Instance
 	createComputeInstance(t, projectID, zone, instanceName)

--- a/modules/helm/install_test.go
+++ b/modules/helm/install_test.go
@@ -26,7 +26,7 @@ import (
 const (
 	remoteChartSource  = "https://charts.bitnami.com/bitnami"
 	remoteChartName    = "nginx"
-	remoteChartVersion = "9.7.4"
+	remoteChartVersion = "13.2.23"
 )
 
 // Test that we can install a remote chart (e.g bitnami/nginx)

--- a/test/gcp/packer_gcp_basic_example_test.go
+++ b/test/gcp/packer_gcp_basic_example_test.go
@@ -22,6 +22,9 @@ var DefaultRetryablePackerErrors = map[string]string{
 }
 var DefaultTimeBetweenPackerRetries = 15 * time.Second
 
+// Regions that support running f1-micro instances
+var RegionsThatSupportF1Micro = []string{"us-central1", "us-east1", "us-west1", "europe-west1"}
+
 // Zones that support running f1-micro instances
 var ZonesThatSupportF1Micro = []string{"us-central1-a", "us-east1-b", "us-west1-a", "europe-north1-a", "europe-west1-b", "europe-central2-a"}
 

--- a/test/gcp/packer_gcp_basic_example_test.go
+++ b/test/gcp/packer_gcp_basic_example_test.go
@@ -22,8 +22,8 @@ var DefaultRetryablePackerErrors = map[string]string{
 }
 var DefaultTimeBetweenPackerRetries = 15 * time.Second
 
-// Regions that don't support n1-standard-1 instances
-var RegionsToAvoid = []string{"asia-east2", "southamerica-west1", "europe-west8", "europe-southwest1", "us-east5-a"}
+// Zones that support running f1-micro instances
+var ZonesThatSupportF1Micro = []string{"us-central1-a", "us-east1-b", "us-west1-a", "europe-north1-a", "europe-west1-b", "europe-central2-a"}
 
 const DefaultMaxPackerRetries = 3
 
@@ -35,7 +35,7 @@ func TestPackerGCPBasicExample(t *testing.T) {
 	projectID := gcp.GetGoogleProjectIDFromEnvVar(t)
 
 	// Pick a random GCP zone to test in. This helps ensure your code works in all regions.
-	zone := gcp.GetRandomZone(t, projectID, nil, nil, RegionsToAvoid)
+	zone := gcp.GetRandomZone(t, projectID, ZonesThatSupportF1Micro, nil, nil)
 
 	packerOptions := &packer.Options{
 		// The path to where the Packer template is located

--- a/test/gcp/packer_gcp_basic_example_test.go
+++ b/test/gcp/packer_gcp_basic_example_test.go
@@ -23,7 +23,7 @@ var DefaultRetryablePackerErrors = map[string]string{
 var DefaultTimeBetweenPackerRetries = 15 * time.Second
 
 // Regions that don't support n1-standard-1 instances
-var RegionsToAvoid = []string{"asia-east2", "southamerica-west1", "europe-west8", "europe-southwest1"}
+var RegionsToAvoid = []string{"asia-east2", "southamerica-west1", "europe-west8", "europe-southwest1", "us-east5-a"}
 
 const DefaultMaxPackerRetries = 3
 

--- a/test/gcp/terraform_gcp_example_test.go
+++ b/test/gcp/terraform_gcp_example_test.go
@@ -109,7 +109,7 @@ func TestSshAccessToComputeInstance(t *testing.T) {
 	// Setup values for our Terraform apply
 	projectID := gcp.GetGoogleProjectIDFromEnvVar(t)
 	randomValidGcpName := gcp.RandomValidGcpName()
-	zone := gcp.GetRandomZone(t, projectID, nil, nil, RegionsToAvoid)
+	zone := gcp.GetRandomZone(t, projectID, ZonesThatSupportF1Micro, nil, nil)
 
 	terraformOptions := &terraform.Options{
 		// The path to where our Terraform code is located

--- a/test/gcp/terraform_gcp_ig_example_test.go
+++ b/test/gcp/terraform_gcp_ig_example_test.go
@@ -24,7 +24,7 @@ func TestTerraformGcpInstanceGroupExample(t *testing.T) {
 	// Setup values for our Terraform apply
 	projectId := gcp.GetGoogleProjectIDFromEnvVar(t)
 
-	region := gcp.GetRandomRegion(t, projectId, nil, RegionsToAvoid)
+	region := gcp.GetRandomRegion(t, projectId, RegionsThatSupportF1Micro, nil)
 
 	randomValidGcpName := gcp.RandomValidGcpName()
 	clusterSize := 3


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Updated helm chart installation test to use actual nginx version.
Updated GCP test to not run instances on regions that don't support `f1-micro` instances.

Fixes #1233.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)
N/A

### Migration Guide
N/A
