### PR TITLE
feat: Allow other types with use of generics in collections module

### DIFF
--- a/modules/collections/lists.go
+++ b/modules/collections/lists.go
@@ -2,8 +2,8 @@ package collections
 
 // ListIntersection returns all the items in both list1 and list2. Note that this will dedup the items so that the
 // output is more predictable. Otherwise, the end list depends on which list was used as the base.
-func ListIntersection(list1 []string, list2 []string) []string {
-	out := []string{}
+func ListIntersection[T comparable](list1 []T, list2 []T) []T {
+	out := []T{}
 
 	// Only need to iterate list1, because we want items in both lists, not union.
 	for _, item := range list1 {
@@ -16,8 +16,8 @@ func ListIntersection(list1 []string, list2 []string) []string {
 }
 
 // ListSubtract removes all the items in list2 from list1.
-func ListSubtract(list1 []string, list2 []string) []string {
-	out := []string{}
+func ListSubtract[T comparable](list1 []T, list2 []T) []T {
+	out := []T{}
 
 	for _, item := range list1 {
 		if !ListContains(list2, item) {
@@ -29,7 +29,7 @@ func ListSubtract(list1 []string, list2 []string) []string {
 }
 
 // ListContains returns true if the given list of strings (haystack) contains the given string (needle).
-func ListContains(haystack []string, needle string) bool {
+func ListContains[T comparable](haystack []T, needle T) bool {
 	for _, str := range haystack {
 		if needle == str {
 			return true


### PR DESCRIPTION
## Description

Adds support for more types in the `collections` module by using generics (introduced in go 1.18)

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->
