### PR TITLE
Add passing of options to RunHelmCommandAndGetOutputE

### DIFF
--- a/modules/helm/template.go
+++ b/modules/helm/template.go
@@ -35,7 +35,7 @@ func RenderTemplateE(t testing.TestingT, options *Options, chartDir string, rele
 	}
 
 	// check chart dependencies
-	if _, err := RunHelmCommandAndGetOutputE(t, &Options{}, "dependency", "build", chartDir); err != nil {
+	if _, err := RunHelmCommandAndGetOutputE(t, options, "dependency", "build", chartDir); err != nil {
 		return "", errors.WithStackTrace(err)
 	}
 

--- a/test/helm_log_redirect_integration_test.go
+++ b/test/helm_log_redirect_integration_test.go
@@ -1,0 +1,78 @@
+//go:build kubeall || helm
+// +build kubeall helm
+
+// **NOTE**: we have build tags to differentiate kubernetes tests from non-kubernetes tests, and further differentiate helm
+// tests. This is done because minikube is heavy and can interfere with docker related tests in terratest. Similarly, helm
+// can overload the minikube system and thus interfere with the other kubernetes tests. Specifically, many of the tests
+// start to fail with `connection refused` errors from `minikube`. To avoid overloading the system, we run the kubernetes
+// tests and helm tests separately from the others. This may not be necessary if you have a sufficiently powerful machine.
+// We recommend at least 4 cores and 16GB of RAM if you want to run all the tests together.
+
+package test
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/logger"
+	tftesting "github.com/gruntwork-io/terratest/modules/testing"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gruntwork-io/terratest/modules/helm"
+	"github.com/gruntwork-io/terratest/modules/k8s"
+	"github.com/gruntwork-io/terratest/modules/random"
+)
+
+// Example how to redirect helm logs to custom logger
+func TestHelmLogsRedirect(t *testing.T) {
+	t.Parallel()
+
+	// Path to the helm chart we will test
+	helmChartPath, err := filepath.Abs("../examples/helm-basic-example")
+	require.NoError(t, err)
+
+	// Namespace to deploy helm chart
+	namespaceName := fmt.Sprintf("helm-logs-%s", strings.ToLower(random.UniqueId()))
+
+	// Setup the kubectl config and context. Here we choose to use the defaults, which is:
+	// - HOME/.kube/config for the kubectl config file
+	// - Current context of the kubectl config file
+	kubectlOptions := k8s.NewKubectlOptions("", "", namespaceName)
+
+	k8s.CreateNamespace(t, kubectlOptions, namespaceName)
+	defer k8s.DeleteNamespace(t, kubectlOptions, namespaceName)
+
+	customLogger := helmLogger{}
+
+	options := &helm.Options{
+		KubectlOptions: kubectlOptions,
+		SetValues: map[string]string{
+			"containerImageRepo": "nginx",
+			"containerImageTag":  "1.15.8",
+		},
+		Logger: logger.New(&customLogger),
+	}
+
+	// Generate a unique release to avoid conflicts with other tests
+	releaseName := fmt.Sprintf(
+		"nginx-service-%s",
+		strings.ToLower(random.UniqueId()),
+	)
+	defer helm.Delete(t, options, releaseName, true)
+
+	helm.Install(t, options, helmChartPath, releaseName)
+
+	// Validate that logs were redirected to custom logger
+	require.Contains(t, customLogger.logs, releaseName)
+	require.Contains(t, customLogger.logs, "STATUS: deployed")
+}
+
+type helmLogger struct {
+	logs string
+}
+
+func (c *helmLogger) Logf(t tftesting.TestingT, format string, args ...interface{}) {
+	c.logs = fmt.Sprintf("%s\n%s", c.logs, fmt.Sprintf(format, args...))
+}


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Updated Helm installation function to allow logs redirection.

Fixes #1273.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Updated Helm chart installation to allow logs redirection

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->
