### PR TITLE
feat(test-structure): add save test data if dne

### DIFF
--- a/modules/test-structure/save_test_data.go
+++ b/modules/test-structure/save_test_data.go
@@ -21,7 +21,14 @@ import (
 // SaveTerraformOptions serializes and saves TerraformOptions into the given folder. This allows you to create TerraformOptions during setup
 // and to reuse that TerraformOptions later during validation and teardown.
 func SaveTerraformOptions(t testing.TestingT, testFolder string, terraformOptions *terraform.Options) {
-	SaveTestData(t, formatTerraformOptionsPath(testFolder), terraformOptions)
+	SaveTestData(t, formatTerraformOptionsPath(testFolder), true, terraformOptions)
+}
+
+// SaveTerraformOptionsIfNotPresent serializes and saves TerraformOptions into the given folder if the file does not exist or the json is
+// empty. This allows you to create TerraformOptions during setup and to reuse that TerraformOptions later during validation and teardown,
+// but will prevent overwritting the contents and potentially duplicating resources.
+func SaveTerraformOptionsIfNotPresent(t testing.TestingT, testFolder string, terraformOptions *terraform.Options) {
+	SaveTestData(t, formatTerraformOptionsPath(testFolder), false, terraformOptions)
 }
 
 // LoadTerraformOptions loads and unserializes TerraformOptions from the given folder. This allows you to reuse a TerraformOptions that was
@@ -40,7 +47,7 @@ func formatTerraformOptionsPath(testFolder string) string {
 // SavePackerOptions serializes and saves PackerOptions into the given folder. This allows you to create PackerOptions during setup
 // and to reuse that PackerOptions later during validation and teardown.
 func SavePackerOptions(t testing.TestingT, testFolder string, packerOptions *packer.Options) {
-	SaveTestData(t, formatPackerOptionsPath(testFolder), packerOptions)
+	SaveTestData(t, formatPackerOptionsPath(testFolder), true, packerOptions)
 }
 
 // LoadPackerOptions loads and unserializes PackerOptions from the given folder. This allows you to reuse a PackerOptions that was
@@ -59,7 +66,7 @@ func formatPackerOptionsPath(testFolder string) string {
 // SaveEc2KeyPair serializes and saves an Ec2KeyPair into the given folder. This allows you to create an Ec2KeyPair during setup
 // and to reuse that Ec2KeyPair later during validation and teardown.
 func SaveEc2KeyPair(t testing.TestingT, testFolder string, keyPair *aws.Ec2Keypair) {
-	SaveTestData(t, formatEc2KeyPairPath(testFolder), keyPair)
+	SaveTestData(t, formatEc2KeyPairPath(testFolder), true, keyPair)
 }
 
 // LoadEc2KeyPair loads and unserializes an Ec2KeyPair from the given folder. This allows you to reuse an Ec2KeyPair that was
@@ -78,7 +85,7 @@ func formatEc2KeyPairPath(testFolder string) string {
 // SaveSshKeyPair serializes and saves an SshKeyPair into the given folder. This allows you to create an SshKeyPair during setup
 // and to reuse that SshKeyPair later during validation and teardown.
 func SaveSshKeyPair(t testing.TestingT, testFolder string, keyPair *ssh.KeyPair) {
-	SaveTestData(t, formatSshKeyPairPath(testFolder), keyPair)
+	SaveTestData(t, formatSshKeyPairPath(testFolder), true, keyPair)
 }
 
 // LoadSshKeyPair loads and unserializes an SshKeyPair from the given folder. This allows you to reuse an SshKeyPair that was
@@ -97,7 +104,7 @@ func formatSshKeyPairPath(testFolder string) string {
 // SaveKubectlOptions serializes and saves KubectlOptions into the given folder. This allows you to create a KubectlOptions during setup
 // and reuse that KubectlOptions later during validation and teardown.
 func SaveKubectlOptions(t testing.TestingT, testFolder string, kubectlOptions *k8s.KubectlOptions) {
-	SaveTestData(t, formatKubectlOptionsPath(testFolder), kubectlOptions)
+	SaveTestData(t, formatKubectlOptionsPath(testFolder), true, kubectlOptions)
 }
 
 // LoadKubectlOptions loads and unserializes a KubectlOptions from the given folder. This allows you to reuse a KubectlOptions that was
@@ -117,7 +124,7 @@ func formatKubectlOptionsPath(testFolder string) string {
 // values during one stage -- each with a unique name -- and to reuse those values during later stages.
 func SaveString(t testing.TestingT, testFolder string, name string, val string) {
 	path := formatNamedTestDataPath(testFolder, name)
-	SaveTestData(t, path, val)
+	SaveTestData(t, path, true, val)
 }
 
 // LoadString loads and unserializes a uniquely named string value from the given folder. This allows you to reuse one or more string
@@ -132,7 +139,7 @@ func LoadString(t testing.TestingT, testFolder string, name string) string {
 // values during one stage -- each with a unique name -- and to reuse those values during later stages.
 func SaveInt(t testing.TestingT, testFolder string, name string, val int) {
 	path := formatNamedTestDataPath(testFolder, name)
-	SaveTestData(t, path, val)
+	SaveTestData(t, path, true, val)
 }
 
 // LoadInt loads a uniquely named int value from the given folder. This allows you to reuse one or more int
@@ -183,12 +190,19 @@ func FormatTestDataPath(testFolder string, filename string) string {
 }
 
 // SaveTestData serializes and saves a value used at test time to the given path. This allows you to create some sort of test data
-// (e.g., TerraformOptions) during setup and to reuse this data later during validation and teardown.
-func SaveTestData(t testing.TestingT, path string, value interface{}) {
+// (e.g., TerraformOptions) during setup and to reuse this data later during validation and teardown. If `overwrite` is `true`,
+// any contents that exist in the file found at `path` will be overwritten. This has the potential for causing duplicated resources
+// and should be used with caution. If `overwrite` is `false`, the save will be skipped and a warning will be logged.
+func SaveTestData(t testing.TestingT, path string, overwrite bool, value interface{}) {
 	logger.Logf(t, "Storing test data in %s so it can be reused later", path)
 
 	if IsTestDataPresent(t, path) {
-		logger.Logf(t, "[WARNING] The named test data at path %s is non-empty. Save operation will overwrite existing value with \"%v\".\n.", path, value)
+		if overwrite {
+			logger.Logf(t, "[WARNING] The named test data at path %s is non-empty. Save operation will overwrite existing value with \"%v\".\n.", path, value)
+		} else {
+			logger.Logf(t, "[WARNING] The named test data at path %s is non-empty. Skipping save operation to prevent overwriting existing value with \"%v\".\n.", path, value)
+			return
+		}
 	}
 
 	bytes, err := json.Marshal(value)


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

SaveTestData is a powerful feature. But with great power comes great responsibility. If a user is not careful, this feature can cause unintended side effects including duplicating resources and overwriting state.

Adding support for only saving if a file does not exists prevent overwriting contents and provides terratest users protection from themselves.

resolves #1318

<!-- Description of the changes introduced by this PR. -->

Adds SaveTerraformOptionsIfNotPresent and updates SaveTestData to include an additional `overwrite bool` attribute.

This change is backwards compatible.

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

Added `SaveTerraformOptionsIfNotPresent`
