### PR TITLE
Adds the -no-color option to the terraform init command

### DIFF
--- a/modules/terraform/init.go
+++ b/modules/terraform/init.go
@@ -27,6 +27,10 @@ func InitE(t testing.TestingT, options *Options) (string, error) {
 	if options.MigrateState {
 		args = append(args, "-migrate-state", "-force-copy")
 	}
+	// Append no-color option if needed
+	if options.NoColor {
+		args = append(args, "-no-color")
+	}
 
 	args = append(args, FormatTerraformBackendConfigAsArgs(options.BackendConfig)...)
 	args = append(args, FormatTerraformPluginDirAsArgs(options.PluginDir)...)


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes https://github.com/gruntwork-io/terratest/issues/1240

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

* Adds the **-no-color** option to the **terraform init** command if needed

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->
