### PR TITLE
add --set-json flag support for the helm module

### DIFF
--- a/modules/helm/cmd.go
+++ b/modules/helm/cmd.go
@@ -35,6 +35,7 @@ func getNamespaceArgs(options *Options) []string {
 func getValuesArgsE(t testing.TestingT, options *Options, args ...string) ([]string, error) {
 	args = append(args, formatSetValuesAsArgs(options.SetValues, "--set")...)
 	args = append(args, formatSetValuesAsArgs(options.SetStrValues, "--set-string")...)
+	args = append(args, formatSetValuesAsArgs(options.SetJsonValues, "--set-json")...)
 
 	valuesFilesArgs, err := formatValuesFilesAsArgsE(t, options.ValuesFiles)
 	if err != nil {

--- a/modules/helm/format.go
+++ b/modules/helm/format.go
@@ -13,7 +13,7 @@ import (
 )
 
 // formatSetValuesAsArgs formats the given values as command line args for helm using the given flag (e.g flags of
-// the format "--set"/"--set-string" resulting in args like --set/set-string key=value...)
+// the format "--set"/"--set-string"/"--set-json" resulting in args like --set/set-string/set-json key=value...)
 func formatSetValuesAsArgs(setValues map[string]string, flag string) []string {
 	args := []string{}
 

--- a/modules/helm/format_test.go
+++ b/modules/helm/format_test.go
@@ -15,16 +15,20 @@ func TestFormatSetValuesAsArgs(t *testing.T) {
 	t.Parallel()
 
 	testCases := []struct {
-		name         string
-		setValues    map[string]string
-		setStrValues map[string]string
-		expected     []string
-		expectedStr  []string
+		name          string
+		setValues     map[string]string
+		setStrValues  map[string]string
+		setJsonValues map[string]string
+		expected      []string
+		expectedStr   []string
+		expectedJson  []string
 	}{
 		{
 			"EmptyValue",
 			map[string]string{},
 			map[string]string{},
+			map[string]string{},
+			[]string{},
 			[]string{},
 			[]string{},
 		},
@@ -32,8 +36,10 @@ func TestFormatSetValuesAsArgs(t *testing.T) {
 			"SingleValue",
 			map[string]string{"containerImage": "null"},
 			map[string]string{"numericString": "123123123123"},
+			map[string]string{"limits": `{"cpu": 1}`},
 			[]string{"--set", "containerImage=null"},
 			[]string{"--set-string", "numericString=123123123123"},
+			[]string{"--set-json", fmt.Sprintf("limits=%s", `{"cpu": 1}`)},
 		},
 		{
 			"MultipleValues",
@@ -45,6 +51,10 @@ func TestFormatSetValuesAsArgs(t *testing.T) {
 				"numericString": "123123123123",
 				"otherString":   "null",
 			},
+			map[string]string{
+				"containerImage": `{"repository": "nginx", "tag": "v1.15.4"}`,
+				"otherString":    "{}",
+			},
 			[]string{
 				"--set", "containerImage.repository=nginx",
 				"--set", "containerImage.tag=v1.15.4",
@@ -52,6 +62,10 @@ func TestFormatSetValuesAsArgs(t *testing.T) {
 			[]string{
 				"--set-string", "numericString=123123123123",
 				"--set-string", "otherString=null",
+			},
+			[]string{
+				"--set-json", fmt.Sprintf("containerImage=%s", `{"repository": "nginx", "tag": "v1.15.4"}`),
+				"--set-json", "otherString={}",
 			},
 		},
 	}
@@ -65,6 +79,7 @@ func TestFormatSetValuesAsArgs(t *testing.T) {
 			t.Parallel()
 			assert.Equal(t, formatSetValuesAsArgs(testCase.setValues, "--set"), testCase.expected)
 			assert.Equal(t, formatSetValuesAsArgs(testCase.setStrValues, "--set-string"), testCase.expectedStr)
+			assert.Equal(t, formatSetValuesAsArgs(testCase.setJsonValues, "--set-json"), testCase.expectedJson)
 		})
 	}
 }

--- a/modules/helm/options.go
+++ b/modules/helm/options.go
@@ -9,6 +9,7 @@ type Options struct {
 	ValuesFiles    []string            // List of values files to render.
 	SetValues      map[string]string   // Values that should be set via the command line.
 	SetStrValues   map[string]string   // Values that should be set via the command line explicitly as `string` types.
+	SetJsonValues  map[string]string   // Values that should be set via the command line in JSON format.
 	SetFiles       map[string]string   // Values that should be set from a file. These should be file paths. Use to avoid logging secrets.
 	KubectlOptions *k8s.KubectlOptions // KubectlOptions to control how to authenticate to kubernetes cluster. `nil` => use defaults.
 	HomePath       string              // The path to the helm home to use when calling out to helm. Empty string means use default ($HOME/.helm).


### PR DESCRIPTION
## Description
Add an ability to provide JSON values

Fixes https://github.com/gruntwork-io/terratest/issues/1292
## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Added ability to define JSON values for the `--set-json` Helm template flag
