### PR TITLE
add logs when pod failed to start when using `WaitUntilPodAvailableE`

### DIFF
--- a/test/fixtures/kubernetes-failing-deployment/container-stops-after-2s-deployment.yml
+++ b/test/fixtures/kubernetes-failing-deployment/container-stops-after-2s-deployment.yml
@@ -1,0 +1,21 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-app
+spec:
+  selector:
+    matchLabels:
+      app: test-app
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: test-app
+    spec:
+      containers:
+        - name: app
+          image: busybox
+          command:
+            ["/bin/sh", "-c", "for i in `seq 1 2`; do echo ${i} sleeping 1 sec; sleep 1; done; echo Finished!"]
+

--- a/test/fixtures/kubernetes-failing-deployment/happy-then-fail-deployment.yml
+++ b/test/fixtures/kubernetes-failing-deployment/happy-then-fail-deployment.yml
@@ -1,0 +1,28 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-app
+spec:
+  selector:
+    matchLabels:
+      app: test-app
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: test-app
+    spec:
+      containers:
+        - name: app
+          image: busybox
+          command:
+            ["/bin/sh", "-c", "touch /tmp/healthy;for i in `seq 1 3`; do echo ${i} sleeping 1 sec; sleep 1; done; rm /tmp/healthy; sleep 1000"]
+          readinessProbe:
+            exec:
+              command:
+                - cat
+                - /tmp/healthy
+            periodSeconds: 1
+            initialDelaySeconds: 1
+

--- a/test/fixtures/kubernetes-failing-deployment/probe-slow-to-pass-deployment.yml
+++ b/test/fixtures/kubernetes-failing-deployment/probe-slow-to-pass-deployment.yml
@@ -1,0 +1,28 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-app
+spec:
+  selector:
+    matchLabels:
+      app: test-app
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: test-app
+    spec:
+      containers:
+        - name: app
+          image: busybox
+          command:
+            ["/bin/sh", "-c", "for i in `seq 1 10`; do echo ${i} sleeping 1 sec; sleep 1; done; touch /tmp/healthy"]
+          startupProbe:
+            exec:
+              command:
+                - cat
+                - /tmp/healthy
+            periodSeconds: 1
+            initialDelaySeconds: 1
+

--- a/test/fixtures/kubernetes-failing-deployment/too-much-resource-deployment.yml
+++ b/test/fixtures/kubernetes-failing-deployment/too-much-resource-deployment.yml
@@ -1,0 +1,23 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-app
+spec:
+  selector:
+    matchLabels:
+      app: test-app
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: test-app
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:1.15.7
+          ports:
+            - containerPort: 80
+          resources:
+            requests:
+              cpu: 100

--- a/test/fixtures/kubernetes-failing-deployment/unknown-image-deployment.yml
+++ b/test/fixtures/kubernetes-failing-deployment/unknown-image-deployment.yml
@@ -1,0 +1,20 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-app
+spec:
+  selector:
+    matchLabels:
+      app: test-app
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: test-app
+    spec:
+      containers:
+        - name: app
+          image: not-an-place/not-an-app
+          ports:
+            - containerPort: 5000

--- a/test/kubernetes_failed_pod_test.go
+++ b/test/kubernetes_failed_pod_test.go
@@ -73,7 +73,7 @@ func setupFailingDeploymentTest(t *testing.T, file string) error {
 	return err
 }
 
-func TestUnknownImage(t *testing.T) {
+func TestKubernetesUnknownImage(t *testing.T) {
 	err := setupFailingDeploymentTest(t, "unknown-image-deployment.yml")
 	notAvailableError := k8s.PodNotAvailable{}
 	require.ErrorAs(t, err, &notAvailableError)
@@ -83,7 +83,7 @@ func TestUnknownImage(t *testing.T) {
 	require.Contains(t, msg, "failed to pull and unpack image \"docker.io/not-an-place/not-an-app:latest\"")
 }
 
-func TestTooMuchResource(t *testing.T) {
+func TestKubernetesTooMuchResource(t *testing.T) {
 	err := setupFailingDeploymentTest(t, "too-much-resource-deployment.yml")
 	notAvailableError := k8s.PodNotAvailable{}
 	require.ErrorAs(t, err, &notAvailableError)
@@ -91,7 +91,7 @@ func TestTooMuchResource(t *testing.T) {
 	require.Contains(t, msg, "PodScheduled:Unschedulable")
 }
 
-func TestFailsAfterASec(t *testing.T) {
+func TestKubernetesFailsAfterASec(t *testing.T) {
 	err := setupFailingDeploymentTest(t, "probe-slow-to-pass-deployment.yml")
 	notAvailableError := k8s.PodNotAvailable{}
 	require.ErrorAs(t, err, &notAvailableError)
@@ -99,7 +99,7 @@ func TestFailsAfterASec(t *testing.T) {
 	require.Contains(t, msg, "Ready:ContainersNotReady")
 }
 
-func TestHappyThenFails(t *testing.T) {
+func TestKubernetesHappyThenFails(t *testing.T) {
 	err := setupFailingDeploymentTest(t, "happy-then-fail-deployment.yml")
 	notAvailableError := k8s.PodNotAvailable{}
 	require.ErrorAs(t, err, &notAvailableError)
@@ -108,7 +108,7 @@ func TestHappyThenFails(t *testing.T) {
 	require.Contains(t, msg, "ContainersReady:ContainersNotReady->containers with unready status: [app]")
 }
 
-func TestStopsAfter5s(t *testing.T) {
+func TestKubernetesStopsAfter5s(t *testing.T) {
 	err := setupFailingDeploymentTest(t, "container-stops-after-2s-deployment.yml")
 	notAvailableError := k8s.PodNotAvailable{}
 	require.ErrorAs(t, err, &notAvailableError)

--- a/test/kubernetes_failed_pod_test.go
+++ b/test/kubernetes_failed_pod_test.go
@@ -1,0 +1,118 @@
+//go:build kubeall || kubernetes
+// +build kubeall kubernetes
+
+// NOTE: we have build tags to differentiate kubernetes tests from non-kubernetes tests. This is done because minikube
+// is heavy and can interfere with docker related tests in terratest. Specifically, many of the tests start to fail with
+// `connection refused` errors from `minikube`. To avoid overloading the system, we run the kubernetes tests and helm
+// tests separately from the others. This may not be necessary if you have a sufficiently powerful machine.  We
+// recommend at least 4 cores and 16GB of RAM if you want to run all the tests together.
+
+package test
+
+import (
+	"path"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gruntwork-io/terratest/modules/k8s"
+	"github.com/gruntwork-io/terratest/modules/random"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func setupFailingDeploymentTest(t *testing.T, file string) error {
+	t.Parallel()
+
+	// Path to the Kubernetes resource config we will test
+	kubeResourcePath, err := filepath.Abs(path.Join("fixtures/kubernetes-failing-deployment", file))
+	require.NoError(t, err)
+
+	// To ensure we can reuse the resource config on the same cluster to test different scenarios, we setup a unique
+	// namespace for the resources for this test.
+	// Note that namespaces must be lowercase.
+	namespaceName := strings.ToLower(random.UniqueId())
+
+	// Setup the kubectl config and context. Here we choose to use the defaults, which is:
+	// - HOME/.kube/config for the kubectl config file
+	// - Current context of the kubectl config file
+	options := k8s.NewKubectlOptions("", "", namespaceName)
+
+	k8s.CreateNamespace(t, options, namespaceName)
+	//// ... and make sure to delete the namespace at the end of the test
+	defer k8s.DeleteNamespace(t, options, namespaceName)
+	//
+	//// At the end of the test, run `kubectl delete -f RESOURCE_CONFIG` to clean up any resources that were created.
+	defer k8s.KubectlDelete(t, options, kubeResourcePath)
+
+	// This will run `kubectl apply -f RESOURCE_CONFIG` and fail the test if there are any errors
+	k8s.KubectlApply(t, options, kubeResourcePath)
+
+	// listOptions are used to select the pods with label app=podinfo
+	listOptions := metav1.ListOptions{
+		LabelSelector: "app=test-app",
+	}
+
+	// Wait for at least 1 Pod to be ready from the DaemonSet
+	k8s.WaitUntilNumPodsCreated(t, options, listOptions, 1, 5, time.Second)
+
+	// Get a list of Pods. The pods are not guaranteed to be in running state.
+	pods := k8s.ListPods(t, options, listOptions)
+
+	// Check that we did not timeout waiting for the Pod of the DaemonSet to be ready
+	require.Greater(t, len(pods), 0)
+
+	pod := pods[0]
+
+	// Wait fot the pod to be started and ready
+	err = k8s.WaitUntilPodConsistentlyAvailableE(t, options, pod.Name, 5, time.Second, 5)
+	require.Error(t, err)
+
+	return err
+}
+
+func TestUnknownImage(t *testing.T) {
+	err := setupFailingDeploymentTest(t, "unknown-image-deployment.yml")
+	notAvailableError := k8s.PodNotAvailable{}
+	require.ErrorAs(t, err, &notAvailableError)
+	msg := notAvailableError.Error()
+	require.Contains(t, msg, "ContainersNotReady")
+	require.Contains(t, msg, "waiting(app):ErrImagePull")
+	require.Contains(t, msg, "failed to pull and unpack image \"docker.io/not-an-place/not-an-app:latest\"")
+}
+
+func TestTooMuchResource(t *testing.T) {
+	err := setupFailingDeploymentTest(t, "too-much-resource-deployment.yml")
+	notAvailableError := k8s.PodNotAvailable{}
+	require.ErrorAs(t, err, &notAvailableError)
+	msg := notAvailableError.Error()
+	require.Contains(t, msg, "PodScheduled:Unschedulable")
+}
+
+func TestFailsAfterASec(t *testing.T) {
+	err := setupFailingDeploymentTest(t, "probe-slow-to-pass-deployment.yml")
+	notAvailableError := k8s.PodNotAvailable{}
+	require.ErrorAs(t, err, &notAvailableError)
+	msg := notAvailableError.Error()
+	require.Contains(t, msg, "Ready:ContainersNotReady")
+}
+
+func TestHappyThenFails(t *testing.T) {
+	err := setupFailingDeploymentTest(t, "happy-then-fail-deployment.yml")
+	notAvailableError := k8s.PodNotAvailable{}
+	require.ErrorAs(t, err, &notAvailableError)
+	msg := notAvailableError.Error()
+	require.Contains(t, msg, "Ready:ContainersNotReady")
+	require.Contains(t, msg, "ContainersReady:ContainersNotReady->containers with unready status: [app]")
+}
+
+func TestStopsAfter5s(t *testing.T) {
+	err := setupFailingDeploymentTest(t, "container-stops-after-2s-deployment.yml")
+	notAvailableError := k8s.PodNotAvailable{}
+	require.ErrorAs(t, err, &notAvailableError)
+	msg := notAvailableError.Error()
+	require.Contains(t, msg, "Ready:ContainersNotReady")
+	require.Contains(t, msg, "terminated(app):Completed")
+}


### PR DESCRIPTION
## Description

Fixes #1251.

<!-- Description of the changes introduced by this PR. -->

Here's an example of this change in [kumahq/kuma](https://github.com/kumahq/kuma):

```
   2023-03-02T12:32:27+01:00 retry.go:91: Wait for pod kuma-control-plane-5948bcb646-7wwn7 to be provisioned.
   2023-03-02T12:32:27+01:00 client.go:42: Configuring Kubernetes client using config file /Users/charly.molter@konghq.com/.kube/kind-kuma-1-config with context
   2023-03-02T12:32:27+01:00 retry.go:104: Wait for pod kuma-control-plane-5948bcb646-7wwn7 to be provisioned. returned an error: Pod kuma-control-plane-5948bcb646-7wwn7 is not available, reason: , message: , phase: Pending, conditions: [{Type:Initialized Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2023-03-02 12:32:27 +0100 CET Reason: Message:} {Type:Ready Status:False LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2023-03-02 12:32:27 +0100 CET Reason:ContainersNotReady Message:containers with unready status: [control-plane]} {Type:ContainersReady Status:False LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2023-03-02 12:32:27 +0100 CET Reason:ContainersNotReady Message:containers with unready status: [control-plane]} {Type:PodScheduled Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2023-03-02 12:32:27 +0100 CET Reason: Message:}]. Sleeping for 3s and will try again.
   2023-03-02T12:32:30+01:00 client.go:42: Configuring Kubernetes client using config file /Users/charly.molter@konghq.com/.kube/kind-kuma-1-config with context
   2023-03-02T12:32:30+01:00 retry.go:104: Wait for pod kuma-control-plane-5948bcb646-7wwn7 to be provisioned. returned an error: Pod kuma-control-plane-5948bcb646-7wwn7 is not available, reason: , message: , phase: Running, conditions: [{Type:Initialized Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2023-03-02 12:32:27 +0100 CET Reason: Message:} {Type:Ready Status:False LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2023-03-02 12:32:27 +0100 CET Reason:ContainersNotReady Message:containers with unready status: [control-plane]} {Type:ContainersReady Status:False LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2023-03-02 12:32:27 +0100 CET Reason:ContainersNotReady Message:containers with unready status: [control-plane]} {Type:PodScheduled Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2023-03-02 12:32:27 +0100 CET Reason: Message:}]. Sleeping for 3s and will try again.
   2023-03-02T12:32:33+01:00 client.go:42: Configuring Kubernetes client using config file /Users/charly.molter@konghq.com/.kube/kind-kuma-1-config with context
   2023-03-02T12:32:33+01:00 retry.go:104: Wait for pod kuma-control-plane-5948bcb646-7wwn7 to be provisioned. returned an error: Pod kuma-control-plane-5948bcb646-7wwn7 is not available, reason: , message: , phase: Running, conditions: [{Type:Initialized Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2023-03-02 12:32:27 +0100 CET Reason: Message:} {Type:Ready Status:False LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2023-03-02 12:32:27 +0100 CET Reason:ContainersNotReady Message:containers with unready status: [control-plane]} {Type:ContainersReady Status:False LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2023-03-02 12:32:27 +0100 CET Reason:ContainersNotReady Message:containers with unready status: [control-plane]} {Type:PodScheduled Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2023-03-02 12:32:27 +0100 CET Reason: Message:}]. Sleeping for 3s and will try again.
   2023-03-02T12:32:36+01:00 client.go:42: Configuring Kubernetes client using config file /Users/charly.molter@konghq.com/.kube/kind-kuma-1-config with context
   2023-03-02T12:32:36+01:00 retry.go:104: Wait for pod kuma-control-plane-5948bcb646-7wwn7 to be provisioned. returned an error: Pod kuma-control-plane-5948bcb646-7wwn7 is not available, reason: , message: , phase: Running, conditions: [{Type:Initialized Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2023-03-02 12:32:27 +0100 CET Reason: Message:} {Type:Ready Status:False LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2023-03-02 12:32:27 +0100 CET Reason:ContainersNotReady Message:containers with unready status: [control-plane]} {Type:ContainersReady Status:False LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2023-03-02 12:32:27 +0100 CET Reason:ContainersNotReady Message:containers with unready status: [control-plane]} {Type:PodScheduled Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2023-03-02 12:32:27 +0100 CET Reason: Message:}]. Sleeping for 3s and will try again.
   2023-03-02T12:32:39+01:00 client.go:42: Configuring Kubernetes client using config file /Users/charly.molter@konghq.com/.kube/kind-kuma-1-config with context
   2023-03-02T12:32:39+01:00 retry.go:104: Wait for pod kuma-control-plane-5948bcb646-7wwn7 to be provisioned. returned an error: Pod kuma-control-plane-5948bcb646-7wwn7 is not available, reason: , message: , phase: Running, conditions: [{Type:Initialized Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2023-03-02 12:32:27 +0100 CET Reason: Message:} {Type:Ready Status:False LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2023-03-02 12:32:27 +0100 CET Reason:ContainersNotReady Message:containers with unready status: [control-plane]} {Type:ContainersReady Status:False LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2023-03-02 12:32:27 +0100 CET Reason:ContainersNotReady Message:containers with unready status: [control-plane]} {Type:PodScheduled Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2023-03-02 12:32:27 +0100 CET Reason: Message:}]. Sleeping for 3s and will try again.
   2023-03-02T12:32:42+01:00 client.go:42: Configuring Kubernetes client using config file /Users/charly.molter@konghq.com/.kube/kind-kuma-1-config with context
   2023-03-02T12:32:42+01:00 retry.go:104: Wait for pod kuma-control-plane-5948bcb646-7wwn7 to be provisioned. returned an error: Pod kuma-control-plane-5948bcb646-7wwn7 is not available, reason: , message: , phase: Running, conditions: [{Type:Initialized Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2023-03-02 12:32:27 +0100 CET Reason: Message:} {Type:Ready Status:False LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2023-03-02 12:32:27 +0100 CET Reason:ContainersNotReady Message:containers with unready status: [control-plane]} {Type:ContainersReady Status:False LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2023-03-02 12:32:27 +0100 CET Reason:ContainersNotReady Message:containers with unready status: [control-plane]} {Type:PodScheduled Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2023-03-02 12:32:27 +0100 CET Reason: Message:}]. Sleeping for 3s and will try again.
   2023-03-02T12:32:45+01:00 pod.go:133: Timedout waiting for Pod to be provisioned 'Wait for pod kuma-control-plane-5948bcb646-7wwn7 to be provisioned.' unsuccessful after 5 retries
   2023-03-02T12:32:45+01:00 logger.go:66: Running command kubectl with args [--kubeconfig /Users/charly.molter@konghq.com/.kube/kind-kuma-1-config --namespace kuma-system logs kuma-control-plane-5948bcb646-7wwn7]
   2023-03-02T12:32:45+01:00 logger.go:66: 2023-03-02T11:32:36.281Z	INFO	plugin.runtime.gateway	registered gateway plugin
   2023-03-02T12:32:45+01:00 logger.go:66: I0302 11:32:37.322522       1 request.go:690] Waited for 1.032916s due to client-side throttling, not priority and fairness, request: GET:https://10.43.0.1:443/apis/admissionregistration.k8s.io/v1beta1?timeout=32s
   2023-03-02T12:32:45+01:00 logger.go:66: 2023-03-02T11:32:38.378Z	INFO	plugin.runtime.k8s	[WARNING] Experimental GatewayAPI feature is enabled, but CRDs are not registered. Disabling support
   2023-03-02T12:32:45+01:00 logger.go:66: 2023-03-02T11:32:38.383Z	INFO	controller-runtime.webhook	Registering webhook	{"path": "/validate-kuma-io-v1alpha1"}
   2023-03-02T12:32:45+01:00 logger.go:66: 2023-03-02T11:32:38.383Z	INFO	controller-runtime.webhook	Registering webhook	{"path": "/validate-v1-service"}
   2023-03-02T12:32:45+01:00 logger.go:66: 2023-03-02T11:32:38.383Z	INFO	controller-runtime.webhook	Registering webhook	{"path": "/validate-v1-secret"}
```

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs. -- N/A
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added more information when pod fail to start

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->
