### PR TITLE
Amazon Linux AMIs search fixes

### DIFF
--- a/modules/aws/ami.go
+++ b/modules/aws/ami.go
@@ -274,7 +274,7 @@ func GetAmazonLinuxAmi(t testing.TestingT, region string) string {
 // GetAmazonLinuxAmiE returns an Amazon Linux AMI HVM, SSD Volume Type public AMI for the given region.
 func GetAmazonLinuxAmiE(t testing.TestingT, region string) (string, error) {
 	filters := map[string][]string{
-		"name":                             {"*amzn-ami-hvm-*-x86_64*"},
+		"name":                             {"*amzn2-ami-hvm-*-x86_64*"},
 		"virtualization-type":              {"hvm"},
 		"architecture":                     {"x86_64"},
 		"root-device-type":                 {"ebs"},


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixed searching for Amazon Linux AMIs:
* removed deprecated Amazon Linux 1 reference
* added usage of Amazon Linux 2

Fixes #1386.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

Updated `GetAmazonLinuxAmiE` to search for Amazon Linux 2 AMIs

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->
