### PR TITLE
Fix bugs in database, docker, and slack modules

### DIFF
--- a/modules/database/database.go
+++ b/modules/database/database.go
@@ -137,10 +137,10 @@ func DBQueryWithCustomValidation(t *testing.T, db *sql.DB, command string, valid
 // DBQueryWithCustomValidationE queries from database and validate whether the result meets the requirement. If not, return an error.
 func DBQueryWithCustomValidationE(t *testing.T, db *sql.DB, command string, validateResponse func(*sql.Rows) bool) error {
 	rows, err := DBQueryE(t, db, command)
-	defer rows.Close()
 	if err != nil {
 		return err
 	}
+	defer rows.Close()
 	if !validateResponse(rows) {
 		return ValidationFunctionFailed{command: command}
 	}

--- a/modules/docker/build.go
+++ b/modules/docker/build.go
@@ -96,7 +96,7 @@ func BuildE(t testing.TestingT, path string, options *BuildOptions) error {
 		for _, tag := range options.Tags {
 			if err := PushE(t, options.Logger, tag); err != nil {
 				options.Logger.Logf(t, "ERROR: error pushing tag %s", tag)
-				errorsOccurred = multierror.Append(err)
+				errorsOccurred = multierror.Append(errorsOccurred, err)
 			}
 		}
 		return errorsOccurred.ErrorOrNil()

--- a/modules/slack/validate.go
+++ b/modules/slack/validate.go
@@ -1,7 +1,6 @@
 package slack
 
 import (
-	"fmt"
 	"strconv"
 	"strings"
 	"time"
@@ -51,7 +50,7 @@ func ValidateExpectedSlackMessageE(
 			}
 		}
 	}
-	return fmt.Errorf("still no message")
+	return MessageNotFoundErr{}
 }
 
 func checkMessageContainsText(msg slack.Msg, expectedText string) bool {


### PR DESCRIPTION
## Summary
- Fix database rows defer before nil check (would panic on error)
- Fix docker multierror.Append missing first argument (errors weren't accumulating)
- Fix slack returning wrong error type (was fmt.Errorf, should be MessageNotFoundErr)