### PR TITLE
Don't merge stderr to stdout

### DIFF
--- a/modules/terraform/cmd.go
+++ b/modules/terraform/cmd.go
@@ -122,7 +122,7 @@ func RunTerraformCommandAndGetStdoutE(t testing.TestingT, additionalOptions *Opt
 	cmd := generateCommand(options, args...)
 	description := fmt.Sprintf("%s %v", options.TerraformBinary, args)
 	return retry.DoWithRetryableErrorsE(t, description, options.RetryableTerraformErrors, options.MaxRetries, options.TimeBetweenRetries, func() (string, error) {
-		s, err := shell.RunCommandAndGetOutputE(t, cmd)
+		s, err := shell.RunCommandAndGetStdOutE(t, cmd)
 		if err != nil {
 			return s, err
 		}


### PR DESCRIPTION
`RunTerraformCommandAndGetStdoutE` actually returns stdout and stderr combined. This commit fixes that.

Terragrunt and Terraform output their warnings to stderr. Commands like `terraform output -json` and `terraform show -json` are especially vulnerable to keeping their output clean.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.
- [x] Make a plan for release of the functionality in this PR. If it delivers value to an end user, you are responsible for ensuring it is released promptly, and correctly. If you are not a maintainer, you are responsible for finding a maintainer to do this for you.

## Release Notes (draft)

* fix: `RunTerraformCommandAndGetStdoutE` no longer merges stderr to its result.

