### PR TITLE
Fix k8s.KubectlApplyFromKustomizeE describtion

### DIFF
--- a/modules/k8s/kubectl.go
+++ b/modules/k8s/kubectl.go
@@ -100,7 +100,7 @@ func KubectlApplyFromKustomize(t testing.TestingT, options *KubectlOptions, conf
 	require.NoError(t, KubectlApplyFromKustomizeE(t, options, configPath))
 }
 
-// KubectlApplyFromKustomizeE will take in a kustomization directory path and delete it from the cluster targeted by KubectlOptions.
+// KubectlApplyFromKustomizeE will take in a kustomization directory path and apply it to the cluster targeted by KubectlOptions.
 func KubectlApplyFromKustomizeE(t testing.TestingT, options *KubectlOptions, configPath string) error {
 	return RunKubectlE(t, options, "apply", "-k", configPath)
 }


### PR DESCRIPTION
## Description

Fixes the description of `k8s.KubectlApplyFromKustomizeE` which refers to "delete".

## Release Notes (draft)

Fixed the description of `k8s.KubectlApplyFromKustomizeE` which refered to "delete".
