### PR TITLE
fix: replace the deprecated logger.Logf and logger.Log for the new Logger

### DIFF
--- a/modules/aws/ami.go
+++ b/modules/aws/ami.go
@@ -59,7 +59,7 @@ func GetEbsSnapshotsForAmi(t testing.TestingT, region string, ami string) []stri
 
 // GetEbsSnapshotsForAmi retrieves the EBS snapshots which back the given AMI
 func GetEbsSnapshotsForAmiE(t testing.TestingT, region string, ami string) ([]string, error) {
-	logger.Logf(t, "Retrieving EBS snapshots backing AMI %s", ami)
+	logger.Default.Logf(t, "Retrieving EBS snapshots backing AMI %s", ami)
 	ec2Client, err := NewEc2ClientE(t, region)
 	if err != nil {
 		return nil, err

--- a/modules/aws/asg.go
+++ b/modules/aws/asg.go
@@ -120,7 +120,7 @@ func WaitForCapacityE(
 			return fmt.Sprintf("ASG %s is now at desired capacity %d", asgName, capacityInfo.DesiredCapacity), nil
 		},
 	)
-	logger.Log(t, msg)
+	logger.Default.Logf(t, "%s", msg)
 	return err
 }
 

--- a/modules/aws/ebs.go
+++ b/modules/aws/ebs.go
@@ -17,7 +17,7 @@ func DeleteEbsSnapshot(t testing.TestingT, region string, snapshot string) {
 
 // DeleteEbsSnapshot deletes the given EBS snapshot
 func DeleteEbsSnapshotE(t testing.TestingT, region string, snapshot string) error {
-	logger.Logf(t, "Deleting EBS snapshot %s", snapshot)
+	logger.Default.Logf(t, "Deleting EBS snapshot %s", snapshot)
 	ec2Client, err := NewEc2ClientE(t, region)
 	if err != nil {
 		return err

--- a/modules/aws/ec2-syslog.go
+++ b/modules/aws/ec2-syslog.go
@@ -33,7 +33,7 @@ func GetSyslogForInstanceE(t testing.TestingT, instanceID string, region string)
 	maxRetries := 120
 	timeBetweenRetries := 5 * time.Second
 
-	logger.Log(t, description)
+	logger.Default.Logf(t, "%s", description)
 
 	client, err := NewEc2ClientE(t, region)
 	if err != nil {
@@ -89,7 +89,7 @@ func GetSyslogForInstancesInAsg(t testing.TestingT, asgName string, awsRegion st
 // minute after the Instance boots and are very useful for debugging boot-time issues, such as an error in User Data.
 // Returns a map of Instance Id -> Syslog for that Instance.
 func GetSyslogForInstancesInAsgE(t testing.TestingT, asgName string, awsRegion string) (map[string]string, error) {
-	logger.Logf(t, "Fetching syslog for each Instance in ASG %s in %s", asgName, awsRegion)
+	logger.Default.Logf(t, "Fetching syslog for each Instance in ASG %s in %s", asgName, awsRegion)
 
 	instanceIDs, err := GetEc2InstanceIdsByTagE(t, awsRegion, "aws:autoscaling:groupName", asgName)
 	if err != nil {

--- a/modules/aws/ec2.go
+++ b/modules/aws/ec2.go
@@ -268,7 +268,7 @@ func DeleteAmi(t testing.TestingT, region string, imageID string) {
 
 // DeleteAmiE deletes the given AMI in the given region.
 func DeleteAmiE(t testing.TestingT, region string, imageID string) error {
-	logger.Logf(t, "Deregistering AMI %s", imageID)
+	logger.Default.Logf(t, "Deregistering AMI %s", imageID)
 
 	client, err := NewEc2ClientE(t, region)
 	if err != nil {
@@ -314,7 +314,7 @@ func TerminateInstance(t testing.TestingT, region string, instanceID string) {
 
 // TerminateInstanceE terminates the EC2 instance with the given ID in the given region.
 func TerminateInstanceE(t testing.TestingT, region string, instanceID string) error {
-	logger.Logf(t, "Terminating Instance %s", instanceID)
+	logger.Default.Logf(t, "Terminating Instance %s", instanceID)
 
 	client, err := NewEc2ClientE(t, region)
 	if err != nil {

--- a/modules/aws/ecr.go
+++ b/modules/aws/ecr.go
@@ -126,7 +126,7 @@ func PutECRRepoLifecyclePolicy(t testing.TestingT, region string, repo *ecr.Repo
 
 // PutEcrRepoLifecyclePolicy puts the given policy for the given ECR repository.
 func PutECRRepoLifecyclePolicyE(t testing.TestingT, region string, repo *ecr.Repository, policy string) error {
-	logger.Logf(t, "Applying policy for repository %s in %s", *repo.RepositoryName, region)
+	logger.Default.Logf(t, "Applying policy for repository %s in %s", *repo.RepositoryName, region)
 
 	client, err := NewECRClientE(t, region)
 	if err != nil {

--- a/modules/aws/iam.go
+++ b/modules/aws/iam.go
@@ -68,7 +68,7 @@ func CreateMfaDevice(t testing.TestingT, iamClient *iam.IAM, deviceName string) 
 
 // CreateMfaDeviceE creates an MFA device using the given IAM client.
 func CreateMfaDeviceE(t testing.TestingT, iamClient *iam.IAM, deviceName string) (*iam.VirtualMFADevice, error) {
-	logger.Logf(t, "Creating an MFA device called %s", deviceName)
+	logger.Default.Logf(t, "Creating an MFA device called %s", deviceName)
 
 	output, err := iamClient.CreateVirtualMFADevice(&iam.CreateVirtualMFADeviceInput{
 		VirtualMFADeviceName: aws.String(deviceName),
@@ -96,7 +96,7 @@ func EnableMfaDevice(t testing.TestingT, iamClient *iam.IAM, mfaDevice *iam.Virt
 // EnableMfaDeviceE enables a newly created MFA Device by supplying the first two one-time passwords, so that it can be used for future
 // logins by the given IAM User.
 func EnableMfaDeviceE(t testing.TestingT, iamClient *iam.IAM, mfaDevice *iam.VirtualMFADevice) error {
-	logger.Logf(t, "Enabling MFA device %s", aws.StringValue(mfaDevice.SerialNumber))
+	logger.Default.Logf(t, "Enabling MFA device %s", aws.StringValue(mfaDevice.SerialNumber))
 
 	iamUserName, err := GetIamCurrentUserArnE(t)
 	if err != nil {
@@ -108,7 +108,7 @@ func EnableMfaDeviceE(t testing.TestingT, iamClient *iam.IAM, mfaDevice *iam.Vir
 		return err
 	}
 
-	logger.Logf(t, "Waiting 30 seconds for a new MFA Token to be generated...")
+	logger.Default.Logf(t, "Waiting 30 seconds for a new MFA Token to be generated...")
 	time.Sleep(30 * time.Second)
 
 	authCode2, err := GetTimeBasedOneTimePassword(mfaDevice)
@@ -127,7 +127,7 @@ func EnableMfaDeviceE(t testing.TestingT, iamClient *iam.IAM, mfaDevice *iam.Vir
 		return err
 	}
 
-	logger.Log(t, "Waiting for MFA Device enablement to propagate.")
+	logger.Default.Logf(t, "Waiting for MFA Device enablement to propagate.")
 	time.Sleep(10 * time.Second)
 
 	return nil

--- a/modules/aws/keypair.go
+++ b/modules/aws/keypair.go
@@ -45,7 +45,7 @@ func ImportEC2KeyPair(t testing.TestingT, region string, name string, keyPair *s
 
 // ImportEC2KeyPairE creates a Key Pair in EC2 by importing an existing public key.
 func ImportEC2KeyPairE(t testing.TestingT, region string, name string, keyPair *ssh.KeyPair) (*Ec2Keypair, error) {
-	logger.Logf(t, "Creating new Key Pair in EC2 region %s named %s", region, name)
+	logger.Default.Logf(t, "Creating new Key Pair in EC2 region %s named %s", region, name)
 
 	client, err := NewEc2ClientE(t, region)
 	if err != nil {
@@ -75,7 +75,7 @@ func DeleteEC2KeyPair(t testing.TestingT, keyPair *Ec2Keypair) {
 
 // DeleteEC2KeyPairE deletes an EC2 key pair.
 func DeleteEC2KeyPairE(t testing.TestingT, keyPair *Ec2Keypair) error {
-	logger.Logf(t, "Deleting Key Pair in EC2 region %s named %s", keyPair.Region, keyPair.Name)
+	logger.Default.Logf(t, "Deleting Key Pair in EC2 region %s named %s", keyPair.Region, keyPair.Name)
 
 	client, err := NewEc2ClientE(t, keyPair.Region)
 	if err != nil {

--- a/modules/aws/region.go
+++ b/modules/aws/region.go
@@ -74,7 +74,7 @@ func GetRandomRegion(t testing.TestingT, approvedRegions []string, forbiddenRegi
 func GetRandomRegionE(t testing.TestingT, approvedRegions []string, forbiddenRegions []string) (string, error) {
 	regionFromEnvVar := os.Getenv(regionOverrideEnvVarName)
 	if regionFromEnvVar != "" {
-		logger.Logf(t, "Using AWS region %s from environment variable %s", regionFromEnvVar, regionOverrideEnvVarName)
+		logger.Default.Logf(t, "Using AWS region %s from environment variable %s", regionFromEnvVar, regionOverrideEnvVarName)
 		return regionFromEnvVar, nil
 	}
 
@@ -91,7 +91,7 @@ func GetRandomRegionE(t testing.TestingT, approvedRegions []string, forbiddenReg
 	regionsToPickFrom = collections.ListSubtract(regionsToPickFrom, forbiddenRegions)
 	region := random.RandomString(regionsToPickFrom)
 
-	logger.Logf(t, "Using region %s", region)
+	logger.Default.Logf(t, "Using region %s", region)
 	return region, nil
 }
 
@@ -106,7 +106,7 @@ func GetAllAwsRegions(t testing.TestingT) []string {
 
 // GetAllAwsRegionsE gets the list of AWS regions available in this account.
 func GetAllAwsRegionsE(t testing.TestingT) ([]string, error) {
-	logger.Log(t, "Looking up all AWS regions available in this account")
+	logger.Default.Logf(t, "Looking up all AWS regions available in this account")
 
 	ec2Client, err := NewEc2ClientE(t, defaultRegion)
 	if err != nil {
@@ -139,7 +139,7 @@ func GetAvailabilityZones(t testing.TestingT, region string) []string {
 // GetAvailabilityZonesE gets the Availability Zones for a given AWS region. Note that for certain regions (e.g. us-east-1), different AWS
 // accounts have access to different availability zones.
 func GetAvailabilityZonesE(t testing.TestingT, region string) ([]string, error) {
-	logger.Logf(t, "Looking up all availability zones available in this account for region %s", region)
+	logger.Default.Logf(t, "Looking up all availability zones available in this account for region %s", region)
 
 	ec2Client, err := NewEc2ClientE(t, region)
 	if err != nil {

--- a/modules/aws/s3.go
+++ b/modules/aws/s3.go
@@ -53,7 +53,7 @@ func FindS3BucketWithTagE(t testing.TestingT, awsRegion string, key string, valu
 
 		for _, tag := range tagResponse.TagSet {
 			if *tag.Key == key && *tag.Value == value {
-				logger.Logf(t, "Found S3 bucket %s with tag %s=%s", *bucket.Name, key, value)
+				logger.Default.Logf(t, "Found S3 bucket %s with tag %s=%s", *bucket.Name, key, value)
 				return *bucket.Name, nil
 			}
 		}
@@ -123,7 +123,7 @@ func GetS3ObjectContentsE(t testing.TestingT, awsRegion string, bucket string, k
 	}
 
 	contents := buf.String()
-	logger.Logf(t, "Read contents from s3://%s/%s", bucket, key)
+	logger.Default.Logf(t, "Read contents from s3://%s/%s", bucket, key)
 
 	return contents, nil
 }
@@ -136,7 +136,7 @@ func CreateS3Bucket(t testing.TestingT, region string, name string) {
 
 // CreateS3BucketE creates an S3 bucket in the given region with the given name. Note that S3 bucket names must be globally unique.
 func CreateS3BucketE(t testing.TestingT, region string, name string) error {
-	logger.Logf(t, "Creating bucket %s in %s", name, region)
+	logger.Default.Logf(t, "Creating bucket %s in %s", name, region)
 
 	s3Client, err := NewS3ClientE(t, region)
 	if err != nil {
@@ -160,7 +160,7 @@ func PutS3BucketPolicy(t testing.TestingT, region string, bucketName string, pol
 
 // PutS3BucketPolicyE applies an IAM resource policy to a given S3 bucket to create it's bucket policy
 func PutS3BucketPolicyE(t testing.TestingT, region string, bucketName string, policyJSONString string) error {
-	logger.Logf(t, "Applying bucket policy for bucket %s in %s", bucketName, region)
+	logger.Default.Logf(t, "Applying bucket policy for bucket %s in %s", bucketName, region)
 
 	s3Client, err := NewS3ClientE(t, region)
 	if err != nil {
@@ -184,7 +184,7 @@ func PutS3BucketVersioning(t testing.TestingT, region string, bucketName string)
 
 // PutS3BucketVersioningE creates an S3 bucket versioning configuration in the given region against the given bucket name, WITHOUT requiring MFA to remove versioning.
 func PutS3BucketVersioningE(t testing.TestingT, region string, bucketName string) error {
-	logger.Logf(t, "Creating bucket versioning configuration for bucket %s in %s", bucketName, region)
+	logger.Default.Logf(t, "Creating bucket versioning configuration for bucket %s in %s", bucketName, region)
 
 	s3Client, err := NewS3ClientE(t, region)
 	if err != nil {
@@ -211,7 +211,7 @@ func DeleteS3Bucket(t testing.TestingT, region string, name string) {
 
 // DeleteS3BucketE destroys the S3 bucket in the given region with the given name.
 func DeleteS3BucketE(t testing.TestingT, region string, name string) error {
-	logger.Logf(t, "Deleting bucket %s in %s", region, name)
+	logger.Default.Logf(t, "Deleting bucket %s in %s", region, name)
 
 	s3Client, err := NewS3ClientE(t, region)
 	if err != nil {
@@ -233,7 +233,7 @@ func EmptyS3Bucket(t testing.TestingT, region string, name string) {
 
 // EmptyS3BucketE removes the contents of an S3 bucket in the given region with the given name.
 func EmptyS3BucketE(t testing.TestingT, region string, name string) error {
-	logger.Logf(t, "Emptying bucket %s in %s", name, region)
+	logger.Default.Logf(t, "Emptying bucket %s in %s", name, region)
 
 	s3Client, err := NewS3ClientE(t, region)
 	if err != nil {
@@ -253,7 +253,7 @@ func EmptyS3BucketE(t testing.TestingT, region string, name string) error {
 
 		//Checks if the bucket is already empty
 		if len((*bucketObjects).Versions) == 0 {
-			logger.Logf(t, "Bucket %s is already empty", name)
+			logger.Default.Logf(t, "Bucket %s is already empty", name)
 			return nil
 		}
 
@@ -291,12 +291,12 @@ func EmptyS3BucketE(t testing.TestingT, region string, name string) error {
 		if *(*bucketObjects).IsTruncated { //if there are more objects in the bucket, IsTruncated = true
 			// params.Marker = (*deleteParams).Delete.Objects[len((*deleteParams).Delete.Objects)-1].Key
 			params.KeyMarker = bucketObjects.NextKeyMarker
-			logger.Logf(t, "Requesting next batch | %s", *(params.KeyMarker))
+			logger.Default.Logf(t, "Requesting next batch | %s", *(params.KeyMarker))
 		} else { //if all objects in the bucket have been cleaned up.
 			break
 		}
 	}
-	logger.Logf(t, "Bucket %s is now empty", name)
+	logger.Default.Logf(t, "Bucket %s is now empty", name)
 	return err
 }
 

--- a/modules/aws/secretsmanager.go
+++ b/modules/aws/secretsmanager.go
@@ -17,7 +17,7 @@ func CreateSecretStringWithDefaultKey(t testing.TestingT, awsRegion, description
 
 // CreateSecretStringWithDefaultKeyE creates a new secret in Secrets Manager using the default "aws/secretsmanager" KMS key and returns the secret ARN
 func CreateSecretStringWithDefaultKeyE(t testing.TestingT, awsRegion, description, name, secretString string) (string, error) {
-	logger.Logf(t, "Creating new secret in secrets manager named %s", name)
+	logger.Default.Logf(t, "Creating new secret in secrets manager named %s", name)
 
 	client := NewSecretsManagerClient(t, awsRegion)
 
@@ -43,7 +43,7 @@ func GetSecretValue(t testing.TestingT, awsRegion, id string) string {
 
 // GetSecretValueE takes the friendly name or ARN of a secret and returns the plaintext value
 func GetSecretValueE(t testing.TestingT, awsRegion, id string) (string, error) {
-	logger.Logf(t, "Getting value of secret with ID %s", id)
+	logger.Default.Logf(t, "Getting value of secret with ID %s", id)
 
 	client := NewSecretsManagerClient(t, awsRegion)
 
@@ -65,7 +65,7 @@ func DeleteSecret(t testing.TestingT, awsRegion, id string, forceDelete bool) {
 
 // DeleteSecretE deletes a secret. If forceDelete is true, the secret will be deleted after a short delay. If forceDelete is false, the secret will be deleted after a 30 day recovery window.
 func DeleteSecretE(t testing.TestingT, awsRegion, id string, forceDelete bool) error {
-	logger.Logf(t, "Deleting secret with ID %s", id)
+	logger.Default.Logf(t, "Deleting secret with ID %s", id)
 
 	client := NewSecretsManagerClient(t, awsRegion)
 

--- a/modules/aws/sns.go
+++ b/modules/aws/sns.go
@@ -18,7 +18,7 @@ func CreateSnsTopic(t testing.TestingT, region string, snsTopicName string) stri
 
 // CreateSnsTopicE creates an SNS Topic and return the ARN.
 func CreateSnsTopicE(t testing.TestingT, region string, snsTopicName string) (string, error) {
-	logger.Logf(t, "Creating SNS topic %s in %s", snsTopicName, region)
+	logger.Default.Logf(t, "Creating SNS topic %s in %s", snsTopicName, region)
 
 	snsClient, err := NewSnsClientE(t, region)
 	if err != nil {
@@ -47,7 +47,7 @@ func DeleteSNSTopic(t testing.TestingT, region string, snsTopicArn string) {
 
 // DeleteSNSTopicE deletes an SNS Topic.
 func DeleteSNSTopicE(t testing.TestingT, region string, snsTopicArn string) error {
-	logger.Logf(t, "Deleting SNS topic %s in %s", snsTopicArn, region)
+	logger.Default.Logf(t, "Deleting SNS topic %s in %s", snsTopicArn, region)
 
 	snsClient, err := NewSnsClientE(t, region)
 	if err != nil {

--- a/modules/aws/sqs.go
+++ b/modules/aws/sqs.go
@@ -23,7 +23,7 @@ func CreateRandomQueue(t testing.TestingT, awsRegion string, prefix string) stri
 
 // CreateRandomQueueE creates a new SQS queue with a random name that starts with the given prefix and return the queue URL.
 func CreateRandomQueueE(t testing.TestingT, awsRegion string, prefix string) (string, error) {
-	logger.Logf(t, "Creating randomly named SQS queue with prefix %s", prefix)
+	logger.Default.Logf(t, "Creating randomly named SQS queue with prefix %s", prefix)
 
 	sqsClient, err := NewSqsClientE(t, awsRegion)
 	if err != nil {
@@ -59,7 +59,7 @@ func CreateRandomFifoQueue(t testing.TestingT, awsRegion string, prefix string) 
 
 // CreateRandomFifoQueueE creates a new FIFO SQS queue with a random name that starts with the given prefix and return the queue URL.
 func CreateRandomFifoQueueE(t testing.TestingT, awsRegion string, prefix string) (string, error) {
-	logger.Logf(t, "Creating randomly named FIFO SQS queue with prefix %s", prefix)
+	logger.Default.Logf(t, "Creating randomly named FIFO SQS queue with prefix %s", prefix)
 
 	sqsClient, err := NewSqsClientE(t, awsRegion)
 	if err != nil {
@@ -98,7 +98,7 @@ func DeleteQueue(t testing.TestingT, awsRegion string, queueURL string) {
 
 // DeleteQueueE deletes the SQS queue with the given URL.
 func DeleteQueueE(t testing.TestingT, awsRegion string, queueURL string) error {
-	logger.Logf(t, "Deleting SQS Queue %s", queueURL)
+	logger.Default.Logf(t, "Deleting SQS Queue %s", queueURL)
 
 	sqsClient, err := NewSqsClientE(t, awsRegion)
 	if err != nil {
@@ -122,7 +122,7 @@ func DeleteMessageFromQueue(t testing.TestingT, awsRegion string, queueURL strin
 
 // DeleteMessageFromQueueE deletes the message with the given receipt from the SQS queue with the given URL.
 func DeleteMessageFromQueueE(t testing.TestingT, awsRegion string, queueURL string, receipt string) error {
-	logger.Logf(t, "Deleting message from queue %s (%s)", queueURL, receipt)
+	logger.Default.Logf(t, "Deleting message from queue %s (%s)", queueURL, receipt)
 
 	sqsClient, err := NewSqsClientE(t, awsRegion)
 	if err != nil {
@@ -147,7 +147,7 @@ func SendMessageToQueue(t testing.TestingT, awsRegion string, queueURL string, m
 
 // SendMessageToQueueE sends the given message to the SQS queue with the given URL.
 func SendMessageToQueueE(t testing.TestingT, awsRegion string, queueURL string, message string) error {
-	logger.Logf(t, "Sending message %s to queue %s", message, queueURL)
+	logger.Default.Logf(t, "Sending message %s to queue %s", message, queueURL)
 
 	sqsClient, err := NewSqsClientE(t, awsRegion)
 	if err != nil {
@@ -161,13 +161,13 @@ func SendMessageToQueueE(t testing.TestingT, awsRegion string, queueURL string, 
 
 	if err != nil {
 		if strings.Contains(err.Error(), "AWS.SimpleQueueService.NonExistentQueue") {
-			logger.Logf(t, fmt.Sprintf("WARN: Client has stopped listening on queue %s", queueURL))
+			logger.Default.Logf(t, fmt.Sprintf("WARN: Client has stopped listening on queue %s", queueURL))
 			return nil
 		}
 		return err
 	}
 
-	logger.Logf(t, "Message id %s sent to queue %s", aws.StringValue(res.MessageId), queueURL)
+	logger.Default.Logf(t, "Message id %s sent to queue %s", aws.StringValue(res.MessageId), queueURL)
 
 	return nil
 }
@@ -182,7 +182,7 @@ func SendMessageFifoToQueue(t testing.TestingT, awsRegion string, queueURL strin
 
 // SendMessageToFifoQueueE sends the given message to the FIFO SQS queue with the given URL.
 func SendMessageToFifoQueueE(t testing.TestingT, awsRegion string, queueURL string, message string, messageGroupID string) error {
-	logger.Logf(t, "Sending message %s to queue %s", message, queueURL)
+	logger.Default.Logf(t, "Sending message %s to queue %s", message, queueURL)
 
 	sqsClient, err := NewSqsClientE(t, awsRegion)
 	if err != nil {
@@ -197,13 +197,13 @@ func SendMessageToFifoQueueE(t testing.TestingT, awsRegion string, queueURL stri
 
 	if err != nil {
 		if strings.Contains(err.Error(), "AWS.SimpleQueueService.NonExistentQueue") {
-			logger.Logf(t, fmt.Sprintf("WARN: Client has stopped listening on queue %s", queueURL))
+			logger.Default.Logf(t, fmt.Sprintf("WARN: Client has stopped listening on queue %s", queueURL))
 			return nil
 		}
 		return err
 	}
 
-	logger.Logf(t, "Message id %s sent to queue %s", aws.StringValue(res.MessageId), queueURL)
+	logger.Default.Logf(t, "Message id %s sent to queue %s", aws.StringValue(res.MessageId), queueURL)
 
 	return nil
 }
@@ -231,7 +231,7 @@ func WaitForQueueMessage(t testing.TestingT, awsRegion string, queueURL string, 
 	}
 
 	for i := 0; i < cycles; i++ {
-		logger.Logf(t, "Waiting for message on %s (%ss)", queueURL, strconv.Itoa(i*cycleLength))
+		logger.Default.Logf(t, "Waiting for message on %s (%ss)", queueURL, strconv.Itoa(i*cycleLength))
 		result, err := sqsClient.ReceiveMessage(&sqs.ReceiveMessageInput{
 			QueueUrl:              aws.String(queueURL),
 			AttributeNames:        aws.StringSlice([]string{"SentTimestamp"}),
@@ -245,7 +245,7 @@ func WaitForQueueMessage(t testing.TestingT, awsRegion string, queueURL string, 
 		}
 
 		if len(result.Messages) > 0 {
-			logger.Logf(t, "Message %s received on %s", *result.Messages[0].MessageId, queueURL)
+			logger.Default.Logf(t, "Message %s received on %s", *result.Messages[0].MessageId, queueURL)
 			return QueueMessageResponse{ReceiptHandle: *result.Messages[0].ReceiptHandle, MessageBody: *result.Messages[0].Body}
 		}
 	}

--- a/modules/aws/ssm.go
+++ b/modules/aws/ssm.go
@@ -186,7 +186,7 @@ func CheckSsmCommandWithDocument(t testing.TestingT, awsRegion, instanceID, comm
 
 // CheckSsmCommandWithDocumentE checks that you can run the given command on the given instance through AWS SSM with specified Command Doc type. Returns the result and an error if one occurs.
 func CheckSsmCommandWithDocumentE(t testing.TestingT, awsRegion, instanceID, command string, commandDocName string, timeout time.Duration) (*CommandOutput, error) {
-	logger.Logf(t, "Running command '%s' on EC2 instance with ID '%s'", command, instanceID)
+	logger.Default.Logf(t, "Running command '%s' on EC2 instance with ID '%s'", command, instanceID)
 
 	// Now that we know the instance in the SSM inventory, we can send the command
 	client, err := NewSsmClientE(t, awsRegion)

--- a/modules/dns-helper/dns_helper.go
+++ b/modules/dns-helper/dns_helper.go
@@ -65,12 +65,12 @@ func DNSFindNameserversE(t testing.TestingT, fqdn string, resolvers []string) ([
 				nameservers = append(nameservers, strings.TrimSuffix(ns, "."))
 			}
 
-			logger.Logf(t, "FQDN %s belongs to domain %s, found NS record: %s", fqdn, domain, nameservers)
+			logger.Default.Logf(t, "FQDN %s belongs to domain %s, found NS record: %s", fqdn, domain, nameservers)
 			return nameservers, nil
 		}
 
 		if err != nil {
-			logger.Logf(t, err.Error())
+			logger.Default.Logf(t, err.Error())
 		}
 	}
 
@@ -309,7 +309,7 @@ func dnsLookup(t testing.TestingT, query DNSQuery, resolver string) (DNSAnswers,
 
 	in, _, err := c.Exchange(m, resolver)
 	if err != nil {
-		logger.Logf(t, "Error sending DNS query %s: %s", query, err)
+		logger.Default.Logf(t, "Error sending DNS query %s: %s", query, err)
 		return nil, err
 	}
 

--- a/modules/gcp/compute.go
+++ b/modules/gcp/compute.go
@@ -58,7 +58,7 @@ func FetchInstance(t testing.TestingT, projectID string, name string) *Instance 
 
 // FetchInstance queries GCP to return an instance of the (GCP Compute) Instance type
 func FetchInstanceE(t testing.TestingT, projectID string, name string) (*Instance, error) {
-	logger.Logf(t, "Getting Compute Instance %s", name)
+	logger.Default.Logf(t, "Getting Compute Instance %s", name)
 
 	ctx := context.Background()
 	service, err := NewComputeServiceE(t)
@@ -96,7 +96,7 @@ func FetchImage(t testing.TestingT, projectID string, name string) *Image {
 
 // FetchImage queries GCP to return a new instance of the (GCP Compute) Image type
 func FetchImageE(t testing.TestingT, projectID string, name string) (*Image, error) {
-	logger.Logf(t, "Getting Image %s", name)
+	logger.Default.Logf(t, "Getting Image %s", name)
 
 	ctx := context.Background()
 	service, err := NewComputeServiceE(t)
@@ -125,7 +125,7 @@ func FetchRegionalInstanceGroup(t testing.TestingT, projectID string, region str
 
 // FetchRegionalInstanceGroup queries GCP to return a new instance of the Regional Instance Group type
 func FetchRegionalInstanceGroupE(t testing.TestingT, projectID string, region string, name string) (*RegionalInstanceGroup, error) {
-	logger.Logf(t, "Getting Regional Instance Group %s", name)
+	logger.Default.Logf(t, "Getting Regional Instance Group %s", name)
 
 	ctx := context.Background()
 	service, err := NewComputeServiceE(t)
@@ -154,7 +154,7 @@ func FetchZonalInstanceGroup(t testing.TestingT, projectID string, zone string, 
 
 // FetchZonalInstanceGroup queries GCP to return a new instance of the Regional Instance Group type
 func FetchZonalInstanceGroupE(t testing.TestingT, projectID string, zone string, name string) (*ZonalInstanceGroup, error) {
-	logger.Logf(t, "Getting Zonal Instance Group %s", name)
+	logger.Default.Logf(t, "Getting Zonal Instance Group %s", name)
 
 	ctx := context.Background()
 	service, err := NewComputeServiceE(t)
@@ -213,7 +213,7 @@ func (i *Instance) SetLabels(t testing.TestingT, labels map[string]string) {
 
 // SetLabelsE adds the tags to the given Compute Instance.
 func (i *Instance) SetLabelsE(t testing.TestingT, labels map[string]string) error {
-	logger.Logf(t, "Adding labels to instance %s in zone %s", i.Name, i.Zone)
+	logger.Default.Logf(t, "Adding labels to instance %s in zone %s", i.Name, i.Zone)
 
 	ctx := context.Background()
 	service, err := NewComputeServiceE(t)
@@ -244,7 +244,7 @@ func (i *Instance) SetMetadata(t testing.TestingT, metadata map[string]string) {
 
 // SetLabelsE adds the given metadata map to the existing metadata of the given Compute Instance.
 func (i *Instance) SetMetadataE(t testing.TestingT, metadata map[string]string) error {
-	logger.Logf(t, "Adding metadata to instance %s in zone %s", i.Name, i.Zone)
+	logger.Default.Logf(t, "Adding metadata to instance %s in zone %s", i.Name, i.Zone)
 
 	ctx := context.Background()
 	service, err := NewInstancesServiceE(t)
@@ -293,7 +293,7 @@ func (i *Instance) AddSshKey(t testing.TestingT, username string, publicKey stri
 
 // Add the given public SSH key to the Compute Instance. Users can SSH in with the given username.
 func (i *Instance) AddSshKeyE(t testing.TestingT, username string, publicKey string) error {
-	logger.Logf(t, "Adding SSH Key to Compute Instance %s for username %s\n", i.Name, username)
+	logger.Default.Logf(t, "Adding SSH Key to Compute Instance %s for username %s\n", i.Name, username)
 
 	// We represent the key in the format required per GCP docs (https://cloud.google.com/compute/docs/instances/adding-removing-ssh-keys)
 	publicKeyFormatted := strings.TrimSpace(publicKey)
@@ -321,7 +321,7 @@ func (i *Image) DeleteImage(t testing.TestingT) {
 
 // DeleteImageE deletes the given Compute Image.
 func (i *Image) DeleteImageE(t testing.TestingT) error {
-	logger.Logf(t, "Destroying Image %s", i.Name)
+	logger.Default.Logf(t, "Destroying Image %s", i.Name)
 
 	ctx := context.Background()
 	service, err := NewComputeServiceE(t)
@@ -347,7 +347,7 @@ func (ig *ZonalInstanceGroup) GetInstanceIds(t testing.TestingT) []string {
 
 // GetInstanceIdsE gets the IDs of Instances in the given Zonal Instance Group.
 func (ig *ZonalInstanceGroup) GetInstanceIdsE(t testing.TestingT) ([]string, error) {
-	logger.Logf(t, "Get instances for Zonal Instance Group %s", ig.Name)
+	logger.Default.Logf(t, "Get instances for Zonal Instance Group %s", ig.Name)
 
 	ctx := context.Background()
 	service, err := NewComputeServiceE(t)
@@ -392,7 +392,7 @@ func (ig *RegionalInstanceGroup) GetInstanceIds(t testing.TestingT) []string {
 
 // GetInstanceIdsE gets the IDs of Instances in the given Regional Instance Group.
 func (ig *RegionalInstanceGroup) GetInstanceIdsE(t testing.TestingT) ([]string, error) {
-	logger.Logf(t, "Get instances for Regional Instance Group %s", ig.Name)
+	logger.Default.Logf(t, "Get instances for Regional Instance Group %s", ig.Name)
 
 	ctx := context.Background()
 
@@ -603,7 +603,7 @@ func NewComputeServiceE(t testing.TestingT) (*compute.Service, error) {
 		client = rawClient
 		return "Successfully retrieved default GCP client", nil
 	})
-	logger.Logf(t, msg)
+	logger.Default.Logf(t, msg)
 
 	if retryErr != nil {
 		return nil, retryErr

--- a/modules/gcp/gcr.go
+++ b/modules/gcp/gcr.go
@@ -30,7 +30,7 @@ func DeleteGCRRepoE(t testing.TestingT, repo string) error {
 		return fmt.Errorf("Failed to get repo. Got error: %v", err)
 	}
 
-	logger.Logf(t, "Retriving Image Digests %s", gcrrepo)
+	logger.Default.Logf(t, "Retriving Image Digests %s", gcrrepo)
 	tags, err := gcrgoogle.List(gcrrepo, gcrgoogle.WithAuth(auther))
 	if err != nil {
 		return fmt.Errorf("Failed to list tags for repo %s. Got error: %v", repo, err)
@@ -38,7 +38,7 @@ func DeleteGCRRepoE(t testing.TestingT, repo string) error {
 
 	// attempt to delete the latest image tag
 	latestRef := repo + ":latest"
-	logger.Logf(t, "Deleting Image Ref %s", latestRef)
+	logger.Default.Logf(t, "Deleting Image Ref %s", latestRef)
 	if err := DeleteGCRImageRefE(t, latestRef); err != nil {
 		return fmt.Errorf("Failed to delete GCR Image Reference %s. Got error: %v", latestRef, err)
 	}
@@ -46,7 +46,7 @@ func DeleteGCRRepoE(t testing.TestingT, repo string) error {
 	// delete image references sequentially
 	for k := range tags.Manifests {
 		ref := repo + "@" + k
-		logger.Logf(t, "Deleting Image Ref %s", ref)
+		logger.Default.Logf(t, "Deleting Image Ref %s", ref)
 
 		if err := DeleteGCRImageRefE(t, ref); err != nil {
 			return fmt.Errorf("Failed to delete GCR Image Reference %s. Got error: %v", ref, err)

--- a/modules/gcp/oslogin.go
+++ b/modules/gcp/oslogin.go
@@ -24,7 +24,7 @@ func ImportSSHKey(t testing.TestingT, user, key string) {
 // The `user` parameter should be the email address of the user.
 // The `key` parameter should be the public key of the SSH key being uploaded.
 func ImportSSHKeyE(t testing.TestingT, user, key string) error {
-	logger.Logf(t, "Importing SSH key for user %s", user)
+	logger.Default.Logf(t, "Importing SSH key for user %s", user)
 
 	ctx := context.Background()
 	service, err := NewOSLoginServiceE(t)
@@ -58,7 +58,7 @@ func DeleteSSHKey(t testing.TestingT, user, key string) {
 // The `user` parameter should be the email address of the user.
 // The `key` parameter should be the public key of the SSH key that was uploaded.
 func DeleteSSHKeyE(t testing.TestingT, user, key string) error {
-	logger.Logf(t, "Deleting SSH key for user %s", user)
+	logger.Default.Logf(t, "Deleting SSH key for user %s", user)
 
 	ctx := context.Background()
 	service, err := NewOSLoginServiceE(t)
@@ -98,7 +98,7 @@ func GetLoginProfile(t testing.TestingT, user string) *oslogin.LoginProfile {
 // accounts the user will appear as. Generally, this will only be the OS Login key + account, but `gcloud compute ssh` could create temporary keys and profiles.
 // The `user` parameter should be the email address of the user.
 func GetLoginProfileE(t testing.TestingT, user string) (*oslogin.LoginProfile, error) {
-	logger.Logf(t, "Getting login profile for user %s", user)
+	logger.Default.Logf(t, "Getting login profile for user %s", user)
 
 	ctx := context.Background()
 	service, err := NewOSLoginServiceE(t)

--- a/modules/gcp/region.go
+++ b/modules/gcp/region.go
@@ -47,7 +47,7 @@ func GetRandomRegion(t testing.TestingT, projectID string, approvedRegions []str
 func GetRandomRegionE(t testing.TestingT, projectID string, approvedRegions []string, forbiddenRegions []string) (string, error) {
 	regionFromEnvVar := os.Getenv(regionOverrideEnvVarName)
 	if regionFromEnvVar != "" {
-		logger.Logf(t, "Using GCP Region %s from environment variable %s", regionFromEnvVar, regionOverrideEnvVarName)
+		logger.Default.Logf(t, "Using GCP Region %s from environment variable %s", regionFromEnvVar, regionOverrideEnvVarName)
 		return regionFromEnvVar, nil
 	}
 
@@ -64,7 +64,7 @@ func GetRandomRegionE(t testing.TestingT, projectID string, approvedRegions []st
 	regionsToPickFrom = collections.ListSubtract(regionsToPickFrom, forbiddenRegions)
 	region := random.RandomString(regionsToPickFrom)
 
-	logger.Logf(t, "Using Region %s", region)
+	logger.Default.Logf(t, "Using Region %s", region)
 	return region, nil
 }
 
@@ -85,7 +85,7 @@ func GetRandomZone(t testing.TestingT, projectID string, approvedZones []string,
 func GetRandomZoneE(t testing.TestingT, projectID string, approvedZones []string, forbiddenZones []string, forbiddenRegions []string) (string, error) {
 	zoneFromEnvVar := os.Getenv(zoneOverrideEnvVarName)
 	if zoneFromEnvVar != "" {
-		logger.Logf(t, "Using GCP Zone %s from environment variable %s", zoneFromEnvVar, zoneOverrideEnvVarName)
+		logger.Default.Logf(t, "Using GCP Zone %s from environment variable %s", zoneFromEnvVar, zoneOverrideEnvVarName)
 		return zoneFromEnvVar, nil
 	}
 
@@ -126,7 +126,7 @@ func GetRandomZoneForRegion(t testing.TestingT, projectID string, region string)
 func GetRandomZoneForRegionE(t testing.TestingT, projectID string, region string) (string, error) {
 	zoneFromEnvVar := os.Getenv(zoneOverrideEnvVarName)
 	if zoneFromEnvVar != "" {
-		logger.Logf(t, "Using GCP Zone %s from environment variable %s", zoneFromEnvVar, zoneOverrideEnvVarName)
+		logger.Default.Logf(t, "Using GCP Zone %s from environment variable %s", zoneFromEnvVar, zoneOverrideEnvVarName)
 		return zoneFromEnvVar, nil
 	}
 
@@ -145,7 +145,7 @@ func GetRandomZoneForRegionE(t testing.TestingT, projectID string, region string
 
 	zone := random.RandomString(zonesToPickFrom)
 
-	logger.Logf(t, "Using Zone %s", zone)
+	logger.Default.Logf(t, "Using Zone %s", zone)
 	return zone, nil
 }
 
@@ -160,7 +160,7 @@ func GetAllGcpRegions(t testing.TestingT, projectID string) []string {
 
 // GetAllGcpRegionsE gets the list of GCP regions available in this account.
 func GetAllGcpRegionsE(t testing.TestingT, projectID string) ([]string, error) {
-	logger.Log(t, "Looking up all GCP regions available in this account")
+	logger.Default.Logf(t, "Looking up all GCP regions available in this account")
 
 	// Note that NewComputeServiceE creates a context, but it appears to be empty so we keep the code simpler by
 	// creating a new one here

--- a/modules/gcp/storage.go
+++ b/modules/gcp/storage.go
@@ -21,7 +21,7 @@ func CreateStorageBucket(t testing.TestingT, projectID string, name string, attr
 
 // CreateStorageBucketE creates a Google Cloud bucket with the given BucketAttrs. Note that Google Storage bucket names must be globally unique.
 func CreateStorageBucketE(t testing.TestingT, projectID string, name string, attr *storage.BucketAttrs) error {
-	logger.Logf(t, "Creating bucket %s", name)
+	logger.Default.Logf(t, "Creating bucket %s", name)
 
 	ctx := context.Background()
 
@@ -48,7 +48,7 @@ func DeleteStorageBucket(t testing.TestingT, name string) {
 
 // DeleteStorageBucketE destroys the S3 bucket in the given region with the given name.
 func DeleteStorageBucketE(t testing.TestingT, name string) error {
-	logger.Logf(t, "Deleting bucket %s", name)
+	logger.Default.Logf(t, "Deleting bucket %s", name)
 
 	ctx := context.Background()
 
@@ -71,7 +71,7 @@ func ReadBucketObject(t testing.TestingT, bucketName string, filePath string) io
 
 // ReadBucketObjectE reads an object from the given Storage Bucket and returns its contents.
 func ReadBucketObjectE(t testing.TestingT, bucketName string, filePath string) (io.Reader, error) {
-	logger.Logf(t, "Reading object from bucket %s using path %s", bucketName, filePath)
+	logger.Default.Logf(t, "Reading object from bucket %s using path %s", bucketName, filePath)
 
 	ctx := context.Background()
 
@@ -105,7 +105,7 @@ func WriteBucketObjectE(t testing.TestingT, bucketName string, filePath string, 
 		contentType = "application/octet-stream"
 	}
 
-	logger.Logf(t, "Writing object to bucket %s using path %s and content type %s", bucketName, filePath, contentType)
+	logger.Default.Logf(t, "Writing object to bucket %s using path %s and content type %s", bucketName, filePath, contentType)
 
 	ctx := context.Background()
 
@@ -143,7 +143,7 @@ func EmptyStorageBucket(t testing.TestingT, name string) {
 
 // EmptyStorageBucketE removes the contents of a storage bucket with the given name.
 func EmptyStorageBucketE(t testing.TestingT, name string) error {
-	logger.Logf(t, "Emptying storage bucket %s", name)
+	logger.Default.Logf(t, "Emptying storage bucket %s", name)
 
 	ctx := context.Background()
 
@@ -170,7 +170,7 @@ func EmptyStorageBucketE(t testing.TestingT, name string) error {
 		}
 
 		// purge the object
-		logger.Logf(t, "Deleting storage bucket object %s", objectAttrs.Name)
+		logger.Default.Logf(t, "Deleting storage bucket object %s", objectAttrs.Name)
 		bucket.Object(objectAttrs.Name).Delete(ctx)
 	}
 
@@ -187,7 +187,7 @@ func AssertStorageBucketExists(t testing.TestingT, name string) {
 
 // AssertStorageBucketExistsE checks if the given storage bucket exists and returns an error if it does not.
 func AssertStorageBucketExistsE(t testing.TestingT, name string) error {
-	logger.Logf(t, "Finding bucket %s", name)
+	logger.Default.Logf(t, "Finding bucket %s", name)
 
 	ctx := context.Background()
 

--- a/modules/http-helper/continuous.go
+++ b/modules/http-helper/continuous.go
@@ -33,7 +33,7 @@ func ContinuouslyCheckUrl(
 		for {
 			select {
 			case <-stopChecking:
-				logger.Logf(t, "Got signal to stop downtime checks for URL %s.\n", url)
+				logger.Default.Logf(t, "Got signal to stop downtime checks for URL %s.\n", url)
 				return
 			case <-time.After(sleepBetweenChecks):
 				statusCode, body, err := HttpGetE(t, url, &tls.Config{})
@@ -42,9 +42,9 @@ func ContinuouslyCheckUrl(
 				case responses <- GetResponse{StatusCode: statusCode, Body: body}:
 					// do nothing since all we want to do is send the response
 				default:
-					logger.Logf(t, "WARNING: ContinuouslyCheckUrl responses channel buffer is full")
+					logger.Default.Logf(t, "WARNING: ContinuouslyCheckUrl responses channel buffer is full")
 				}
-				logger.Logf(t, "Got response %d and err %v from URL at %s", statusCode, err, url)
+				logger.Default.Logf(t, "Got response %d and err %v from URL at %s", statusCode, err, url)
 				if err != nil {
 					// We use Errorf instead of Fatalf here because Fatalf is not goroutine safe, while Errorf is. Refer
 					// to the docs on `T`: https://godoc.org/testing#T

--- a/modules/http-helper/dummy_server.go
+++ b/modules/http-helper/dummy_server.go
@@ -34,7 +34,7 @@ func RunDummyServerE(t testing.TestingT, text string) (net.Listener, int, error)
 		fmt.Fprintf(w, text)
 	})
 
-	logger.Logf(t, "Starting dummy HTTP server in port %d that will return the text '%s'", port, text)
+	logger.Default.Logf(t, "Starting dummy HTTP server in port %d that will return the text '%s'", port, text)
 
 	listener, err := net.Listen("tcp", ":"+strconv.Itoa(port))
 	if err != nil {
@@ -67,7 +67,7 @@ func RunDummyServerWithHandlersE(t testing.TestingT, handlers map[string]func(ht
 		http.HandleFunc(path, handler)
 	}
 
-	logger.Logf(t, "Starting dummy HTTP server in port %d", port)
+	logger.Default.Logf(t, "Starting dummy HTTP server in port %d", port)
 
 	listener, err := net.Listen("tcp", ":"+strconv.Itoa(port))
 	if err != nil {

--- a/modules/http-helper/http_helper.go
+++ b/modules/http-helper/http_helper.go
@@ -55,7 +55,7 @@ func HttpGetE(t testing.TestingT, url string, tlsConfig *tls.Config) (int, strin
 // HttpGetWithOptionsE performs an HTTP GET, with an optional pointer to a custom TLS configuration, on the given URL and
 // return the HTTP status code, body, and any error.
 func HttpGetWithOptionsE(t testing.TestingT, options HttpGetOptions) (int, string, error) {
-	logger.Logf(t, "Making an HTTP GET call to URL %s", options.Url)
+	logger.Default.Logf(t, "Making an HTTP GET call to URL %s", options.Url)
 
 	// Set HTTP client transport config
 	tr := http.DefaultTransport.(*http.Transport).Clone()
@@ -260,7 +260,7 @@ func HTTPDoE(
 func HTTPDoWithOptionsE(
 	t testing.TestingT, options HttpDoOptions,
 ) (int, string, error) {
-	logger.Logf(t, "Making an HTTP %s call to URL %s", options.Method, options.Url)
+	logger.Default.Logf(t, "Making an HTTP %s call to URL %s", options.Method, options.Url)
 
 	tr := &http.Transport{
 		TLSClientConfig: options.TlsConfig,
@@ -367,7 +367,7 @@ func HTTPDoWithRetryWithOptionsE(
 			if err != nil {
 				return "", err
 			}
-			logger.Logf(t, "output: %v", out)
+			logger.Default.Logf(t, "output: %v", out)
 			if statusCode != expectedStatus {
 				return "", ValidationFunctionFailed{Url: options.Url, Status: statusCode}
 			}

--- a/modules/k8s/client.go
+++ b/modules/k8s/client.go
@@ -8,7 +8,6 @@ import (
 	// See: https://github.com/kubernetes/client-go/issues/242
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 
-	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/testing"
 )
 
@@ -33,25 +32,25 @@ func GetKubernetesClientFromOptionsE(t testing.TestingT, options *KubectlOptions
 		if err != nil {
 			return nil, err
 		}
-		logger.Log(t, "Configuring Kubernetes client to use the in-cluster serviceaccount token")
+		options.Logger.Logf(t, "Configuring Kubernetes client to use the in-cluster serviceaccount token")
 	} else if options.RestConfig != nil {
 		config = options.RestConfig
-		logger.Log(t, "Configuring Kubernetes client to use provided rest config object set with API server address: %s", config.Host)
+		options.Logger.Logf(t, "Configuring Kubernetes client to use provided rest config object set with API server address: %s", config.Host)
 	} else {
 		kubeConfigPath, err := options.GetConfigPath(t)
 		if err != nil {
 			return nil, err
 		}
-		logger.Logf(t, "Configuring Kubernetes client using config file %s with context %s", kubeConfigPath, options.ContextName)
+		options.Logger.Logf(t, "Configuring Kubernetes client using config file %s with context %s", kubeConfigPath, options.ContextName)
 		// Load API config (instead of more low level ClientConfig)
 		config, err = LoadApiClientConfigE(kubeConfigPath, options.ContextName)
 		if err != nil {
-			logger.Logf(t, "Error loading api client config, falling back to in-cluster authentication via serviceaccount token: %s", err)
+			options.Logger.Logf(t, "Error loading api client config, falling back to in-cluster authentication via serviceaccount token: %s", err)
 			config, err = rest.InClusterConfig()
 			if err != nil {
 				return nil, err
 			}
-			logger.Log(t, "Configuring Kubernetes client to use the in-cluster serviceaccount token")
+			options.Logger.Logf(t, "Configuring Kubernetes client to use the in-cluster serviceaccount token")
 		}
 	}
 

--- a/modules/k8s/config.go
+++ b/modules/k8s/config.go
@@ -55,7 +55,7 @@ func DeleteConfigContextE(t testing.TestingT, contextName string) error {
 // DeleteConfigContextWithPathE will remove the context specified at the provided name, and remove any clusters and
 // authinfos that are orphaned as a result of it.
 func DeleteConfigContextWithPathE(t testing.TestingT, kubeConfigPath string, contextName string) error {
-	logger.Logf(t, "Removing kubectl config context %s from config at path %s", contextName, kubeConfigPath)
+	logger.Default.Logf(t, "Removing kubectl config context %s from config at path %s", contextName, kubeConfigPath)
 
 	// Load config and get data structure representing config info
 	config := LoadConfigFromPath(kubeConfigPath)
@@ -67,7 +67,7 @@ func DeleteConfigContextWithPathE(t testing.TestingT, kubeConfigPath string, con
 	// Check if the context we want to delete actually exists, and if so, delete it.
 	_, ok := rawConfig.Contexts[contextName]
 	if !ok {
-		logger.Logf(t, "WARNING: Could not find context %s from config at path %s", contextName, kubeConfigPath)
+		logger.Default.Logf(t, "WARNING: Could not find context %s from config at path %s", contextName, kubeConfigPath)
 		return nil
 	}
 	delete(rawConfig.Contexts, contextName)
@@ -85,7 +85,7 @@ func DeleteConfigContextWithPathE(t testing.TestingT, kubeConfigPath string, con
 		return err
 	}
 
-	logger.Logf(
+	logger.Default.Logf(
 		t,
 		"Removed context %s from config at path %s and any orphaned clusters and authinfos",
 		contextName,

--- a/modules/k8s/configmap.go
+++ b/modules/k8s/configmap.go
@@ -8,7 +8,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/retry"
 	"github.com/gruntwork-io/terratest/modules/testing"
 	"github.com/stretchr/testify/require"
@@ -50,5 +49,5 @@ func WaitUntilConfigMapAvailable(t testing.TestingT, options *KubectlOptions, co
 			return "configmap is now available", nil
 		},
 	)
-	logger.Logf(t, message)
+	options.Logger.Logf(t, message)
 }

--- a/modules/k8s/deployment.go
+++ b/modules/k8s/deployment.go
@@ -10,7 +10,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/retry"
 	"github.com/gruntwork-io/terratest/modules/testing"
 )
@@ -89,10 +88,10 @@ func WaitUntilDeploymentAvailableE(
 		},
 	)
 	if err != nil {
-		logger.Logf(t, "Timedout waiting for Deployment to be provisioned: %s", err)
+		options.Logger.Logf(t, "Timedout waiting for Deployment to be provisioned: %s", err)
 		return err
 	}
-	logger.Logf(t, message)
+	options.Logger.Logf(t, message)
 	return nil
 }
 

--- a/modules/k8s/ingress.go
+++ b/modules/k8s/ingress.go
@@ -10,7 +10,6 @@ import (
 	networkingv1beta1 "k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/retry"
 	"github.com/gruntwork-io/terratest/modules/testing"
 )
@@ -80,7 +79,7 @@ func WaitUntilIngressAvailable(t testing.TestingT, options *KubectlOptions, ingr
 			return "Ingress is now available", nil
 		},
 	)
-	logger.Logf(t, message)
+	options.Logger.Logf(t, message)
 }
 
 // ListIngressesV1Beta1 will look for Ingress resources in the given namespace that match the given filters and return
@@ -152,5 +151,5 @@ func WaitUntilIngressAvailableV1Beta1(t testing.TestingT, options *KubectlOption
 			return "Ingress is now available", nil
 		},
 	)
-	logger.Logf(t, message)
+	options.Logger.Logf(t, message)
 }

--- a/modules/k8s/job.go
+++ b/modules/k8s/job.go
@@ -10,7 +10,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/retry"
 	"github.com/gruntwork-io/terratest/modules/testing"
 )
@@ -81,10 +80,10 @@ func WaitUntilJobSucceedE(t testing.TestingT, options *KubectlOptions, jobName s
 		},
 	)
 	if err != nil {
-		logger.Logf(t, "Timed out waiting for Job to be provisioned: %s", err)
+		options.Logger.Logf(t, "Timed out waiting for Job to be provisioned: %s", err)
 		return err
 	}
-	logger.Logf(t, message)
+	options.Logger.Logf(t, message)
 	return nil
 }
 

--- a/modules/k8s/networkpolicy.go
+++ b/modules/k8s/networkpolicy.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/retry"
 	"github.com/gruntwork-io/terratest/modules/testing"
 	"github.com/stretchr/testify/require"
@@ -49,5 +48,5 @@ func WaitUntilNetworkPolicyAvailable(t testing.TestingT, options *KubectlOptions
 			return "networkpolicy is now available", nil
 		},
 	)
-	logger.Logf(t, message)
+	options.Logger.Logf(t, message)
 }

--- a/modules/k8s/node.go
+++ b/modules/k8s/node.go
@@ -9,7 +9,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/retry"
 	"github.com/gruntwork-io/terratest/modules/testing"
 )
@@ -30,7 +29,7 @@ func GetNodesE(t testing.TestingT, options *KubectlOptions) ([]corev1.Node, erro
 // GetNodesByFilterE queries Kubernetes for information about the worker nodes registered to the cluster, filtering the
 // list of nodes using the provided ListOptions.
 func GetNodesByFilterE(t testing.TestingT, options *KubectlOptions, filter metav1.ListOptions) ([]corev1.Node, error) {
-	logger.Logf(t, "Getting list of nodes from Kubernetes")
+	options.Logger.Logf(t, "Getting list of nodes from Kubernetes")
 
 	clientset, err := GetKubernetesClientFromOptionsE(t, options)
 	if err != nil {
@@ -59,7 +58,7 @@ func GetReadyNodesE(t testing.TestingT, options *KubectlOptions) ([]corev1.Node,
 	if err != nil {
 		return nil, err
 	}
-	logger.Logf(t, "Filtering list of nodes from Kubernetes for Ready nodes")
+	options.Logger.Logf(t, "Filtering list of nodes from Kubernetes for Ready nodes")
 	nodesFiltered := []corev1.Node{}
 	for _, node := range nodes {
 		if IsNodeReady(node) {
@@ -102,7 +101,7 @@ func WaitUntilAllNodesReadyE(t testing.TestingT, options *KubectlOptions, retrie
 			return "All nodes ready", nil
 		},
 	)
-	logger.Logf(t, message)
+	options.Logger.Logf(t, message)
 	return err
 }
 

--- a/modules/k8s/persistent_volume.go
+++ b/modules/k8s/persistent_volume.go
@@ -10,7 +10,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/retry"
 	"github.com/gruntwork-io/terratest/modules/testing"
 )
@@ -90,10 +89,10 @@ func WaitUntilPersistentVolumeInStatusE(
 		},
 	)
 	if err != nil {
-		logger.Logf(t, "Timeout waiting for PersistentVolume to be '%s': %s", *pvStatusPhase, err)
+		options.Logger.Logf(t, "Timeout waiting for PersistentVolume to be '%s': %s", *pvStatusPhase, err)
 		return err
 	}
-	logger.Logf(t, message)
+	options.Logger.Logf(t, message)
 	return nil
 }
 

--- a/modules/k8s/pod.go
+++ b/modules/k8s/pod.go
@@ -9,7 +9,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/retry"
 	"github.com/gruntwork-io/terratest/modules/testing"
 )
@@ -95,10 +94,10 @@ func WaitUntilNumPodsCreatedE(
 		},
 	)
 	if err != nil {
-		logger.Logf(t, "Timedout waiting for the desired number of Pods to be created: %s", err)
+		options.Logger.Logf(t, "Timedout waiting for the desired number of Pods to be created: %s", err)
 		return err
 	}
-	logger.Logf(t, message)
+	options.Logger.Logf(t, message)
 	return nil
 }
 
@@ -129,10 +128,10 @@ func WaitUntilPodAvailableE(t testing.TestingT, options *KubectlOptions, podName
 		},
 	)
 	if err != nil {
-		logger.Logf(t, "Timedout waiting for Pod to be provisioned: %s", err)
+		options.Logger.Logf(t, "Timedout waiting for Pod to be provisioned: %s", err)
 		return err
 	}
-	logger.Logf(t, message)
+	options.Logger.Logf(t, message)
 	return nil
 }
 

--- a/modules/k8s/secret.go
+++ b/modules/k8s/secret.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/retry"
 	"github.com/gruntwork-io/terratest/modules/testing"
 	"github.com/stretchr/testify/require"
@@ -49,5 +48,5 @@ func WaitUntilSecretAvailable(t testing.TestingT, options *KubectlOptions, secre
 			return "Secret is now available", nil
 		},
 	)
-	logger.Logf(t, message)
+	options.Logger.Logf(t, message)
 }

--- a/modules/k8s/self_subject_access_review.go
+++ b/modules/k8s/self_subject_access_review.go
@@ -8,7 +8,6 @@ import (
 	authv1 "k8s.io/api/authorization/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/testing"
 )
 
@@ -35,7 +34,7 @@ func CanIDoE(t testing.TestingT, options *KubectlOptions, action authv1.Resource
 		return false, errors.WithStackTrace(err)
 	}
 	if !resp.Status.Allowed {
-		logger.Logf(t, "Denied action %s on resource %s with name '%s' for reason %s", action.Verb, action.Resource, action.Name, resp.Status.Reason)
+		options.Logger.Logf(t, "Denied action %s on resource %s with name '%s' for reason %s", action.Verb, action.Resource, action.Name, resp.Status.Reason)
 	}
 	return resp.Status.Allowed, nil
 }

--- a/modules/k8s/service.go
+++ b/modules/k8s/service.go
@@ -12,7 +12,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/gruntwork-io/terratest/modules/aws"
-	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/gruntwork-io/terratest/modules/retry"
 	"github.com/gruntwork-io/terratest/modules/testing"
@@ -83,7 +82,7 @@ func WaitUntilServiceAvailable(t testing.TestingT, options *KubectlOptions, serv
 			return "Service is now available", nil
 		},
 	)
-	logger.Logf(t, message)
+	options.Logger.Logf(t, message)
 }
 
 // IsServiceAvailable returns true if the service endpoint is ready to accept traffic. Note that for Minikube, this

--- a/modules/k8s/service_account.go
+++ b/modules/k8s/service_account.go
@@ -12,7 +12,6 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/clientcmd/api"
 
-	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/retry"
 	"github.com/gruntwork-io/terratest/modules/testing"
 )
@@ -77,11 +76,11 @@ func GetServiceAccountAuthTokenE(t testing.TestingT, kubectlOptions *KubectlOpti
 		30,
 		10*time.Second,
 		func() (string, error) {
-			logger.Logf(t, "Checking if service account has secret")
+			kubectlOptions.Logger.Logf(t, "Checking if service account has secret")
 			serviceAccount := GetServiceAccount(t, kubectlOptions, serviceAccountName)
 			if len(serviceAccount.Secrets) == 0 {
 				msg := "No secrets on the service account yet"
-				logger.Logf(t, msg)
+				kubectlOptions.Logger.Logf(t, msg)
 				return "", fmt.Errorf(msg)
 			}
 			return "Service Account has secret", nil
@@ -90,7 +89,7 @@ func GetServiceAccountAuthTokenE(t testing.TestingT, kubectlOptions *KubectlOpti
 	if err != nil {
 		return "", err
 	}
-	logger.Logf(t, msg)
+	kubectlOptions.Logger.Logf(t, msg)
 
 	// Then get the service account token
 	serviceAccount, err := GetServiceAccountE(t, kubectlOptions, serviceAccountName)

--- a/modules/oci/compute.go
+++ b/modules/oci/compute.go
@@ -21,7 +21,7 @@ func DeleteImage(t testing.TestingT, ocid string) {
 
 // DeleteImageE deletes a custom image with given OCID.
 func DeleteImageE(t testing.TestingT, ocid string) error {
-	logger.Logf(t, "Deleting image with OCID %s", ocid)
+	logger.Default.Logf(t, "Deleting image with OCID %s", ocid)
 
 	configProvider := common.DefaultConfigProvider()
 	client, err := core.NewComputeClientWithConfigurationProvider(configProvider)

--- a/modules/oci/identity.go
+++ b/modules/oci/identity.go
@@ -27,7 +27,7 @@ func GetRandomAvailabilityDomain(t testing.TestingT, compartmentID string) strin
 func GetRandomAvailabilityDomainE(t testing.TestingT, compartmentID string) (string, error) {
 	adFromEnvVar := os.Getenv(availabilityDomainEnvVar)
 	if adFromEnvVar != "" {
-		logger.Logf(t, "Using availability domain %s from environment variable %s", adFromEnvVar, availabilityDomainEnvVar)
+		logger.Default.Logf(t, "Using availability domain %s from environment variable %s", adFromEnvVar, availabilityDomainEnvVar)
 		return adFromEnvVar, nil
 	}
 
@@ -38,7 +38,7 @@ func GetRandomAvailabilityDomainE(t testing.TestingT, compartmentID string) (str
 
 	ad := random.RandomString(allADs)
 
-	logger.Logf(t, "Using availability domain %s", ad)
+	logger.Default.Logf(t, "Using availability domain %s", ad)
 	return ad, nil
 }
 

--- a/modules/oci/network.go
+++ b/modules/oci/network.go
@@ -51,7 +51,7 @@ func GetRandomSubnetIDE(t testing.TestingT, compartmentID string, availabilityDo
 
 	subnetID := random.RandomString(allSubnetIDs[availabilityDomain])
 
-	logger.Logf(t, "Using subnet with OCID %s", subnetID)
+	logger.Default.Logf(t, "Using subnet with OCID %s", subnetID)
 	return subnetID, nil
 }
 

--- a/modules/opa/download_policy.go
+++ b/modules/opa/download_policy.go
@@ -52,7 +52,7 @@ func DownloadPolicyE(t testing.TestingT, rulePath string) (string, error) {
 	baseDir, subDir := getter.SourceDirSubdir(rulePath)
 	downloadPath, hasDownloaded := policyDirCache.Load(baseDir)
 	if hasDownloaded {
-		logger.Logf(t, "Previously downloaded %s: returning cached path", baseDir)
+		logger.Default.Logf(t, "Previously downloaded %s: returning cached path", baseDir)
 		return filepath.Join(downloadPath.(string), subDir), nil
 	}
 
@@ -65,7 +65,7 @@ func DownloadPolicyE(t testing.TestingT, rulePath string) (string, error) {
 	// tempDir to make sure we feed a directory that doesn't exist yet.
 	tempDir = filepath.Join(tempDir, "getter")
 
-	logger.Logf(t, "Downloading %s to temp dir %s", rulePath, tempDir)
+	logger.Default.Logf(t, "Downloading %s to temp dir %s", rulePath, tempDir)
 	if err := getter.GetAny(tempDir, baseDir); err != nil {
 		return "", err
 	}

--- a/modules/retry/retry.go
+++ b/modules/retry/retry.go
@@ -88,7 +88,7 @@ func DoWithRetryInterfaceE(t testing.TestingT, actionDescription string, maxRetr
 	var err error
 
 	for i := 0; i <= maxRetries; i++ {
-		logger.Log(t, actionDescription)
+		logger.Default.Logf(t, "%s", actionDescription)
 
 		output, err = action()
 		if err == nil {
@@ -96,11 +96,11 @@ func DoWithRetryInterfaceE(t testing.TestingT, actionDescription string, maxRetr
 		}
 
 		if _, isFatalErr := err.(FatalError); isFatalErr {
-			logger.Logf(t, "Returning due to fatal error: %v", err)
+			logger.Default.Logf(t, "Returning due to fatal error: %v", err)
 			return output, err
 		}
 
-		logger.Logf(t, "%s returned an error: %s. Sleeping for %s and will try again.", actionDescription, err.Error(), sleepBetweenRetries)
+		logger.Default.Logf(t, "%s returned an error: %s. Sleeping for %s and will try again.", actionDescription, err.Error(), sleepBetweenRetries)
 		time.Sleep(sleepBetweenRetries)
 	}
 
@@ -141,7 +141,7 @@ func DoWithRetryableErrorsE(t testing.TestingT, actionDescription string, retrya
 
 		for errorRegexp, errorMessage := range retryableErrorsRegexp {
 			if errorRegexp.MatchString(output) || errorRegexp.MatchString(err.Error()) {
-				logger.Logf(t, "'%s' failed with the error '%s' but this error was expected and warrants a retry. Further details: %s\n", actionDescription, err.Error(), errorMessage)
+				logger.Default.Logf(t, "'%s' failed with the error '%s' but this error was expected and warrants a retry. Further details: %s\n", actionDescription, err.Error(), errorMessage)
 				return output, err
 			}
 		}
@@ -167,17 +167,17 @@ func DoInBackgroundUntilStopped(t testing.TestingT, actionDescription string, sl
 
 	go func() {
 		for {
-			logger.Logf(t, "Executing action '%s'", actionDescription)
+			logger.Default.Logf(t, "Executing action '%s'", actionDescription)
 
 			action()
 
-			logger.Logf(t, "Sleeping for %s before repeating action '%s'", sleepBetweenRepeats, actionDescription)
+			logger.Default.Logf(t, "Sleeping for %s before repeating action '%s'", sleepBetweenRepeats, actionDescription)
 
 			select {
 			case <-time.After(sleepBetweenRepeats):
 				// Nothing to do, just allow the loop to continue
 			case <-stop:
-				logger.Logf(t, "Received stop signal for action '%s'.", actionDescription)
+				logger.Default.Logf(t, "Received stop signal for action '%s'.", actionDescription)
 				return
 			}
 		}

--- a/modules/ssh/agent.go
+++ b/modules/ssh/agent.go
@@ -57,7 +57,7 @@ func (s *SshAgent) run(t testing.TestingT) {
 					return
 					// When s.ln.Accept() returns a legit error, we print it and continue accepting further requests
 				default:
-					logger.Logf(t, "could not accept connection to agent %v", err)
+					logger.Default.Logf(t, "could not accept connection to agent %v", err)
 					continue
 				}
 			} else {
@@ -65,7 +65,7 @@ func (s *SshAgent) run(t testing.TestingT) {
 				go func(c io.ReadWriter) {
 					err := agent.ServeAgent(s.agent, c)
 					if err != nil {
-						logger.Logf(t, "could not serve ssh agent %v", err)
+						logger.Default.Logf(t, "could not serve ssh agent %v", err)
 					}
 				}(c)
 			}
@@ -111,7 +111,7 @@ func SshAgentWithKeyPairs(t testing.TestingT, keyPairs []*KeyPair) *SshAgent {
 // Instantiates and returns an in-memory ssh agent with the given KeyPair(s) already added
 // You should stop the agent to cleanup files afterwards by calling `defer sshAgent.Stop()`
 func SshAgentWithKeyPairsE(t testing.TestingT, keyPairs []*KeyPair) (*SshAgent, error) {
-	logger.Logf(t, "Generating SSH Agent with given KeyPair(s)")
+	logger.Default.Logf(t, "Generating SSH Agent with given KeyPair(s)")
 
 	// Instantiate a temporary SSH agent
 	socketDir, err := os.MkdirTemp("", "ssh-agent-")

--- a/modules/ssh/key_pair.go
+++ b/modules/ssh/key_pair.go
@@ -28,7 +28,7 @@ func GenerateRSAKeyPair(t testing.TestingT, keySize int) *KeyPair {
 
 // GenerateRSAKeyPairE generates an RSA Keypair and return the public and private keys.
 func GenerateRSAKeyPairE(t testing.TestingT, keySize int) (*KeyPair, error) {
-	logger.Logf(t, "Generating new public/private key of size %d", keySize)
+	logger.Default.Logf(t, "Generating new public/private key of size %d", keySize)
 
 	rsaKeyPair, err := rsa.GenerateKey(rand.Reader, keySize)
 	if err != nil {

--- a/modules/ssh/session.go
+++ b/modules/ssh/session.go
@@ -83,7 +83,7 @@ func Close(t testing.TestingT, closeable Closeable, ignoreErrors ...string) {
 	}
 
 	if err := closeable.Close(); err != nil && !collections.ListContains(ignoreErrors, err.Error()) {
-		logger.Logf(t, "Error closing %s: %s", closeable, err.Error())
+		logger.Default.Logf(t, "Error closing %s: %s", closeable, err.Error())
 	}
 }
 

--- a/modules/ssh/ssh.go
+++ b/modules/ssh/ssh.go
@@ -177,7 +177,7 @@ func ScpDirFromE(t testing.TestingT, options ScpDownloadOptions, useSudo bool) e
 			return err
 		}
 
-		logger.Logf(t, "Copying remote file: %s to local path %s", fullRemoteFilePath, localFilePath)
+		logger.Default.Logf(t, "Copying remote file: %s to local path %s", fullRemoteFilePath, localFilePath)
 
 		err = copyFileFromRemote(t, sshSession, localFile, fullRemoteFilePath, useSudo)
 		errorsOccurred = multierror.Append(errorsOccurred, err)
@@ -389,7 +389,7 @@ func FetchContentsOfFileE(t testing.TestingT, host Host, useSudo bool, filePath 
 }
 
 func listFileInRemoteDir(t testing.TestingT, sshSession *SshSession, options ScpDownloadOptions, useSudo bool) ([]string, error) {
-	logger.Logf(t, "Running command %s on %s@%s", sshSession.Options.Command, sshSession.Options.Username, sshSession.Options.Address)
+	logger.Default.Logf(t, "Running command %s on %s@%s", sshSession.Options.Command, sshSession.Options.Username, sshSession.Options.Address)
 
 	var result []string
 	var findCommandArgs []string
@@ -454,7 +454,7 @@ func copyFileFromRemote(t testing.TestingT, sshSession *SshSession, file *os.Fil
 		command = fmt.Sprintf("sudo %s", command)
 	}
 
-	logger.Logf(t, "Running command %s on %s@%s", command, sshSession.Options.Username, sshSession.Options.Address)
+	logger.Default.Logf(t, "Running command %s on %s@%s", command, sshSession.Options.Username, sshSession.Options.Address)
 
 	r, err := sshSession.Session.Output(command)
 	if err != nil {
@@ -468,7 +468,7 @@ func copyFileFromRemote(t testing.TestingT, sshSession *SshSession, file *os.Fil
 }
 
 func runSSHCommand(t testing.TestingT, sshSession *SshSession) (string, error) {
-	logger.Logf(t, "Running command %s on %s@%s", sshSession.Options.Command, sshSession.Options.Username, sshSession.Options.Address)
+	logger.Default.Logf(t, "Running command %s on %s@%s", sshSession.Options.Command, sshSession.Options.Username, sshSession.Options.Address)
 	if err := setUpSSHClient(sshSession); err != nil {
 		return "", err
 	}

--- a/modules/test-structure/save_test_data.go
+++ b/modules/test-structure/save_test_data.go
@@ -193,13 +193,13 @@ func FormatTestDataPath(testFolder string, filename string) string {
 // any contents that exist in the file found at `path` will be overwritten. This has the potential for causing duplicated resources
 // and should be used with caution. If `overwrite` is `false`, the save will be skipped and a warning will be logged.
 func SaveTestData(t testing.TestingT, path string, overwrite bool, value interface{}) {
-	logger.Logf(t, "Storing test data in %s so it can be reused later", path)
+	logger.Default.Logf(t, "Storing test data in %s so it can be reused later", path)
 
 	if IsTestDataPresent(t, path) {
 		if overwrite {
-			logger.Logf(t, "[WARNING] The named test data at path %s is non-empty. Save operation will overwrite existing value with \"%v\".\n.", path, value)
+			logger.Default.Logf(t, "[WARNING] The named test data at path %s is non-empty. Save operation will overwrite existing value with \"%v\".\n.", path, value)
 		} else {
-			logger.Logf(t, "[WARNING] The named test data at path %s is non-empty. Skipping save operation to prevent overwriting existing value with \"%v\".\n.", path, value)
+			logger.Default.Logf(t, "[WARNING] The named test data at path %s is non-empty. Skipping save operation to prevent overwriting existing value with \"%v\".\n.", path, value)
 			return
 		}
 	}
@@ -209,7 +209,7 @@ func SaveTestData(t testing.TestingT, path string, overwrite bool, value interfa
 		t.Fatalf("Failed to convert value %s to JSON: %v", path, err)
 	}
 
-	logger.Logf(t, "Marshalled JSON: %s", string(bytes))
+	logger.Default.Logf(t, "Marshalled JSON: %s", string(bytes))
 
 	parentDir := filepath.Dir(path)
 	if err := os.MkdirAll(parentDir, 0777); err != nil {
@@ -225,7 +225,7 @@ func SaveTestData(t testing.TestingT, path string, overwrite bool, value interfa
 // value will be deserialized. This allows you to reuse some sort of test data (e.g., TerraformOptions) from earlier
 // setup steps in later validation and teardown steps.
 func LoadTestData(t testing.TestingT, path string, value interface{}) {
-	logger.Logf(t, "Loading test data from %s", path)
+	logger.Default.Logf(t, "Loading test data from %s", path)
 
 	bytes, err := os.ReadFile(path)
 	if err != nil {
@@ -308,12 +308,12 @@ func isEmptyJSON(t testing.TestingT, bytes []byte) bool {
 // CleanupTestData cleans up the test data at the given path.
 func CleanupTestData(t testing.TestingT, path string) {
 	if files.FileExists(path) {
-		logger.Logf(t, "Cleaning up test data from %s", path)
+		logger.Default.Logf(t, "Cleaning up test data from %s", path)
 		if err := os.Remove(path); err != nil {
 			t.Fatalf("Failed to clean up file at %s: %v", path, err)
 		}
 	} else {
-		logger.Logf(t, "%s does not exist. Nothing to cleanup.", path)
+		logger.Default.Logf(t, "%s does not exist. Nothing to cleanup.", path)
 	}
 }
 
@@ -329,16 +329,16 @@ func CleanupTestDataFolderE(t testing.TestingT, path string) error {
 	path = filepath.Join(path, ".test-data")
 	exists, err := files.FileExistsE(path)
 	if err != nil {
-		logger.Logf(t, "Failed to clean up test data folder at %s: %v", path, err)
+		logger.Default.Logf(t, "Failed to clean up test data folder at %s: %v", path, err)
 		return err
 	}
 
 	if !exists {
-		logger.Logf(t, "%s does not exist. Nothing to cleanup.", path)
+		logger.Default.Logf(t, "%s does not exist. Nothing to cleanup.", path)
 		return nil
 	}
 	if err := os.RemoveAll(path); err != nil {
-		logger.Logf(t, "Failed to clean up test data folder at %s: %v", path, err)
+		logger.Default.Logf(t, "Failed to clean up test data folder at %s: %v", path, err)
 		return err
 	}
 

--- a/modules/test-structure/test_structure.go
+++ b/modules/test-structure/test_structure.go
@@ -26,10 +26,10 @@ const SKIP_STAGE_ENV_VAR_PREFIX = "SKIP_"
 func RunTestStage(t testing.TestingT, stageName string, stage func()) {
 	envVarName := fmt.Sprintf("%s%s", SKIP_STAGE_ENV_VAR_PREFIX, stageName)
 	if os.Getenv(envVarName) == "" {
-		logger.Logf(t, "The '%s' environment variable is not set, so executing stage '%s'.", envVarName, stageName)
+		logger.Default.Logf(t, "The '%s' environment variable is not set, so executing stage '%s'.", envVarName, stageName)
 		stage()
 	} else {
-		logger.Logf(t, "The '%s' environment variable is set, so skipping stage '%s'.", envVarName, stageName)
+		logger.Default.Logf(t, "The '%s' environment variable is set, so skipping stage '%s'.", envVarName, stageName)
 	}
 }
 
@@ -109,7 +109,7 @@ func CopyTerraformFolderToTemp(t testing.TestingT, rootFolder string, terraformM
 // case, we do NOT copy anything to a temp folder, and return the path to the original terraform module folder instead.
 func CopyTerraformFolderToDest(t testing.TestingT, rootFolder string, terraformModuleFolder string, destRootFolder string) string {
 	if SkipStageEnvVarSet() {
-		logger.Logf(t, "A SKIP_XXX environment variable is set. Using original examples folder rather than a temp folder so we can cache data between stages for faster local testing.")
+		logger.Default.Logf(t, "A SKIP_XXX environment variable is set. Using original examples folder rather than a temp folder so we can cache data between stages for faster local testing.")
 		return filepath.Join(rootFolder, terraformModuleFolder)
 	}
 
@@ -129,7 +129,7 @@ func CopyTerraformFolderToDest(t testing.TestingT, rootFolder string, terraformM
 	tmpTestFolder := filepath.Join(tmpRootFolder, terraformModuleFolder)
 
 	// Log temp folder so we can see it
-	logger.Logf(t, "Copied terraform folder %s to %s", fullTerraformModuleFolder, tmpTestFolder)
+	logger.Default.Logf(t, "Copied terraform folder %s to %s", fullTerraformModuleFolder, tmpTestFolder)
 
 	return tmpTestFolder
 }


### PR DESCRIPTION
## Description

Fixes #1448.

<!-- Description of the changes introduced by this PR. -->

Replaces the deprecated `logger.Logf` and `logger.Log` for the new Logger.

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Removed the use of the deprecated logger.Logf and logger.Log and use the new Logger instead.

### Migration Guide

Not required.