### PR TITLE
Simplify terragrunt function names

### DIFF
--- a/modules/terragrunt/README.md
+++ b/modules/terragrunt/README.md
@@ -88,19 +88,17 @@ Work with standard terragrunt configurations (dependencies via `dependency` bloc
 - `ApplyAll(t, options)` - Apply all modules with dependencies
 - `DestroyAll(t, options)` - Destroy all modules with dependencies
 - `PlanAllExitCode(t, options)` - Plan all and return exit code (0=no changes, 2=changes)
-- `TgInit(t, options)` - Initialize configuration
+- `Init(t, options)` - Initialize configuration
 
 ### Stack Commands
 Work with `terragrunt.stack.hcl` configurations:
 
-- `TgStackGenerate(t, options)` - Generate stack from stack.hcl
-- `TgStackRun(t, options)` - Run command on generated stack
-- `TgStackClean(t, options)` - Remove .terragrunt-stack directory
-- `TgOutput(t, options, key)` - Get stack output value
-- `TgOutputJson(t, options, key)` - Get stack output as JSON
-- `TgOutputAll(t, options)` - Get all stack outputs as map
-
-> **Note**: Function naming is inconsistent - run-all commands lack the `Tg` prefix while stack commands have it. This is for historical reasons.
+- `StackGenerate(t, options)` - Generate stack from stack.hcl
+- `StackRun(t, options)` - Run command on generated stack
+- `StackClean(t, options)` - Remove .terragrunt-stack directory
+- `Output(t, options, key)` - Get stack output value
+- `OutputJson(t, options, key)` - Get stack output as JSON
+- `OutputAll(t, options)` - Get all stack outputs as map
 
 ## Examples
 
@@ -135,7 +133,7 @@ func TestWithCustomArgs(t *testing.T) {
         TerraformArgs:  []string{"-upgrade"},
     }
 
-    terragrunt.TgInit(t, options)
+    terragrunt.Init(t, options)
 }
 ```
 
@@ -153,11 +151,11 @@ func TestStackOutput(t *testing.T) {
     defer terragrunt.DestroyAll(t, options)
 
     // Get specific output
-    vpcID := terragrunt.TgOutput(t, options, "vpc_id")
+    vpcID := terragrunt.Output(t, options, "vpc_id")
     assert.NotEmpty(t, vpcID)
 
     // Get all outputs
-    outputs := terragrunt.TgOutputAll(t, options)
+    outputs := terragrunt.OutputAll(t, options)
     assert.Contains(t, outputs, "vpc_id")
 }
 ```

--- a/modules/terragrunt/cmd.go
+++ b/modules/terragrunt/cmd.go
@@ -10,7 +10,7 @@ import (
 	"github.com/gruntwork-io/terratest/modules/testing"
 )
 
-// runTerragruntStackCommandE executes tg stack commands
+// runTerragruntStackCommandE executes terragrunt stack commands
 // It handles argument construction, retry logic, and error handling for all stack commands
 func runTerragruntStackCommandE(
 	t testing.TestingT, opts *Options, subCommand string, additionalArgs ...string) (string, error) {

--- a/modules/terragrunt/cmd_args_test.go
+++ b/modules/terragrunt/cmd_args_test.go
@@ -25,7 +25,7 @@ func TestTerragruntArgsIncluded(t *testing.T) {
 	}
 
 	// Run init - if TerragruntArgs work, we should only see error-level logs
-	output, err := TgInitE(t, options)
+	output, err := InitE(t, options)
 	require.NoError(t, err)
 
 	// With --log-level error, we shouldn't see info-level messages
@@ -51,7 +51,7 @@ func TestTerraformArgsIncluded(t *testing.T) {
 	}
 
 	// Run init with -backend=false flag
-	output, err := TgInitE(t, options)
+	output, err := InitE(t, options)
 	require.NoError(t, err)
 
 	// With -backend=false, we should NOT see backend initialization messages
@@ -112,7 +112,7 @@ func TestCombinedArgsOrdering(t *testing.T) {
 	}
 
 	// Run init - both args should be passed in the correct order
-	output, err := TgInitE(t, options)
+	output, err := InitE(t, options)
 	require.NoError(t, err)
 
 	// Verify TerragruntArgs effect: should not see info-level logs
@@ -258,7 +258,7 @@ func TestEnvVarsPropagation(t *testing.T) {
 	}
 
 	// Run init - should succeed with env vars set
-	output, err := TgInitE(t, options)
+	output, err := InitE(t, options)
 	require.NoError(t, err)
 	require.NotEmpty(t, output)
 	// With TG_LOG_LEVEL=error, should not see info logs

--- a/modules/terragrunt/init.go
+++ b/modules/terragrunt/init.go
@@ -5,22 +5,22 @@ import (
 	"github.com/gruntwork-io/terratest/modules/testing"
 )
 
-// TgInit calls tg init and return stdout/stderr
-func TgInit(t testing.TestingT, options *Options) string {
-	out, err := TgInitE(t, options)
+// Init calls terragrunt init and return stdout/stderr
+func Init(t testing.TestingT, options *Options) string {
+	out, err := InitE(t, options)
 	if err != nil {
 		t.Fatal(err)
 	}
 	return out
 }
 
-// TgInitE calls tg init and return stdout/stderr
-func TgInitE(t testing.TestingT, options *Options) (string, error) {
-	// Use regular tg init command (not tg stack init)
+// InitE calls terragrunt init and return stdout/stderr
+func InitE(t testing.TestingT, options *Options) (string, error) {
+	// Use regular terragrunt init command (not terragrunt stack init)
 	return runTerragruntCommandE(t, options, "init", initArgs(options)...)
 }
 
-// initArgs builds the argument list for tg init command.
+// initArgs builds the argument list for terragrunt init command.
 // This function handles complex configuration that requires special formatting.
 func initArgs(options *Options) []string {
 	var args []string

--- a/modules/terragrunt/init_test.go
+++ b/modules/terragrunt/init_test.go
@@ -8,14 +8,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestTgInit(t *testing.T) {
+func TestInit(t *testing.T) {
 	t.Parallel()
 
 	testFolder, err := files.CopyTerraformFolderToTemp(
 		"../../test/fixtures/terragrunt/terragrunt-no-error", t.Name())
 	require.NoError(t, err)
 
-	out, err := TgInitE(t, &Options{
+	out, err := InitE(t, &Options{
 		TerragruntDir:    testFolder,
 		TerragruntBinary: "terragrunt",
 		TerraformArgs:    []string{"-upgrade=true"}, // Common terraform init flag
@@ -24,7 +24,7 @@ func TestTgInit(t *testing.T) {
 	require.Contains(t, out, "Terraform has been successfully initialized!")
 }
 
-func TestTgInitWithInvalidConfig(t *testing.T) {
+func TestInitWithInvalidConfig(t *testing.T) {
 	t.Parallel()
 	// Test error handling when tg.hcl has invalid HCL syntax
 	testFolder, err := files.CopyTerraformFolderToTemp(
@@ -32,7 +32,7 @@ func TestTgInitWithInvalidConfig(t *testing.T) {
 	require.NoError(t, err)
 
 	// This should fail due to invalid HCL syntax in tg.hcl
-	_, err = TgInitE(t, &Options{
+	_, err = InitE(t, &Options{
 		TerragruntDir:    testFolder,
 		TerragruntBinary: "terragrunt",
 		TerraformArgs:    []string{"-upgrade=true"}, // Common terraform init flag
@@ -42,8 +42,8 @@ func TestTgInitWithInvalidConfig(t *testing.T) {
 	require.Contains(t, err.Error(), "Missing expression")
 }
 
-// TestTgInitWithBothArgTypes verifies init works with both TerragruntArgs and TerraformArgs
-func TestTgInitWithBothArgTypes(t *testing.T) {
+// TestInitWithBothArgTypes verifies init works with both TerragruntArgs and TerraformArgs
+func TestInitWithBothArgTypes(t *testing.T) {
 	t.Parallel()
 
 	testFolder, err := files.CopyTerraformFolderToTemp(
@@ -57,7 +57,7 @@ func TestTgInitWithBothArgTypes(t *testing.T) {
 		TerraformArgs:    []string{"-upgrade"},
 	}
 
-	output, err := TgInitE(t, options)
+	output, err := InitE(t, options)
 	require.NoError(t, err)
 	// Verify TerragruntArgs: no info logs
 	require.NotContains(t, output, "level=info")

--- a/modules/terragrunt/options.go
+++ b/modules/terragrunt/options.go
@@ -17,7 +17,7 @@ import (
 // Example:
 //
 //	// For init with terraform flags
-//	TgInitE(t, &Options{
+//	InitE(t, &Options{
 //	    TerragruntDir: "/path/to/config",
 //	    TerragruntArgs: []string{"--log-level", "info"},
 //	    TerraformArgs: []string{"-upgrade=true"},

--- a/modules/terragrunt/plan_test.go
+++ b/modules/terragrunt/plan_test.go
@@ -30,7 +30,7 @@ func TestTgPlanAllNoError(t *testing.T) {
 		t.Fatal(errExitCode)
 	}
 
-	// Since PlanAllExitCodeTgE returns error codes, we want to compare against 1
+	// Since PlanAllExitCodeE returns error codes, we want to compare against 1
 	require.Equal(t, 0, getExitCode)
 }
 
@@ -52,7 +52,7 @@ func TestTgPlanAllWithError(t *testing.T) {
 	require.Equal(t, 1, getExitCode)
 }
 
-func TestAssertTgPlanAllExitCodeNoError(t *testing.T) {
+func TestAssertPlanAllExitCodeNoError(t *testing.T) {
 	t.Parallel()
 
 	testFolder, err := files.CopyTerragruntFolderToTemp("../../test/fixtures/terragrunt/terragrunt-multi-plan", t.Name())
@@ -84,7 +84,7 @@ func TestAssertTgPlanAllExitCodeNoError(t *testing.T) {
 	assertPlanAllExitCode(t, getExitCode, true)
 }
 
-func TestAssertTgPlanAllExitCodeWithError(t *testing.T) {
+func TestAssertPlanAllExitCodeWithError(t *testing.T) {
 	t.Parallel()
 
 	testFolder, err := files.CopyTerragruntFolderToTemp("../../test/fixtures/terragrunt/terragrunt-with-plan-error", t.Name())

--- a/modules/terragrunt/stack_clean.go
+++ b/modules/terragrunt/stack_clean.go
@@ -4,18 +4,18 @@ import (
 	"github.com/gruntwork-io/terratest/modules/testing"
 )
 
-// TgStackClean calls tg stack clean to remove the .terragrunt-stack directory
+// StackClean calls terragrunt stack clean to remove the .terragrunt-stack directory
 // This command cleans up the generated stack files created by stack generate or stack run
-func TgStackClean(t testing.TestingT, options *Options) string {
-	out, err := TgStackCleanE(t, options)
+func StackClean(t testing.TestingT, options *Options) string {
+	out, err := StackCleanE(t, options)
 	if err != nil {
 		t.Fatal(err)
 	}
 	return out
 }
 
-// TgStackCleanE calls tg stack clean to remove the .terragrunt-stack directory
+// StackCleanE calls terragrunt stack clean to remove the .terragrunt-stack directory
 // This command cleans up the generated stack files created by stack generate or stack run
-func TgStackCleanE(t testing.TestingT, options *Options) (string, error) {
+func StackCleanE(t testing.TestingT, options *Options) (string, error) {
 	return runTerragruntStackCommandE(t, options, "clean")
 }

--- a/modules/terragrunt/stack_clean_test.go
+++ b/modules/terragrunt/stack_clean_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestTgStackClean(t *testing.T) {
+func TestStackClean(t *testing.T) {
 	t.Parallel()
 
 	testFolder, err := files.CopyTerraformFolderToTemp(
@@ -18,7 +18,7 @@ func TestTgStackClean(t *testing.T) {
 	stackDir := path.Join(testFolder, "live", ".terragrunt-stack")
 
 	// First generate the stack to create .terragrunt-stack directory
-	_, err = TgStackGenerateE(t, &Options{
+	_, err = StackGenerateE(t, &Options{
 		TerragruntDir:    path.Join(testFolder, "live"),
 		TerragruntBinary: "terragrunt",
 	})
@@ -28,7 +28,7 @@ func TestTgStackClean(t *testing.T) {
 	require.DirExists(t, stackDir)
 
 	// Clean the stack
-	out, err := TgStackCleanE(t, &Options{
+	out, err := StackCleanE(t, &Options{
 		TerragruntDir:    path.Join(testFolder, "live"),
 		TerragruntBinary: "terragrunt",
 	})
@@ -41,7 +41,7 @@ func TestTgStackClean(t *testing.T) {
 	require.NoDirExists(t, stackDir)
 }
 
-func TestTgStackCleanNonExistentStack(t *testing.T) {
+func TestStackCleanNonExistentStack(t *testing.T) {
 	t.Parallel()
 
 	testFolder, err := files.CopyTerraformFolderToTemp(
@@ -54,14 +54,14 @@ func TestTgStackCleanNonExistentStack(t *testing.T) {
 	require.NoDirExists(t, stackDir)
 
 	// Clean should succeed even if .terragrunt-stack doesn't exist
-	_, err = TgStackCleanE(t, &Options{
+	_, err = StackCleanE(t, &Options{
 		TerragruntDir:    path.Join(testFolder, "live"),
 		TerragruntBinary: "terragrunt",
 	})
 	require.NoError(t, err)
 }
 
-func TestTgStackCleanAfterRun(t *testing.T) {
+func TestStackCleanAfterRun(t *testing.T) {
 	t.Parallel()
 
 	testFolder, err := files.CopyTerraformFolderToTemp(
@@ -71,7 +71,7 @@ func TestTgStackCleanAfterRun(t *testing.T) {
 	stackDir := path.Join(testFolder, "live", ".terragrunt-stack")
 
 	// Initialize the stack
-	_, err = TgInitE(t, &Options{
+	_, err = InitE(t, &Options{
 		TerragruntDir:    path.Join(testFolder, "live"),
 		TerragruntBinary: "terragrunt",
 		TerraformArgs:    []string{"-upgrade=true"},
@@ -79,7 +79,7 @@ func TestTgStackCleanAfterRun(t *testing.T) {
 	require.NoError(t, err)
 
 	// Run plan to generate the stack
-	_, err = TgStackRunE(t, &Options{
+	_, err = StackRunE(t, &Options{
 		TerragruntDir:    path.Join(testFolder, "live"),
 		TerragruntBinary: "terragrunt",
 		TerraformArgs:    []string{"plan"},
@@ -90,7 +90,7 @@ func TestTgStackCleanAfterRun(t *testing.T) {
 	require.DirExists(t, stackDir)
 
 	// Clean the stack
-	out, err := TgStackCleanE(t, &Options{
+	out, err := StackCleanE(t, &Options{
 		TerragruntDir:    path.Join(testFolder, "live"),
 		TerragruntBinary: "terragrunt",
 	})

--- a/modules/terragrunt/stack_generate.go
+++ b/modules/terragrunt/stack_generate.go
@@ -4,16 +4,16 @@ import (
 	"github.com/gruntwork-io/terratest/modules/testing"
 )
 
-// TgStackGenerate calls tg stack generate and returns stdout/stderr
-func TgStackGenerate(t testing.TestingT, options *Options) string {
-	out, err := TgStackGenerateE(t, options)
+// StackGenerate calls terragrunt stack generate and returns stdout/stderr
+func StackGenerate(t testing.TestingT, options *Options) string {
+	out, err := StackGenerateE(t, options)
 	if err != nil {
 		t.Fatal(err)
 	}
 	return out
 }
 
-// TgStackGenerateE calls tg stack generate and returns stdout/stderr
-func TgStackGenerateE(t testing.TestingT, options *Options) (string, error) {
+// StackGenerateE calls terragrunt stack generate and returns stdout/stderr
+func StackGenerateE(t testing.TestingT, options *Options) (string, error) {
 	return runTerragruntStackCommandE(t, options, "generate")
 }

--- a/modules/terragrunt/stack_generate_test.go
+++ b/modules/terragrunt/stack_generate_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestTgStackGenerate(t *testing.T) {
+func TestStackGenerate(t *testing.T) {
 	t.Parallel()
 
 	testFolder, err := files.CopyTerraformFolderToTemp(
@@ -17,7 +17,7 @@ func TestTgStackGenerate(t *testing.T) {
 	require.NoError(t, err)
 
 	// First initialize the stack
-	_, err = TgInitE(t, &Options{
+	_, err = InitE(t, &Options{
 		TerragruntDir:    path.Join(testFolder, "live"),
 		TerragruntBinary: "terragrunt",
 		TerraformArgs:    []string{"-upgrade=true"},
@@ -25,7 +25,7 @@ func TestTgStackGenerate(t *testing.T) {
 	require.NoError(t, err)
 
 	// Then generate the stack
-	out, err := TgStackGenerateE(t, &Options{
+	out, err := StackGenerateE(t, &Options{
 		TerragruntDir:    path.Join(testFolder, "live"),
 		TerragruntBinary: "terragrunt",
 	})
@@ -47,7 +47,7 @@ func TestTgStackGenerate(t *testing.T) {
 	}
 }
 
-func TestTgStackGenerateWithNoColor(t *testing.T) {
+func TestStackGenerateWithNoColor(t *testing.T) {
 	t.Parallel()
 
 	testFolder, err := files.CopyTerraformFolderToTemp(
@@ -55,7 +55,7 @@ func TestTgStackGenerateWithNoColor(t *testing.T) {
 	require.NoError(t, err)
 
 	// First initialize the stack
-	_, err = TgInitE(t, &Options{
+	_, err = InitE(t, &Options{
 		TerragruntDir:    path.Join(testFolder, "live"),
 		TerragruntBinary: "terragrunt",
 		TerraformArgs:    []string{"-upgrade=true"},
@@ -63,7 +63,7 @@ func TestTgStackGenerateWithNoColor(t *testing.T) {
 	require.NoError(t, err)
 
 	// Generate with no-color option
-	out, err := TgStackGenerateE(t, &Options{
+	out, err := StackGenerateE(t, &Options{
 		TerragruntDir:    path.Join(testFolder, "live"),
 		TerragruntBinary: "terragrunt",
 		TerragruntArgs:   []string{"--no-color"},
@@ -79,7 +79,7 @@ func TestTgStackGenerateWithNoColor(t *testing.T) {
 	require.DirExists(t, stackDir)
 }
 
-func TestTgStackGenerateWithExtraArgs(t *testing.T) {
+func TestStackGenerateWithExtraArgs(t *testing.T) {
 	t.Parallel()
 
 	testFolder, err := files.CopyTerraformFolderToTemp(
@@ -87,7 +87,7 @@ func TestTgStackGenerateWithExtraArgs(t *testing.T) {
 	require.NoError(t, err)
 
 	// First initialize the stack
-	_, err = TgInitE(t, &Options{
+	_, err = InitE(t, &Options{
 		TerragruntDir:    path.Join(testFolder, "live"),
 		TerragruntBinary: "terragrunt",
 		TerraformArgs:    []string{"-upgrade=true"},
@@ -95,7 +95,7 @@ func TestTgStackGenerateWithExtraArgs(t *testing.T) {
 	require.NoError(t, err)
 
 	// Generate with extra args
-	out, err := TgStackGenerateE(t, &Options{
+	out, err := StackGenerateE(t, &Options{
 		TerragruntDir:    path.Join(testFolder, "live"),
 		TerragruntBinary: "terragrunt",
 		TerragruntArgs:   []string{"--log-level", "info"},
@@ -111,11 +111,11 @@ func TestTgStackGenerateWithExtraArgs(t *testing.T) {
 	require.DirExists(t, stackDir)
 }
 
-func TestTgStackGenerateNonExistentDir(t *testing.T) {
+func TestStackGenerateNonExistentDir(t *testing.T) {
 	t.Parallel()
 
 	// Test with non-existent directory
-	_, err := TgStackGenerateE(t, &Options{
+	_, err := StackGenerateE(t, &Options{
 		TerragruntDir:    "/non/existent/path",
 		TerragruntBinary: "terragrunt",
 	})
@@ -136,14 +136,14 @@ func TestStackGenerateWithArgs(t *testing.T) {
 	require.NoError(t, err)
 
 	// Initialize first
-	_, err = TgInitE(t, &Options{
+	_, err = InitE(t, &Options{
 		TerragruntDir:    path.Join(testFolder, "live"),
 		TerragruntBinary: "terragrunt",
 	})
 	require.NoError(t, err)
 
 	// Generate with TerragruntArgs
-	out, err := TgStackGenerateE(t, &Options{
+	out, err := StackGenerateE(t, &Options{
 		TerragruntDir:    path.Join(testFolder, "live"),
 		TerragruntBinary: "terragrunt",
 		TerragruntArgs:   []string{"--log-level", "error"},

--- a/modules/terragrunt/stack_output.go
+++ b/modules/terragrunt/stack_output.go
@@ -8,17 +8,17 @@ import (
 	"github.com/gruntwork-io/terratest/modules/testing"
 )
 
-// TgOutput calls tg stack output for the given variable and returns its value as a string
-func TgOutput(t testing.TestingT, options *Options, key string) string {
-	out, err := TgOutputE(t, options, key)
+// Output calls terragrunt stack output for the given variable and returns its value as a string
+func Output(t testing.TestingT, options *Options, key string) string {
+	out, err := OutputE(t, options, key)
 	if err != nil {
 		t.Fatal(err)
 	}
 	return out
 }
 
-// TgOutputE calls tg stack output for the given variable and returns its value as a string
-func TgOutputE(t testing.TestingT, options *Options, key string) (string, error) {
+// OutputE calls terragrunt stack output for the given variable and returns its value as a string
+func OutputE(t testing.TestingT, options *Options, key string) (string, error) {
 	// Prepare options with no-color flag for parsing
 	optsCopy := *options
 	optsCopy.TerragruntArgs = append([]string{"--no-color"}, options.TerragruntArgs...)
@@ -47,20 +47,20 @@ func TgOutputE(t testing.TestingT, options *Options, key string) (string, error)
 	return cleaned, nil
 }
 
-// TgOutputJson calls tg stack output for the given variable and returns the result as the json string.
+// OutputJson calls terragrunt stack output for the given variable and returns the result as the json string.
 // If key is an empty string, it will return all the output variables.
-func TgOutputJson(t testing.TestingT, options *Options, key string) string {
-	str, err := TgOutputJsonE(t, options, key)
+func OutputJson(t testing.TestingT, options *Options, key string) string {
+	str, err := OutputJsonE(t, options, key)
 	if err != nil {
 		t.Fatal(err)
 	}
 	return str
 }
 
-// TgOutputJsonE calls tg stack output for the given variable and returns the
+// OutputJsonE calls terragrunt stack output for the given variable and returns the
 // result as the json string.
 // If key is an empty string, it will return all the output variables.
-func TgOutputJsonE(t testing.TestingT, options *Options, key string) (string, error) {
+func OutputJsonE(t testing.TestingT, options *Options, key string) (string, error) {
 	// Prepare options with no-color flag
 	optsCopy := *options
 	optsCopy.TerragruntArgs = append([]string{"--no-color"}, options.TerragruntArgs...)
@@ -110,7 +110,7 @@ func removeLogLines(rawOutput string) string {
 	return strings.Join(result, "\n")
 }
 
-// cleanTerragruntOutput extracts the actual output value from tg stack's verbose output
+// cleanTerragruntOutput extracts the actual output value from terragrunt stack's verbose output
 //
 // Example input (raw tg output):
 //
@@ -152,7 +152,7 @@ func cleanTerragruntOutput(rawOutput string) (string, error) {
 	return finalOutput, nil
 }
 
-// cleanTerragruntJson cleans the JSON output from tg stack command
+// cleanTerragruntJson cleans the JSON output from terragrunt stack command
 //
 // Example input (raw tg JSON output):
 //

--- a/modules/terragrunt/stack_output_test.go
+++ b/modules/terragrunt/stack_output_test.go
@@ -11,8 +11,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// Integration test using actual tg stack fixture
-func TestTgOutputIntegration(t *testing.T) {
+// Integration test using actual terragrunt stack fixture
+func TestOutputIntegration(t *testing.T) {
 	t.Parallel()
 
 	// Create a temporary copy of the stack fixture
@@ -27,7 +27,7 @@ func TestTgOutputIntegration(t *testing.T) {
 	}
 
 	// Initialize and apply tg using stack commands
-	_, err = TgInitE(t, options)
+	_, err = InitE(t, options)
 	require.NoError(t, err)
 
 	applyOptions := &Options{
@@ -36,7 +36,7 @@ func TestTgOutputIntegration(t *testing.T) {
 		Logger:           logger.Discard,
 		TerraformArgs:    []string{"apply"}, // stack run auto-approves by default
 	}
-	_, err = TgStackRunE(t, applyOptions)
+	_, err = StackRunE(t, applyOptions)
 	require.NoError(t, err)
 
 	// Clean up after test
@@ -47,26 +47,26 @@ func TestTgOutputIntegration(t *testing.T) {
 			Logger:           logger.Discard,
 			TerraformArgs:    []string{"destroy"}, // stack run auto-approves by default
 		}
-		_, _ = TgStackRunE(t, destroyOptions)
+		_, _ = StackRunE(t, destroyOptions)
 	}()
 
 	// Test string stack output - get output from mother unit
-	strOutput := TgOutput(t, options, "mother")
+	strOutput := Output(t, options, "mother")
 	assert.Contains(t, strOutput, "./test.txt")
 
-	// Test getting stack output as JSON using the TgOutputJson function
+	// Test getting stack output as JSON using the OutputJson function
 	jsonOptions := &Options{
 		TerragruntDir:    testFolder + "/live",
 		TerragruntBinary: "terragrunt",
 		Logger:           logger.Discard,
 	}
 
-	strOutputJson := TgOutputJson(t, jsonOptions, "mother")
+	strOutputJson := OutputJson(t, jsonOptions, "mother")
 	// The JSON output for a single value should still be cleaned to just show the value
 	assert.Contains(t, strOutputJson, "./test.txt")
 
 	// Test getting all stack outputs as JSON
-	allOutputsJson := TgOutputJson(t, jsonOptions, "")
+	allOutputsJson := OutputJson(t, jsonOptions, "")
 	require.NotEmpty(t, allOutputsJson)
 
 	// For JSON output of all outputs, we should get valid JSON
@@ -97,7 +97,7 @@ func TestTgOutputIntegration(t *testing.T) {
 }
 
 // Test error handling with non-existent stack output
-func TestTgOutputErrorHandling(t *testing.T) {
+func TestOutputErrorHandling(t *testing.T) {
 	t.Parallel()
 
 	// Create a temporary copy of the stack fixture
@@ -112,7 +112,7 @@ func TestTgOutputErrorHandling(t *testing.T) {
 	}
 
 	// Initialize and apply tg using stack commands
-	_, err = TgInitE(t, options)
+	_, err = InitE(t, options)
 	require.NoError(t, err)
 
 	applyOptions := &Options{
@@ -121,7 +121,7 @@ func TestTgOutputErrorHandling(t *testing.T) {
 		Logger:           logger.Discard,
 		TerraformArgs:    []string{"apply"}, // stack run auto-approves by default
 	}
-	_, err = TgStackRunE(t, applyOptions)
+	_, err = StackRunE(t, applyOptions)
 	require.NoError(t, err)
 
 	// Clean up after test
@@ -132,11 +132,11 @@ func TestTgOutputErrorHandling(t *testing.T) {
 			Logger:           logger.Discard,
 			TerraformArgs:    []string{"destroy"}, // stack run auto-approves by default
 		}
-		_, _ = TgStackRunE(t, destroyOptions)
+		_, _ = StackRunE(t, destroyOptions)
 	}()
 
 	// Test that non-existent stack output returns error or empty string
-	output, err := TgOutputE(t, options, "non_existent_output")
+	output, err := OutputE(t, options, "non_existent_output")
 	// Tg stack output might return empty string for non-existent outputs
 	// rather than an error, so we need to handle both cases
 	if err != nil {

--- a/modules/terragrunt/stack_run.go
+++ b/modules/terragrunt/stack_run.go
@@ -4,16 +4,16 @@ import (
 	"github.com/gruntwork-io/terratest/modules/testing"
 )
 
-// TgStackRun calls tg stack run and returns stdout/stderr
-func TgStackRun(t testing.TestingT, options *Options) string {
-	out, err := TgStackRunE(t, options)
+// StackRun calls terragrunt stack run and returns stdout/stderr
+func StackRun(t testing.TestingT, options *Options) string {
+	out, err := StackRunE(t, options)
 	if err != nil {
 		t.Fatal(err)
 	}
 	return out
 }
 
-// TgStackRunE calls tg stack run and returns stdout/stderr
-func TgStackRunE(t testing.TestingT, options *Options) (string, error) {
+// StackRunE calls terragrunt stack run and returns stdout/stderr
+func StackRunE(t testing.TestingT, options *Options) (string, error) {
 	return runTerragruntStackCommandE(t, options, "run")
 }

--- a/modules/terragrunt/stack_run_test.go
+++ b/modules/terragrunt/stack_run_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestTgStackRunPlan(t *testing.T) {
+func TestStackRunPlan(t *testing.T) {
 	t.Parallel()
 
 	testFolder, err := files.CopyTerraformFolderToTemp(
@@ -16,7 +16,7 @@ func TestTgStackRunPlan(t *testing.T) {
 	require.NoError(t, err)
 
 	// First initialize the stack
-	_, err = TgInitE(t, &Options{
+	_, err = InitE(t, &Options{
 		TerragruntDir:    path.Join(testFolder, "live"),
 		TerragruntBinary: "terragrunt",
 		TerraformArgs:    []string{"-upgrade=true"},
@@ -24,7 +24,7 @@ func TestTgStackRunPlan(t *testing.T) {
 	require.NoError(t, err)
 
 	// Then run plan on the stack
-	out, err := TgStackRunE(t, &Options{
+	out, err := StackRunE(t, &Options{
 		TerragruntDir:    path.Join(testFolder, "live"),
 		TerragruntBinary: "terragrunt",
 		TerraformArgs:    []string{"plan"},
@@ -47,7 +47,7 @@ func TestTgStackRunPlan(t *testing.T) {
 	}
 }
 
-func TestTgStackRunPlanWithNoColor(t *testing.T) {
+func TestStackRunPlanWithNoColor(t *testing.T) {
 	t.Parallel()
 
 	testFolder, err := files.CopyTerraformFolderToTemp(
@@ -55,7 +55,7 @@ func TestTgStackRunPlanWithNoColor(t *testing.T) {
 	require.NoError(t, err)
 
 	// First initialize the stack
-	_, err = TgInitE(t, &Options{
+	_, err = InitE(t, &Options{
 		TerragruntDir:    path.Join(testFolder, "live"),
 		TerragruntBinary: "terragrunt",
 		TerraformArgs:    []string{"-upgrade=true"},
@@ -63,7 +63,7 @@ func TestTgStackRunPlanWithNoColor(t *testing.T) {
 	require.NoError(t, err)
 
 	// Run plan with no-color option
-	out, err := TgStackRunE(t, &Options{
+	out, err := StackRunE(t, &Options{
 		TerragruntDir:    path.Join(testFolder, "live"),
 		TerragruntBinary: "terragrunt",
 		TerragruntArgs:   []string{"--no-color"},
@@ -80,22 +80,22 @@ func TestTgStackRunPlanWithNoColor(t *testing.T) {
 	require.DirExists(t, stackDir)
 }
 
-func TestTgStackRunNonExistentDir(t *testing.T) {
+func TestStackRunNonExistentDir(t *testing.T) {
 	t.Parallel()
 
 	// Test with non-existent directory
-	_, err := TgStackRunE(t, &Options{
+	_, err := StackRunE(t, &Options{
 		TerragruntDir:    "/non/existent/path",
 		TerragruntBinary: "terragrunt",
 	})
 	require.Error(t, err)
 }
 
-func TestTgStackRunEmptyOptions(t *testing.T) {
+func TestStackRunEmptyOptions(t *testing.T) {
 	t.Parallel()
 
 	// Test with minimal options to verify default behavior
-	_, err := TgStackRunE(t, &Options{})
+	_, err := StackRunE(t, &Options{})
 	require.Error(t, err)
 	// Should fail due to missing TerragruntDir
 }

--- a/modules/terragrunt/terragrunt_e2e_test.go
+++ b/modules/terragrunt/terragrunt_e2e_test.go
@@ -72,13 +72,13 @@ func TestStackEndToEndIntegration(t *testing.T) {
 
 	// Step 1: Initialize stack
 	t.Log("Step 1: Initializing stack with TerragruntArgs")
-	output, err := TgInitE(t, options)
+	output, err := InitE(t, options)
 	require.NoError(t, err)
 	require.NotContains(t, output, "level=info", "TerragruntArgs should suppress info logs")
 
 	// Step 2: Generate stack
 	t.Log("Step 2: Generating stack with TerragruntArgs")
-	genOutput, err := TgStackGenerateE(t, options)
+	genOutput, err := StackGenerateE(t, options)
 	require.NoError(t, err)
 	require.NotContains(t, genOutput, "level=info", "TerragruntArgs should suppress info logs")
 
@@ -86,13 +86,13 @@ func TestStackEndToEndIntegration(t *testing.T) {
 	t.Log("Step 3: Running stack plan with TerraformArgs")
 	runOptions := *options
 	runOptions.TerraformArgs = []string{"plan"}
-	planOutput, err := TgStackRunE(t, &runOptions)
+	planOutput, err := StackRunE(t, &runOptions)
 	require.NoError(t, err)
 	require.Contains(t, planOutput, "Terraform will perform", "Stack run should execute plan")
 
 	// Step 4: Clean stack
 	t.Log("Step 4: Cleaning stack")
-	_, err = TgStackCleanE(t, options)
+	_, err = StackCleanE(t, options)
 	require.NoError(t, err)
 
 	t.Log("Stack integration test completed successfully")


### PR DESCRIPTION
## Description

Simplifies function names by removing the `Tg` prefix, following Terragrunt's own simplification of removing `terragrunt-` prefixes from CLI flags.

⚠️ **BREAKING CHANGE**: All function names have been updated. Users will need to update their test code when upgrading.

## Changes

**Function renames:**
- `ApplyAll` (was `TgApplyAll`)
- `DestroyAll` (was `TgDestroyAll`)
- `PlanAllExitCode` (was `TgPlanAllExitCode`)
- `Init` (was `TgInit`)
- `StackGenerate`, `StackRun`, `StackClean` (removed `Tg` prefix)
- `Output`, `OutputJson`, `OutputAll` (removed `Tg` prefix)

All tests and documentation updated.

## Migration Guide

```go
// Before
terragrunt.TgApplyAll(t, options)
defer terragrunt.TgDestroyAll(t, options)
terragrunt.TgInit(t, options)

// After
terragrunt.ApplyAll(t, options)
defer terragrunt.DestroyAll(t, options)
terragrunt.Init(t, options)
```

Simple find-replace: Remove `Tg` prefix from all terragrunt function calls.

## Benefits

- Simpler, cleaner API
- Package name already indicates these are terragrunt functions
- Consistent with Terragrunt CLI simplification
- Less typing, easier to read

Fixes #1618