### PR TITLE
feat: Add put method into AWS Secrets Manager helper interface.

### DIFF
--- a/modules/aws/secretsmanager.go
+++ b/modules/aws/secretsmanager.go
@@ -57,6 +57,26 @@ func GetSecretValueE(t testing.TestingT, awsRegion, id string) (string, error) {
 	return aws.StringValue(secret.SecretString), nil
 }
 
+// UpdateSecretString updates a secret in Secrets Manager to a new string value
+func PutSecretString(t testing.TestingT, awsRegion, id string, secretString string) {
+	err := PutSecretStringE(t, awsRegion, id, secretString)
+	require.NoError(t, err)
+}
+
+// UpdateSecretStringE updates a secret in Secrets Manager to a new string value
+func PutSecretStringE(t testing.TestingT, awsRegion, id string, secretString string) error {
+	logger.Default.Logf(t, "Updating secret with ID %s", id)
+
+	client := NewSecretsManagerClient(t, awsRegion)
+
+	_, err := client.PutSecretValue(&secretsmanager.PutSecretValueInput{
+		SecretId:     aws.String(id),
+		SecretString: aws.String(secretString),
+	})
+
+	return err
+}
+
 // DeleteSecret deletes a secret. If forceDelete is true, the secret will be deleted after a short delay. If forceDelete is false, the secret will be deleted after a 30 day recovery window.
 func DeleteSecret(t testing.TestingT, awsRegion, id string, forceDelete bool) {
 	err := DeleteSecretE(t, awsRegion, id, forceDelete)

--- a/modules/aws/secretsmanager_test.go
+++ b/modules/aws/secretsmanager_test.go
@@ -14,13 +14,19 @@ func TestSecretsManagerMethods(t *testing.T) {
 	region := GetRandomStableRegion(t, nil, nil)
 	name := random.UniqueId()
 	description := "This is just a secrets manager test description."
-	secretValue := "This is the secret value."
+	secretOriginalValue := "This is the secret value."
+	secretUpdatedValue := "This is the NEW secret value."
 
-	secretARN := CreateSecretStringWithDefaultKey(t, region, description, name, secretValue)
+	secretARN := CreateSecretStringWithDefaultKey(t, region, description, name, secretOriginalValue)
 	defer deleteSecret(t, region, secretARN)
 
 	storedValue := GetSecretValue(t, region, secretARN)
-	assert.Equal(t, secretValue, storedValue)
+	assert.Equal(t, secretOriginalValue, storedValue)
+
+	PutSecretString(t, region, secretARN, secretUpdatedValue)
+
+	storedValueAfterUpdate := GetSecretValue(t, region, secretARN)
+	assert.Equal(t, secretUpdatedValue, storedValueAfterUpdate)
 }
 
 func deleteSecret(t *testing.T, region, id string) {


### PR DESCRIPTION
## Description

Adds missing method to the AWS Secrets Manager helpers defined in #578 .

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs. (None present for existing methods in file, the method names explain themselves well)
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Added Put method for AWS Secrets Manager helper [X].
