### PR TITLE
feat(gcp): add support for verifying Pub/Sub Topics and Subscriptions

### DIFF
--- a/examples/terraform-gcp-pubsub-example/README.md
+++ b/examples/terraform-gcp-pubsub-example/README.md
@@ -1,0 +1,33 @@
+# Terraform GCP Pub/Sub Example
+
+This folder contains a simple Terraform module that deploys resources in [GCP](https://cloud.google.com/) to demonstrate
+how you can use Terratest to write automated tests for your GCP Terraform code. This module deploys a [Pub/Sub Topic](https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.topics) and a [Pub/Sub Subscription](https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions) attached to that topic.
+
+Check out [test/gcp/terraform_gcp_pubsub_example_test.go](../../test/gcp/terraform_gcp_pubsub_example_test.go) to see how 
+you can write automated tests for this module.
+
+**WARNING**: This module and the automated tests for it deploy real resources into your GCP account which can cost you
+money. The resources are typically part of the [GCP Free Tier](https://cloud.google.com/free/), so if you haven't used that up,
+it should be free, but you are completely responsible for all GCP charges.
+
+## Running this module manually
+
+1. Sign up for [GCP](https://cloud.google.com/).
+1. Configure your GCP credentials using one of the [supported methods for GCP CLI
+   tools](https://cloud.google.com/sdk/docs/quickstarts).
+1. Install [Terraform](https://www.terraform.io/) and make sure it's in your `PATH`.
+1. Ensure the desired Project ID is set: `export GOOGLE_CLOUD_PROJECT=your-project-id`.
+1. Run `terraform init`.
+1. Run `terraform apply`.
+1. When you're done, run `terraform destroy`.
+
+## Running automated tests against this module
+
+1. Sign up for [GCP](https://cloud.google.com/free/).
+1. Configure your GCP credentials using the [GCP CLI
+   tools](https://cloud.google.com/sdk/docs/quickstarts).
+1. Install [Terraform](https://www.terraform.io/) and make sure it's on your `PATH`.
+1. Install [Golang](https://golang.org/) and make sure this code is checked out into your `GOPATH`.
+1. Set `GOOGLE_CLOUD_PROJECT` environment variable to your project name.
+1. `cd test/gcp`
+1. `go test -v -tags=gcp -run TestTerraformGcpPubSubExample`

--- a/examples/terraform-gcp-pubsub-example/main.tf
+++ b/examples/terraform-gcp-pubsub-example/main.tf
@@ -1,0 +1,29 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# PIN TERRAFORM VERSION TO >= 0.12
+# The examples have been upgraded to 0.12 syntax
+# ---------------------------------------------------------------------------------------------------------------------
+
+terraform {
+  # This module is now only being tested with Terraform 0.13.x. However, to make upgrading easier, we are setting
+  # 0.12.26 as the minimum version, as that version added support for required_providers with source URLs, making it
+  # forwards compatible with 0.13.x code.
+  required_version = ">= 0.12.26"
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# DEPLOY A PUBSUB TOPIC AND SUBSCRIPTION
+# See test/gcp/terraform_gcp_pubsub_example_test.go for how to write automated tests for this code.
+# ---------------------------------------------------------------------------------------------------------------------
+
+# website::tag::1:: Deploy a Pub/Sub topic
+resource "google_pubsub_topic" "example" {
+  project = var.gcp_project_id
+  name    = var.topic_name
+}
+
+# website::tag::2:: Create a Subscription to the topic so we can verify it
+resource "google_pubsub_subscription" "example" {
+  project = var.gcp_project_id
+  name    = var.subscription_name
+  topic   = google_pubsub_topic.example.name
+}

--- a/examples/terraform-gcp-pubsub-example/outputs.tf
+++ b/examples/terraform-gcp-pubsub-example/outputs.tf
@@ -1,0 +1,9 @@
+output "topic_name" {
+  description = "The name of the Pub/Sub topic created."
+  value       = google_pubsub_topic.example.name
+}
+
+output "subscription_name" {
+  description = "The name of the Pub/Sub subscription created."
+  value       = google_pubsub_subscription.example.name
+}

--- a/examples/terraform-gcp-pubsub-example/variables.tf
+++ b/examples/terraform-gcp-pubsub-example/variables.tf
@@ -1,0 +1,35 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# ENVIRONMENT VARIABLES
+# You must define the following environment variables.
+# ---------------------------------------------------------------------------------------------------------------------
+
+# GOOGLE_CREDENTIALS
+# or
+# GOOGLE_APPLICATION_CREDENTIALS
+
+variable "gcp_project_id" {
+  description = "The ID of the GCP project in which these resources will be created."
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# REQUIRED PARAMETERS
+# You must provide a value for each of these parameters.
+# ---------------------------------------------------------------------------------------------------------------------
+# (none)
+
+# ---------------------------------------------------------------------------------------------------------------------
+# OPTIONAL PARAMETERS
+# These parameters have reasonable defaults.
+# ---------------------------------------------------------------------------------------------------------------------
+
+variable "topic_name" {
+  description = "The name of the Pub/Sub topic to create."
+  type        = string
+  default     = "terratest-example-topic"
+}
+
+variable "subscription_name" {
+  description = "The name of the Pub/Sub subscription to create."
+  type        = string
+  default     = "terratest-example-sub"
+}

--- a/go.mod
+++ b/go.mod
@@ -45,6 +45,7 @@ require (
 
 require (
 	cloud.google.com/go/cloudbuild v1.19.0
+	cloud.google.com/go/pubsub v1.45.1
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.18.0
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.10.1
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/appcontainers/armappcontainers/v3 v3.0.0

--- a/go.sum
+++ b/go.sum
@@ -13,12 +13,16 @@ cloud.google.com/go/compute/metadata v0.9.0 h1:pDUj4QMoPejqq20dK0Pg2N4yG9zIkYGdB
 cloud.google.com/go/compute/metadata v0.9.0/go.mod h1:E0bWwX5wTnLPedCKqk3pJmVgCBSM6qQI1yTBdEb3C10=
 cloud.google.com/go/iam v1.2.2 h1:ozUSofHUGf/F4tCNy/mu9tHLTaxZFLOUiKzjcgWHGIA=
 cloud.google.com/go/iam v1.2.2/go.mod h1:0Ys8ccaZHdI1dEUilwzqng/6ps2YB6vRsjIe00/+6JY=
+cloud.google.com/go/kms v1.20.1 h1:og29Wv59uf2FVaZlesaiDAqHFzHaoUyHI3HYp9VUHVg=
+cloud.google.com/go/kms v1.20.1/go.mod h1:LywpNiVCvzYNJWS9JUcGJSVTNSwPwi0vBAotzDqn2nc=
 cloud.google.com/go/logging v1.12.0 h1:ex1igYcGFd4S/RZWOCU51StlIEuey5bjqwH9ZYjHibk=
 cloud.google.com/go/logging v1.12.0/go.mod h1:wwYBt5HlYP1InnrtYI0wtwttpVU1rifnMT7RejksUAM=
 cloud.google.com/go/longrunning v0.6.2 h1:xjDfh1pQcWPEvnfjZmwjKQEcHnpz6lHjfy7Fo0MK+hc=
 cloud.google.com/go/longrunning v0.6.2/go.mod h1:k/vIs83RN4bE3YCswdXC5PFfWVILjm3hpEUlSko4PiI=
 cloud.google.com/go/monitoring v1.21.2 h1:FChwVtClH19E7pJ+e0xUhJPGksctZNVOk2UhMmblmdU=
 cloud.google.com/go/monitoring v1.21.2/go.mod h1:hS3pXvaG8KgWTSz+dAdyzPrGUYmi2Q+WFX8g2hqVEZU=
+cloud.google.com/go/pubsub v1.45.1 h1:ZC/UzYcrmK12THWn1P72z+Pnp2vu/zCZRXyhAfP1hJY=
+cloud.google.com/go/pubsub v1.45.1/go.mod h1:3bn7fTmzZFwaUjllitv1WlsNMkqBgGUb3UdMhI54eCc=
 cloud.google.com/go/storage v1.47.0 h1:ajqgt30fnOMmLfWfu1PWcb+V9Dxz6n+9WKjdNg5R4HM=
 cloud.google.com/go/storage v1.47.0/go.mod h1:Ks0vP374w0PW6jOUameJbapbQKXqkjGd/OJRp2fb9IQ=
 cloud.google.com/go/trace v1.11.2 h1:4ZmaBdL8Ng/ajrgKqY5jfvzqMXbrDcBsUGXOT9aqTtI=
@@ -528,6 +532,8 @@ github.com/zclconf/go-cty v1.15.0 h1:tTCRWxsexYUmtt/wVxgDClUe+uQusuI443uL6e+5sXQ
 github.com/zclconf/go-cty v1.15.0/go.mod h1:VvMs5i0vgZdhYawQNq5kePSpLAoz8u1xvZgrPIxfnZE=
 github.com/zclconf/go-cty-debug v0.0.0-20240509010212-0d6042c53940 h1:4r45xpDWB6ZMSMNJFMOjqrGHynW3DIBuR2H9j0ug+Mo=
 github.com/zclconf/go-cty-debug v0.0.0-20240509010212-0d6042c53940/go.mod h1:CmBdvvj3nqzfzJ6nTCIwDTPZ56aVGvDrmztiO5g3qrM=
+go.einride.tech/aip v0.68.0 h1:4seM66oLzTpz50u4K1zlJyOXQ3tCzcJN7I22tKkjipw=
+go.einride.tech/aip v0.68.0/go.mod h1:7y9FF8VtPWqpxuAxl0KQWqaULxW4zFIesD6zF5RIHHg=
 go.opencensus.io v0.24.0 h1:y73uSU6J157QMP2kn2r30vwW1A2W2WFwSCGnAVxeaD0=
 go.opencensus.io v0.24.0/go.mod h1:vNK8G9p7aAivkbmorf4v+7Hgx+Zs0yY+0fOtgBfjQKo=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=

--- a/modules/gcp/pubsub.go
+++ b/modules/gcp/pubsub.go
@@ -1,0 +1,195 @@
+package gcp
+
+import (
+	"context"
+	"fmt"
+
+	"cloud.google.com/go/pubsub"
+	"github.com/gruntwork-io/terratest/modules/logger"
+	"github.com/gruntwork-io/terratest/modules/testing"
+)
+
+// AssertTopicExistsContext checks if the given Pub/Sub topic exists and fails the test if it does not.
+// The ctx parameter supports cancellation and timeouts.
+func AssertTopicExistsContext(t testing.TestingT, ctx context.Context, projectID string, topicName string) {
+	err := AssertTopicExistsContextE(t, ctx, projectID, topicName)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+// AssertTopicExistsContextE checks if the given Pub/Sub topic exists and returns an error if it does not.
+// The ctx parameter supports cancellation and timeouts.
+func AssertTopicExistsContextE(t testing.TestingT, ctx context.Context, projectID string, topicName string) error {
+	logger.Default.Logf(t, "Verifying Pub/Sub topic %s exists in project %s", topicName, projectID)
+
+	client, err := newPubSubClient(ctx, projectID)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = client.Close() }()
+
+	exists, err := client.Topic(topicName).Exists(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to check if Pub/Sub topic %s exists in project %s: %w", topicName, projectID, err)
+	}
+
+	if !exists {
+		return fmt.Errorf("Pub/Sub topic %s does not exist in project %s", topicName, projectID)
+	}
+
+	return nil
+}
+
+// AssertSubscriptionExistsContext checks if the given Pub/Sub subscription exists and fails the test if it does not.
+// The ctx parameter supports cancellation and timeouts.
+func AssertSubscriptionExistsContext(t testing.TestingT, ctx context.Context, projectID string, subscriptionName string) {
+	err := AssertSubscriptionExistsContextE(t, ctx, projectID, subscriptionName)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+// AssertSubscriptionExistsContextE checks if the given Pub/Sub subscription exists and returns an error if it does not.
+// The ctx parameter supports cancellation and timeouts.
+func AssertSubscriptionExistsContextE(t testing.TestingT, ctx context.Context, projectID string, subscriptionName string) error {
+	logger.Default.Logf(t, "Verifying Pub/Sub subscription %s exists in project %s", subscriptionName, projectID)
+
+	client, err := newPubSubClient(ctx, projectID)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = client.Close() }()
+
+	exists, err := client.Subscription(subscriptionName).Exists(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to check if Pub/Sub subscription %s exists in project %s: %w", subscriptionName, projectID, err)
+	}
+
+	if !exists {
+		return fmt.Errorf("Pub/Sub subscription %s does not exist in project %s", subscriptionName, projectID)
+	}
+
+	return nil
+}
+
+// CreateTopicContext creates a new Pub/Sub topic and fails the test if it cannot.
+// The ctx parameter supports cancellation and timeouts.
+func CreateTopicContext(t testing.TestingT, ctx context.Context, projectID string, topicName string) {
+	err := CreateTopicContextE(t, ctx, projectID, topicName)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+// CreateTopicContextE creates a new Pub/Sub topic and returns an error if it fails.
+// The ctx parameter supports cancellation and timeouts.
+func CreateTopicContextE(t testing.TestingT, ctx context.Context, projectID string, topicName string) error {
+	logger.Default.Logf(t, "Creating Pub/Sub topic %s in project %s", topicName, projectID)
+
+	client, err := newPubSubClient(ctx, projectID)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = client.Close() }()
+
+	_, err = client.CreateTopic(ctx, topicName)
+	if err != nil {
+		return fmt.Errorf("failed to create Pub/Sub topic %s in project %s: %w", topicName, projectID, err)
+	}
+
+	return nil
+}
+
+// DeleteTopicContext deletes the given Pub/Sub topic and fails the test if it cannot.
+// The ctx parameter supports cancellation and timeouts.
+func DeleteTopicContext(t testing.TestingT, ctx context.Context, projectID string, topicName string) {
+	err := DeleteTopicContextE(t, ctx, projectID, topicName)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+// DeleteTopicContextE deletes the given Pub/Sub topic and returns an error if it fails.
+// The ctx parameter supports cancellation and timeouts.
+func DeleteTopicContextE(t testing.TestingT, ctx context.Context, projectID string, topicName string) error {
+	logger.Default.Logf(t, "Deleting Pub/Sub topic %s in project %s", topicName, projectID)
+
+	client, err := newPubSubClient(ctx, projectID)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = client.Close() }()
+
+	if err := client.Topic(topicName).Delete(ctx); err != nil {
+		return fmt.Errorf("failed to delete Pub/Sub topic %s in project %s: %w", topicName, projectID, err)
+	}
+
+	return nil
+}
+
+// CreateSubscriptionContext creates a new Pub/Sub subscription on the given topic and fails the test if it cannot.
+// The ctx parameter supports cancellation and timeouts.
+func CreateSubscriptionContext(t testing.TestingT, ctx context.Context, projectID string, subscriptionName string, topicName string) {
+	err := CreateSubscriptionContextE(t, ctx, projectID, subscriptionName, topicName)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+// CreateSubscriptionContextE creates a new Pub/Sub subscription on the given topic and returns an error if it fails.
+// The ctx parameter supports cancellation and timeouts.
+func CreateSubscriptionContextE(t testing.TestingT, ctx context.Context, projectID string, subscriptionName string, topicName string) error {
+	logger.Default.Logf(t, "Creating Pub/Sub subscription %s on topic %s in project %s", subscriptionName, topicName, projectID)
+
+	client, err := newPubSubClient(ctx, projectID)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = client.Close() }()
+
+	_, err = client.CreateSubscription(ctx, subscriptionName, pubsub.SubscriptionConfig{
+		Topic: client.Topic(topicName),
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create Pub/Sub subscription %s in project %s: %w", subscriptionName, projectID, err)
+	}
+
+	return nil
+}
+
+// DeleteSubscriptionContext deletes the given Pub/Sub subscription and fails the test if it cannot.
+// The ctx parameter supports cancellation and timeouts.
+func DeleteSubscriptionContext(t testing.TestingT, ctx context.Context, projectID string, subscriptionName string) {
+	err := DeleteSubscriptionContextE(t, ctx, projectID, subscriptionName)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+// DeleteSubscriptionContextE deletes the given Pub/Sub subscription and returns an error if it fails.
+// The ctx parameter supports cancellation and timeouts.
+func DeleteSubscriptionContextE(t testing.TestingT, ctx context.Context, projectID string, subscriptionName string) error {
+	logger.Default.Logf(t, "Deleting Pub/Sub subscription %s in project %s", subscriptionName, projectID)
+
+	client, err := newPubSubClient(ctx, projectID)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = client.Close() }()
+
+	if err := client.Subscription(subscriptionName).Delete(ctx); err != nil {
+		return fmt.Errorf("failed to delete Pub/Sub subscription %s in project %s: %w", subscriptionName, projectID, err)
+	}
+
+	return nil
+}
+
+// newPubSubClient creates a new Pub/Sub client using the provided project ID and global GCP auth options.
+func newPubSubClient(ctx context.Context, projectID string) (*pubsub.Client, error) {
+	client, err := pubsub.NewClient(ctx, projectID, withOptions()...)
+	if err != nil {
+		return nil, err
+	}
+	return client, nil
+}

--- a/modules/gcp/pubsub_test.go
+++ b/modules/gcp/pubsub_test.go
@@ -1,0 +1,96 @@
+//go:build gcp
+// +build gcp
+
+// NOTE: We use build tags to differentiate GCP testing for better isolation and parallelism when executing our tests.
+
+package gcp
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/logger"
+	"github.com/gruntwork-io/terratest/modules/random"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAssertTopicExistsNoFalseNegative(t *testing.T) {
+	t.Parallel()
+
+	projectID := GetGoogleProjectIDFromEnvVar(t)
+	topicName := fmt.Sprintf("pubsub-topic-%s", random.UniqueId())
+	logger.Logf(t, "Creating Pub/Sub topic %s to verify existence check works", topicName)
+
+	CreateTopicContext(t, context.Background(), projectID, topicName)
+	defer DeleteTopicContext(t, context.Background(), projectID, topicName)
+
+	AssertTopicExistsContext(t, context.Background(), projectID, topicName)
+}
+
+func TestAssertTopicExistsNoFalsePositive(t *testing.T) {
+	t.Parallel()
+
+	projectID := GetGoogleProjectIDFromEnvVar(t)
+	topicName := fmt.Sprintf("pubsub-topic-%s", random.UniqueId())
+	logger.Logf(t, "Checking that non-existent Pub/Sub topic %s returns an error", topicName)
+
+	err := AssertTopicExistsContextE(t, context.Background(), projectID, topicName)
+	require.Error(t, err, "Expected an error for non-existent Pub/Sub topic, but got none")
+}
+
+func TestAssertSubscriptionExistsNoFalseNegative(t *testing.T) {
+	t.Parallel()
+
+	projectID := GetGoogleProjectIDFromEnvVar(t)
+	topicName := fmt.Sprintf("pubsub-topic-%s", random.UniqueId())
+	subscriptionName := fmt.Sprintf("pubsub-sub-%s", random.UniqueId())
+	logger.Logf(t, "Creating Pub/Sub topic %s and subscription %s to verify existence check works", topicName, subscriptionName)
+
+	CreateTopicContext(t, context.Background(), projectID, topicName)
+	defer DeleteTopicContext(t, context.Background(), projectID, topicName)
+
+	CreateSubscriptionContext(t, context.Background(), projectID, subscriptionName, topicName)
+	defer DeleteSubscriptionContext(t, context.Background(), projectID, subscriptionName)
+
+	AssertSubscriptionExistsContext(t, context.Background(), projectID, subscriptionName)
+}
+
+func TestAssertSubscriptionExistsNoFalsePositive(t *testing.T) {
+	t.Parallel()
+
+	projectID := GetGoogleProjectIDFromEnvVar(t)
+	subscriptionName := fmt.Sprintf("pubsub-sub-%s", random.UniqueId())
+	logger.Logf(t, "Checking that non-existent Pub/Sub subscription %s returns an error", subscriptionName)
+
+	err := AssertSubscriptionExistsContextE(t, context.Background(), projectID, subscriptionName)
+	require.Error(t, err, "Expected an error for non-existent Pub/Sub subscription, but got none")
+}
+
+func TestAssertTopicAndSubscriptionExist(t *testing.T) {
+	t.Parallel()
+
+	projectID := GetGoogleProjectIDFromEnvVar(t)
+	topicName := fmt.Sprintf("pubsub-topic-%s", random.UniqueId())
+	subscriptionName := fmt.Sprintf("pubsub-sub-%s", random.UniqueId())
+	logger.Logf(t, "Creating Pub/Sub topic %s and subscription %s", topicName, subscriptionName)
+
+	CreateTopicContext(t, context.Background(), projectID, topicName)
+	defer DeleteTopicContext(t, context.Background(), projectID, topicName)
+
+	CreateSubscriptionContext(t, context.Background(), projectID, subscriptionName, topicName)
+	defer DeleteSubscriptionContext(t, context.Background(), projectID, subscriptionName)
+
+	AssertTopicExistsContext(t, context.Background(), projectID, topicName)
+	AssertSubscriptionExistsContext(t, context.Background(), projectID, subscriptionName)
+
+	// Verify subscription is linked to the correct topic
+	client, err := newPubSubClient(context.Background(), projectID)
+	require.NoError(t, err)
+	defer func() { _ = client.Close() }()
+
+	cfg, err := client.Subscription(subscriptionName).Config(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, fmt.Sprintf("projects/%s/topics/%s", projectID, topicName), cfg.Topic.String())
+}

--- a/test/gcp/terraform_gcp_pubsub_example_test.go
+++ b/test/gcp/terraform_gcp_pubsub_example_test.go
@@ -1,0 +1,60 @@
+//go:build gcp
+// +build gcp
+
+// NOTE: We use build tags to differentiate GCP testing for better isolation
+
+package test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/gcp"
+	"github.com/gruntwork-io/terratest/modules/random"
+	"github.com/gruntwork-io/terratest/modules/terraform"
+	test_structure "github.com/gruntwork-io/terratest/modules/test-structure"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTerraformGcpPubSubExample(t *testing.T) {
+	t.Parallel()
+
+	// Get the Project ID from the environment variable.
+	projectID := gcp.GetGoogleProjectIDFromEnvVar(t)
+
+	// Create random unique names for our Pub/Sub resources
+	// so multiple tests running simultaneously don't collide.
+	expectedTopicName := fmt.Sprintf("pubsub-topic-%s", random.UniqueId())
+	expectedSubscriptionName := fmt.Sprintf("pubsub-sub-%s", random.UniqueId())
+
+	exampleDir := test_structure.CopyTerraformFolderToTemp(t, "../../", "examples/terraform-gcp-pubsub-example")
+
+	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
+		TerraformDir: exampleDir,
+
+		Vars: map[string]interface{}{
+			"gcp_project_id":    projectID,
+			"topic_name":        expectedTopicName,
+			"subscription_name": expectedSubscriptionName,
+		},
+	})
+
+	// At the end of the test, run `terraform destroy` to clean up any resources that were created
+	defer terraform.Destroy(t, terraformOptions)
+
+	// This will run `terraform init` and `terraform apply` and fail the test if there are any errors
+	terraform.InitAndApply(t, terraformOptions)
+
+	// Pull out the outputs from the Terraform configuration
+	actualTopicName := terraform.Output(t, terraformOptions, "topic_name")
+	actualSubscriptionName := terraform.Output(t, terraformOptions, "subscription_name")
+
+	// Verify the Terraform outputs match what we expected
+	assert.Equal(t, expectedTopicName, actualTopicName)
+	assert.Equal(t, expectedSubscriptionName, actualSubscriptionName)
+
+	// Verify the topic and subscription exist in GCP
+	gcp.AssertTopicExistsContext(t, context.Background(), projectID, actualTopicName)
+	gcp.AssertSubscriptionExistsContext(t, context.Background(), projectID, actualSubscriptionName)
+}


### PR DESCRIPTION
## Description

This PR adds support for **Google Cloud Pub/Sub** to the GCP module. It introduces helper functions to verify the existence of Pub/Sub Topics and Subscriptions, along with a complete Terraform example and automated integration tests. 

This is a new feature addition and does not introduce any backward-incompatible changes.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.
- [x] Make a plan for release of the functionality in this PR. If it delivers value to an end user, you are responsible for ensuring it is released promptly, and correctly. If you are not a maintainer, you are responsible for finding a maintainer to do this for you.

## Release Notes (draft)

Added support for verifying Google Cloud Pub/Sub Topics and Subscriptions in the GCP module.

### Migration Guide
No backward incompatible changes were introduced.

---

### Verification Results
I have verified this PR locally against a real GCP project:
- **Linting**: Passed using `golangci-lint run`.
- **Formatting**: Passed `go fmt` and `terraform fmt`.
- **Integration Test**: Successfully ran `TestTerraformGcpPubSubExample`.

**Test Output Snippet:**
```text
=== RUN   TestTerraformGcpPubSubExample
...
TestTerraformGcpPubSubExample 2026-03-08T16:21:20 logger.go:67: Verifying Pub/Sub topic pubsub-topic-mt4hzw exists in project amith-1772452782257
TestTerraformGcpPubSubExample 2026-03-08T16:21:21 logger.go:67: Verifying Pub/Sub subscription pubsub-sub-fzusep exists in project amith-1772452782257
...
--- PASS: TestTerraformGcpPubSubExample (49.30s)
PASS
```
