### PR TITLE
Create a function to extract default az subnets

### DIFF
--- a/modules/aws/vpc_test.go
+++ b/modules/aws/vpc_test.go
@@ -169,6 +169,18 @@ func TestGetTagsForSubnet(t *testing.T) {
 	assert.True(t, testTags["TagKey2"] == "TagValue2")
 }
 
+func TestGetDefaultAzSubnets(t *testing.T) {
+	t.Parallel()
+
+	region := GetRandomStableRegion(t, nil, nil)
+	vpc := GetDefaultVpc(t, region)
+
+	// Note: cannot know exact list of default azs aheard of time, but we know that
+	//it must be greater than 0 for default vpc.
+	subnets := GetAzDefaultSubnetsForVpc(t, vpc.Id, region)
+	assert.NotZero(t, len(subnets))
+}
+
 func createPublicRoute(t *testing.T, vpcId string, routeTableId string, region string) {
 	ec2Client := NewEc2Client(t, region)
 


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Adding a new function to extract default az subnets from a vpc. 
Need this change for https://github.com/gruntwork-io/terraform-aws-data-storage/pull/281 - fixing tests in data storage module. 

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].
Added [A new method to get default az subnets]

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->
