### PR TITLE
Fix root path lookup in validate-all

### DIFF
--- a/modules/git/git.go
+++ b/modules/git/git.go
@@ -2,6 +2,7 @@
 package git
 
 import (
+	"os"
 	"os/exec"
 	"strings"
 
@@ -106,7 +107,24 @@ func GetRepoRoot(t testing.TestingT) string {
 
 // GetRepoRootE retrieves the path to the root directory of the repo.
 func GetRepoRootE(t testing.TestingT) (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	return GetRepoRootForDirE(t, dir)
+}
+
+// GetRepoRootForDir retrieves the path to the root directory of the repo in which dir resides
+func GetRepoRootForDir(t testing.TestingT, dir string) string {
+	out, err := GetRepoRootForDirE(t, dir)
+	require.NoError(t, err)
+	return out
+}
+
+// GetRepoRootForDirE retrieves the path to the root directory of the repo in which dir resides
+func GetRepoRootForDirE(t testing.TestingT, dir string) (string, error) {
 	cmd := exec.Command("git", "rev-parse", "--show-toplevel")
+	cmd.Dir = dir
 	bytes, err := cmd.Output()
 	if err != nil {
 		return "", err

--- a/modules/test-structure/test_structure.go
+++ b/modules/test-structure/test_structure.go
@@ -217,8 +217,6 @@ func runValidateOnAllTerraformModules(
 	for _, dir := range dirsToValidate {
 		dir := dir
 		t.Run(strings.TrimLeft(dir, "/"), func(t *go_test.T) {
-			t.Logf("Original root = %s, git root = %s, testFolder = %s, dir = %s", opts.RootDir, gitRoot, testFolder, dir)
-
 			// Run the validation function on the test folder that was copied to /tmp to avoid any potential conflicts
 			// with tests that may not use the same copy to /tmp behavior
 			tfOpts := &terraform.Options{TerraformDir: dir}

--- a/modules/test-structure/test_structure.go
+++ b/modules/test-structure/test_structure.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/gruntwork-io/terratest/modules/git"
+
 	go_test "testing"
 
 	"github.com/gruntwork-io/terratest/modules/files"
@@ -192,29 +194,35 @@ func runValidateOnAllTerraformModules(
 	opts *ValidationOptions,
 	validationFunc func(t *go_test.T, fileType ValidateFileType, tfOps *terraform.Options),
 ) {
-	dirsToValidate, readErr := FindTerraformModulePathsInRootE(opts)
+	// Find the Git root
+	gitRoot, err := git.GetRepoRootForDirE(t, opts.RootDir)
+	require.NoError(t, err)
+
+	// Find the relative path between the root dir and the git root
+	relPath, err := filepath.Rel(gitRoot, opts.RootDir)
+	require.NoError(t, err)
+
+	// Copy git root to tmp
+	testFolder := CopyTerraformFolderToTemp(t, gitRoot, relPath)
+	require.NotNil(t, testFolder)
+
+	// Clone opts and override the root dir to the temp folder
+	clonedOpts, err := CloneWithNewRootDir(opts, testFolder)
+	require.NoError(t, err)
+
+	// Find TF modules
+	dirsToValidate, readErr := FindTerraformModulePathsInRootE(clonedOpts)
 	require.NoError(t, readErr)
 
 	for _, dir := range dirsToValidate {
 		dir := dir
 		t.Run(strings.TrimLeft(dir, "/"), func(t *go_test.T) {
-			// Determine the absolute path to the git repository root
-			cwd, cwdErr := os.Getwd()
-			require.NoError(t, cwdErr)
-			gitRoot, gitRootErr := filepath.Abs(filepath.Join(cwd, "../../"))
-			require.NoError(t, gitRootErr)
+			t.Logf("Original root = %s, git root = %s, testFolder = %s, dir = %s", opts.RootDir, gitRoot, testFolder, dir)
 
-			// Determine the relative path to the example, module, etc that is currently being considered
-			relativePath, pathErr := filepath.Rel(gitRoot, dir)
-			require.NoError(t, pathErr)
-			// Copy git root to tmp and supply the path to the current module to run init and validate on
-			testFolder := CopyTerraformFolderToTemp(t, gitRoot, relativePath)
-			require.NotNil(t, testFolder)
-
-			// Run Terraform init and terraform validate on the test folder that was copied to /tmp
-			// to avoid any potential conflicts with tests that may not use the same copy to /tmp behavior
-			tfOpts := &terraform.Options{TerraformDir: testFolder}
-			validationFunc(t, opts.FileType, tfOpts)
+			// Run the validation function on the test folder that was copied to /tmp to avoid any potential conflicts
+			// with tests that may not use the same copy to /tmp behavior
+			tfOpts := &terraform.Options{TerraformDir: dir}
+			validationFunc(t, clonedOpts.FileType, tfOpts)
 		})
 	}
 }


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes #1374. 

I've updated the `runValidateOnAllTerraformModules` function, which is used under the hood by `ValidateAllTerraformModules` and `OPAEvalAllTerraformModules`, to:

1. Find the Git root using `git.GetRepoRootForDirE`, instead of a hard-coded `../../` file path.
2. Copy the Git root to a temp folder once, rather than once per sub-test.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->
