### PR TITLE
fix: Bump K8s/minikube versions and fix test fixtures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,8 +12,8 @@ env: &env
     OPA_VERSION: v1.1.0
     GO_VERSION: 1.26.0
     GO111MODULE: auto
-    K8S_VERSION: v1.20.0  # Same as EKS
-    MINIKUBE_VERSION: v1.22.0
+    K8S_VERSION: v1.28.0  # Same as EKS
+    MINIKUBE_VERSION: v1.32.0
     HELM_VERSION: v3.13.1
     KUBECONFIG: /home/circleci/.kube/config
     BIN_BUILD_PARALLELISM: 3

--- a/modules/k8s/ingress_test.go
+++ b/modules/k8s/ingress_test.go
@@ -116,7 +116,7 @@ spec:
   type: NodePort
 ---
 kind: Ingress
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 metadata:
   name: nginx-service-ingress
   namespace: %s
@@ -125,7 +125,10 @@ spec:
   - http:
       paths:
       - path: /app-%s
+        pathType: Prefix
         backend:
-          serviceName: nginx-service
-          servicePort: 80
+          service:
+            name: nginx-service
+            port:
+              number: 80
 `

--- a/modules/k8s/pod_test.go
+++ b/modules/k8s/pod_test.go
@@ -169,7 +169,8 @@ spec:
         - name: NAME
           value: "nginx-two"
     ports:
-    - containerPort: 80
+    - containerPort: 8080
+    command: ["sh", "-c", "sed -i 's/80/8080/' /etc/nginx/conf.d/default.conf && nginx -g 'daemon off;'"]
 `
 
 const EXAMPLE_POD_WITH_READINESS_PROBE = EXAMPLE_POD_YAML_TEMPLATE + `


### PR DESCRIPTION
## Summary
- Bump K8S_VERSION from v1.20.0 to v1.28.0 and MINIKUBE_VERSION from v1.22.0 to v1.32.0
- Update Ingress test fixture from `extensions/v1beta1` to `networking.k8s.io/v1`
- Fix port conflict in multi-container pod fixture (both containers bound port 80)

## Root cause
CI was running K8s v1.20.0 (EOL since 2022). This caused:
- **CronJob tests** (`TestListCronJobs`, `TestGetCronJobE`, `TestWaitUntilCronJobSchedule`, `TestCreateJobFromCronJob`): `batch/v1` CronJob requires K8s >= 1.21
- **Multi-container pod tests** (`TestWaitUntilPodWithMultipleContainers`, `TestExecPod/WithContainer`): both containers bound port 80, causing `nginx-two` to crash-loop
- **Ingress tests**: `extensions/v1beta1` was removed in K8s 1.22

## Test plan
- [x] Verify CronJob tests pass
- [x] Verify multi-container pod tests pass
- [x] Verify Ingress tests pass