### PR TITLE
feat(k8s): Add function to create job from cronjob

### DIFF
--- a/modules/k8s/job.go
+++ b/modules/k8s/job.go
@@ -97,3 +97,43 @@ func IsJobSucceeded(job *batchv1.Job) bool {
 	}
 	return false
 }
+
+// CreateJobFromCronJob creates a Job from the specified CronJob in the given namespace and returns the created Job.
+func CreateJobFromCronJob(t testing.TestingT, options *KubectlOptions, cronJobName, newJobName string) *batchv1.Job {
+	job, err := CreateJobFromCronJobE(t, options, cronJobName, newJobName)
+	require.NoError(t, err)
+	return job
+}
+
+// CreateJobFromCronJobE creates a Job from the specified CronJob in the given namespace and returns the created Job.
+// This function is similar to running `kubectl create job --from=cronjob/<cron-job-name> <new-job-name>`.
+func CreateJobFromCronJobE(t testing.TestingT, options *KubectlOptions, cronJobName, newJobName string) (*batchv1.Job, error) {
+	clientset, err := GetKubernetesClientFromOptionsE(t, options)
+	if err != nil {
+		return nil, err
+	}
+
+	cronJob, err := GetCronJobE(t, options, cronJobName)
+	if err != nil {
+		return nil, err
+	}
+
+	annotations := make(map[string]string)
+	for k, v := range cronJob.Spec.JobTemplate.Annotations {
+		annotations[k] = v
+	}
+
+	job := &batchv1.Job{
+		TypeMeta: metav1.TypeMeta{APIVersion: batchv1.SchemeGroupVersion.String(), Kind: "Job"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        newJobName,
+			Namespace:   options.Namespace,
+			Labels:      cronJob.Spec.JobTemplate.Labels,
+			Annotations: annotations,
+		},
+		Spec: cronJob.Spec.JobTemplate.Spec,
+	}
+
+	createdJob, err := clientset.BatchV1().Jobs(options.Namespace).Create(context.Background(), job, metav1.CreateOptions{})
+	return createdJob, err
+}


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

This PR introduces the functionality to create Kubernetes `Jobs` from an already applied `CronJob`. This function is similar to the command `kubectl create job xyz --from=cronjob/xyz` (see https://kubernetes.io/docs/reference/kubectl/generated/kubectl_create/kubectl_create_job/#synopsis). As the documentation of Kubernetes already implies, this functionality is mainly used for testing `CronJob`s, so it would perfectly align with terratest's mission.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.
- [ ] Make a plan for release of the functionality in this PR. If it delivers value to an end user, you are responsible for ensuring it is released promptly, and correctly. If you are not a maintainer, you are responsible for finding a maintainer to do this for you.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added functionality to create Kubernetes `Jobs` from an existing `CronJob`.

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->
There is no migration guide needed.