### PR TITLE
Updated helm dependencies with field to build dependencies

### DIFF
--- a/modules/helm/install.go
+++ b/modules/helm/install.go
@@ -29,7 +29,7 @@ func InstallE(t testing.TestingT, options *Options, chart string, releaseName st
 	}
 
 	// build chart dependencies
-	if !options.SkipBuildDependencies {
+	if options.BuildDependencies {
 		if _, err := RunHelmCommandAndGetOutputE(t, options, "dependency", "build", chart); err != nil {
 			return errors.WithStackTrace(err)
 		}

--- a/modules/helm/install.go
+++ b/modules/helm/install.go
@@ -29,7 +29,7 @@ func InstallE(t testing.TestingT, options *Options, chart string, releaseName st
 	}
 
 	// build chart dependencies
-	if options.BuildDependencies {
+	if !options.SkipBuildDependencies {
 		if _, err := RunHelmCommandAndGetOutputE(t, options, "dependency", "build", chart); err != nil {
 			return errors.WithStackTrace(err)
 		}

--- a/modules/helm/install.go
+++ b/modules/helm/install.go
@@ -28,6 +28,12 @@ func InstallE(t testing.TestingT, options *Options, chart string, releaseName st
 		chart = absChartDir
 	}
 
+	// build chart dependencies
+	if options.BuildDependencies {
+		if _, err := RunHelmCommandAndGetOutputE(t, options, "dependency", "build", chart); err != nil {
+			return errors.WithStackTrace(err)
+		}
+	}
 	// Now call out to helm install to install the charts with the provided options
 	// Declare err here so that we can update args later
 	var err error

--- a/modules/helm/install_test.go
+++ b/modules/helm/install_test.go
@@ -11,9 +11,12 @@ package helm
 import (
 	"crypto/tls"
 	"fmt"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -97,6 +100,53 @@ func TestRemoteChartInstall(t *testing.T) {
 			return statusCode == 200
 		},
 	)
+}
+
+// Test deployment of helm chart with dependencies.
+func TestHelmDependencyInstall(t *testing.T) {
+	t.Parallel()
+
+	// Path to the helm chart with dependencies which we will test
+	helmChartPath, err := filepath.Abs("../../examples/helm-dependency-example")
+	require.NoError(t, err)
+
+	// Custom namespace name.
+	namespaceName := fmt.Sprintf("helm-dependency-example-%s", strings.ToLower(random.UniqueId()))
+
+	// Setup the kubectl config and context. Here we choose to use the defaults, which is:
+	// - HOME/.kube/config for the kubectl config file
+	// - Current context of the kubectl config file
+	kubectlOptions := k8s.NewKubectlOptions("", "", namespaceName)
+
+	k8s.CreateNamespace(t, kubectlOptions, namespaceName)
+	defer k8s.DeleteNamespace(t, kubectlOptions, namespaceName)
+
+	// Helm chart deployment options.
+	options := &Options{
+		KubectlOptions: kubectlOptions,
+		SetValues: map[string]string{
+			"containerImageRepo":       "nginx",
+			"containerImageTag":        "1.15.8",
+			"basic.containerImageRepo": "nginx",
+			"basic.containerImageTag":  "1.15.8",
+		},
+	}
+	// We generate a unique release name so that we can refer to after deployment.
+	// By doing so, we can schedule the delete call here so that at the end of the test, we run
+	// `helm delete RELEASE_NAME` to clean up any resources that were created.
+	releaseName := fmt.Sprintf(
+		"helm-dependency-example-%s",
+		strings.ToLower(random.UniqueId()),
+	)
+	defer Delete(t, options, releaseName, true)
+
+	// Deploy the chart using `helm install`.
+	err = InstallE(t, options, helmChartPath, releaseName)
+	assert.NoError(t, err)
+
+	// Verify that Kubernetes service is available after helm chart deployment.
+	_, err = k8s.GetServiceE(t, kubectlOptions, releaseName)
+	assert.NoError(t, err)
 }
 
 func waitForRemoteChartPods(t *testing.T, kubectlOptions *k8s.KubectlOptions, releaseName string, podCount int) {

--- a/modules/helm/install_test.go
+++ b/modules/helm/install_test.go
@@ -16,6 +16,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gruntwork-io/terratest/modules/files"
+
 	"github.com/stretchr/testify/assert"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -108,6 +110,9 @@ func TestHelmDependencyInstall(t *testing.T) {
 
 	// Path to the helm chart with dependencies which we will test
 	helmChartPath, err := filepath.Abs("../../examples/helm-dependency-example")
+	require.NoError(t, err)
+
+	helmChartPath, err = files.CopyTerraformFolderToTemp(helmChartPath, t.Name())
 	require.NoError(t, err)
 
 	// Custom namespace name.

--- a/modules/helm/install_test.go
+++ b/modules/helm/install_test.go
@@ -135,6 +135,7 @@ func TestHelmDependencyInstall(t *testing.T) {
 			"basic.containerImageRepo": "nginx",
 			"basic.containerImageTag":  "1.15.8",
 		},
+		BuildDependencies: true,
 	}
 	// We generate a unique release name so that we can refer to after deployment.
 	// By doing so, we can schedule the delete call here so that at the end of the test, we run

--- a/modules/helm/install_test.go
+++ b/modules/helm/install_test.go
@@ -16,8 +16,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gruntwork-io/terratest/modules/files"
-
 	"github.com/stretchr/testify/assert"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -110,9 +108,6 @@ func TestHelmDependencyInstall(t *testing.T) {
 
 	// Path to the helm chart with dependencies which we will test
 	helmChartPath, err := filepath.Abs("../../examples/helm-dependency-example")
-	require.NoError(t, err)
-
-	helmChartPath, err = files.CopyTerraformFolderToTemp(helmChartPath, t.Name())
 	require.NoError(t, err)
 
 	// Custom namespace name.

--- a/modules/helm/options.go
+++ b/modules/helm/options.go
@@ -6,15 +6,15 @@ import (
 )
 
 type Options struct {
-	ValuesFiles           []string            // List of values files to render.
-	SetValues             map[string]string   // Values that should be set via the command line.
-	SetStrValues          map[string]string   // Values that should be set via the command line explicitly as `string` types.
-	SetFiles              map[string]string   // Values that should be set from a file. These should be file paths. Use to avoid logging secrets.
-	KubectlOptions        *k8s.KubectlOptions // KubectlOptions to control how to authenticate to kubernetes cluster. `nil` => use defaults.
-	HomePath              string              // The path to the helm home to use when calling out to helm. Empty string means use default ($HOME/.helm).
-	EnvVars               map[string]string   // Environment variables to set when running helm
-	Version               string              // Version of chart
-	Logger                *logger.Logger      // Set a non-default logger that should be used. See the logger package for more info. Use logger.Discard to not print the output while executing the command.
-	ExtraArgs             map[string][]string // Extra arguments to pass to the helm install/upgrade/rollback/delete and helm repo add commands. The key signals the command (e.g., install) while the values are the extra arguments to pass through.
-	SkipBuildDependencies bool                // If true, helm chart dependencies will not be built during template rendering, installation and upgrade of helm chart.
+	ValuesFiles       []string            // List of values files to render.
+	SetValues         map[string]string   // Values that should be set via the command line.
+	SetStrValues      map[string]string   // Values that should be set via the command line explicitly as `string` types.
+	SetFiles          map[string]string   // Values that should be set from a file. These should be file paths. Use to avoid logging secrets.
+	KubectlOptions    *k8s.KubectlOptions // KubectlOptions to control how to authenticate to kubernetes cluster. `nil` => use defaults.
+	HomePath          string              // The path to the helm home to use when calling out to helm. Empty string means use default ($HOME/.helm).
+	EnvVars           map[string]string   // Environment variables to set when running helm
+	Version           string              // Version of chart
+	Logger            *logger.Logger      // Set a non-default logger that should be used. See the logger package for more info. Use logger.Discard to not print the output while executing the command.
+	ExtraArgs         map[string][]string // Extra arguments to pass to the helm install/upgrade/rollback/delete and helm repo add commands. The key signals the command (e.g., install) while the values are the extra arguments to pass through.
+	BuildDependencies bool                // If true, helm dependencies will be built before rendering template, installing or upgrade the chart.
 }

--- a/modules/helm/options.go
+++ b/modules/helm/options.go
@@ -6,15 +6,15 @@ import (
 )
 
 type Options struct {
-	ValuesFiles       []string            // List of values files to render.
-	SetValues         map[string]string   // Values that should be set via the command line.
-	SetStrValues      map[string]string   // Values that should be set via the command line explicitly as `string` types.
-	SetFiles          map[string]string   // Values that should be set from a file. These should be file paths. Use to avoid logging secrets.
-	KubectlOptions    *k8s.KubectlOptions // KubectlOptions to control how to authenticate to kubernetes cluster. `nil` => use defaults.
-	HomePath          string              // The path to the helm home to use when calling out to helm. Empty string means use default ($HOME/.helm).
-	EnvVars           map[string]string   // Environment variables to set when running helm
-	Version           string              // Version of chart
-	Logger            *logger.Logger      // Set a non-default logger that should be used. See the logger package for more info. Use logger.Discard to not print the output while executing the command.
-	ExtraArgs         map[string][]string // Extra arguments to pass to the helm install/upgrade/rollback/delete and helm repo add commands. The key signals the command (e.g., install) while the values are the extra arguments to pass through.
-	BuildDependencies bool                // If true, run helm dependency build before template rendering and installing the chart
+	ValuesFiles           []string            // List of values files to render.
+	SetValues             map[string]string   // Values that should be set via the command line.
+	SetStrValues          map[string]string   // Values that should be set via the command line explicitly as `string` types.
+	SetFiles              map[string]string   // Values that should be set from a file. These should be file paths. Use to avoid logging secrets.
+	KubectlOptions        *k8s.KubectlOptions // KubectlOptions to control how to authenticate to kubernetes cluster. `nil` => use defaults.
+	HomePath              string              // The path to the helm home to use when calling out to helm. Empty string means use default ($HOME/.helm).
+	EnvVars               map[string]string   // Environment variables to set when running helm
+	Version               string              // Version of chart
+	Logger                *logger.Logger      // Set a non-default logger that should be used. See the logger package for more info. Use logger.Discard to not print the output while executing the command.
+	ExtraArgs             map[string][]string // Extra arguments to pass to the helm install/upgrade/rollback/delete and helm repo add commands. The key signals the command (e.g., install) while the values are the extra arguments to pass through.
+	SkipBuildDependencies bool                // If true, helm chart dependencies will not be built.
 }

--- a/modules/helm/options.go
+++ b/modules/helm/options.go
@@ -6,14 +6,15 @@ import (
 )
 
 type Options struct {
-	ValuesFiles    []string            // List of values files to render.
-	SetValues      map[string]string   // Values that should be set via the command line.
-	SetStrValues   map[string]string   // Values that should be set via the command line explicitly as `string` types.
-	SetFiles       map[string]string   // Values that should be set from a file. These should be file paths. Use to avoid logging secrets.
-	KubectlOptions *k8s.KubectlOptions // KubectlOptions to control how to authenticate to kubernetes cluster. `nil` => use defaults.
-	HomePath       string              // The path to the helm home to use when calling out to helm. Empty string means use default ($HOME/.helm).
-	EnvVars        map[string]string   // Environment variables to set when running helm
-	Version        string              // Version of chart
-	Logger         *logger.Logger      // Set a non-default logger that should be used. See the logger package for more info. Use logger.Discard to not print the output while executing the command.
-	ExtraArgs      map[string][]string // Extra arguments to pass to the helm install/upgrade/rollback/delete and helm repo add commands. The key signals the command (e.g., install) while the values are the extra arguments to pass through.
+	ValuesFiles       []string            // List of values files to render.
+	SetValues         map[string]string   // Values that should be set via the command line.
+	SetStrValues      map[string]string   // Values that should be set via the command line explicitly as `string` types.
+	SetFiles          map[string]string   // Values that should be set from a file. These should be file paths. Use to avoid logging secrets.
+	KubectlOptions    *k8s.KubectlOptions // KubectlOptions to control how to authenticate to kubernetes cluster. `nil` => use defaults.
+	HomePath          string              // The path to the helm home to use when calling out to helm. Empty string means use default ($HOME/.helm).
+	EnvVars           map[string]string   // Environment variables to set when running helm
+	Version           string              // Version of chart
+	Logger            *logger.Logger      // Set a non-default logger that should be used. See the logger package for more info. Use logger.Discard to not print the output while executing the command.
+	ExtraArgs         map[string][]string // Extra arguments to pass to the helm install/upgrade/rollback/delete and helm repo add commands. The key signals the command (e.g., install) while the values are the extra arguments to pass through.
+	BuildDependencies bool                // If true, run helm dependency build before template rendering and installing the chart
 }

--- a/modules/helm/options.go
+++ b/modules/helm/options.go
@@ -16,5 +16,5 @@ type Options struct {
 	Version               string              // Version of chart
 	Logger                *logger.Logger      // Set a non-default logger that should be used. See the logger package for more info. Use logger.Discard to not print the output while executing the command.
 	ExtraArgs             map[string][]string // Extra arguments to pass to the helm install/upgrade/rollback/delete and helm repo add commands. The key signals the command (e.g., install) while the values are the extra arguments to pass through.
-	SkipBuildDependencies bool                // If true, helm chart dependencies will not be built.
+	SkipBuildDependencies bool                // If true, helm chart dependencies will not be built during template rendering, installation and upgrade of helm chart.
 }

--- a/modules/helm/template.go
+++ b/modules/helm/template.go
@@ -35,7 +35,7 @@ func RenderTemplateE(t testing.TestingT, options *Options, chartDir string, rele
 	}
 
 	// check chart dependencies
-	if !options.SkipBuildDependencies {
+	if options.BuildDependencies {
 		if _, err := RunHelmCommandAndGetOutputE(t, options, "dependency", "build", chartDir); err != nil {
 			return "", errors.WithStackTrace(err)
 		}

--- a/modules/helm/template.go
+++ b/modules/helm/template.go
@@ -35,8 +35,10 @@ func RenderTemplateE(t testing.TestingT, options *Options, chartDir string, rele
 	}
 
 	// check chart dependencies
-	if _, err := RunHelmCommandAndGetOutputE(t, options, "dependency", "build", chartDir); err != nil {
-		return "", errors.WithStackTrace(err)
+	if options.BuildDependencies {
+		if _, err := RunHelmCommandAndGetOutputE(t, options, "dependency", "build", chartDir); err != nil {
+			return "", errors.WithStackTrace(err)
+		}
 	}
 
 	// Now construct the args

--- a/modules/helm/template.go
+++ b/modules/helm/template.go
@@ -35,7 +35,7 @@ func RenderTemplateE(t testing.TestingT, options *Options, chartDir string, rele
 	}
 
 	// check chart dependencies
-	if options.BuildDependencies {
+	if !options.SkipBuildDependencies {
 		if _, err := RunHelmCommandAndGetOutputE(t, options, "dependency", "build", chartDir); err != nil {
 			return "", errors.WithStackTrace(err)
 		}

--- a/modules/helm/upgrade.go
+++ b/modules/helm/upgrade.go
@@ -28,7 +28,7 @@ func UpgradeE(t testing.TestingT, options *Options, chart string, releaseName st
 	}
 
 	// build chart dependencies
-	if !options.SkipBuildDependencies {
+	if options.BuildDependencies {
 		if _, err := RunHelmCommandAndGetOutputE(t, options, "dependency", "build", chart); err != nil {
 			return errors.WithStackTrace(err)
 		}

--- a/modules/helm/upgrade.go
+++ b/modules/helm/upgrade.go
@@ -27,6 +27,12 @@ func UpgradeE(t testing.TestingT, options *Options, chart string, releaseName st
 		chart = absChartDir
 	}
 
+	// build chart dependencies
+	if options.BuildDependencies {
+		if _, err := RunHelmCommandAndGetOutputE(t, options, "dependency", "build", chart); err != nil {
+			return errors.WithStackTrace(err)
+		}
+	}
 	var err error
 	args := []string{}
 	if options.ExtraArgs != nil {

--- a/modules/helm/upgrade.go
+++ b/modules/helm/upgrade.go
@@ -28,7 +28,7 @@ func UpgradeE(t testing.TestingT, options *Options, chart string, releaseName st
 	}
 
 	// build chart dependencies
-	if options.BuildDependencies {
+	if !options.SkipBuildDependencies {
 		if _, err := RunHelmCommandAndGetOutputE(t, options, "dependency", "build", chart); err != nil {
 			return errors.WithStackTrace(err)
 		}

--- a/modules/helm/upgrade_test.go
+++ b/modules/helm/upgrade_test.go
@@ -128,6 +128,7 @@ func TestHelmDependencyUpgrade(t *testing.T) {
 			"basic.containerImageRepo": "nginx",
 			"basic.containerImageTag":  "1.15.8",
 		},
+		BuildDependencies: true,
 	}
 	// We generate a unique release name so that we can refer to after deployment.
 	// By doing so, we can schedule the delete call here so that at the end of the test, we run

--- a/modules/helm/upgrade_test.go
+++ b/modules/helm/upgrade_test.go
@@ -11,9 +11,13 @@ package helm
 import (
 	"crypto/tls"
 	"fmt"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	http_helper "github.com/gruntwork-io/terratest/modules/http-helper"
 	"github.com/gruntwork-io/terratest/modules/k8s"
@@ -94,4 +98,51 @@ func TestRemoteChartInstallUpgradeRollback(t *testing.T) {
 	// Finally, test rollback functionality. When rolling back, we should see the pods go back down to 1.
 	Rollback(t, options, releaseName, "")
 	waitForRemoteChartPods(t, kubectlOptions, releaseName, 1)
+}
+
+// Test deployment of helm chart with dependencies.
+func TestHelmDependencyUpgrade(t *testing.T) {
+	t.Parallel()
+
+	// Path to the helm chart with dependencies which we will test
+	helmChartPath, err := filepath.Abs("../../examples/helm-dependency-example")
+	require.NoError(t, err)
+
+	// Custom namespace name.
+	namespaceName := fmt.Sprintf("helm-dependency-example-%s", strings.ToLower(random.UniqueId()))
+
+	// Setup the kubectl config and context. Here we choose to use the defaults, which is:
+	// - HOME/.kube/config for the kubectl config file
+	// - Current context of the kubectl config file
+	kubectlOptions := k8s.NewKubectlOptions("", "", namespaceName)
+
+	k8s.CreateNamespace(t, kubectlOptions, namespaceName)
+	defer k8s.DeleteNamespace(t, kubectlOptions, namespaceName)
+
+	// Helm chart deployment options.
+	options := &Options{
+		KubectlOptions: kubectlOptions,
+		SetValues: map[string]string{
+			"containerImageRepo":       "nginx",
+			"containerImageTag":        "1.15.8",
+			"basic.containerImageRepo": "nginx",
+			"basic.containerImageTag":  "1.15.8",
+		},
+	}
+	// We generate a unique release name so that we can refer to after deployment.
+	// By doing so, we can schedule the delete call here so that at the end of the test, we run
+	// `helm delete RELEASE_NAME` to clean up any resources that were created.
+	releaseName := fmt.Sprintf(
+		"helm-dependency-example-%s",
+		strings.ToLower(random.UniqueId()),
+	)
+	defer Delete(t, options, releaseName, true)
+
+	// Deploy the chart using `helm install`.
+	err = InstallE(t, options, helmChartPath, releaseName)
+	assert.NoError(t, err)
+
+	// Verify that upgrade is working as expected.
+	err = UpgradeE(t, options, helmChartPath, releaseName)
+	assert.NoError(t, err)
 }

--- a/test/helm_dependency_example_template_test.go
+++ b/test/helm_dependency_example_template_test.go
@@ -57,7 +57,8 @@ func TestHelmDependencyExampleTemplateRenderedDeployment(t *testing.T) {
 			"basic.containerImageRepo": "nginx",
 			"basic.containerImageTag":  "1.15.8",
 		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", namespaceName),
+		KubectlOptions:    k8s.NewKubectlOptions("", "", namespaceName),
+		BuildDependencies: true,
 	}
 
 	testCases := []struct {

--- a/test/helm_dependency_example_template_test.go
+++ b/test/helm_dependency_example_template_test.go
@@ -57,8 +57,7 @@ func TestHelmDependencyExampleTemplateRenderedDeployment(t *testing.T) {
 			"basic.containerImageRepo": "nginx",
 			"basic.containerImageTag":  "1.15.8",
 		},
-		KubectlOptions:    k8s.NewKubectlOptions("", "", namespaceName),
-		BuildDependencies: true,
+		KubectlOptions: k8s.NewKubectlOptions("", "", namespaceName),
 	}
 
 	testCases := []struct {


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description
Added to `helm.Options` flag `BuildDependencies` to enable helm dependencies building during template rendering, installation, and upgrade.

Fixes #1143.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Updated `helm.Options` with flag `BuildDependencies`, once set, helm chart dependencies building will be performed.

### Migration Guide

For helm charts that require dependencies to be built, should be defined `helm.BuildDependencies=true`

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->
