### PR TITLE
fix: prevent segfault in helm.UnmarshalK8SYaml with empty YAML documents

### DIFF
--- a/modules/helm/template.go
+++ b/modules/helm/template.go
@@ -199,6 +199,10 @@ func UnmarshalK8SYamlE(t testing.TestingT, yamlData string, destinationObj inter
 		if err := decoder.Decode(&rawYaml); err != nil {
 			return errors.WithStackTrace(err)
 		}
+		// If rawYaml is nil (empty document), return without error
+		if rawYaml == nil {
+			return nil
+		}
 		// If the root is an array but destinationObj is a single object, return an error
 		if reflect.TypeOf(rawYaml).Kind() == reflect.Slice {
 			return fmt.Errorf("YAML root is an array, but destinationObj is a single object")
@@ -226,6 +230,11 @@ func UnmarshalK8SYamlE(t testing.TestingT, yamlData string, destinationObj inter
 				break // No more documents
 			}
 			return errors.WithStackTrace(err)
+		}
+
+		// Skip nil documents (empty YAML documents)
+		if rawYaml == nil {
+			continue
 		}
 
 		jsonData, err := json.Marshal(rawYaml)

--- a/modules/helm/template_test.go
+++ b/modules/helm/template_test.go
@@ -185,6 +185,23 @@ configmap-data-value-2;
 `
 		assert.Equal(t, data, configmap.Data["thisIsSomeDataKey"])
 	})
+	t.Run("EmptyDocument", func(t *testing.T) {
+		var deployment appsv1.Deployment
+
+		// Should not panic with empty document separator
+		err := UnmarshalK8SYamlE(t, "---", &deployment)
+		assert.NoError(t, err)
+
+		// Should not panic with multiple empty document separators
+		err = UnmarshalK8SYamlE(t, "---\n---\n---", &deployment)
+		assert.NoError(t, err)
+
+		// Test with slice destination
+		var deployments []appsv1.Deployment
+		err = UnmarshalK8SYamlE(t, "---", &deployments)
+		assert.NoError(t, err)
+		assert.Len(t, deployments, 0) // Should be empty
+	})
 }
 
 func TestRenderWarning(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes a segfault that occurs when `helm.UnmarshalK8SYaml` processes empty YAML documents (e.g., `---` separators without content).

## Changes

1. **Single object unmarshaling**: Added nil check after decoding to return early when encountering empty documents
2. **Slice unmarshaling**: Added nil check to skip empty documents in the loop
3. **Test coverage**: Added `EmptyDocument` test case covering:
   - Single empty document separator (`---`)
   - Multiple empty separators (`---\n---\n---`)
   - Empty documents with slice destination

## Root Cause

The YAML decoder successfully decodes empty documents but returns `nil` for `rawYaml`. The code then attempted to call `json.Marshal(rawYaml)` on nil, causing a segfault.

## Test Plan

- [x] Added unit tests for empty document scenarios
- [x] Verified existing tests still pass
- [x] Confirmed no segfault with empty YAML documents