### PR TITLE
feat: add docker login function

### DIFF
--- a/modules/docker/login.go
+++ b/modules/docker/login.go
@@ -16,12 +16,13 @@ type LoginOptions struct {
 // Login runs the 'docker login' command to login the given registry. This will fail the test if there are any errors.
 // Do not use production password, only for testing purpose.
 func Login(t testing.TestingT, opt LoginOptions) {
-	require.NoError(t, login(t, opt))
+	require.NoError(t, LoginE(t, opt))
 }
 
 // login runs the 'docker login' command to login the given registry.
-func login(t testing.TestingT, opt LoginOptions) error {
+func LoginE(t testing.TestingT, opt LoginOptions) error {
 	logger.Logf(t, "Running 'docker login' for user %s", opt.Login)
+
 	cmd := shell.Command{
 		Command: "docker",
 		Args:    []string{"login", opt.Registry, "-u", opt.Login, "-p", opt.Password},

--- a/modules/docker/login.go
+++ b/modules/docker/login.go
@@ -19,7 +19,7 @@ func Login(t testing.TestingT, opt LoginOptions) {
 	require.NoError(t, LoginE(t, opt))
 }
 
-// login runs the 'docker login' command to login the given registry.
+// LoginE runs the 'docker login' command to login the given registry.
 func LoginE(t testing.TestingT, opt LoginOptions) error {
 	logger.Logf(t, "Running 'docker login' for user %s", opt.Login)
 

--- a/modules/docker/login.go
+++ b/modules/docker/login.go
@@ -1,0 +1,30 @@
+package docker
+
+import (
+	"github.com/gruntwork-io/terratest/modules/logger"
+	"github.com/gruntwork-io/terratest/modules/shell"
+	"github.com/gruntwork-io/terratest/modules/testing"
+	"github.com/stretchr/testify/require"
+)
+
+type LoginOptions struct {
+	Registry string
+	Login    string
+	Password string
+}
+
+// Login runs the 'docker login' command to login the given registry. This will fail the test if there are any errors.
+// Do not use production password, only for testing purpose.
+func Login(t testing.TestingT, opt LoginOptions) {
+	require.NoError(t, login(t, opt))
+}
+
+// login runs the 'docker login' command to login the given registry.
+func login(t testing.TestingT, opt LoginOptions) error {
+	logger.Logf(t, "Running 'docker login' for user %s", opt.Login)
+	cmd := shell.Command{
+		Command: "docker",
+		Args:    []string{"login", opt.Registry, "-u", opt.Login, "-p", opt.Password},
+	}
+	return shell.RunCommandE(t, cmd)
+}

--- a/modules/docker/login_test.go
+++ b/modules/docker/login_test.go
@@ -1,0 +1,14 @@
+package docker
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_Login(t *testing.T) {
+
+	err := LoginE(t, LoginOptions{Registry: "registry-1.docker.io", Login: "1", Password: "1"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "incorrect username or password")
+}


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description
Hello folks!
Just added docker login for testing to push images to a private registry.
Only for testing purpose because use --password options.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [X] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added docker login

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->
