### PR TITLE
feat(terragrunt): Separate terragrunt and terraform arguments

### DIFF
--- a/modules/terragrunt/cmd.go
+++ b/modules/terragrunt/cmd.go
@@ -3,7 +3,6 @@ package terragrunt
 import (
 	"fmt"
 	"regexp"
-	"slices"
 	"strings"
 
 	"github.com/gruntwork-io/terratest/modules/retry"
@@ -41,13 +40,13 @@ func runTerragruntStackCommandWithSeparatorE(t testing.TestingT, opts *Options, 
 	// Apply common terragrunt options and get the final command arguments
 	terragruntOptions, finalArgs := GetCommonOptions(opts, commandArgs...)
 
-	// Append additional arguments with or without "--" separator based on useArgSeparator
+	// Append arguments from options using the new separation logic
+	argsFromOptions := GetArgsForCommand(terragruntOptions, useArgSeparator)
+	finalArgs = append(finalArgs, argsFromOptions...)
+	
+	// Append any additional arguments passed directly to this function
 	if len(additionalArgs) > 0 {
-		if useArgSeparator {
-			finalArgs = append(finalArgs, slices.Insert(additionalArgs, 0, ArgSeparator)...)
-		} else {
-			finalArgs = append(finalArgs, additionalArgs...)
-		}
+		finalArgs = append(finalArgs, additionalArgs...)
 	}
 
 	// Generate the final shell command
@@ -91,7 +90,11 @@ func runTerragruntCommandE(t testing.TestingT, opts *Options, command string, ad
 	// Apply common terragrunt options and get the final command arguments
 	terragruntOptions, finalArgs := GetCommonOptions(opts, commandArgs...)
 
-	// Append additional arguments
+	// For non-stack commands, we typically don't use the separator
+	argsFromOptions := GetArgsForCommand(terragruntOptions, false)
+	finalArgs = append(finalArgs, argsFromOptions...)
+	
+	// Append any additional arguments passed directly to this function
 	finalArgs = append(finalArgs, additionalArgs...)
 
 	// Generate the final shell command

--- a/modules/terragrunt/cmd.go
+++ b/modules/terragrunt/cmd.go
@@ -43,7 +43,7 @@ func runTerragruntStackCommandWithSeparatorE(t testing.TestingT, opts *Options, 
 	// Append arguments from options using the new separation logic
 	argsFromOptions := GetArgsForCommand(terragruntOptions, useArgSeparator)
 	finalArgs = append(finalArgs, argsFromOptions...)
-	
+
 	// Append any additional arguments passed directly to this function
 	if len(additionalArgs) > 0 {
 		finalArgs = append(finalArgs, additionalArgs...)
@@ -93,7 +93,7 @@ func runTerragruntCommandE(t testing.TestingT, opts *Options, command string, ad
 	// For non-stack commands, we typically don't use the separator
 	argsFromOptions := GetArgsForCommand(terragruntOptions, false)
 	finalArgs = append(finalArgs, argsFromOptions...)
-	
+
 	// Append any additional arguments passed directly to this function
 	finalArgs = append(finalArgs, additionalArgs...)
 

--- a/modules/terragrunt/init.go
+++ b/modules/terragrunt/init.go
@@ -21,18 +21,17 @@ func TgStackInitE(t testing.TestingT, options *Options) (string, error) {
 }
 
 // initStackArgs builds the argument list for terragrunt init command.
-// All terragrunt command-line flags are now passed via ExtraArgs.
-// This function only handles complex configuration that requires special formatting.
+// This function handles complex configuration that requires special formatting.
 func initStackArgs(options *Options) []string {
 	var args []string
 
 	// Add complex configuration that requires special formatting
+	// These are terraform-specific arguments that need special formatting
 	args = append(args, terraform.FormatTerraformBackendConfigAsArgs(options.BackendConfig)...)
 	args = append(args, terraform.FormatTerraformPluginDirAsArgs(options.PluginDir)...)
 
-	// Add all user-specified terragrunt command-line arguments
-	// This includes flags like -no-color, -upgrade=true, -reconfigure, etc.
-	args = append(args, options.ExtraArgs...)
+	// User-specified arguments are now handled by GetArgsForCommand
+	// which properly separates TerragruntArgs and TerraformArgs
 
 	return args
 }

--- a/modules/terragrunt/init_test.go
+++ b/modules/terragrunt/init_test.go
@@ -16,7 +16,7 @@ func TestTerragruntInit(t *testing.T) {
 	out, err := TgStackInitE(t, &Options{
 		TerragruntDir:    testFolder,
 		TerragruntBinary: "terragrunt",
-		ExtraArgs:        []string{"-upgrade=true"}, // Common init flag
+		TerraformArgs:    []string{"-upgrade=true"}, // Common terraform init flag
 	})
 	require.NoError(t, err)
 	require.Contains(t, out, "Terraform has been successfully initialized!")
@@ -32,7 +32,7 @@ func TestTerragruntInitWithInvalidConfig(t *testing.T) {
 	_, err = TgStackInitE(t, &Options{
 		TerragruntDir:    testFolder,
 		TerragruntBinary: "terragrunt",
-		ExtraArgs:        []string{"-upgrade=true"}, // Common init flag
+		TerraformArgs:    []string{"-upgrade=true"}, // Common terraform init flag
 	})
 	require.Error(t, err)
 	// The error should contain information about the HCL parsing error

--- a/modules/terragrunt/stack_generate.go
+++ b/modules/terragrunt/stack_generate.go
@@ -19,13 +19,11 @@ func TgStackGenerateE(t testing.TestingT, options *Options) (string, error) {
 }
 
 // generateStackArgs builds the argument list for terragrunt stack generate command.
-// All terragrunt command-line flags are now passed via ExtraArgs.
 func generateStackArgs(options *Options) []string {
 	args := []string{"generate"}
 
-	// Add all user-specified terragrunt command-line arguments
-	// This includes flags like -no-color, etc.
-	args = append(args, options.ExtraArgs...)
+	// User-specified arguments are now handled by GetArgsForCommand
+	// which properly separates TerragruntArgs and TerraformArgs
 
 	return args
 }

--- a/modules/terragrunt/stack_generate_test.go
+++ b/modules/terragrunt/stack_generate_test.go
@@ -18,7 +18,7 @@ func TestTerragruntStackGenerate(t *testing.T) {
 	_, err = TgStackInitE(t, &Options{
 		TerragruntDir:    path.Join(testFolder, "live"),
 		TerragruntBinary: "terragrunt",
-		ExtraArgs:        []string{"-upgrade=true"},
+		TerraformArgs:    []string{"-upgrade=true"},
 	})
 	require.NoError(t, err)
 
@@ -55,7 +55,7 @@ func TestTerragruntStackGenerateWithNoColor(t *testing.T) {
 	_, err = TgStackInitE(t, &Options{
 		TerragruntDir:    path.Join(testFolder, "live"),
 		TerragruntBinary: "terragrunt",
-		ExtraArgs:        []string{"-upgrade=true"},
+		TerraformArgs:    []string{"-upgrade=true"},
 	})
 	require.NoError(t, err)
 
@@ -63,7 +63,7 @@ func TestTerragruntStackGenerateWithNoColor(t *testing.T) {
 	out, err := TgStackGenerateE(t, &Options{
 		TerragruntDir:    path.Join(testFolder, "live"),
 		TerragruntBinary: "terragrunt",
-		ExtraArgs:        []string{"-no-color"},
+		TerragruntArgs:   []string{"--no-color"},
 	})
 	require.NoError(t, err)
 
@@ -86,7 +86,7 @@ func TestTerragruntStackGenerateWithExtraArgs(t *testing.T) {
 	_, err = TgStackInitE(t, &Options{
 		TerragruntDir:    path.Join(testFolder, "live"),
 		TerragruntBinary: "terragrunt",
-		ExtraArgs:        []string{"-upgrade=true"},
+		TerraformArgs:    []string{"-upgrade=true"},
 	})
 	require.NoError(t, err)
 
@@ -94,7 +94,7 @@ func TestTerragruntStackGenerateWithExtraArgs(t *testing.T) {
 	out, err := TgStackGenerateE(t, &Options{
 		TerragruntDir:    path.Join(testFolder, "live"),
 		TerragruntBinary: "terragrunt",
-		ExtraArgs:        []string{"--terragrunt-log-level", "info"},
+		TerragruntArgs:   []string{"--terragrunt-log-level", "info"},
 	})
 	require.NoError(t, err)
 

--- a/modules/terragrunt/stack_output.go
+++ b/modules/terragrunt/stack_output.go
@@ -22,7 +22,7 @@ func TgOutputE(t testing.TestingT, options *Options, key string) (string, error)
 	// Prepare options with no-color flag for parsing
 	optsCopy := *options
 	optsCopy.TerragruntArgs = append([]string{"-no-color"}, options.TerragruntArgs...)
-	
+
 	var args []string
 	if key != "" {
 		args = append(args, key)
@@ -60,7 +60,7 @@ func TgOutputJsonE(t testing.TestingT, options *Options, key string) (string, er
 	// Prepare options with no-color and json flags
 	optsCopy := *options
 	optsCopy.TerragruntArgs = append([]string{"-no-color", "-json"}, options.TerragruntArgs...)
-	
+
 	var args []string
 	if key != "" {
 		args = append(args, key)

--- a/modules/terragrunt/stack_output.go
+++ b/modules/terragrunt/stack_output.go
@@ -19,14 +19,17 @@ func TgOutput(t testing.TestingT, options *Options, key string) string {
 
 // TgOutputE calls terragrunt stack output for the given variable and returns its value as a string
 func TgOutputE(t testing.TestingT, options *Options, key string) (string, error) {
-	args := []string{"-no-color"} // Disable color for parsing
-	args = append(args, options.ExtraArgs...)
+	// Prepare options with no-color flag for parsing
+	optsCopy := *options
+	optsCopy.TerragruntArgs = append([]string{"-no-color"}, options.TerragruntArgs...)
+	
+	var args []string
 	if key != "" {
 		args = append(args, key)
 	}
 
 	// Output command doesn't use -- separator
-	rawOutput, err := runTerragruntStackCommandWithSeparatorE(t, options, "output", false, args...)
+	rawOutput, err := runTerragruntStackCommandWithSeparatorE(t, &optsCopy, "output", false, args...)
 	if err != nil {
 		return "", err
 	}
@@ -54,14 +57,17 @@ func TgOutputJson(t testing.TestingT, options *Options, key string) string {
 // result as the json string.
 // If key is an empty string, it will return all the output variables.
 func TgOutputJsonE(t testing.TestingT, options *Options, key string) (string, error) {
-	args := []string{"-no-color", "-json"} // JSON format without color
-	args = append(args, options.ExtraArgs...)
+	// Prepare options with no-color and json flags
+	optsCopy := *options
+	optsCopy.TerragruntArgs = append([]string{"-no-color", "-json"}, options.TerragruntArgs...)
+	
+	var args []string
 	if key != "" {
 		args = append(args, key)
 	}
 
 	// Output command doesn't use -- separator
-	rawOutput, err := runTerragruntStackCommandWithSeparatorE(t, options, "output", false, args...)
+	rawOutput, err := runTerragruntStackCommandWithSeparatorE(t, &optsCopy, "output", false, args...)
 	if err != nil {
 		return "", err
 	}

--- a/modules/terragrunt/stack_output_test.go
+++ b/modules/terragrunt/stack_output_test.go
@@ -33,7 +33,7 @@ func TestTgOutputIntegration(t *testing.T) {
 		TerragruntDir:    testFolder + "/live",
 		TerragruntBinary: "terragrunt",
 		Logger:           logger.Discard,
-		ExtraArgs:        []string{"apply", "-auto-approve"},
+		TerraformArgs:    []string{"apply", "-auto-approve"},
 	}
 	_, err = TgStackRunE(t, applyOptions)
 	require.NoError(t, err)
@@ -44,7 +44,7 @@ func TestTgOutputIntegration(t *testing.T) {
 			TerragruntDir:    testFolder + "/live",
 			TerragruntBinary: "terragrunt",
 			Logger:           logger.Discard,
-			ExtraArgs:        []string{"destroy", "-auto-approve"},
+			TerraformArgs:    []string{"destroy", "-auto-approve"},
 		}
 		_, _ = TgStackRunE(t, destroyOptions)
 	}()
@@ -58,7 +58,7 @@ func TestTgOutputIntegration(t *testing.T) {
 		TerragruntDir:    testFolder + "/live",
 		TerragruntBinary: "terragrunt",
 		Logger:           logger.Discard,
-		ExtraArgs:        []string{"-json"},
+		TerragruntArgs:   []string{"-json"},
 	}
 
 	strOutputJson := TgOutput(t, jsonOptions, "mother")
@@ -118,7 +118,7 @@ func TestTgOutputErrorHandling(t *testing.T) {
 		TerragruntDir:    testFolder + "/live",
 		TerragruntBinary: "terragrunt",
 		Logger:           logger.Discard,
-		ExtraArgs:        []string{"apply", "-auto-approve"},
+		TerraformArgs:    []string{"apply", "-auto-approve"},
 	}
 	_, err = TgStackRunE(t, applyOptions)
 	require.NoError(t, err)
@@ -129,7 +129,7 @@ func TestTgOutputErrorHandling(t *testing.T) {
 			TerragruntDir:    testFolder + "/live",
 			TerragruntBinary: "terragrunt",
 			Logger:           logger.Discard,
-			ExtraArgs:        []string{"destroy", "-auto-approve"},
+			TerraformArgs:    []string{"destroy", "-auto-approve"},
 		}
 		_, _ = TgStackRunE(t, destroyOptions)
 	}()

--- a/modules/terragrunt/stack_run.go
+++ b/modules/terragrunt/stack_run.go
@@ -19,9 +19,10 @@ func TgStackRunE(t testing.TestingT, options *Options) (string, error) {
 }
 
 // runStackArgs builds the argument list for terragrunt stack run command.
-// All terragrunt command-line flags are now passed via ExtraArgs.
+// This function is now just returning an empty slice since arguments
+// are handled by GetArgsForCommand in cmd.go
 func runStackArgs(options *Options) []string {
-	// Return all user-specified terragrunt command-line arguments
-	// The user passes the specific args they need for their stack run operation
-	return options.ExtraArgs
+	// Arguments are now handled by GetArgsForCommand which properly
+	// separates TerragruntArgs and TerraformArgs
+	return []string{}
 }

--- a/modules/terragrunt/stack_run_test.go
+++ b/modules/terragrunt/stack_run_test.go
@@ -18,7 +18,7 @@ func TestTerragruntStackRunPlan(t *testing.T) {
 	_, err = TgStackInitE(t, &Options{
 		TerragruntDir:    path.Join(testFolder, "live"),
 		TerragruntBinary: "terragrunt",
-		ExtraArgs:        []string{"-upgrade=true"},
+		TerraformArgs:    []string{"-upgrade=true"},
 	})
 	require.NoError(t, err)
 
@@ -26,7 +26,7 @@ func TestTerragruntStackRunPlan(t *testing.T) {
 	out, err := TgStackRunE(t, &Options{
 		TerragruntDir:    path.Join(testFolder, "live"),
 		TerragruntBinary: "terragrunt",
-		ExtraArgs:        []string{"plan"},
+		TerraformArgs:    []string{"plan"},
 	})
 	require.NoError(t, err)
 
@@ -56,7 +56,7 @@ func TestTerragruntStackRunPlanWithNoColor(t *testing.T) {
 	_, err = TgStackInitE(t, &Options{
 		TerragruntDir:    path.Join(testFolder, "live"),
 		TerragruntBinary: "terragrunt",
-		ExtraArgs:        []string{"-upgrade=true"},
+		TerraformArgs:    []string{"-upgrade=true"},
 	})
 	require.NoError(t, err)
 
@@ -64,7 +64,8 @@ func TestTerragruntStackRunPlanWithNoColor(t *testing.T) {
 	out, err := TgStackRunE(t, &Options{
 		TerragruntDir:    path.Join(testFolder, "live"),
 		TerragruntBinary: "terragrunt",
-		ExtraArgs:        []string{"plan", "-no-color"},
+		TerragruntArgs:   []string{"--no-color"},
+		TerraformArgs:    []string{"plan"},
 	})
 	require.NoError(t, err)
 


### PR DESCRIPTION
## Summary
This PR refactors the terragrunt module to explicitly separate terragrunt-specific arguments from terraform command arguments, improving API clarity and usability.

## Motivation
The previous implementation used a single `ExtraArgs` field for all arguments, making it unclear which arguments were for terragrunt vs terraform. The `--` separator logic was also handled inconsistently across different commands.

## Changes
- **Options struct refactoring**: Replaced single `ExtraArgs` field with:
  - `TerragruntArgs`: For terragrunt-specific flags (e.g., `--no-color`, `--terragrunt-log-level`)
  - `TerraformArgs`: For terraform commands passed after `--` separator (e.g., `plan`, `apply`, `-upgrade`)
- **Automatic separator handling**: The `--` separator is now automatically added when `TerraformArgs` are present
- **Test updates**: All tests updated to use the new argument structure

## Benefits
- ✅ Clear separation of concerns between terragrunt and terraform arguments
- ✅ Automatic handling of `--` separator reduces boilerplate
- ✅ Better type safety - prevents accidental mixing of argument types
- ✅ More intuitive and maintainable API

## Testing
All existing tests have been updated and are passing:
```bash
go test ./modules/terragrunt -v
# PASS
# ok github.com/gruntwork-io/terratest/modules/terragrunt
```

## Breaking Changes
This is a breaking change for the beta terragrunt module. Users will need to update their code to use `TerragruntArgs` and `TerraformArgs` instead of `ExtraArgs`.

### Migration Example
Before:
```go
options := &terragrunt.Options{
    TerragruntDir: "/path/to/config",
    ExtraArgs: []string{"--no-color", "plan", "-out=tfplan"},
}
```

After:
```go
options := &terragrunt.Options{
    TerragruntDir: "/path/to/config",
    TerragruntArgs: []string{"--no-color"},
    TerraformArgs: []string{"plan", "-out=tfplan"},
}
```