### PR TITLE
Add support for Events in k8s module

### DIFF
--- a/modules/k8s/event.go
+++ b/modules/k8s/event.go
@@ -1,0 +1,34 @@
+package k8s
+
+import (
+	"context"
+
+	"github.com/stretchr/testify/require"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/gruntwork-io/terratest/modules/testing"
+)
+
+// ListEvents will retrieve the Events in the given namespace that match the given filters and return them. This will fail the
+// test if there is an error.
+func ListEvents(t testing.TestingT, options *KubectlOptions, filters metav1.ListOptions) []corev1.Event {
+	events, err := ListEventsE(t, options, filters)
+	require.NoError(t, err)
+	return events
+}
+
+// ListEventsE will retrieve the Events that match the given filters and return them.
+func ListEventsE(t testing.TestingT, options *KubectlOptions, filters metav1.ListOptions) ([]corev1.Event, error) {
+	clientset, err := GetKubernetesClientFromOptionsE(t, options)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := clientset.CoreV1().Events(options.Namespace).List(context.Background(), filters)
+	if err != nil {
+		return nil, err
+	}
+	return resp.Items, nil
+}

--- a/modules/k8s/event_test.go
+++ b/modules/k8s/event_test.go
@@ -18,12 +18,20 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 )
 
-func TestListEventsInNamespace(t *testing.T) {
+func TestListEventsEReturnsNilErrorWhenListingEvents(t *testing.T) {
 	t.Parallel()
 
 	options := NewKubectlOptions("", "", "kube-system")
 	events, err := ListEventsE(t, options, v1.ListOptions{})
 	require.Nil(t, err)
+	require.Greater(t, len(events), 0)
+}
+
+func TestListEventsInNamespace(t *testing.T) {
+	t.Parallel()
+
+	options := NewKubectlOptions("", "", "kube-system")
+	events := ListEvents(t, options, v1.ListOptions{})
 	require.Greater(t, len(events), 0)
 }
 
@@ -37,7 +45,6 @@ func TestListEventsReturnsZeroEventsIfNoneCreated(t *testing.T) {
 	CreateNamespace(t, options, ns)
 
 	options.Namespace = ns
-	events, err := ListEventsE(t, options, v1.ListOptions{})
-	require.Nil(t, err)
+	events := ListEvents(t, options, v1.ListOptions{})
 	require.Equal(t, 0, len(events))
 }

--- a/modules/k8s/event_test.go
+++ b/modules/k8s/event_test.go
@@ -1,0 +1,43 @@
+//go:build kubernetes
+// +build kubernetes
+
+// NOTE: we have build tags to differentiate kubernetes tests from non-kubernetes tests. This is done because minikube
+// is heavy and can interfere with docker related tests in terratest. Specifically, many of the tests start to fail with
+// `connection refused` errors from `minikube`. To avoid overloading the system, we run the kubernetes tests and helm
+// tests separately from the others. This may not be necessary if you have a sufficiently powerful machine.  We
+// recommend at least 4 cores and 16GB of RAM if you want to run all the tests together.
+
+package k8s
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
+)
+
+func TestListEventsInNamespace(t *testing.T) {
+	t.Parallel()
+
+	options := NewKubectlOptions("", "", "kube-system")
+	events, err := ListEventsE(t, options, v1.ListOptions{})
+	require.Nil(t, err)
+	require.Greater(t, len(events), 0)
+}
+
+func TestListEventsReturnsZeroEventsIfNoneCreated(t *testing.T) {
+	t.Parallel()
+	ns := "test-ns"
+
+	options := NewKubectlOptions("", "", "")
+
+	defer DeleteNamespace(t, options, ns)
+	CreateNamespace(t, options, ns)
+
+	options.Namespace = ns
+	events, err := ListEventsE(t, options, v1.ListOptions{})
+	require.Nil(t, err)
+	require.Equal(t, 0, len(events))
+}


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

This PR adds support for k8s `Events` as stated in #1296 

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [X] Update the docs.
- [X] Run the relevant tests successfully, including pre-commit checks.
- [X] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backwards incompatible, include a migration guide.

## Release Notes (draft)

- [X] Added Event functions.

### Migration Guide

There aren`t backwards incompatible changes

