### PR TITLE
Feat: Add ability to get a random region for a specific service

### DIFF
--- a/modules/aws/region_test.go
+++ b/modules/aws/region_test.go
@@ -54,3 +54,14 @@ func TestGetAvailabilityZones(t *testing.T) {
 		assert.Regexp(t, fmt.Sprintf("^%s[a-z]$", randomRegion), az)
 	}
 }
+
+func TestGetRandomRegionForService(t *testing.T) {
+	t.Parallel()
+
+	serviceName := "apigatewayv2"
+
+	regionsForService, _ := GetRegionsForServiceE(t, serviceName)
+	randomRegionForService := GetRandomRegionForService(t, serviceName)
+
+	assert.Contains(t, regionsForService, randomRegionForService)
+}


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Adds ability to get a random region that is known to be supported for specific service. This avoids the scenario where a test using `GetRandomRegion` tries to create a resource in an AWS region where it may not be supported yet.

This is a convenience feature for consumers of this package who are testing a module containing a single resource (e.g., AWS Api Gateway V2) _and_ who want to test the module in random regions. 

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added GetRandomRegionForService to support retrieving a random region that is supported for a specific AWS service.

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->
