### PR TITLE
feat: add AssertTgPlanAllExitCode

### DIFF
--- a/modules/terraform/plan.go
+++ b/modules/terraform/plan.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/testing"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -142,6 +143,24 @@ func TgPlanAllExitCodeE(t testing.TestingT, options *Options) (int, error) {
 
 	return GetExitCodeForTerraformCommandE(t, options, FormatArgs(options, "run-all", "plan", "--input=false",
 		"--lock=true", "--detailed-exitcode")...)
+}
+
+// AssertTgPlanAllExitCode asserts the succuess (or failure) of a terragrunt run-all plan.
+// On success, terragrunt will exit 0 on a plan that has previously been applied (has state)
+// and exit with 2 for plans that have never been applied when ran with `-detailed-exitcode`.
+func AssertTgPlanAllExitCode(t testing.TestingT, exitCode int, assertTrue bool) {
+
+	validExitCodes := map[int]bool{
+		0: true,
+		2: true,
+	}
+
+	_, hasKey := validExitCodes[exitCode]
+	if assertTrue {
+		assert.True(t, hasKey)
+	} else {
+		assert.False(t, hasKey)
+	}
 }
 
 // Custom errors

--- a/modules/terraform/plan_test.go
+++ b/modules/terraform/plan_test.go
@@ -191,3 +191,52 @@ func TestTgPlanAllWithError(t *testing.T) {
 
 	require.Equal(t, DefaultErrorExitCode, getExitCode)
 }
+
+func TestAssertTgPlanAllExitCodeNoError(t *testing.T) {
+	t.Parallel()
+
+	testFolder, err := files.CopyTerragruntFolderToTemp("../../test/fixtures/terragrunt/terragrunt-multi-plan", t.Name())
+	require.NoError(t, err)
+
+	options := &Options{
+		TerraformDir:    testFolder,
+		TerraformBinary: "terragrunt",
+	}
+
+	getExitCode, errExitCode := TgPlanAllExitCodeE(t, options)
+	if errExitCode != nil {
+		t.Fatal(errExitCode)
+	}
+
+	// since there is no state file we expect `2` to be the success exit code
+	assert.Equal(t, 2, getExitCode)
+	AssertTgPlanAllExitCode(t, getExitCode, true)
+
+	TgApplyAll(t, options)
+
+	getExitCode, errExitCode = TgPlanAllExitCodeE(t, options)
+	if errExitCode != nil {
+		t.Fatal(errExitCode)
+	}
+
+	// since there is a state file we expect `0` to be the success exit code
+	assert.Equal(t, 0, getExitCode)
+	AssertTgPlanAllExitCode(t, getExitCode, true)
+}
+
+func TestAssertTgPlanAllExitCodeWithError(t *testing.T) {
+	t.Parallel()
+
+	testFolder, err := files.CopyTerragruntFolderToTemp("../../test/fixtures/terragrunt/terragrunt-with-plan-error", t.Name())
+	require.NoError(t, err)
+
+	options := &Options{
+		TerraformDir:    testFolder,
+		TerraformBinary: "terragrunt",
+	}
+
+	getExitCode, errExitCode := TgPlanAllExitCodeE(t, options)
+	require.NoError(t, errExitCode)
+
+	AssertTgPlanAllExitCode(t, getExitCode, false)
+}


### PR DESCRIPTION
## Description

this adds an assertion to use with `TgPlanAllExitCode`.

since run-all plan with `-detailed-exitcode` can return a `0` or `2` on successful plans, this assertions checks for either acceptable value and asserts if true or false depending on the assertion under test, designated by the `assertTrue` input arg.

this has been passed around as a helper function for simple regression testing using plan all across many modules, seemed like time to share it with the community.

resolves #1324

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

Added `AssertTgPlanAllExitCode` to validate TgPlanAllE
