### PR TITLE
add platform parameter to docker run command. fix #1310

### DIFF
--- a/examples/packer-hello-world-example/build.pkr.hcl
+++ b/examples/packer-hello-world-example/build.pkr.hcl
@@ -9,8 +9,10 @@ packer {
 
 source "docker" "ubuntu-docker" {
   changes = ["ENTRYPOINT [\"\"]"]
-  commit  = true
-  image   = "gruntwork/ubuntu-test:16.04"
+
+  commit   = true
+  image    = "gruntwork/ubuntu-test:16.04"
+  platform = "linux/amd64"
 }
 
 build {
@@ -22,6 +24,6 @@ build {
 
   post-processor "docker-tag" {
     repository = "gruntwork/packer-hello-world-example"
-    tag        = ["latest"]
+    tag = ["latest"]
   }
 }

--- a/modules/docker/run.go
+++ b/modules/docker/run.go
@@ -28,6 +28,9 @@ type RunOptions struct {
 	// Assign a name to the container
 	Name string
 
+	// Set platform
+	Platform string
+
 	// If set to true, pass the --privileged flag to 'docker run' to give extended privileges to the container
 	Privileged bool
 
@@ -127,6 +130,10 @@ func formatDockerRunArgs(image string, options *RunOptions) ([]string, error) {
 
 	if options.Name != "" {
 		args = append(args, "--name", options.Name)
+	}
+
+	if options.Platform != "" {
+		args = append(args, "--platform", options.Platform)
 	}
 
 	if options.Privileged {

--- a/test/packer_hello_world_example_test.go
+++ b/test/packer_hello_world_example_test.go
@@ -18,7 +18,11 @@ func TestPackerHelloWorldExample(t *testing.T) {
 	packer.BuildArtifact(t, packerOptions)
 
 	// website::tag::3:: Run the Docker image, read the text file from it, and make sure it contains the expected output.
-	opts := &docker.RunOptions{Command: []string{"cat", "/test.txt"}}
+	opts := &docker.RunOptions{
+		Command:  []string{"cat", "/test.txt"},
+		Platform: "linux/amd64",
+	}
+
 	output := docker.Run(t, "gruntwork/packer-hello-world-example", opts)
 	assert.Equal(t, "Hello, World!", output)
 }


### PR DESCRIPTION
## Description

Fixes #1310 add platform parameter to docker run command

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Added `platform` parameter to *docker run* command

### Migration Guide

n/a
