### PR TITLE
Failing tests fixes

### DIFF
--- a/examples/packer-basic-example/build-gcp.pkr.hcl
+++ b/examples/packer-basic-example/build-gcp.pkr.hcl
@@ -21,7 +21,7 @@ source "googlecompute" "ubuntu-bionic" {
   image_family        = "terratest"
   image_name          = "terratest-packer-example-${formatdate("YYYYMMDD-hhmm", timestamp())}"
   project_id          = var.gcp_project_id
-  source_image_family = "ubuntu-1804-lts"
+  source_image_family = "ubuntu-2204-lts"
   ssh_username        = "ubuntu"
   zone                = var.gcp_zone
 }

--- a/examples/terraform-aws-rds-example/main.tf
+++ b/examples/terraform-aws-rds-example/main.tf
@@ -109,7 +109,7 @@ resource "aws_db_instance" "example" {
   engine                 = var.engine_name
   engine_version         = var.engine_version
   port                   = var.port
-  name                   = var.database_name
+  db_name                = var.database_name
   username               = var.username
   password               = var.password
   instance_class         = var.instance_class

--- a/examples/terraform-aws-rds-example/main.tf
+++ b/examples/terraform-aws-rds-example/main.tf
@@ -12,6 +12,13 @@ terraform {
   # 0.12.26 as the minimum version, as that version added support for required_providers with source URLs, making it
   # forwards compatible with 0.13.x code.
   required_version = ">= 0.12.26"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.61.0, < 5.0.0"
+    }
+  }
 }
 
 # ---------------------------------------------------------------------------------------------------------------------

--- a/examples/terraform-gcp-hello-world-example/main.tf
+++ b/examples/terraform-gcp-hello-world-example/main.tf
@@ -15,10 +15,10 @@ resource "google_compute_instance" "example" {
   machine_type = "f1-micro"
   zone         = "us-east1-b"
 
-  # website::tag::2:: Run Ubuntu 18.04 on the instace
+  # website::tag::2:: Run Ubuntu 22.04 on the instance
   boot_disk {
     initialize_params {
-      image = "ubuntu-os-cloud/ubuntu-1804-lts"
+      image = "ubuntu-os-cloud/ubuntu-2204-lts"
     }
   }
 

--- a/modules/gcp/compute_test.go
+++ b/modules/gcp/compute_test.go
@@ -20,7 +20,7 @@ import (
 
 const DEFAULT_MACHINE_TYPE = "f1-micro"
 const DEFAULT_IMAGE_FAMILY_PROJECT_NAME = "ubuntu-os-cloud"
-const DEFAULT_IMAGE_FAMILY_NAME = "family/ubuntu-1804-lts"
+const DEFAULT_IMAGE_FAMILY_NAME = "family/ubuntu-2204-lts"
 
 // Zones that support running f1-micro instances
 var ZonesThatSupportF1Micro = []string{"us-central1-a", "us-east1-b", "us-west1-a", "europe-north1-a", "europe-west1-b", "europe-central2-a"}


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Included changes:
 * Updated Ubuntu image used in GCP tests to actual 2204 lts version.
 * Fixed aws provider version in terraform-aws-rds-example, version 5.x introduce incompatible changes
 
![image](https://github.com/gruntwork-io/terratest/assets/10694338/dd44f803-33a1-4e16-a569-9a0da91a488c)


<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Fixed GCP and `terraform-aws-rds-example` tests

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->
