### PR TITLE
Adjust warning patterns

### DIFF
--- a/modules/terraform/cmd.go
+++ b/modules/terraform/cmd.go
@@ -198,7 +198,7 @@ func defaultTerraformExecutable() string {
 
 func hasWarning(opts *Options, out string) error {
 	for k, v := range opts.WarningsAsErrors {
-		str := fmt.Sprintf("\nWarning: %s[^\n]*\n", k)
+		str := fmt.Sprintf("\n.*(?i:Warning): %s[^\n]*\n", k)
 		re, err := regexp.Compile(str)
 		if err != nil {
 			return fmt.Errorf("cannot compile regex for warning detection: %w", err)

--- a/modules/terraform/cmd_test.go
+++ b/modules/terraform/cmd_test.go
@@ -27,6 +27,24 @@ func TestTerraformCommand(t *testing.T) {
 		assert.Greater(t, code, 0)
 	})
 
+	t.Run("WithWarning", func(t *testing.T) {
+		testFolder, err := files.CopyTerraformFolderToTemp("../../test/fixtures/terraform-with-warning", strings.ReplaceAll(t.Name(), "/", "-"))
+		require.NoError(t, err)
+		options := &Options{
+			TerraformDir: testFolder,
+			WarningsAsErrors: map[string]string{
+				".*lorem ipsum.*": "this warning message should shown.",
+			},
+		}
+		Init(t, options)
+
+		stdout, stderr, code, err := RunTerraformCommandAndGetStdOutErrCodeE(t, options, "apply", "-input=false", "-auto-approve")
+		assert.Error(t, err)
+		assert.Contains(t, stdout, "Creating...", "should capture stdout")
+		assert.Contains(t, stderr, "", "should capture stderr")
+		assert.Greater(t, code, 0)
+	})
+
 	t.Run("NoError", func(t *testing.T) {
 		testFolder, err := files.CopyTerraformFolderToTemp("../../test/fixtures/terraform-no-error", strings.ReplaceAll(t.Name(), "/", "-"))
 		require.NoError(t, err)


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes https://github.com/gruntwork-io/terratest/issues/1549. 

to test:
add this to `terraform.Options` on `terraform_aws_s3_example_test.go`
```
WarningsAsErrors: map[string]string{
			".*deprecated.*": "Fix the deprecation shown in the log.",
		},
```

add this to `examples/terraform-aws-s3-example/main.tf` line 31.
```
# --- START DEPRECATED BLOCK ---
  # Using the deprecated server_side_encryption_configuration block directly
  # within the bucket resource.
  # This should trigger a deprecation warning in Terraform.
  server_side_encryption_configuration {
    rule {
      apply_server_side_encryption_by_default {
        sse_algorithm     = "AES256"
      }
    }
  }
  # --- END DEPRECATED BLOCK ---
```
run test `go test -run TestTerraformAwsS3Example github.com/gruntwork-io/terratest/test`

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.
- [ ] Make a plan for release of the functionality in this PR. If it delivers value to an end user, you are responsible for ensuring it is released promptly, and correctly. If you are not a maintainer, you are responsible for finding a maintainer to do this for you.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->
