### PR TITLE
Expose additional args to init command 

### DIFF
--- a/modules/terraform/init.go
+++ b/modules/terraform/init.go
@@ -2,6 +2,7 @@ package terraform
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/gruntwork-io/terratest/modules/testing"
 )
@@ -30,5 +31,19 @@ func InitE(t testing.TestingT, options *Options) (string, error) {
 
 	args = append(args, FormatTerraformBackendConfigAsArgs(options.BackendConfig)...)
 	args = append(args, FormatTerraformPluginDirAsArgs(options.PluginDir)...)
+	// Down to the user to supply to correct flags
+	if len(options.AdditionalInitFlags) > 0 {
+
+		for _, v := range options.AdditionalInitFlags {
+			if strings.HasPrefix(v, "-upgrade") ||
+				strings.HasPrefix(v, "-reconfigure") ||
+				strings.HasPrefix(v, "-migrate-state") ||
+				strings.HasPrefix(v, "-force-copy") {
+				continue
+			}
+			args = append(args, v)
+		}
+	}
+
 	return RunTerraformCommandE(t, options, args...)
 }

--- a/modules/terraform/init.go
+++ b/modules/terraform/init.go
@@ -31,9 +31,11 @@ func InitE(t testing.TestingT, options *Options) (string, error) {
 
 	args = append(args, FormatTerraformBackendConfigAsArgs(options.BackendConfig)...)
 	args = append(args, FormatTerraformPluginDirAsArgs(options.PluginDir)...)
-	// Down to the user to supply to correct flags
-	if len(options.AdditionalInitFlags) > 0 {
 
+	// Down to the user to supply to correct flags
+	// AdditionalInitFlags should not overwrite previously set
+	// flags via Options public properties
+	if len(options.AdditionalInitFlags) > 0 {
 		for _, v := range options.AdditionalInitFlags {
 			if strings.HasPrefix(v, "-upgrade") ||
 				strings.HasPrefix(v, "-reconfigure") ||

--- a/modules/terraform/init_test.go
+++ b/modules/terraform/init_test.go
@@ -158,7 +158,7 @@ func TestInitAdditionalFlags(t *testing.T) {
 				b := &bytes.Buffer{}
 				l := testLog{b}
 				stateDirectory := t.TempDir()
-				testFolder, err := files.CopyTerraformFolderToTemp("../../test/fixtures/terraform-backend", "")
+				testFolder, err := files.CopyTerraformFolderToTemp("../../test/fixtures/terraform-backend", "be-set-to-false")
 				require.NoError(t, err)
 				backendPath := filepath.Join(stateDirectory, "backend.tfstate")
 
@@ -183,7 +183,7 @@ func TestInitAdditionalFlags(t *testing.T) {
 				b := &bytes.Buffer{}
 				l := testLog{b}
 				stateDirectory := t.TempDir()
-				testFolder, err := files.CopyTerraformFolderToTemp("../../test/fixtures/terraform-backend", "")
+				testFolder, err := files.CopyTerraformFolderToTemp("../../test/fixtures/terraform-backend", "be-set-to-true")
 				require.NoError(t, err)
 				backendPath := filepath.Join(stateDirectory, "backend.tfstate")
 
@@ -207,7 +207,7 @@ func TestInitAdditionalFlags(t *testing.T) {
 				b := &bytes.Buffer{}
 				l := testLog{b}
 				stateDirectory := t.TempDir()
-				testFolder, err := files.CopyTerraformFolderToTemp("../../test/fixtures/terraform-backend", "")
+				testFolder, err := files.CopyTerraformFolderToTemp("../../test/fixtures/terraform-backend", "not-set-via-args")
 				require.NoError(t, err)
 				backendPath := filepath.Join(stateDirectory, "backend.tfstate")
 
@@ -232,7 +232,7 @@ func TestInitAdditionalFlags(t *testing.T) {
 				b := &bytes.Buffer{}
 				l := testLog{b}
 				stateDirectory := t.TempDir()
-				testFolder, err := files.CopyTerraformFolderToTemp("../../test/fixtures/terraform-backend", "")
+				testFolder, err := files.CopyTerraformFolderToTemp("../../test/fixtures/terraform-backend", "be-no-specified")
 				require.NoError(t, err)
 				backendPath := filepath.Join(stateDirectory, "backend.tfstate")
 				return b,

--- a/modules/terraform/init_test.go
+++ b/modules/terraform/init_test.go
@@ -258,22 +258,9 @@ func TestInitAdditionalFlags(t *testing.T) {
 
 			b, options, expect, cleanUp := tt.setup(t)
 			defer cleanUp()
-			_, _ = InitE(t, options)
+			_, err := InitE(t, options)
 			assert.Contains(t, b.String(), expect)
-
-			if expect == "-backend=true" {
-				if statePath, ok := options.BackendConfig["path"]; ok {
-					ls, _ := os.ReadDir(fmt.Sprintf("%s", statePath))
-					for idx, v := range ls {
-						if v.Name() == "backend.tfstate" {
-							return
-						}
-						if idx == len(ls) {
-							t.Errorf("failed to find backend state file when it should have been created under: %s", statePath)
-						}
-					}
-				}
-			}
+			assert.NoError(t, err)
 		})
 	}
 }

--- a/modules/terraform/options.go
+++ b/modules/terraform/options.go
@@ -71,6 +71,8 @@ type Options struct {
 	PlanFilePath             string                 // The path to output a plan file to (for the plan command) or read one from (for the apply command)
 	PluginDir                string                 // The path of downloaded plugins to pass to the terraform init command (-plugin-dir)
 	SetVarsAfterVarFiles     bool                   // Pass -var options after -var-file options to Terraform commands
+	AdditionalInitFlags      []string               // additional flags to pass to init command - e.g. `-backend=false`. complete list of options [here](https://developer.hashicorp.com/terraform/cli/commands/init)
+	// AdditionalApplyDestroylags []string               // additional flags to pass to apply/destroy command
 }
 
 // Clone makes a deep copy of most fields on the Options object and returns it.


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Expose additional args to init command, maintaining old behaviour of allowing existing properties to certain configurations.

Fixes #318.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->
