### PR TITLE
fix #1478 we should copy the TF module into a temporary directory before running tests in parallel

### DIFF
--- a/test/terraform_aws_rds_example_test.go
+++ b/test/terraform_aws_rds_example_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/gruntwork-io/terratest/modules/aws"
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/gruntwork-io/terratest/modules/terraform"
+	test_structure "github.com/gruntwork-io/terratest/modules/test-structure"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -75,12 +76,13 @@ func TestTerraformAwsRdsExample(t *testing.T) {
 			awsRegion := aws.GetRandomStableRegion(t, nil, nil)
 			engineVersion := aws.GetValidEngineVersion(t, awsRegion, tt.engineName, tt.majorEngineVersion)
 			instanceType := aws.GetRecommendedRdsInstanceType(t, awsRegion, tt.engineName, engineVersion, []string{"db.t2.micro", "db.t3.micro", "db.t3.small"})
+			moduleFolder := test_structure.CopyTerraformFolderToTemp(t, "../", "examples/terraform-aws-rds-example")
 
 			// Construct the terraform options with default retryable errors to handle the most common retryable errors in
 			// terraform testing.
 			terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
 				// The path to where our Terraform code is located
-				TerraformDir: "../examples/terraform-aws-rds-example",
+				TerraformDir: moduleFolder,
 
 				// Variables to pass to our Terraform code using -var options
 				// "username" and "password" should not be passed from here in a production scenario.


### PR DESCRIPTION
## Description

fix #1478 we should copy the TF module into a temporary directory before running tests in parallel

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

update AWS RDS tests to execute in a tmp dir fix #1478 


### Migration Guide

n/a