### PR TITLE
Updated the subnet struct and corresponding function to fetch the subnet CIDR range

### DIFF
--- a/modules/aws/vpc.go
+++ b/modules/aws/vpc.go
@@ -31,6 +31,7 @@ type Subnet struct {
 	AvailabilityZone string            // The Availability Zone the subnet is in
 	DefaultForAz     bool              // If the subnet is default for the Availability Zone
 	Tags             map[string]string // The tags associated with the subnet
+	CidrBlock        string            // The CIDR block associated with the subnet
 }
 
 const vpcIDFilterName = "vpc-id"
@@ -201,7 +202,7 @@ func GetSubnetsForVpcE(t testing.TestingT, region string, filters []types.Filter
 
 	for _, ec2Subnet := range subnetOutput.Subnets {
 		subnetTags := GetTagsForSubnet(t, *ec2Subnet.SubnetId, region)
-		subnet := Subnet{Id: aws.ToString(ec2Subnet.SubnetId), AvailabilityZone: aws.ToString(ec2Subnet.AvailabilityZone), DefaultForAz: aws.ToBool(ec2Subnet.DefaultForAz), Tags: subnetTags}
+		subnet := Subnet{Id: aws.ToString(ec2Subnet.SubnetId), AvailabilityZone: aws.ToString(ec2Subnet.AvailabilityZone), DefaultForAz: aws.ToBool(ec2Subnet.DefaultForAz), Tags: subnetTags, CidrBlock: aws.ToString(ec2Subnet.CidrBlock)}
 		subnets = append(subnets, subnet)
 	}
 


### PR DESCRIPTION

Description:

1.Updated subnet struct to include CIDR block variable 
2.Updated the function GetSubnetsForVpcE to assign the CIDR block value to the struct variable before returning.

By this update users can fetch the subnet CIDR along with the other details for writing tests, particularly this is usefull when user trying to check if the CIDR allocated to the created subnet is expected or not with out writing any extra code.




