### PR TITLE
feat: Add support for custom OPA command line arguments

### DIFF
--- a/examples/terraform-opa-example/README.md
+++ b/examples/terraform-opa-example/README.md
@@ -32,3 +32,15 @@ tests for this module.
 1. Install [Golang](https://golang.org/).
 1. `cd test`
 1. `go test -v -run TestOPAEvalTerraformModule`
+
+## Using extra command line arguments
+
+If you need to pass additional command line arguments to OPA (e.g., `--v0-compatible` for OPA v0.x compatibility), you can use the `ExtraArgs` field in `EvalOptions`:
+
+```go
+opaOpts := &opa.EvalOptions{
+    RulePath: "../examples/terraform-opa-example/policy/enforce_source.rego",
+    FailMode: opa.FailUndefined,
+    ExtraArgs: []string{"--v0-compatible"},
+}
+```

--- a/modules/opa/eval.go
+++ b/modules/opa/eval.go
@@ -25,6 +25,10 @@ type EvalOptions struct {
 	// Set a logger that should be used. See the logger package for more info.
 	Logger *logger.Logger
 
+	// Extra command line arguments to pass to opa eval. These are added after the standard arguments.
+	// Example: []string{"--v0-compatible"} to enable OPA v0 compatibility mode.
+	ExtraArgs []string
+
 	// The following options can be used to change the behavior of the related functions for debuggability.
 
 	// When true, keep any temp files and folders that are created for the purpose of running opa eval.
@@ -164,6 +168,11 @@ func formatOPAEvalArgs(options *EvalOptions, rulePath, jsonFilePath, resultQuery
 		args = append(args, "--fail")
 	case FailDefined:
 		args = append(args, "--fail-defined")
+	}
+
+	// Add any extra arguments provided by the user
+	if len(options.ExtraArgs) > 0 {
+		args = append(args, options.ExtraArgs...)
 	}
 
 	args = append(

--- a/modules/opa/eval_test.go
+++ b/modules/opa/eval_test.go
@@ -8,6 +8,60 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestFormatOPAEvalArgs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		options  *EvalOptions
+		rulePath string
+		jsonFile string
+		query    string
+		expected []string
+	}{
+		{
+			name: "Basic args without extras",
+			options: &EvalOptions{
+				FailMode: NoFail,
+			},
+			rulePath: "/path/to/policy.rego",
+			jsonFile: "/path/to/input.json",
+			query:    "data.test.allow",
+			expected: []string{"eval", "-i", "/path/to/input.json", "-d", "/path/to/policy.rego", "data.test.allow"},
+		},
+		{
+			name: "With fail mode",
+			options: &EvalOptions{
+				FailMode: FailUndefined,
+			},
+			rulePath: "/path/to/policy.rego",
+			jsonFile: "/path/to/input.json",
+			query:    "data.test.allow",
+			expected: []string{"eval", "--fail", "-i", "/path/to/input.json", "-d", "/path/to/policy.rego", "data.test.allow"},
+		},
+		{
+			name: "With extra args",
+			options: &EvalOptions{
+				FailMode:  FailUndefined,
+				ExtraArgs: []string{"--v0-compatible", "--format", "json"},
+			},
+			rulePath: "/path/to/policy.rego",
+			jsonFile: "/path/to/input.json",
+			query:    "data.test.allow",
+			expected: []string{"eval", "--fail", "--v0-compatible", "--format", "json", "-i", "/path/to/input.json", "-d", "/path/to/policy.rego", "data.test.allow"},
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			actual := formatOPAEvalArgs(test.options, test.rulePath, test.jsonFile, test.query)
+			assert.Equal(t, test.expected, actual)
+		})
+	}
+}
+
 func TestEvalWithOutput(t *testing.T) {
 	t.Parallel()
 

--- a/test/terraform_opa_example_extra_args_test.go
+++ b/test/terraform_opa_example_extra_args_test.go
@@ -1,0 +1,28 @@
+package test
+
+import (
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/opa"
+	"github.com/gruntwork-io/terratest/modules/terraform"
+)
+
+// TestOPAEvalTerraformModuleWithExtraArgs demonstrates how to pass extra command line arguments to OPA,
+// such as --v0-compatible for backwards compatibility with OPA v0.x.
+func TestOPAEvalTerraformModuleWithExtraArgs(t *testing.T) {
+	t.Parallel()
+
+	tfOpts := &terraform.Options{
+		TerraformDir: "../examples/terraform-opa-example/pass",
+	}
+
+	opaOpts := &opa.EvalOptions{
+		RulePath: "../examples/terraform-opa-example/policy/enforce_source.rego",
+		FailMode: opa.FailUndefined,
+		// Pass extra command line arguments to OPA
+		ExtraArgs: []string{"--v0-compatible"},
+	}
+
+	// This will run: opa eval --fail --v0-compatible -i <jsonfile> -d <rulepath> data.enforce_source.allow
+	terraform.OPAEval(t, tfOpts, opaOpts, "data.enforce_source.allow")
+}


### PR DESCRIPTION
## Summary
This PR adds the ability to pass custom command line arguments to OPA through the `opa.EvalOptions` struct, addressing the need to pass flags like `--v0-compatible` for OPA v0.x compatibility.

## Changes
- Added `ExtraArgs []string` field to the `opa.EvalOptions` struct
- Updated `formatOPAEvalArgs` function to include extra arguments in the correct position in the command line
- Added comprehensive unit tests for the `formatOPAEvalArgs` function
- Created an integration test demonstrating usage with the `--v0-compatible` flag
- Updated documentation with usage examples

## Test plan
- [x] Unit tests added for `formatOPAEvalArgs` function covering various scenarios
- [x] Integration test added showing usage with `--v0-compatible` flag
- [x] All existing OPA tests pass without modification
- [x] Manual testing confirms extra arguments are passed correctly to OPA

## Usage Example
```go
opaOpts := &opa.EvalOptions{
    RulePath: "policy/enforce_source.rego",  
    FailMode: opa.FailUndefined,
    ExtraArgs: []string{"--v0-compatible"},
}
```

This will execute OPA with: `opa eval --fail --v0-compatible -i input.json -d policy.rego query`

## Related Issue
Closes the feature request for passing custom command line arguments to OPA, specifically the `--v0-compatible` flag.