### PR TITLE
feat: Add stdin support for terragrunt run command

### DIFF
--- a/examples/terragrunt-example/main.tf
+++ b/examples/terragrunt-example/main.tf
@@ -4,3 +4,7 @@ variable "other_input" {}
 output "output" {
   value = "${var.input} ${var.other_input}"
 }
+
+locals {
+  mylocal = "local variable named mylocal"
+}

--- a/modules/shell/command.go
+++ b/modules/shell/command.go
@@ -24,6 +24,8 @@ type Command struct {
 	Env        map[string]string // Additional environment variables to set
 	// Use the specified logger for the command's output. Use logger.Discard to not print the output while executing the command.
 	Logger *logger.Logger
+
+	Stdin io.Reader
 }
 
 // RunCommand runs a shell command and redirects its stdout and stderr to the stdout of the atomic script itself. If
@@ -122,7 +124,11 @@ func runCommand(t testing.TestingT, command Command) (*output, error) {
 
 	cmd := exec.Command(command.Command, command.Args...)
 	cmd.Dir = command.WorkingDir
-	cmd.Stdin = os.Stdin
+	if command.Stdin != nil {
+		cmd.Stdin = command.Stdin
+	} else {
+		cmd.Stdin = os.Stdin
+	}
 	cmd.Env = formatEnvVars(command)
 
 	stdout, err := cmd.StdoutPipe()

--- a/modules/shell/command_test.go
+++ b/modules/shell/command_test.go
@@ -210,3 +210,16 @@ func TestCommandWithStdoutAndStdErr(t *testing.T) {
 	})
 
 }
+
+func TestRunCommandWithStdinAndGetOutput(t *testing.T) {
+	t.Parallel()
+
+	text := "Hello, World"
+	cmd := Command{
+		Command: "cat",
+		Stdin:   strings.NewReader(text),
+	}
+
+	out := RunCommandAndGetOutput(t, cmd)
+	assert.Equal(t, text, strings.TrimSpace(out))
+}

--- a/modules/terraform/cmd.go
+++ b/modules/terraform/cmd.go
@@ -21,6 +21,7 @@ func generateCommand(options *Options, args ...string) shell.Command {
 		WorkingDir: options.TerraformDir,
 		Env:        options.EnvVars,
 		Logger:     options.Logger,
+		Stdin:      options.Stdin,
 	}
 	return cmd
 }

--- a/modules/terraform/options.go
+++ b/modules/terraform/options.go
@@ -1,6 +1,7 @@
 package terraform
 
 import (
+	"io"
 	"time"
 
 	"github.com/gruntwork-io/terratest/modules/logger"
@@ -74,6 +75,7 @@ type Options struct {
 	SetVarsAfterVarFiles     bool                   // Pass -var options after -var-file options to Terraform commands
 	WarningsAsErrors         map[string]string      // Terraform warning messages that should be treated as errors. The keys are a regexp to match against the warning and the value is what to display to a user if that warning is matched.
 	ExtraArgs                ExtraArgs              // Extra arguments passed to Terraform commands
+	Stdin                    io.Reader              // Optional stdin to pass to Terraform commands
 }
 
 type ExtraArgs struct {

--- a/modules/terragrunt/cmd.go
+++ b/modules/terragrunt/cmd.go
@@ -164,5 +164,6 @@ func generateCommand(terragruntOptions *Options, commandArgs ...string) shell.Co
 		WorkingDir: terragruntOptions.TerragruntDir,
 		Env:        terragruntOptions.EnvVars,
 		Logger:     terragruntOptions.Logger,
+		Stdin:      terragruntOptions.Stdin,
 	}
 }

--- a/modules/terragrunt/options.go
+++ b/modules/terragrunt/options.go
@@ -1,6 +1,7 @@
 package terragrunt
 
 import (
+	"io"
 	"os"
 	"time"
 
@@ -73,6 +74,9 @@ type Options struct {
 
 	// All terragrunt command-line arguments for the specific command being executed
 	ExtraArgs []string
+
+	// Optional stdin to pass to Terraform commands
+	Stdin io.Reader
 }
 
 // GetCommonOptions extracts common terragrunt options and prepares arguments

--- a/test/terragrunt_example_test.go
+++ b/test/terragrunt_example_test.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/gruntwork-io/terratest/modules/terraform"
@@ -25,4 +26,23 @@ func TestTerragruntExample(t *testing.T) {
 	// website::tag::5:: Run `terraform output` to get the values of output variables and check they have the expected values.
 	output := terraform.Output(t, terraformOptions, "output")
 	assert.Equal(t, "one input another input", output)
+}
+
+func TestTerragruntConsole(t *testing.T) {
+	// website::tag::3:: Construct the terraform options with default retryable errors to handle the most common retryable errors in terraform testing.
+	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
+		// website::tag::1:: Set the path to the Terragrunt module that will be tested.
+		TerraformDir: "../examples/terragrunt-example",
+		// website::tag::2:: Set the terraform binary path to terragrunt so that terratest uses terragrunt instead of terraform. You must ensure that you have terragrunt downloaded and available in your PATH.
+		TerraformBinary: "terragrunt",
+		// website::tag::3:: Set stdin to a string reader to simulate user input.
+		Stdin: strings.NewReader("local.mylocal"),
+	})
+
+	// website::tag::6:: Clean up resources with "terragrunt destroy" at the end of the test.
+	defer terraform.Destroy(t, terraformOptions)
+
+	// website::tag::4:: Run "terragrunt console".
+	out := terraform.RunTerraformCommand(t, terraformOptions, "console")
+	assert.Contains(t, out, `"local variable named mylocal"`)
 }


### PR DESCRIPTION
## Summary
- Added stdin support to the `terragrunt stack run` command, enabling execution of console-like operations that require stdin input
- Follows the same pattern as the existing terraform console implementation

## Test plan
✅ Updated test suite to include terragrunt console test with stdin
✅ Existing terragrunt tests continue to pass
✅ Example usage demonstrates how to get computed local variable values

## Example usage

This PR enables users to get computed local variable values in Terratest, similar to how it's done with `echo 'local.mylocal' | terragrunt run -- console`:

```go
terragruntOptions := &terragrunt.Options{
    TerragruntDir: "../examples/terragrunt-example",
    TerragruntBinary: "terragrunt",
    Stdin: strings.NewReader("local.mylocal"),
    ExtraArgs: []string{"console"},
}

// Run terragrunt stack run -- console with stdin
output, err := terragrunt.TgStackRunE(t, terragruntOptions)

// Output will contain the computed value of local.mylocal
assert.Contains(t, output, "expected_value")
```

This addresses the client request for using Terratest to get computed values of local variables, providing the same functionality as the CLI command `echo 'local.mylocal' | terragrunt run -- console`.