### PR TITLE
fix: update --terragrunt-non-interactive with --non-interactive

### DIFF
--- a/modules/terraform/cmd.go
+++ b/modules/terraform/cmd.go
@@ -56,7 +56,7 @@ func GetCommonOptions(options *Options, args ...string) (*Options, []string) {
 	}
 
 	if options.TerraformBinary == TerragruntDefaultPath {
-		args = append(args, "--terragrunt-non-interactive")
+		args = append(args, "--non-interactive")
 
 		// for newer Terragrunt version, setting simplified log formatting
 		setTerragruntLogFormatting(options)


### PR DESCRIPTION
## Description

--terragrunt-non-interactive is replaced  by --non-interactive because the terragrunt- prefix is deprecated.

Reference to the Terragrunt docs: https://terragrunt.gruntwork.io/docs/migrate/cli-redesign/#remove-terragrunt--prefix-from-flags

## Release Notes (draft)
Updated: --terragrunt-non-interactive is replaced  by --non-interactive 


