### PR TITLE
Fix bugs in GCP module

### DIFF
--- a/modules/gcp/compute.go
+++ b/modules/gcp/compute.go
@@ -273,7 +273,7 @@ func newMetadata(t testing.TestingT, oldMetadata *compute.Metadata, kvs map[stri
 			Value: &val,
 		}
 
-		items = append(oldMetadata.Items, item)
+		items = append(items, item)
 	}
 
 	newMetadata := &compute.Metadata{

--- a/modules/gcp/region.go
+++ b/modules/gcp/region.go
@@ -178,7 +178,7 @@ func GetAllGcpRegionsE(t testing.TestingT, projectID string) ([]string, error) {
 		for _, region := range page.Items {
 			regions = append(regions, region.Name)
 		}
-		return err
+		return nil
 	})
 	if err != nil {
 		return nil, err
@@ -214,7 +214,7 @@ func GetAllGcpZonesE(t testing.TestingT, projectID string) ([]string, error) {
 		for _, zone := range page.Items {
 			zones = append(zones, zone.Name)
 		}
-		return err
+		return nil
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary
- Fix newMetadata appending to wrong slice (was appending to oldMetadata.Items instead of items)
- Fix error variable shadowing in GetAllGcpRegionsE callback
- Fix error variable shadowing in GetAllGcpZonesE callback