### PR TITLE
publicly expose terraform.ParsePlanJSON function

### DIFF
--- a/modules/terraform/plan.go
+++ b/modules/terraform/plan.go
@@ -93,7 +93,7 @@ func InitAndPlanAndShowWithStructE(t testing.TestingT, options *Options) (*PlanS
 	if err != nil {
 		return nil, err
 	}
-	return parsePlanJson(jsonOut)
+	return ParsePlanJSON(jsonOut)
 }
 
 // InitAndPlanWithExitCode runs terraform init and plan with the given options and returns exitcode for the plan command.

--- a/modules/terraform/plan_struct.go
+++ b/modules/terraform/plan_struct.go
@@ -27,9 +27,9 @@ type PlanStruct struct {
 	ResourceChangesMap map[string]*tfjson.ResourceChange
 }
 
-// parsePlanJson takes in the json string representation of the terraform plan and returns a go struct representation
+// ParsePlanJSON takes in the json string representation of the terraform plan and returns a go struct representation
 // for easy introspection.
-func parsePlanJson(jsonStr string) (*PlanStruct, error) {
+func ParsePlanJSON(jsonStr string) (*PlanStruct, error) {
 	plan := &PlanStruct{}
 
 	if err := json.Unmarshal([]byte(jsonStr), &plan.RawPlan); err != nil {

--- a/modules/terraform/plan_struct_test.go
+++ b/modules/terraform/plan_struct_test.go
@@ -23,7 +23,7 @@ func TestPlannedValuesMapWithBasicJson(t *testing.T) {
 
 	// Retrieve test data from the terraform-json project.
 	_, jsonData := http_helper.HttpGet(t, basicJsonUrl, nil)
-	plan, err := parsePlanJson(jsonData)
+	plan, err := ParsePlanJSON(jsonData)
 	require.NoError(t, err)
 
 	query := []string{
@@ -48,7 +48,7 @@ func TestPlannedValuesMapWithDeepModuleJson(t *testing.T) {
 
 	// Retrieve test data from the terraform-json project.
 	_, jsonData := http_helper.HttpGet(t, deepModuleJsonUrl, nil)
-	plan, err := parsePlanJson(jsonData)
+	plan, err := ParsePlanJSON(jsonData)
 	require.NoError(t, err)
 
 	query := []string{
@@ -64,7 +64,7 @@ func TestResourceChangesJson(t *testing.T) {
 
 	// Retrieve test data from the terraform-json project.
 	_, jsonData := http_helper.HttpGet(t, changesJsonUrl, nil)
-	plan, err := parsePlanJson(jsonData)
+	plan, err := ParsePlanJSON(jsonData)
 	require.NoError(t, err)
 
 	// Spot check a few changes to make sure the right address was registered

--- a/modules/terraform/show.go
+++ b/modules/terraform/show.go
@@ -40,7 +40,7 @@ func ShowWithStructE(t testing.TestingT, options *Options) (*PlanStruct, error) 
 	if err != nil {
 		return nil, err
 	}
-	planStruct, err := parsePlanJson(json)
+	planStruct, err := ParsePlanJSON(json)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Description

This seeks to address #1308 by publicly exposing the `terraform.ParsePlanJSON` function, in effect better enabling the use of `terratest` for programmatically analyzing and validating a Terraform plan produced by an upstream, non-`terratest` process.


<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [X] Update the docs.
- [X] Run the relevant tests successfully, including pre-commit checks.
- [X] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [X] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Added public `ParsePlanJSON` function to `terraform` module.
