### PR TITLE
add function to retrieve latest version of a policy document

### DIFF
--- a/modules/aws/iam_test.go
+++ b/modules/aws/iam_test.go
@@ -1,9 +1,15 @@
 package aws
 
 import (
+	"context"
+	"strings"
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetIamCurrentUserName(t *testing.T) {
@@ -18,4 +24,50 @@ func TestGetIamCurrentUserArn(t *testing.T) {
 
 	username := GetIamCurrentUserArn(t)
 	assert.Regexp(t, "^arn:aws:iam::[0-9]{12}:user/.+$", username)
+}
+
+func TestGetIAMPolicyDocument(t *testing.T) {
+	t.Parallel()
+
+	region := GetRandomRegion(t, nil, nil)
+
+	t.Run("Exists", func(t *testing.T) {
+		iamClient, err := NewIamClientE(t, region)
+		require.NoError(t, err)
+
+		policyDocument := `{
+			"Version": "2012-10-17",
+			"Statement": [
+				{
+					"Sid": "Stmt1530709892083",
+					"Action": "*",
+					"Effect": "Allow",
+					"Resource": "*"
+				}
+			]
+		}`
+		input := &iam.CreatePolicyInput{
+			PolicyName:     aws.String(strings.ToLower(random.UniqueId())),
+			PolicyDocument: aws.String(policyDocument),
+		}
+		policy, err := iamClient.CreatePolicy(context.Background(), input)
+		require.NoError(t, err)
+
+		t.Cleanup(func() {
+			t.Log("Deleting IAM Policy Document")
+			_, err := iamClient.DeletePolicy(context.Background(), &iam.DeletePolicyInput{
+				PolicyArn: policy.Policy.Arn,
+			})
+			require.NoError(t, err)
+		})
+
+		p := GetIamPolicyDocument(t, region, *policy.Policy.Arn)
+		t.Log("Retrieved Policy Document:", p)
+		assert.JSONEq(t, policyDocument, p)
+	})
+
+	t.Run("DoesNotExist", func(t *testing.T) {
+		_, err := GetIamPolicyDocumentE(t, region, "arn:aws:iam::1234567890:policy/does-not-exist")
+		require.Error(t, err)
+	})
 }


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes https://github.com/gruntwork-io/terratest/issues/991.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->
