### PR TITLE
Fix plan output parsing for Terraform 1.14+

### DIFF
--- a/modules/terraform/count.go
+++ b/modules/terraform/count.go
@@ -20,7 +20,7 @@ type ResourceCount struct {
 const (
 	applyRegexp             = `Apply complete! Resources: (\d+) added, (\d+) changed, (\d+) destroyed\.`
 	destroyRegexp           = `Destroy complete! Resources: (\d+) destroyed\.`
-	planWithChangesRegexp   = `(\033\[1m)?Plan:(\033\[0m)? (\d+) to add, (\d+) to change, (\d+) to destroy\.`
+	planWithChangesRegexp   = `(\033\[1m)?Plan:(\033\[0m)? (\d+) to add, (\d+) to change, (\d+) to destroy`
 	planWithNoChangesRegexp = `No changes\. (Infrastructure is up-to-date)|(Your infrastructure matches the configuration)\.`
 
 	// '.' doesn't match newline by default in go. We must instruct the regex to match it with the 's' flag.


### PR DESCRIPTION
## Summary

- Fix `GetResourceCount` failing to parse Terraform 1.14+ plan output
- Remove trailing `\.` requirement from `planWithChangesRegexp` regex

## Background

Terraform 1.14 introduced Actions, which can append `. Actions: N to invoke.` to the plan summary line. The previous regex required a period immediately after "destroy", causing parsing to fail.

Fixes #1660

## Test plan

- [x] Existing `TestGetResourceCountEColor` and `TestGetResourceCountENoColor` tests pass
- [x] Verified regex matches both old and new output formats