### PR TITLE
Update copyright year in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,4 +34,4 @@ Please see the following for more info:
 
 This code is released under the Apache 2.0 License. Please see [LICENSE](LICENSE) and [NOTICE](NOTICE) for more details.
 
-Copyright &copy; 2020 Gruntwork, Inc.
+Copyright &copy; 2025 Gruntwork, Inc.


### PR DESCRIPTION
I personally have trepidation when encountering outdated copyright text as it usually indicates lack of maintenance, so thought I would help out here

edit: let me know if you would prefer for the copyright line to be removed instead, that might be better