### PR TITLE
Updated Azure example documentation to include AZURE_ENVIRONMENT env variable

### DIFF
--- a/examples/azure/README.md
+++ b/examples/azure/README.md
@@ -37,11 +37,20 @@ go build terraform_azure_*_test.go
 
 As part of configuring terraform for Azure, we'll want to check that we have set the appropriate [credentials](https://docs.microsoft.com/azure/terraform/terraform-install-configure?toc=https%3A%2F%2Fdocs.microsoft.com%2Fen-us%2Fazure%2Fterraform%2Ftoc.json&bc=https%3A%2F%2Fdocs.microsoft.com%2Fen-us%2Fazure%2Fbread%2Ftoc.json#set-up-terraform-access-to-azure) and also that we set the [environment variables](https://docs.microsoft.com/azure/terraform/terraform-install-configure?toc=https%3A%2F%2Fdocs.microsoft.com%2Fen-us%2Fazure%2Fterraform%2Ftoc.json&bc=https%3A%2F%2Fdocs.microsoft.com%2Fen-us%2Fazure%2Fbread%2Ftoc.json#configure-terraform-environment-variables) on the testing host.
 
+For non-commercial cloud deployments, set the "AZURE_ENVIRONMENT" environment variable to the appropriate cloud environment (this is used by the [client_factory](../../modules/azure/client_factory.go) to set the correct azure endpoints):
+
 ```bash
 export ARM_CLIENT_ID=your_app_id
 export ARM_CLIENT_SECRET=your_password
 export ARM_SUBSCRIPTION_ID=your_subscription_id
 export ARM_TENANT_ID=your_tenant_id
+
+# AZURE_ENVIRONMENT is the name of the Azure environment to use. Set to one of the following:
+export AZURE_ENVIRONMENT=AzureUSGovernmentCloud
+export AZURE_ENVIRONMENT=AzureChinaCloud
+export AZURE_ENVIRONMENT=AzureGermanCloud
+export AZURE_ENVIRONMENT=AzurePublicCloud
+export AZURE_ENVIRONMENT=AzureStackCloud
 ```
 
 Note, in a Windows environment, these should be set as **system environment variables**. We can use a PowerShell console with administrative rights to update these environment variables:
@@ -51,4 +60,5 @@ Note, in a Windows environment, these should be set as **system environment vari
 [System.Environment]::SetEnvironmentVariable("ARM_CLIENT_SECRET",$your_password,[System.EnvironmentVariableTarget]::Machine)
 [System.Environment]::SetEnvironmentVariable("ARM_SUBSCRIPTION_ID",$your_subscription_id,[System.EnvironmentVariableTarget]::Machine)
 [System.Environment]::SetEnvironmentVariable("ARM_TENANT_ID",$your_tenant_id,[System.EnvironmentVariableTarget]::Machine)
+[System.Environment]::SetEnvironmentVariable("AZURE_ENVIRONMENT",$your_azure_env,[System.EnvironmentVariableTarget]::Machine)
 ```

--- a/examples/azure/terraform-azure-example/README.md
+++ b/examples/azure/terraform-azure-example/README.md
@@ -74,20 +74,30 @@ go build terraform_azure_example_test.go
 
 ## Review Environment Variables
 
-As part of configuring terraform for Azure, we'll want to check that we have set the appropriate [credentials](https://docs.microsoft.com/en-us/azure/terraform/terraform-install-configure?toc=https%3A%2F%2Fdocs.microsoft.com%2Fen-us%2Fazure%2Fterraform%2Ftoc.json&bc=https%3A%2F%2Fdocs.microsoft.com%2Fen-us%2Fazure%2Fbread%2Ftoc.json#set-up-terraform-access-to-azure) and also that we set the [environment variables](https://docs.microsoft.com/en-us/azure/terraform/terraform-install-configure?toc=https%3A%2F%2Fdocs.microsoft.com%2Fen-us%2Fazure%2Fterraform%2Ftoc.json&bc=https%3A%2F%2Fdocs.microsoft.com%2Fen-us%2Fazure%2Fbread%2Ftoc.json#configure-terraform-environment-variables) on the testing host.
+As part of configuring terraform for Azure, we'll want to check that we have set the appropriate [credentials](https://docs.microsoft.com/azure/terraform/terraform-install-configure?toc=https%3A%2F%2Fdocs.microsoft.com%2Fen-us%2Fazure%2Fterraform%2Ftoc.json&bc=https%3A%2F%2Fdocs.microsoft.com%2Fen-us%2Fazure%2Fbread%2Ftoc.json#set-up-terraform-access-to-azure) and also that we set the [environment variables](https://docs.microsoft.com/azure/terraform/terraform-install-configure?toc=https%3A%2F%2Fdocs.microsoft.com%2Fen-us%2Fazure%2Fterraform%2Ftoc.json&bc=https%3A%2F%2Fdocs.microsoft.com%2Fen-us%2Fazure%2Fbread%2Ftoc.json#configure-terraform-environment-variables) on the testing host.
+
+For non-commercial cloud deployments, set the "AZURE_ENVIRONMENT" environment variable to the appropriate cloud environment (this is used by the [client_factory](../../modules/azure/client_factory.go) to set the correct azure endpoints):
 
 ```bash
 export ARM_CLIENT_ID=your_app_id
 export ARM_CLIENT_SECRET=your_password
 export ARM_SUBSCRIPTION_ID=your_subscription_id
 export ARM_TENANT_ID=your_tenant_id
+
+# AZURE_ENVIRONMENT is the name of the Azure environment to use. Set to one of the following:
+export AZURE_ENVIRONMENT=AzureUSGovernmentCloud
+export AZURE_ENVIRONMENT=AzureChinaCloud
+export AZURE_ENVIRONMENT=AzureGermanCloud
+export AZURE_ENVIRONMENT=AzurePublicCloud
+export AZURE_ENVIRONMENT=AzureStackCloud
 ```
 
-Note, in a Windows environment, these should be set as **system environment variables**.  We can use a PowerShell console with administrative rights to update these environment variables:
+Note, in a Windows environment, these should be set as **system environment variables**. We can use a PowerShell console with administrative rights to update these environment variables:
 
 ```powershell
 [System.Environment]::SetEnvironmentVariable("ARM_CLIENT_ID",$your_app_id,[System.EnvironmentVariableTarget]::Machine)
 [System.Environment]::SetEnvironmentVariable("ARM_CLIENT_SECRET",$your_password,[System.EnvironmentVariableTarget]::Machine)
 [System.Environment]::SetEnvironmentVariable("ARM_SUBSCRIPTION_ID",$your_subscription_id,[System.EnvironmentVariableTarget]::Machine)
 [System.Environment]::SetEnvironmentVariable("ARM_TENANT_ID",$your_tenant_id,[System.EnvironmentVariableTarget]::Machine)
+[System.Environment]::SetEnvironmentVariable("AZURE_ENVIRONMENT",$your_azure_env,[System.EnvironmentVariableTarget]::Machine)
 ```


### PR DESCRIPTION
## Description
The Azure example documentation did not contain information about setting the AZURE_ENVIRONMENT env variable. This env variable is needed for being able to test on non-commercial clouds. 

I updated the README's to include instructions on setting this variable.

Fixes #1345 

<!-- Description of the changes introduced by this PR. -->
- Updated README's in `examples/azure`

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes

<!-- One-line description of the PR that can be included in the final release notes. -->
Added documentation to examples for setting the AZURE_ENVIRONMENT environment variable

