### PR TITLE
Fix SetMetadata to preserve existing GCP instance metadata

### DIFF
--- a/modules/gcp/compute_unit_test.go
+++ b/modules/gcp/compute_unit_test.go
@@ -1,0 +1,32 @@
+package gcp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/api/compute/v1"
+)
+
+// TestNewMetadataPreservesExisting is a regression test for issue #1655.
+// Verifies that existing metadata is preserved when adding new key-value pairs.
+func TestNewMetadataPreservesExisting(t *testing.T) {
+	t.Parallel()
+
+	existingVal := "existing-value"
+	oldMetadata := &compute.Metadata{
+		Fingerprint: "test-fingerprint",
+		Items:       []*compute.MetadataItems{{Key: "existing-key", Value: &existingVal}},
+	}
+
+	result := newMetadata(t, oldMetadata, map[string]string{"new-key": "new-value"})
+
+	// Convert to map for easier assertion
+	got := make(map[string]string)
+	for _, item := range result.Items {
+		got[item.Key] = *item.Value
+	}
+
+	assert.Equal(t, "test-fingerprint", result.Fingerprint)
+	assert.Equal(t, "existing-value", got["existing-key"], "existing metadata should be preserved")
+	assert.Equal(t, "new-value", got["new-key"], "new metadata should be added")
+}


### PR DESCRIPTION
## Summary
- Fix `newMetadata` to preserve existing metadata items when adding new key-value pairs
- Add unit tests for the `newMetadata` function

## Problem
Since v0.55.0, `SetMetadata` and `AddSshKey` replaced all instance metadata instead of merging new items with existing ones.

## Solution
Modified `newMetadata` to first copy existing metadata items, then add/update with new key-value pairs.

Fixes #1655