### PR TITLE
Make `Log` and `Logf` threadsafe

### DIFF
--- a/modules/logger/logger.go
+++ b/modules/logger/logger.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"runtime"
 	"strings"
+	"sync"
 	gotesting "testing"
 	"time"
 
@@ -125,6 +126,8 @@ func Logf(t testing.TestingT, format string, args ...interface{}) {
 		tt.Helper()
 	}
 
+	mutexStdout.Lock()
+	defer mutexStdout.Unlock()
 	DoLog(t, 2, os.Stdout, fmt.Sprintf(format, args...))
 }
 
@@ -136,8 +139,12 @@ func Log(t testing.TestingT, args ...interface{}) {
 		tt.Helper()
 	}
 
+	mutexStdout.Lock()
+	defer mutexStdout.Unlock()
 	DoLog(t, 2, os.Stdout, args...)
 }
+
+var mutexStdout sync.Mutex
 
 // DoLog logs the given arguments to the given writer, along with a timestamp and information about what test and file is
 // doing the logging.


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes https://github.com/gruntwork-io/terratest/issues/1457.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->
