### PR TITLE
[k8s] Fix panic in WaitUntilDeploymentAvailable

### DIFF
--- a/modules/k8s/deployment.go
+++ b/modules/k8s/deployment.go
@@ -98,13 +98,16 @@ func WaitUntilDeploymentAvailableE(
 
 // IsDeploymentAvailable returns true if all pods within the deployment are ready and started
 func IsDeploymentAvailable(deploy *appsv1.Deployment) bool {
-	for _, dc := range deploy.Status.Conditions {
-		if dc.Type == appsv1.DeploymentProgressing &&
-			dc.Status == v1.ConditionTrue &&
-			dc.Reason == "NewReplicaSetAvailable" {
-			return true
+	dc := getDeploymentCondition(deploy, appsv1.DeploymentProgressing)
+	return dc != nil && dc.Status == v1.ConditionTrue && dc.Reason == "NewReplicaSetAvailable"
+}
+
+func getDeploymentCondition(deploy *appsv1.Deployment, cType appsv1.DeploymentConditionType) *appsv1.DeploymentCondition {
+	for idx := range deploy.Status.Conditions {
+		dc := &deploy.Status.Conditions[idx]
+		if dc.Type == cType {
+			return dc
 		}
 	}
-
-	return false
+	return nil
 }

--- a/modules/k8s/deployment_test.go
+++ b/modules/k8s/deployment_test.go
@@ -110,6 +110,15 @@ func TestTestIsDeploymentAvailable(t *testing.T) {
 			},
 			expectedResult: false,
 		},
+		{
+			title: "TestIsDeploymentAvailableWithoutProgressingCondition",
+			deploy: &appsv1.Deployment{
+				Status: appsv1.DeploymentStatus{
+					Conditions: []appsv1.DeploymentCondition{},
+				},
+			},
+			expectedResult: false,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/modules/k8s/errors.go
+++ b/modules/k8s/errors.go
@@ -69,11 +69,21 @@ type DeploymentNotAvailable struct {
 
 // Error is a simple function to return a formatted error message as a string
 func (err DeploymentNotAvailable) Error() string {
+	dc := getDeploymentCondition(err.deploy, appsv1.DeploymentProgressing)
+	if dc == nil {
+		return fmt.Sprintf(
+			"Deployment %s is not available, missing '%s' condition",
+			err.deploy.Name,
+			appsv1.DeploymentProgressing,
+		)
+	}
 	return fmt.Sprintf(
-		"Deployment %s is not available, reason: %s, message: %s",
+		"Deployment %s is not available as '%s' condition indicates that the Deployment is not complete, status: %v, reason: %s, message: %s",
 		err.deploy.Name,
-		err.deploy.Status.Conditions[0].Reason,
-		err.deploy.Status.Conditions[0].Message,
+		appsv1.DeploymentProgressing,
+		dc.Status,
+		dc.Reason,
+		dc.Message,
 	)
 }
 

--- a/modules/k8s/errors_test.go
+++ b/modules/k8s/errors_test.go
@@ -1,0 +1,60 @@
+package k8s
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestErrorDeploymentNotAvailable(t *testing.T) {
+	testCases := []struct {
+		title       string
+		deploy      *appsv1.Deployment
+		expectedErr string
+	}{
+		{
+			title: "NoProgressingCondition",
+			deploy: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "foo",
+				},
+				Status: appsv1.DeploymentStatus{
+					Conditions: []appsv1.DeploymentCondition{},
+				},
+			},
+			expectedErr: "Deployment foo is not available, missing 'Progressing' condition",
+		},
+		{
+			title: "DeploymentNotComplete",
+			deploy: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "foo",
+				},
+				Status: appsv1.DeploymentStatus{
+					Conditions: []appsv1.DeploymentCondition{
+						{
+							Type:    appsv1.DeploymentProgressing,
+							Status:  v1.ConditionTrue,
+							Reason:  "ReplicaSetUpdated",
+							Message: "bar",
+						},
+					},
+				},
+			},
+			expectedErr: "Deployment foo is not available as 'Progressing' condition indicates that the Deployment is not complete, status: True, reason: ReplicaSetUpdated, message: bar",
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.title, func(t *testing.T) {
+			t.Parallel()
+			err := NewDeploymentNotAvailableError(tc.deploy)
+			assert.EqualError(t, err, tc.expectedErr)
+		})
+	}
+}


### PR DESCRIPTION
## Description

Fixes #1329

The `func (err DeploymentNotAvailable) Error()` method should not assume that `Status.Conditions[0]` is always valid for the Deployment.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs. N/A
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable. N/A
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Fixed panic in WaitUntilDeploymentAvailable in the k8s module.

### Migration Guide

N/A
