### PR TITLE
adds custom logger to kubectl options

### DIFF
--- a/modules/k8s/kubectl.go
+++ b/modules/k8s/kubectl.go
@@ -40,6 +40,7 @@ func RunKubectlAndGetOutputE(t testing.TestingT, options *KubectlOptions, args .
 		Command: "kubectl",
 		Args:    cmdArgs,
 		Env:     options.Env,
+		Logger:  options.Logger,
 	}
 	return shell.RunCommandAndGetOutputE(t, command)
 }

--- a/modules/k8s/kubectl_options.go
+++ b/modules/k8s/kubectl_options.go
@@ -1,6 +1,7 @@
 package k8s
 
 import (
+	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/testing"
 )
 
@@ -11,6 +12,7 @@ type KubectlOptions struct {
 	Namespace     string
 	Env           map[string]string
 	InClusterAuth bool
+	Logger        *logger.Logger
 }
 
 // NewKubectlOptions will return a pointer to new instance of KubectlOptions with the configured options


### PR DESCRIPTION
This commit adds the custom logging facility to kubectl options and to the Kubectl Run with output that can be used to suppress stdout from Kubectl run if needed.

The logging facility was introduced on #510 but it missed kubectl options.

Fixes #358 since @blame19 recalled that the behavior was missing on the k8s module.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Updated k8s module to add custom logging facility
