### PR TITLE
Add 4 new variables for NSGRuleSummary

### DIFF
--- a/modules/azure/common.go
+++ b/modules/azure/common.go
@@ -64,3 +64,11 @@ func safePtrToInt32(raw *int32) int32 {
 	}
 	return *raw
 }
+
+// safePtrToList converts a []string pointer to a non-pointer []string value, or to initialization of an empty slice if the pointer is nil.
+func safePtrToList(raw *[]string) []string {
+	if raw == nil {
+		return []string{}
+	}
+	return *raw
+}

--- a/modules/azure/nsg.go
+++ b/modules/azure/nsg.go
@@ -20,16 +20,20 @@ type NsgRuleSummaryList struct {
 // NsgRuleSummary is a string-based (non-pointer) summary of an NSG rule with several helper methods attached
 // to help with verification of rule configuratoin.
 type NsgRuleSummary struct {
-	Name                     string
-	Description              string
-	Protocol                 string
-	SourcePortRange          string
-	DestinationPortRange     string
-	SourceAddressPrefix      string
-	DestinationAddressPrefix string
-	Access                   string
-	Priority                 int32
-	Direction                string
+	Name                       string
+	Description                string
+	Protocol                   string
+	SourcePortRange            string
+	SourcePortRanges           []string
+	DestinationPortRange       string
+	DestinationPortRanges      []string
+	SourceAddressPrefix        string
+	SourceAdresssPrefixes      []string
+	DestinationAddressPrefix   string
+	DestinationAddressPrefixes []string
+	Access                     string
+	Priority                   int32
+	Direction                  string
 }
 
 // GetDefaultNsgRulesClient returns a rules client which can be used to read the list of *default* security rules
@@ -169,9 +173,13 @@ func convertToNsgRuleSummary(name *string, rule *network.SecurityRulePropertiesF
 	summary.Name = safePtrToString(name)
 	summary.Protocol = string(rule.Protocol)
 	summary.SourcePortRange = safePtrToString(rule.SourcePortRange)
+	summary.SourcePortRanges = safePtrToList(rule.SourcePortRanges)
 	summary.DestinationPortRange = safePtrToString(rule.DestinationPortRange)
+	summary.DestinationPortRanges = safePtrToList(rule.DestinationPortRanges)
 	summary.SourceAddressPrefix = safePtrToString(rule.SourceAddressPrefix)
+	summary.SourceAdresssPrefixes = safePtrToList(rule.SourceAddressPrefixes)
 	summary.DestinationAddressPrefix = safePtrToString(rule.DestinationAddressPrefix)
+	summary.DestinationAddressPrefixes = safePtrToList(rule.DestinationAddressPrefixes)
 	summary.Access = string(rule.Access)
 	summary.Priority = safePtrToInt32(rule.Priority)
 	summary.Direction = string(rule.Direction)


### PR DESCRIPTION
## Description

It will add only new variables in struct NsgRuleSummary, it will not change functionality.

I use function GetAllNSGRules and at it function FindRuleByName but currently it return empty value if your rule have list of strings for variables.

- SourcePortRange            
- DestinationPortRange
- SourceAddressPrefix
- DestinationAddressPrefix

Variables returned from network.SecurityRulePropertiesFormat in method convertToNsgRuleSummary, so solve problem is easy and all to do is catch this values.

If i add  in to struct NsgRuleSummary variables

- SourcePortRanges           []string
- DestinationPortRanges      []string
- SourceAdresssPrefixes      []string
- DestinationAddressPrefixes []string

And assign them to values from rules in convertToNsgRuleSummary then function FindRuleByName should return for me expected data with all []string where are need.


