### PR TITLE
feat: Renaming `master` to `main` wherever it's referenced

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Terratest
 
 [![Maintained by Gruntwork.io](https://img.shields.io/badge/maintained%20by-gruntwork.io-%235849a6.svg)](https://gruntwork.io/?ref=repo_terratest)
-[![CircleCI](https://dl.circleci.com/status-badge/img/gh/gruntwork-io/terratest/tree/master.svg?style=svg&circle-token=8abd167739d60e4c1b6c1502d2092339a6c6a133)](https://dl.circleci.com/status-badge/redirect/gh/gruntwork-io/terratest/tree/master)
+[![CircleCI](https://dl.circleci.com/status-badge/img/gh/gruntwork-io/terratest/tree/main.svg?style=svg&circle-token=8abd167739d60e4c1b6c1502d2092339a6c6a133)](https://dl.circleci.com/status-badge/redirect/gh/gruntwork-io/terratest/tree/main)
 [![Go Report Card](https://goreportcard.com/badge/github.com/gruntwork-io/terratest)](https://goreportcard.com/report/github.com/gruntwork-io/terratest)
 [![go.dev reference](https://img.shields.io/badge/go.dev-reference-007d9c?logo=go&logoColor=white&style=flat-square)](https://pkg.go.dev/mod/github.com/gruntwork-io/terratest?tab=overview)
 ![go.mod version](https://img.shields.io/github/go-mod/go-version/gruntwork-io/terratest)

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 This is the code for the [Terratest website](https://terratest.gruntwork.io).
 
-Terratest website is built with Jekyll and published on Github Pages from `docs` folder on `master` branch.
+Terratest website is built with Jekyll and published on Github Pages from `docs` folder on `main` branch.
 
 # Quick Start
 
@@ -43,7 +43,7 @@ Clone or fork Terratest [repository](https://github.com/gruntwork-io/terratest).
 
 # Deployment
 
-GitHub Pages automatically rebuilds the website from the `/docs` folder whenever you commit and push changes to the `master`
+GitHub Pages automatically rebuilds the website from the `/docs` folder whenever you commit and push changes to the `main`
 branch.
 
 # Working with the documentation

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -33,7 +33,7 @@ repository: "github.com/gruntwork-io/terratest"
 twitter_username: https://twitter.com/gruntwork_io
 github_username:  https://github.com/gruntwork-io
 
-github_api_url: https://raw.githubusercontent.com/gruntwork-io/terratest/master
+github_api_url: https://raw.githubusercontent.com/gruntwork-io/terratest/main
 
 # Build settings
 # theme: minima

--- a/docs/_data/examples.yml
+++ b/docs/_data/examples.yml
@@ -9,7 +9,7 @@
       default: true
   learn_more:
     - name: Terraform Hello, World
-      url: https://github.com/gruntwork-io/terratest/tree/master/examples/terraform-hello-world-example
+      url: https://github.com/gruntwork-io/terratest/tree/main/examples/terraform-hello-world-example
 
 - id: packer-hello-world
   name: Packer Hello, World Example
@@ -22,7 +22,7 @@
       default: true
   learn_more:
     - name: Packer Hello, World
-      url: https://github.com/gruntwork-io/terratest/tree/master/examples/packer-hello-world-example
+      url: https://github.com/gruntwork-io/terratest/tree/main/examples/packer-hello-world-example
 
 - id: docker-hello-world
   name: Docker Hello, World Example
@@ -36,7 +36,7 @@
       default: true
   learn_more:
     - name: Docker Hello, World
-      url: https://github.com/gruntwork-io/terratest/tree/master/examples/docker-hello-world-example
+      url: https://github.com/gruntwork-io/terratest/tree/main/examples/docker-hello-world-example
 
 - id: kubernetes-hello-world
   name: Kubernetes Hello, World Example
@@ -49,7 +49,7 @@
       default: true
   learn_more:
     - name: Kubernetes Hello, World
-      url: https://github.com/gruntwork-io/terratest/tree/master/examples/kubernetes-hello-world-example
+      url: https://github.com/gruntwork-io/terratest/tree/main/examples/kubernetes-hello-world-example
 
 - id: terragrunt-hello-world
   name: Terragrunt Example
@@ -64,7 +64,7 @@
       default: true
   learn_more:
     - name: Terragrunt
-      url: https://github.com/gruntwork-io/terratest/tree/master/examples/terragrunt-example
+      url: https://github.com/gruntwork-io/terratest/tree/main/examples/terragrunt-example
 
 - id: aws-hello-world
   name: AWS Hello, World Example
@@ -77,7 +77,7 @@
       default: true
   learn_more:
     - name: AWS Hello, World
-      url: https://github.com/gruntwork-io/terratest/tree/master/examples/terraform-aws-hello-world-example
+      url: https://github.com/gruntwork-io/terratest/tree/main/examples/terraform-aws-hello-world-example
 
 - id: gcp-hello-world
   name: GCP Hello, World Example
@@ -90,7 +90,7 @@
       default: true
   learn_more:
     - name: GCP Hello, World
-      url: https://github.com/gruntwork-io/terratest/tree/master/examples/terraform-gcp-hello-world-example
+      url: https://github.com/gruntwork-io/terratest/tree/main/examples/terraform-gcp-hello-world-example
 
 - id: azure-basic
   name: Azure Hello, World Example
@@ -107,7 +107,7 @@
       default: true
   learn_more:
     - name: Terraform Azure Example
-      url: https://github.com/gruntwork-io/terratest/tree/master/examples/azure/terraform-azure-example
+      url: https://github.com/gruntwork-io/terratest/tree/main/examples/azure/terraform-azure-example
 
 - id: opa-terraform
   name: OPA Terraform Example
@@ -124,7 +124,7 @@
       default: true
   learn_more:
     - name: Terraform OPA Example
-      url: https://github.com/gruntwork-io/terratest/tree/master/examples/terraform-opa-example
+      url: https://github.com/gruntwork-io/terratest/tree/main/examples/terraform-opa-example
 
 - id: client-factory
   name: Azure Client Factory

--- a/docs/_docs/01_getting-started/packages-overview.md
+++ b/docs/_docs/01_getting-started/packages-overview.md
@@ -11,7 +11,7 @@ nav_title_link: /docs/
 ---
 
 Now that you've had a chance to browse the examples and their tests, here's an overview of the packages you'll find in
-Terratest's [modules folder](https://github.com/gruntwork-io/terratest/tree/master/modules) and how they can help you test different types infrastructure:
+Terratest's [modules folder](https://github.com/gruntwork-io/terratest/tree/main/modules) and how they can help you test different types infrastructure:
 
 {:.doc-styled-table}
 | Package            | Description                                                                                                                                                                                                                                                                                          |
@@ -27,7 +27,7 @@ Terratest's [modules folder](https://github.com/gruntwork-io/terratest/tree/mast
 | **http-helper**    | Functions for making HTTP requests. Examples: make an HTTP request to a URL and check the status code and body contain the expected values, run a simple HTTP server locally.                                                                                                                        |
 | **k8s**            | Functions that make it easier to work with Kubernetes. Examples: Getting the list of nodes in a cluster, waiting until all nodes in a cluster is ready.                                                                                                                                              |
 | **logger**         | A replacement for Go's `t.Log` and `t.Logf` that writes the logs to `stdout` immediately, rather than buffering them until the very end of the test. This makes debugging and iterating easier.                                                                                                      |
-| **logger/parser**  | Includes functions for parsing out interleaved go test output and piecing out the individual test logs. Used by the [terratest_log_parser](https://github.com/gruntwork-io/terratest/tree/master/cmd/terratest_log_parser) command.                                                                                                                       |
+| **logger/parser**  | Includes functions for parsing out interleaved go test output and piecing out the individual test logs. Used by the [terratest_log_parser](https://github.com/gruntwork-io/terratest/tree/main/cmd/terratest_log_parser) command.                                                                                                                       |
 | **oci**            | Functions that make it easier to work with OCI. Examples: Getting the most recent image of a compartment + OS pair, deleting a custom image, retrieving a random subnet.                                                                                                                             |
 | **packer**         | Functions for working with Packer. Examples: run a Packer build and return the ID of the artifact that was created.                                                                                                                                                                                  |
 | **random**         | Functions for generating random data. Examples: generate a unique ID that can be used to namespace resources so multiple tests running in parallel don't clash.                                                                                                                                      |

--- a/docs/_docs/01_getting-started/quick-start.md
+++ b/docs/_docs/01_getting-started/quick-start.md
@@ -26,9 +26,9 @@ types of infrastructure code you can test (e.g., Packer, Kubernetes, etc).
 
 1. Create an `examples` and `test` folder.
 
-1. Copy the folder including all the files from the [basic terraform example](https://github.com/gruntwork-io/terratest/tree/master/examples/terraform-basic-example/) into the `examples` folder.
+1. Copy the folder including all the files from the [basic terraform example](https://github.com/gruntwork-io/terratest/tree/main/examples/terraform-basic-example/) into the `examples` folder.
 
-1. Copy the [basic terraform example test](https://github.com/gruntwork-io/terratest/blob/master/test/terraform_basic_example_test.go) into the `test` folder.
+1. Copy the [basic terraform example test](https://github.com/gruntwork-io/terratest/blob/main/test/terraform_basic_example_test.go) into the `test` folder.
 
 1. To configure dependencies, run:
 

--- a/docs/_docs/02_testing-best-practices/debugging-interleaved-test-output.md
+++ b/docs/_docs/02_testing-best-practices/debugging-interleaved-test-output.md
@@ -36,7 +36,7 @@ This will:
 - Create a `report.xml` file containing a Junit XML file of the test summary (so it can be integrated in your CI).
 
 The output can be integrated in your CI engine to further enhance the debugging experience. See Terratest's own
-[circleci configuration](https://github.com/gruntwork-io/terratest/blob/master/.circleci/config.yml) for an example of how to integrate the utility with CircleCI. This
+[circleci configuration](https://github.com/gruntwork-io/terratest/blob/main/.circleci/config.yml) for an example of how to integrate the utility with CircleCI. This
 provides for each build:
 
 - A test summary view showing you which tests failed:

--- a/docs/_docs/02_testing-best-practices/iterating-locally-using-docker.md
+++ b/docs/_docs/02_testing-best-practices/iterating-locally-using-docker.md
@@ -19,13 +19,13 @@ Here are some techniques we use with Docker:
 
 - If your script is used in a Packer template, add a [Docker
   builder](https://www.packer.io/docs/builders/docker.html) to the template so you can create a Docker image from the
-  same code. See the [Packer Docker Example](https://github.com/gruntwork-io/terratest/tree/master/examples/packer-docker-example) for working sample code.
+  same code. See the [Packer Docker Example](https://github.com/gruntwork-io/terratest/tree/main/examples/packer-docker-example) for working sample code.
 
 - We have prebuilt Docker images for major Linux distros that have many important dependencies (e.g., curl, vim,
-  tar, sudo) already installed. See the [test-docker-images folder](https://github.com/gruntwork-io/terratest/tree/master/test-docker-images) for more details.
+  tar, sudo) already installed. See the [test-docker-images folder](https://github.com/gruntwork-io/terratest/tree/main/test-docker-images) for more details.
 
 - Create a `docker-compose.yml` to make it easier to run your Docker image with all the ports, environment variables,
-  and other settings it needs. See the [Packer Docker Example](https://github.com/gruntwork-io/terratest/tree/master/examples/packer-docker-example) for working sample code.
+  and other settings it needs. See the [Packer Docker Example](https://github.com/gruntwork-io/terratest/tree/main/examples/packer-docker-example) for working sample code.
 
 - With scripts in Docker, you can replace _some_ real-world dependencies with mocks! One way to do this is to create
   some "mock scripts" and to bind-mount them in `docker-compose.yml` in a way that replaces the real dependency. For

--- a/docs/_docs/02_testing-best-practices/iterating-locally-using-test-stages.md
+++ b/docs/_docs/02_testing-best-practices/iterating-locally-using-test-stages.md
@@ -23,5 +23,5 @@ each time you change a single line of code can be very slow.
 
 This is where Terratest's `test_structure` package comes in handy: it allows you to explicitly break up your tests into
 stages and to be able to disable any one of those stages simply by setting an environment variable. Check out the
-[terraform_packer_example_test.go](https://github.com/gruntwork-io/terratest/blob/master/test/terraform_packer_example_test.go) 
+[terraform_packer_example_test.go](https://github.com/gruntwork-io/terratest/blob/main/test/terraform_packer_example_test.go) 
 for working sample code.

--- a/docs/_docs/04_community/contributing.md
+++ b/docs/_docs/04_community/contributing.md
@@ -112,7 +112,7 @@ Development](http://tom.preston-werner.com/2010/08/23/readme-driven-development.
 stays up to date and allows you to think through the problem at a high level before you get lost in the weeds of
 coding.
 
-The documentation is built with Jekyll and hosted on the Github Pages from `docs` folder on `master` branch. Check out [Terratest website](https://github.com/gruntwork-io/terratest/tree/master/docs#working-with-the-documentation) to learn more about working with the documentation.
+The documentation is built with Jekyll and hosted on the Github Pages from `docs` folder on `main` branch. Check out [Terratest website](https://github.com/gruntwork-io/terratest/tree/main/docs#working-with-the-documentation) to learn more about working with the documentation.
 
 ### Update the tests
 

--- a/docs/_docs/04_community/license.md
+++ b/docs/_docs/04_community/license.md
@@ -12,4 +12,4 @@ nav_title_link: /docs/
 
 ## License
 
-This code is released under the Apache 2.0 License. See [LICENSE](https://github.com/gruntwork-io/terratest/blob/master/LICENSE){:target="_blank"} and [NOTICE](https://github.com/gruntwork-io/terratest/blob/master/NOTICE){:target="_blank"} for more details.
+This code is released under the Apache 2.0 License. See [LICENSE](https://github.com/gruntwork-io/terratest/blob/main/LICENSE){:target="_blank"} and [NOTICE](https://github.com/gruntwork-io/terratest/blob/main/NOTICE){:target="_blank"} for more details.

--- a/docs/_includes/examples/example.html
+++ b/docs/_includes/examples/example.html
@@ -58,7 +58,7 @@
         {% unless include.skip_view_on_github %}
           <div class="example__file-link">
             <p>View on GitHub:</p>
-            <a href="https://{{ site.repository }}/tree/master{{ file.url }}">{{ site.repository }}{{ file.url }}</a>
+            <a href="https://{{ site.repository }}/tree/main{{ file.url }}">{{ site.repository }}{{ file.url }}</a>
           </div>
         {% endunless %}
       </div>

--- a/docs/_includes/examples/explorer.html
+++ b/docs/_includes/examples/explorer.html
@@ -26,7 +26,7 @@
     {% if include.example_id == nil %}
       <div class="hidden-navs__static-links">
         <a
-          href="https://github.com/gruntwork-io/terratest/tree/master/examples"
+          href="https://github.com/gruntwork-io/terratest/tree/main/examples"
           class="examples__nav-item static-link nav-{{ example.id }}"
           target="_blank"
           >

--- a/examples/azure/README.md
+++ b/examples/azure/README.md
@@ -17,7 +17,7 @@ These modules are currently using the latest version of Go and was tested with *
 
 ## Azure-sdk-for-go version
 
-Let's make sure [go.mod](https://github.com/gruntwork-io/terratest/blob/master/go.mod) includes the appropriate [azure-sdk-for-go version](https://github.com/Azure/azure-sdk-for-go/releases/tag/v46.1.0):
+Let's make sure [go.mod](https://github.com/gruntwork-io/terratest/blob/main/go.mod) includes the appropriate [azure-sdk-for-go version](https://github.com/Azure/azure-sdk-for-go/releases/tag/v46.1.0):
 
 ```go
 require (

--- a/examples/azure/terraform-azure-example/README.md
+++ b/examples/azure/terraform-azure-example/README.md
@@ -41,13 +41,13 @@ it should be free, but you are completely responsible for all Azure charges.
 
 ## Check Go Dependencies
 
-Check that the `github.com/Azure/azure-sdk-for-go` version in your generated `go.mod` for this test matches the version in the terratest [go.mod](https://github.com/gruntwork-io/terratest/blob/master/go.mod) file.
+Check that the `github.com/Azure/azure-sdk-for-go` version in your generated `go.mod` for this test matches the version in the terratest [go.mod](https://github.com/gruntwork-io/terratest/blob/main/go.mod) file.
 
 > This was tested with **go1.14.1**.
 
 ### Check Azure-sdk-for-go version
 
-Let's make sure [go.mod](https://github.com/gruntwork-io/terratest/blob/master/go.mod) includes the appropriate [azure-sdk-for-go version](https://github.com/Azure/azure-sdk-for-go/releases/tag/v38.1.0):
+Let's make sure [go.mod](https://github.com/gruntwork-io/terratest/blob/main/go.mod) includes the appropriate [azure-sdk-for-go version](https://github.com/Azure/azure-sdk-for-go/releases/tag/v38.1.0):
 
 ```go
 require (

--- a/modules/docker/build_test.go
+++ b/modules/docker/build_test.go
@@ -95,8 +95,8 @@ func TestGitCloneAndBuild(t *testing.T) {
 	}
 	gitBranchName := git.GetCurrentBranchName(t)
 	if gitBranchName == "" {
-		logger.Logf(t, "WARNING: git.GetCurrentBranchName returned an empty string; falling back to master")
-		gitBranchName = "master"
+		logger.Logf(t, "WARNING: git.GetCurrentBranchName returned an empty string; falling back to main")
+		gitBranchName = "main"
 	}
 	GitCloneAndBuild(t, "git@github.com:gruntwork-io/terratest.git", gitBranchName, "test/fixtures/docker", buildOpts)
 

--- a/modules/git/git_test.go
+++ b/modules/git/git_test.go
@@ -11,12 +11,12 @@ import (
 )
 
 func testGetCurrentBranchNameReturnsBranchName(t *testing.T) {
-	err := exec.Command("git", "checkout", "master").Run()
+	err := exec.Command("git", "checkout", "main").Run()
 	require.NoError(t, err)
 
 	name := GetCurrentBranchName(t)
 
-	assert.Equal(t, "master", name)
+	assert.Equal(t, "main", name)
 }
 
 func testGetCurrentBranchNameReturnsEmptyForDetachedState(t *testing.T) {
@@ -29,12 +29,12 @@ func testGetCurrentBranchNameReturnsEmptyForDetachedState(t *testing.T) {
 }
 
 func testGetCurrentRefReturnsBranchName(t *testing.T) {
-	err := exec.Command("git", "checkout", "master").Run()
+	err := exec.Command("git", "checkout", "main").Run()
 	require.NoError(t, err)
 
 	name := GetCurrentGitRef(t)
 
-	assert.Equal(t, "master", name)
+	assert.Equal(t, "main", name)
 }
 
 func testGetCurrentRefReturnsTagValue(t *testing.T) {

--- a/modules/opa/download_policy.go
+++ b/modules/opa/download_policy.go
@@ -22,11 +22,11 @@ var (
 // across calls.
 // For example, if you call DownloadPolicyE with the go-getter URL multiple times:
 //
-//	git::https://github.com/gruntwork-io/terratest.git//policies/foo.rego?ref=master
+//	git::https://github.com/gruntwork-io/terratest.git//policies/foo.rego?ref=main
 //
 // The first time the gruntwork-io/terratest repo will be downloaded to a new temp directory. All subsequent calls will
 // reuse that first temporary dir where the repo was cloned. This is preserved even if a different subdir is requested
-// later, e.g.: git::https://github.com/gruntwork-io/terratest.git//examples/bar.rego?ref=master.
+// later, e.g.: git::https://github.com/gruntwork-io/terratest.git//examples/bar.rego?ref=main
 // Note that the query parameters are always included in the base URL. This means that if you use a different ref (e.g.,
 // git::https://github.com/gruntwork-io/terratest.git//examples/bar.rego?ref=v0.39.3), then that will be cloned to a new
 // temporary directory rather than the cached dir.

--- a/modules/opa/download_policy_test.go
+++ b/modules/opa/download_policy_test.go
@@ -63,9 +63,9 @@ func TestDownloadPolicyDownloadsRemote(t *testing.T) {
 func TestDownloadPolicyReusesCachedDir(t *testing.T) {
 	t.Parallel()
 
-	baseDir := "git::https://github.com/gruntwork-io/terratest.git?ref=master"
-	remotePath := "git::https://github.com/gruntwork-io/terratest.git//examples/terraform-opa-example/policy/enforce_source.rego?ref=master"
-	remotePathAltSubPath := "git::https://github.com/gruntwork-io/terratest.git//modules/opa/eval.go?ref=master"
+	baseDir := "git::https://github.com/gruntwork-io/terratest.git?ref=main"
+	remotePath := "git::https://github.com/gruntwork-io/terratest.git//examples/terraform-opa-example/policy/enforce_source.rego?ref=main"
+	remotePathAltSubPath := "git::https://github.com/gruntwork-io/terratest.git//modules/opa/eval.go?ref=main"
 
 	// Make sure we clean up the downloaded file, while simultaneously asserting that the download dir was stored in the
 	// cache.

--- a/test/terraform_opa_example_test.go
+++ b/test/terraform_opa_example_test.go
@@ -58,7 +58,7 @@ func TestOPAEvalTerraformModuleRemotePolicy(t *testing.T) {
 		TerraformDir: "../examples/terraform-opa-example/pass",
 	}
 	opaOpts := &opa.EvalOptions{
-		RulePath: "git::https://github.com/gruntwork-io/terratest.git//examples/terraform-opa-example/policy/enforce_source.rego?ref=master",
+		RulePath: "git::https://github.com/gruntwork-io/terratest.git//examples/terraform-opa-example/policy/enforce_source.rego?ref=main",
 		FailMode: opa.FailUndefined,
 	}
 	terraform.OPAEval(t, tfOpts, opaOpts, "data.enforce_source.allow")


### PR DESCRIPTION
## Description

Fixes #1473.

Right before merging this, we'll need to explicitly perform the rename of the default branch from `master` to `main` in the GitHub repository settings.

This will ensure that all PRs get moved over to the new branch name, etc.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Updated default branch from `master` to `main`.

### Migration Guide

If you have a locally cloned copy of Terratest, make sure to delete the `master` branch and check out the `main` branch.
