### PR TITLE
Add terragrunt stack clean functionality

### DIFF
--- a/modules/terragrunt/stack_clean.go
+++ b/modules/terragrunt/stack_clean.go
@@ -1,0 +1,27 @@
+package terragrunt
+
+import (
+	"github.com/gruntwork-io/terratest/modules/testing"
+)
+
+// TgStackClean calls terragrunt stack clean and returns stdout/stderr
+func TgStackClean(t testing.TestingT, options *Options) string {
+	out, err := TgStackCleanE(t, options)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return out
+}
+
+// TgStackCleanE calls terragrunt stack clean and returns stdout/stderr
+func TgStackCleanE(t testing.TestingT, options *Options) (string, error) {
+	return runTerragruntStackCommandE(t, options, "clean", cleanStackArgs(options)...)
+}
+
+// cleanStackArgs builds the argument list for terragrunt stack clean command.
+// All terragrunt command-line flags are now passed via ExtraArgs.
+func cleanStackArgs(options *Options) []string {
+	// Return all user-specified terragrunt command-line arguments
+	// The user passes the specific args they need for their stack clean operation
+	return options.ExtraArgs
+}

--- a/modules/terragrunt/stack_clean_test.go
+++ b/modules/terragrunt/stack_clean_test.go
@@ -1,0 +1,98 @@
+package terragrunt
+
+import (
+	"path"
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/files"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTerragruntStackClean(t *testing.T) {
+	t.Parallel()
+
+	testFolder, err := files.CopyTerraformFolderToTemp("../../test/fixtures/terragrunt/terragrunt-stack-init", t.Name())
+	require.NoError(t, err)
+
+	// First initialize the stack
+	_, err = TgStackInitE(t, &Options{
+		TerragruntDir:    path.Join(testFolder, "live"),
+		TerragruntBinary: "terragrunt",
+		ExtraArgs:        []string{"-upgrade=true"},
+	})
+	require.NoError(t, err)
+
+	// Generate stack to create .terragrunt-stack directory
+	_, err = TgStackGenerateE(t, &Options{
+		TerragruntDir:    path.Join(testFolder, "live"),
+		TerragruntBinary: "terragrunt",
+	})
+	require.NoError(t, err)
+
+	// Verify that the .terragrunt-stack directory was created
+	stackDir := path.Join(testFolder, "live", ".terragrunt-stack")
+	require.DirExists(t, stackDir)
+
+	// Now run stack clean
+	out, err := TgStackCleanE(t, &Options{
+		TerragruntDir:    path.Join(testFolder, "live"),
+		TerragruntBinary: "terragrunt",
+	})
+	require.NoError(t, err)
+
+	// Validate that clean command produced output
+	require.Contains(t, out, "Cleaning stack")
+}
+
+func TestTerragruntStackCleanWithNoColor(t *testing.T) {
+	t.Parallel()
+
+	testFolder, err := files.CopyTerraformFolderToTemp("../../test/fixtures/terragrunt/terragrunt-stack-init", t.Name())
+	require.NoError(t, err)
+
+	// First initialize the stack
+	_, err = TgStackInitE(t, &Options{
+		TerragruntDir:    path.Join(testFolder, "live"),
+		TerragruntBinary: "terragrunt",
+		ExtraArgs:        []string{"-upgrade=true"},
+	})
+	require.NoError(t, err)
+
+	// Generate stack to create .terragrunt-stack directory
+	_, err = TgStackGenerateE(t, &Options{
+		TerragruntDir:    path.Join(testFolder, "live"),
+		TerragruntBinary: "terragrunt",
+	})
+	require.NoError(t, err)
+
+	// Run clean with no-color option
+	out, err := TgStackCleanE(t, &Options{
+		TerragruntDir:    path.Join(testFolder, "live"),
+		TerragruntBinary: "terragrunt",
+		ExtraArgs:        []string{"-no-color"},
+	})
+	require.NoError(t, err)
+
+	// Validate that clean command produced output
+	require.Contains(t, out, "Cleaning stack")
+}
+
+func TestTerragruntStackCleanNonExistentDir(t *testing.T) {
+	t.Parallel()
+
+	// Test with non-existent directory
+	_, err := TgStackCleanE(t, &Options{
+		TerragruntDir:    "/non/existent/path",
+		TerragruntBinary: "terragrunt",
+	})
+	require.Error(t, err)
+}
+
+func TestTerragruntStackCleanEmptyOptions(t *testing.T) {
+	t.Parallel()
+
+	// Test with minimal options to verify default behavior
+	_, err := TgStackCleanE(t, &Options{})
+	require.Error(t, err)
+	// Should fail due to missing TerragruntDir
+}


### PR DESCRIPTION
## Summary
- Adds `TgStackClean()` and `TgStackCleanE()` functions to support terragrunt stack clean command
- Follows established patterns from other stack commands (`stack_run`, `stack_generate`, `stack_output`)
- Includes comprehensive test coverage for various scenarios

## Test plan
- [x] Basic stack clean functionality test
- [x] Stack clean with `-no-color` flag test  
- [x] Error handling for non-existent directories
- [x] Error handling for empty options
- [x] Follows same patterns as existing stack commands