### PR TITLE
Refactor terragrunt module and add dedicated test pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -198,10 +198,13 @@ jobs:
       # to kill the build after more than 10 minutes without log output.
       # NOTE: because this doesn't build with the kubernetes tag, it will not run the kubernetes tests. See
       # kubernetes_test build steps.
+      # NOTE: terragrunt tests are excluded here and run in a separate terragrunt_test job.
       - run: mkdir -p /tmp/logs
       # check we can compile the azure code, but don't actually run the tests
       - run: run-go-tests --packages "-p 1 -tags=azure -run IDontExist ./modules/azure"
-      - run: run-go-tests --packages "-p 1 ./..." | tee /tmp/logs/test_output.log
+      - run: |
+          # Run all tests except terragrunt module (which has its own dedicated job)
+          run-go-tests --packages "-p 1 $(go list ./... | grep -v './modules/terragrunt' | tr '\n' ' ')" | tee /tmp/logs/test_output.log
 
       - run:
           command: |
@@ -378,6 +381,41 @@ jobs:
       - store_test_results:
           path: /tmp/logs
 
+  # Dedicated terragrunt tests that require terragrunt binary to be available
+  terragrunt_test:
+    <<: *defaults
+    resource_class: large
+    steps:
+      - attach_workspace:
+          at: /home/circleci
+
+      - run:
+          <<: *install_gruntwork_utils
+      - run:
+          <<: *install_docker_buildx
+
+      # The weird way you have to set PATH in Circle 2.0
+      - run: |
+          echo 'export PATH=$HOME/.local/bin:$HOME/terraform:$HOME/packer:$PATH' >> $BASH_ENV
+
+      # Run the terragrunt-specific tests. These tests specifically target the terragrunt module
+      # and require terragrunt binary to be available (which is installed via install_gruntwork_utils)
+      - run:
+          command: |
+            mkdir -p /tmp/logs
+            # Run only the terragrunt module tests
+            run-go-tests --packages "-p 1 ./modules/terragrunt" | tee /tmp/logs/test_output.log
+
+      - run:
+          command: |
+            ./cmd/bin/terratest_log_parser_linux_amd64 --testlog /tmp/logs/test_output.log --outputdir /tmp/logs
+          when: always
+
+      # Store test result and log artifacts for browsing purposes
+      - store_artifacts:
+          path: /tmp/logs
+      - store_test_results:
+          path: /tmp/logs
 
   deploy:
     <<: *defaults
@@ -416,6 +454,16 @@ workflows:
               only: /^v.*/
 
       - helm_test:
+          context:
+            - AWS__PHXDEVOPS__circle-ci-test
+            - GITHUB__PAT__gruntwork-ci
+          requires:
+            - setup
+          filters:
+            tags:
+              only: /^v.*/
+
+      - terragrunt_test:
           context:
             - AWS__PHXDEVOPS__circle-ci-test
             - GITHUB__PAT__gruntwork-ci

--- a/modules/terragrunt/init.go
+++ b/modules/terragrunt/init.go
@@ -1,8 +1,6 @@
 package terragrunt
 
 import (
-	"fmt"
-
 	"github.com/gruntwork-io/terratest/modules/terraform"
 	"github.com/gruntwork-io/terratest/modules/testing"
 )
@@ -22,24 +20,19 @@ func TgStackInitE(t testing.TestingT, options *Options) (string, error) {
 	return runTerragruntCommandE(t, options, "init", initStackArgs(options)...)
 }
 
+// initStackArgs builds the argument list for terragrunt init command.
+// All terragrunt command-line flags are now passed via ExtraArgs.
+// This function only handles complex configuration that requires special formatting.
 func initStackArgs(options *Options) []string {
-	args := []string{fmt.Sprintf("-upgrade=%t", options.Upgrade)}
+	var args []string
 
-	// Append reconfigure option if specified
-	if options.Reconfigure {
-		args = append(args, "-reconfigure")
-	}
-	// Append combination of migrate-state and force-copy to suppress answer prompt
-	if options.MigrateState {
-		args = append(args, "-migrate-state", "-force-copy")
-	}
-	// Append no-color option if needed
-	if options.NoColor {
-		args = append(args, "-no-color")
-	}
-
+	// Add complex configuration that requires special formatting
 	args = append(args, terraform.FormatTerraformBackendConfigAsArgs(options.BackendConfig)...)
 	args = append(args, terraform.FormatTerraformPluginDirAsArgs(options.PluginDir)...)
-	args = append(args, options.ExtraArgs.Init...)
+
+	// Add all user-specified terragrunt command-line arguments
+	// This includes flags like -no-color, -upgrade=true, -reconfigure, etc.
+	args = append(args, options.ExtraArgs...)
+
 	return args
 }

--- a/modules/terragrunt/init_test.go
+++ b/modules/terragrunt/init_test.go
@@ -16,6 +16,7 @@ func TestTerragruntInit(t *testing.T) {
 	out, err := TgStackInitE(t, &Options{
 		TerragruntDir:    testFolder,
 		TerragruntBinary: "terragrunt",
+		ExtraArgs:        []string{"-upgrade=true"}, // Common init flag
 	})
 	require.NoError(t, err)
 	require.Contains(t, out, "Terraform has been successfully initialized!")
@@ -31,6 +32,7 @@ func TestTerragruntInitWithInvalidConfig(t *testing.T) {
 	_, err = TgStackInitE(t, &Options{
 		TerragruntDir:    testFolder,
 		TerragruntBinary: "terragrunt",
+		ExtraArgs:        []string{"-upgrade=true"}, // Common init flag
 	})
 	require.Error(t, err)
 	// The error should contain information about the HCL parsing error

--- a/modules/terragrunt/options.go
+++ b/modules/terragrunt/options.go
@@ -14,17 +14,18 @@ import (
 // - Use ExtraArgs to pass ALL command-line arguments (including -no-color, -upgrade, etc.)
 //
 // Example:
-//   // For init
-//   TgStackInitE(t, &Options{
-//       TerragruntDir: "/path/to/config",
-//       ExtraArgs: []string{"-upgrade=true", "-no-color"},
-//   })
 //
-//   // For generate
-//   TgStackGenerateE(t, &Options{
-//       TerragruntDir: "/path/to/config",
-//       ExtraArgs: []string{"-no-color"},
-//   })
+//	// For init
+//	TgStackInitE(t, &Options{
+//	    TerragruntDir: "/path/to/config",
+//	    ExtraArgs: []string{"-upgrade=true", "-no-color"},
+//	})
+//
+//	// For generate
+//	TgStackGenerateE(t, &Options{
+//	    TerragruntDir: "/path/to/config",
+//	    ExtraArgs: []string{"-no-color"},
+//	})
 //
 // Constants for test framework configuration and environment variables
 const (
@@ -73,7 +74,6 @@ type Options struct {
 	// All terragrunt command-line arguments for the specific command being executed
 	ExtraArgs []string
 }
-
 
 // GetCommonOptions extracts common terragrunt options and prepares arguments
 // This is the terragrunt-specific version of terraform.GetCommonOptions

--- a/modules/terragrunt/stack_generate.go
+++ b/modules/terragrunt/stack_generate.go
@@ -18,17 +18,14 @@ func TgStackGenerateE(t testing.TestingT, options *Options) (string, error) {
 	return terragruntStackCommandE(t, options, generateStackArgs(options)...)
 }
 
+// generateStackArgs builds the argument list for terragrunt stack generate command.
+// All terragrunt command-line flags are now passed via ExtraArgs.
 func generateStackArgs(options *Options) []string {
 	args := []string{"generate"}
 
-	// Append no-color option if needed
-	if options.NoColor {
-		args = append(args, "-no-color")
-	}
+	// Add all user-specified terragrunt command-line arguments
+	// This includes flags like -no-color, etc.
+	args = append(args, options.ExtraArgs...)
 
-	// Use Apply extra args for generate command as it's a similar operation
-	if len(options.ExtraArgs.Apply) > 0 {
-		args = append(args, options.ExtraArgs.Apply...)
-	}
 	return args
 }

--- a/modules/terragrunt/stack_generate_test.go
+++ b/modules/terragrunt/stack_generate_test.go
@@ -18,6 +18,7 @@ func TestTerragruntStackGenerate(t *testing.T) {
 	_, err = TgStackInitE(t, &Options{
 		TerragruntDir:    path.Join(testFolder, "live"),
 		TerragruntBinary: "terragrunt",
+		ExtraArgs:        []string{"-upgrade=true"},
 	})
 	require.NoError(t, err)
 
@@ -54,6 +55,7 @@ func TestTerragruntStackGenerateWithNoColor(t *testing.T) {
 	_, err = TgStackInitE(t, &Options{
 		TerragruntDir:    path.Join(testFolder, "live"),
 		TerragruntBinary: "terragrunt",
+		ExtraArgs:        []string{"-upgrade=true"},
 	})
 	require.NoError(t, err)
 
@@ -61,7 +63,7 @@ func TestTerragruntStackGenerateWithNoColor(t *testing.T) {
 	out, err := TgStackGenerateE(t, &Options{
 		TerragruntDir:    path.Join(testFolder, "live"),
 		TerragruntBinary: "terragrunt",
-		NoColor:          true,
+		ExtraArgs:        []string{"-no-color"},
 	})
 	require.NoError(t, err)
 
@@ -84,6 +86,7 @@ func TestTerragruntStackGenerateWithExtraArgs(t *testing.T) {
 	_, err = TgStackInitE(t, &Options{
 		TerragruntDir:    path.Join(testFolder, "live"),
 		TerragruntBinary: "terragrunt",
+		ExtraArgs:        []string{"-upgrade=true"},
 	})
 	require.NoError(t, err)
 
@@ -91,9 +94,7 @@ func TestTerragruntStackGenerateWithExtraArgs(t *testing.T) {
 	out, err := TgStackGenerateE(t, &Options{
 		TerragruntDir:    path.Join(testFolder, "live"),
 		TerragruntBinary: "terragrunt",
-		ExtraArgs: ExtraArgs{
-			Apply: []string{"--terragrunt-log-level", "info"},
-		},
+		ExtraArgs:        []string{"--terragrunt-log-level", "info"},
 	})
 	require.NoError(t, err)
 

--- a/modules/terragrunt/stack_run.go
+++ b/modules/terragrunt/stack_run.go
@@ -1,11 +1,6 @@
 package terragrunt
 
 import (
-	"fmt"
-	"slices"
-
-	"github.com/gruntwork-io/terratest/modules/retry"
-	"github.com/gruntwork-io/terratest/modules/shell"
 	"github.com/gruntwork-io/terratest/modules/testing"
 )
 
@@ -20,59 +15,13 @@ func TgStackRun(t testing.TestingT, options *Options) string {
 
 // TgStackRunE calls terragrunt stack run and returns stdout/stderr
 func TgStackRunE(t testing.TestingT, options *Options) (string, error) {
-	return runTerragruntStackRunCommandE(t, options, runStackArgs(options)...)
+	return runTerragruntStackCommandE(t, options, "run", runStackArgs(options)...)
 }
 
-// runTerragruntStackRunCommandE executes a terragrunt stack run command
-// This is the specific implementation for stack run operations
-func runTerragruntStackRunCommandE(t testing.TestingT, opts *Options, additionalArgs ...string) (string, error) {
-	// Build the base command arguments starting with "stack run"
-	commandArgs := []string{"stack", "run"}
-
-	// Apply common terragrunt options and get the final command arguments
-	terragruntOptions, finalArgs := GetCommonOptions(opts, commandArgs...)
-
-	// Append additional arguments with "--" separator
-	finalArgs = append(finalArgs, slices.Insert(additionalArgs, 0, "--")...)
-
-	// Generate the final shell command
-	execCommand := generateCommand(terragruntOptions, finalArgs...)
-	commandDescription := fmt.Sprintf("%s %v", terragruntOptions.TerragruntBinary, finalArgs)
-
-	// Execute the command with retry logic and error handling
-	return retry.DoWithRetryableErrorsE(
-		t,
-		commandDescription,
-		terragruntOptions.RetryableTerraformErrors,
-		terragruntOptions.MaxRetries,
-		terragruntOptions.TimeBetweenRetries,
-		func() (string, error) {
-			output, err := shell.RunCommandAndGetOutputE(t, execCommand)
-			if err != nil {
-				return output, err
-			}
-
-			// Check for warnings that should be treated as errors
-			if warningErr := hasWarning(opts, output); warningErr != nil {
-				return output, warningErr
-			}
-
-			return output, nil
-		},
-	)
-}
-
+// runStackArgs builds the argument list for terragrunt stack run command.
+// All terragrunt command-line flags are now passed via ExtraArgs.
 func runStackArgs(options *Options) []string {
-	args := []string{}
-
-	args = append(args, options.ExtraArgs.Plan...)
-	args = append(args, options.ExtraArgs.Apply...)
-	args = append(args, options.ExtraArgs.Destroy...)
-
-	// Append no-color option if needed
-	if options.NoColor {
-		args = append(args, "-no-color")
-	}
-
-	return args
+	// Return all user-specified terragrunt command-line arguments
+	// The user passes the specific args they need for their stack run operation
+	return options.ExtraArgs
 }

--- a/modules/terragrunt/stack_run_test.go
+++ b/modules/terragrunt/stack_run_test.go
@@ -18,16 +18,15 @@ func TestTerragruntStackRunPlan(t *testing.T) {
 	_, err = TgStackInitE(t, &Options{
 		TerragruntDir:    path.Join(testFolder, "live"),
 		TerragruntBinary: "terragrunt",
+		ExtraArgs:        []string{"-upgrade=true"},
 	})
 	require.NoError(t, err)
 
-	// Then generate the stack
+	// Then run plan on the stack
 	out, err := TgStackRunE(t, &Options{
 		TerragruntDir:    path.Join(testFolder, "live"),
 		TerragruntBinary: "terragrunt",
-		ExtraArgs: ExtraArgs{
-			Plan: []string{"plan"},
-		},
+		ExtraArgs:        []string{"plan"},
 	})
 	require.NoError(t, err)
 
@@ -57,17 +56,15 @@ func TestTerragruntStackRunPlanWithNoColor(t *testing.T) {
 	_, err = TgStackInitE(t, &Options{
 		TerragruntDir:    path.Join(testFolder, "live"),
 		TerragruntBinary: "terragrunt",
+		ExtraArgs:        []string{"-upgrade=true"},
 	})
 	require.NoError(t, err)
 
-	// Generate with no-color option
+	// Run plan with no-color option
 	out, err := TgStackRunE(t, &Options{
 		TerragruntDir:    path.Join(testFolder, "live"),
 		TerragruntBinary: "terragrunt",
-		NoColor:          true,
-		ExtraArgs: ExtraArgs{
-			Plan: []string{"plan"},
-		},
+		ExtraArgs:        []string{"plan", "-no-color"},
 	})
 	require.NoError(t, err)
 


### PR DESCRIPTION
## Summary
- Simplified Options vs ExtraArgs API pattern for better clarity
- Added dedicated terragrunt test pipeline in CircleCI
- Consolidated duplicate code and improved documentation

## Key Changes
- **API Simplification**: Use single `ExtraArgs []string` instead of per-command fields
- **Clear Separation**: Options for test framework config, ExtraArgs for terragrunt command-line args
- **Dedicated Pipeline**: Added `terragrunt_test` job in CircleCI for isolated terragrunt testing
- **Code Cleanup**: Consolidated duplicate functions, added validation, extracted constants

## Test Plan
- [x] All existing tests pass
- [x] New simplified API tested in all test files
- [x] CircleCI pipeline includes dedicated terragrunt test job