### PR TITLE
Fix the check in IsDeploymentAvailable function.

### DIFF
--- a/modules/k8s/deployment.go
+++ b/modules/k8s/deployment.go
@@ -98,11 +98,13 @@ func WaitUntilDeploymentAvailableE(
 
 // IsDeploymentAvailable returns true if all pods within the deployment are ready and started
 func IsDeploymentAvailable(deploy *appsv1.Deployment) bool {
-	availableType := 0
-
-	if deploy.Status.UnavailableReplicas > 0 {
-		return false
+	for _, dc := range deploy.Status.Conditions {
+		if dc.Type == appsv1.DeploymentProgressing &&
+			dc.Status == v1.ConditionTrue &&
+			dc.Reason == "NewReplicaSetAvailable" {
+			return true
+		}
 	}
 
-	return deploy.Status.Conditions[availableType].Status == v1.ConditionTrue
+	return false
 }


### PR DESCRIPTION
## Description

According to the documentation of [Deployment complete status](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#complete-deployment), the statuses that must be checked to validate that a deployment has been completed are:

* Type: Progressing
* Status: True
* Reason: NewReplicaSetAvailable

Fixes #1277.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [X] Update the docs.
- [X] Run the relevant tests successfully, including pre-commit checks.
- [X] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
- [X] Fixed IsDeploymentAvailable function.
- [X] Updated test related to IsDeploymentAvailable function.
