### PR TITLE
ci: add dedicated azure_test job for Azure integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -209,12 +209,15 @@ jobs:
       # NOTE: because this doesn't build with the kubernetes tag, it will not run the kubernetes tests. See
       # kubernetes_test build steps.
       # NOTE: terragrunt tests are excluded here and run in a separate terragrunt_test job.
+      # NOTE: Azure tests are run in a separate azure_test job with Azure credentials.
+      # NOTE: AWS tests are run in a separate aws_test job with AWS credentials.
       - run: mkdir -p /tmp/logs
-      # check we can compile the azure code, but don't actually run the tests
+      # check we can compile the azure and aws code (actual tests run in dedicated jobs)
       - run: run-go-tests --packages "-p 1 -tags=azure -run IDontExist ./modules/azure"
+      - run: run-go-tests --packages "-p 1 -tags=aws -run IDontExist ./modules/aws"
       - run: |
-          # Run all tests except terragrunt module (which has its own dedicated job)
-          run-go-tests --packages "-p 1 $(go list ./... | grep -v './modules/terragrunt' | tr '\n' ' ')" | tee /tmp/logs/test_output.log
+          # Run all tests except terragrunt module and cloud-specific tests (which have their own dedicated jobs)
+          run-go-tests --packages "-p 1 $(go list ./... | grep -v './modules/terragrunt' | grep -v './modules/aws' | tr '\n' ' ')" | tee /tmp/logs/test_output.log
 
       - run:
           command: |
@@ -254,12 +257,15 @@ jobs:
       # NOTE: because this doesn't build with the kubernetes tag, it will not run the kubernetes tests. See
       # kubernetes_test build steps.
       # NOTE: terragrunt tests are excluded here and run in a separate terragrunt_test job.
+      # NOTE: Azure tests are run in a separate azure_test job with Azure credentials.
+      # NOTE: AWS tests are run in a separate aws_test job with AWS credentials.
       - run: mkdir -p /tmp/logs
-      # check we can compile the azure code, but don't actually run the tests
+      # check we can compile the azure and aws code (actual tests run in dedicated jobs)
       - run: run-go-tests --packages "-p 1 -tags=azure -run IDontExist ./modules/azure"
+      - run: run-go-tests --packages "-p 1 -tags=aws -run IDontExist ./modules/aws"
       - run: |
-          # Run all tests except terragrunt module (which has its own dedicated job)
-          run-go-tests --packages "-p 1 $(go list ./... | grep -v './modules/terragrunt' | tr '\n' ' ')" | tee /tmp/logs/test_output.log
+          # Run all tests except terragrunt module and cloud-specific tests (which have their own dedicated jobs)
+          run-go-tests --packages "-p 1 $(go list ./... | grep -v './modules/terragrunt' | grep -v './modules/aws' | tr '\n' ' ')" | tee /tmp/logs/test_output.log
 
       - run:
           command: |
@@ -303,6 +309,84 @@ jobs:
             # require additional filtering.
             run-go-tests --packages "-tags gcp ./modules/gcp" | tee /tmp/logs/test_output.log
             run-go-tests --packages "-tags=gcp ./test/gcp" | tee /tmp/logs/test_output.log
+
+      - run:
+          command: |
+            ./cmd/bin/terratest_log_parser_linux_amd64 --testlog /tmp/logs/test_output.log --outputdir /tmp/logs
+          when: always
+
+      # Store test result and log artifacts for browsing purposes
+      - store_artifacts:
+          path: /tmp/logs
+      - store_test_results:
+          path: /tmp/logs
+
+  # Azure tests - requires Azure credentials to be configured in CircleCI context
+  # NOTE: Azure tests use the 'azure' build tag and are located in ./modules/azure and ./test/azure
+  azure_test:
+    <<: *env
+    docker:
+      - image: cimg/base:2022.03
+
+    steps:
+      - attach_workspace:
+          at: /home/circleci
+
+      - run:
+          <<: *install_gruntwork_utils
+
+      # The weird way you have to set PATH in Circle 2.0
+      - run: |
+          echo 'export PATH=$HOME/.local/bin:$HOME/terraform:$HOME/packer:$PATH' >> $BASH_ENV
+
+      # Run the Azure tests. These tests are run because the azure build tag is included, and we explicitly
+      # select the Azure tests
+      - run:
+          command: |
+            mkdir -p /tmp/logs
+            # Run the unit tests first, then the integration tests. They are separate because the integration tests
+            # require additional filtering.
+            run-go-tests --packages "-tags azure ./modules/azure" | tee /tmp/logs/test_output.log
+            run-go-tests --packages "-tags=azure ./test/azure" | tee -a /tmp/logs/test_output.log
+
+      - run:
+          command: |
+            ./cmd/bin/terratest_log_parser_linux_amd64 --testlog /tmp/logs/test_output.log --outputdir /tmp/logs
+          when: always
+
+      # Store test result and log artifacts for browsing purposes
+      - store_artifacts:
+          path: /tmp/logs
+      - store_test_results:
+          path: /tmp/logs
+
+  # AWS tests - uses AWS credentials from the existing AWS context
+  # NOTE: AWS tests use the 'aws' build tag and are located in ./modules/aws and ./test
+  aws_test:
+    <<: *env
+    docker:
+      - image: cimg/base:2022.03
+
+    steps:
+      - attach_workspace:
+          at: /home/circleci
+
+      - run:
+          <<: *install_gruntwork_utils
+
+      # The weird way you have to set PATH in Circle 2.0
+      - run: |
+          echo 'export PATH=$HOME/.local/bin:$HOME/terraform:$HOME/packer:$PATH' >> $BASH_ENV
+
+      # Run the AWS tests. These tests are run because the aws build tag is included, and we explicitly
+      # select the AWS tests
+      - run:
+          command: |
+            mkdir -p /tmp/logs
+            # Run the unit tests first, then the integration tests. They are separate because the integration tests
+            # require additional filtering.
+            run-go-tests --packages "-tags aws ./modules/aws" | tee /tmp/logs/test_output.log
+            run-go-tests --packages "-tags=aws -run TestTerraformAws ./test" | tee -a /tmp/logs/test_output.log
 
       - run:
           command: |
@@ -571,6 +655,26 @@ workflows:
       - gcp_test:
           context:
             - GCP__automated-tests
+            - GITHUB__PAT__gruntwork-ci
+          requires:
+            - setup
+          filters:
+            tags:
+              only: /^v.*/
+
+      - azure_test:
+          context:
+            - AZURE__automated-tests
+            - GITHUB__PAT__gruntwork-ci
+          requires:
+            - setup
+          filters:
+            tags:
+              only: /^v.*/
+
+      - aws_test:
+          context:
+            - AWS__PHXDEVOPS__circle-ci-test
             - GITHUB__PAT__gruntwork-ci
           requires:
             - setup

--- a/modules/aws/account_test.go
+++ b/modules/aws/account_test.go
@@ -1,3 +1,6 @@
+//go:build aws
+// +build aws
+
 package aws
 
 import (

--- a/modules/aws/ami_test.go
+++ b/modules/aws/ami_test.go
@@ -1,3 +1,6 @@
+//go:build aws
+// +build aws
+
 package aws
 
 import (

--- a/modules/aws/asg_test.go
+++ b/modules/aws/asg_test.go
@@ -1,3 +1,6 @@
+//go:build aws
+// +build aws
+
 package aws
 
 import (

--- a/modules/aws/ec2_test.go
+++ b/modules/aws/ec2_test.go
@@ -1,3 +1,6 @@
+//go:build aws
+// +build aws
+
 package aws
 
 import (

--- a/modules/aws/ecr_test.go
+++ b/modules/aws/ecr_test.go
@@ -1,3 +1,6 @@
+//go:build aws
+// +build aws
+
 package aws
 
 import (

--- a/modules/aws/ecs_test.go
+++ b/modules/aws/ecs_test.go
@@ -1,3 +1,6 @@
+//go:build aws
+// +build aws
+
 package aws
 
 import (

--- a/modules/aws/iam_test.go
+++ b/modules/aws/iam_test.go
@@ -1,3 +1,6 @@
+//go:build aws
+// +build aws
+
 package aws
 
 import (

--- a/modules/aws/keypair_test.go
+++ b/modules/aws/keypair_test.go
@@ -1,3 +1,6 @@
+//go:build aws
+// +build aws
+
 package aws
 
 import (

--- a/modules/aws/lambda_test.go
+++ b/modules/aws/lambda_test.go
@@ -1,3 +1,6 @@
+//go:build aws
+// +build aws
+
 package aws
 
 import (

--- a/modules/aws/rds_test.go
+++ b/modules/aws/rds_test.go
@@ -1,3 +1,6 @@
+//go:build aws
+// +build aws
+
 package aws
 
 import (

--- a/modules/aws/region_test.go
+++ b/modules/aws/region_test.go
@@ -1,3 +1,6 @@
+//go:build aws
+// +build aws
+
 package aws
 
 import (

--- a/modules/aws/route53_test.go
+++ b/modules/aws/route53_test.go
@@ -1,3 +1,6 @@
+//go:build aws
+// +build aws
+
 package aws
 
 import (

--- a/modules/aws/s3_test.go
+++ b/modules/aws/s3_test.go
@@ -1,3 +1,6 @@
+//go:build aws
+// +build aws
+
 // Integration tests that validate S3-related code in AWS.
 package aws
 

--- a/modules/aws/secretsmanager_test.go
+++ b/modules/aws/secretsmanager_test.go
@@ -1,3 +1,6 @@
+//go:build aws
+// +build aws
+
 package aws
 
 import (

--- a/modules/aws/sns_test.go
+++ b/modules/aws/sns_test.go
@@ -1,3 +1,6 @@
+//go:build aws
+// +build aws
+
 package aws
 
 import (

--- a/modules/aws/sqs_test.go
+++ b/modules/aws/sqs_test.go
@@ -1,3 +1,6 @@
+//go:build aws
+// +build aws
+
 package aws
 
 import (

--- a/modules/aws/ssm_test.go
+++ b/modules/aws/ssm_test.go
@@ -1,3 +1,6 @@
+//go:build aws
+// +build aws
+
 package aws
 
 import (

--- a/modules/aws/vpc_test.go
+++ b/modules/aws/vpc_test.go
@@ -1,3 +1,6 @@
+//go:build aws
+// +build aws
+
 package aws
 
 import (

--- a/test/terraform_aws_dynamodb_example_test.go
+++ b/test/terraform_aws_dynamodb_example_test.go
@@ -1,3 +1,6 @@
+//go:build aws
+// +build aws
+
 package test
 
 import (

--- a/test/terraform_aws_ec2_windows_test.go
+++ b/test/terraform_aws_ec2_windows_test.go
@@ -1,3 +1,6 @@
+//go:build aws
+// +build aws
+
 package test
 
 import (

--- a/test/terraform_aws_ecs_example_test.go
+++ b/test/terraform_aws_ecs_example_test.go
@@ -1,3 +1,6 @@
+//go:build aws
+// +build aws
+
 package test
 
 import (

--- a/test/terraform_aws_example_plan_test.go
+++ b/test/terraform_aws_example_plan_test.go
@@ -1,3 +1,6 @@
+//go:build aws
+// +build aws
+
 package test
 
 import (

--- a/test/terraform_aws_example_test.go
+++ b/test/terraform_aws_example_test.go
@@ -1,3 +1,6 @@
+//go:build aws
+// +build aws
+
 package test
 
 import (

--- a/test/terraform_aws_hello_world_example_test.go
+++ b/test/terraform_aws_hello_world_example_test.go
@@ -1,3 +1,6 @@
+//go:build aws
+// +build aws
+
 package test
 
 import (

--- a/test/terraform_aws_lambda_example_test.go
+++ b/test/terraform_aws_lambda_example_test.go
@@ -1,3 +1,6 @@
+//go:build aws
+// +build aws
+
 package test
 
 import (

--- a/test/terraform_aws_network_example_test.go
+++ b/test/terraform_aws_network_example_test.go
@@ -1,3 +1,6 @@
+//go:build aws
+// +build aws
+
 package test
 
 import (

--- a/test/terraform_aws_rds_example_test.go
+++ b/test/terraform_aws_rds_example_test.go
@@ -1,3 +1,6 @@
+//go:build aws
+// +build aws
+
 package test
 
 import (

--- a/test/terraform_aws_s3_example_test.go
+++ b/test/terraform_aws_s3_example_test.go
@@ -1,3 +1,6 @@
+//go:build aws
+// +build aws
+
 package test
 
 import (

--- a/test/terraform_aws_ssm_example_test.go
+++ b/test/terraform_aws_ssm_example_test.go
@@ -1,3 +1,6 @@
+//go:build aws
+// +build aws
+
 package test
 
 import (


### PR DESCRIPTION
## Summary

Separate cloud provider tests into dedicated CircleCI jobs for better isolation and credential management.

### Changes

**CircleCI Configuration:**
- Add `azure_test` job using Docker executor with `AZURE__automated-tests` context
- Add `aws_test` job using Docker executor with `AWS__PHXDEVOPS__circle-ci-test` context
- Update `terraform_test` and `terraform_test_tofu` jobs to exclude cloud-specific module tests
- Add compile-only checks for azure and aws modules in terraform_test jobs

**AWS Build Tags:**
- Add `//go:build aws` tags to all AWS test files:
  - `modules/aws/*_test.go` (18 files)
  - `test/terraform_aws_*.go` (11 files)

### Test Structure After This Change

| Job | Tests |
|-----|-------|
| `gcp_test` | GCP integration tests (`./modules/gcp`, `./test/gcp`) |
| `azure_test` | Azure integration tests (`./modules/azure`, `./test/azure`) |
| `aws_test` | AWS integration tests (`./modules/aws`, `./test/terraform_aws_*`) |
| `terraform_test` | Non-cloud-specific tests |
| `kubernetes_test` | Kubernetes tests |
| `helm_test` | Helm tests |
| `terragrunt_test` | Terragrunt tests |

### Prerequisites

For the `azure_test` job to run, the `AZURE__automated-tests` context needs to be configured in CircleCI with:
- `AZURE_SUBSCRIPTION_ID`
- `AZURE_TENANT_ID`
- `AZURE_CLIENT_ID`
- `AZURE_CLIENT_SECRET`

The `aws_test` job uses the existing `AWS__PHXDEVOPS__circle-ci-test` context.

## Test plan

- [ ] CI passes
- [ ] Verify AWS tests compile with `-tags=aws`
- [ ] Verify Azure tests compile with `-tags=azure`