### PR TITLE
feat: Add support for verifying Cloud SQL instances

### DIFF
--- a/examples/terraform-gcp-cloudsql-example/README.md
+++ b/examples/terraform-gcp-cloudsql-example/README.md
@@ -1,0 +1,33 @@
+# Terraform GCP Cloud SQL Example
+
+This folder contains a simple Terraform module that deploys resources in [GCP](https://cloud.google.com/) to demonstrate
+how you can use Terratest to write automated tests for your GCP Terraform code. This module deploys a [Cloud SQL Instance](https://cloud.google.com/sql/docs/introduction) with a configurable database engine (MySQL, PostgreSQL, or SQL Server).
+
+Check out [test/gcp/terraform_gcp_cloudsql_example_test.go](../../test/gcp/terraform_gcp_cloudsql_example_test.go) to see how
+you can write automated tests for this module.
+
+**WARNING**: This module and the automated tests for it deploy real resources into your GCP account which can cost you
+money. The resources are typically part of the [GCP Free Tier](https://cloud.google.com/free/), so if you haven't used that up,
+it should be free, but you are completely responsible for all GCP charges.
+
+## Running this module manually
+
+1. Sign up for [GCP](https://cloud.google.com/).
+1. Configure your GCP credentials using one of the [supported methods for GCP CLI
+   tools](https://cloud.google.com/sdk/docs/quickstarts).
+1. Install [Terraform](https://www.terraform.io/) and make sure it's in your `PATH`.
+1. Ensure the desired Project ID is set: `export GOOGLE_CLOUD_PROJECT=your-project-id`.
+1. Run `terraform init`.
+1. Run `terraform apply`.
+1. When you're done, run `terraform destroy`.
+
+## Running automated tests against this module
+
+1. Sign up for [GCP](https://cloud.google.com/free/).
+1. Configure your GCP credentials using the [GCP CLI
+   tools](https://cloud.google.com/sdk/docs/quickstarts).
+1. Install [Terraform](https://www.terraform.io/) and make sure it's on your `PATH`.
+1. Install [Golang](https://golang.org/) and make sure this code is checked out into your `GOPATH`.
+1. Set `GOOGLE_CLOUD_PROJECT` environment variable to your project name.
+1. `cd test/gcp`
+1. `go test -v -tags=gcp -run TestTerraformGcpCloudSQLExample`

--- a/examples/terraform-gcp-cloudsql-example/main.tf
+++ b/examples/terraform-gcp-cloudsql-example/main.tf
@@ -1,0 +1,30 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# PIN TERRAFORM VERSION TO >= 0.12
+# The examples have been upgraded to 0.12 syntax
+# ---------------------------------------------------------------------------------------------------------------------
+
+terraform {
+  # This module is now only being tested with Terraform 0.13.x. However, to make upgrading easier, we are setting
+  # 0.12.26 as the minimum version, as that version added support for required_providers with source URLs, making it
+  # forwards compatible with 0.13.x code.
+  required_version = ">= 0.12.26"
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# DEPLOY A CLOUD SQL INSTANCE
+# See test/gcp/terraform_gcp_cloudsql_example_test.go for how to write automated tests for this code.
+# ---------------------------------------------------------------------------------------------------------------------
+
+# website::tag::1:: Deploy a Cloud SQL instance
+resource "google_sql_database_instance" "example" {
+  project          = var.gcp_project_id
+  name             = var.instance_name
+  database_version = var.database_version
+  region           = var.region
+
+  settings {
+    tier = var.tier
+  }
+
+  deletion_protection = false
+}

--- a/examples/terraform-gcp-cloudsql-example/outputs.tf
+++ b/examples/terraform-gcp-cloudsql-example/outputs.tf
@@ -1,0 +1,9 @@
+output "instance_name" {
+  description = "The name of the Cloud SQL instance created."
+  value       = google_sql_database_instance.example.name
+}
+
+output "database_version" {
+  description = "The database engine version of the Cloud SQL instance."
+  value       = google_sql_database_instance.example.database_version
+}

--- a/examples/terraform-gcp-cloudsql-example/variables.tf
+++ b/examples/terraform-gcp-cloudsql-example/variables.tf
@@ -1,0 +1,47 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# ENVIRONMENT VARIABLES
+# You must define the following environment variables.
+# ---------------------------------------------------------------------------------------------------------------------
+
+# GOOGLE_CREDENTIALS
+# or
+# GOOGLE_APPLICATION_CREDENTIALS
+
+variable "gcp_project_id" {
+  description = "The ID of the GCP project in which these resources will be created."
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# REQUIRED PARAMETERS
+# You must provide a value for each of these parameters.
+# ---------------------------------------------------------------------------------------------------------------------
+# (none)
+
+# ---------------------------------------------------------------------------------------------------------------------
+# OPTIONAL PARAMETERS
+# These parameters have reasonable defaults.
+# ---------------------------------------------------------------------------------------------------------------------
+
+variable "instance_name" {
+  description = "The name of the Cloud SQL instance to create."
+  type        = string
+  default     = "terratest-example-cloudsql"
+}
+
+variable "database_version" {
+  description = "The database engine version to use (e.g. MYSQL_8_0, POSTGRES_14, SQLSERVER_2019_STANDARD)."
+  type        = string
+  default     = "POSTGRES_14"
+}
+
+variable "region" {
+  description = "The GCP region in which to create the Cloud SQL instance."
+  type        = string
+  default     = "us-central1"
+}
+
+variable "tier" {
+  description = "The machine type to use for the Cloud SQL instance."
+  type        = string
+  default     = "db-f1-micro"
+}

--- a/modules/gcp/cloudsql.go
+++ b/modules/gcp/cloudsql.go
@@ -1,0 +1,166 @@
+package gcp
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/gruntwork-io/terratest/modules/logger"
+	"github.com/gruntwork-io/terratest/modules/retry"
+	"github.com/gruntwork-io/terratest/modules/testing"
+	"google.golang.org/api/sqladmin/v1"
+)
+
+// AssertCloudSQLInstanceExistsContext checks if the given Cloud SQL instance exists and fails the test if it does not.
+// The ctx parameter supports cancellation and timeouts.
+func AssertCloudSQLInstanceExistsContext(t testing.TestingT, ctx context.Context, projectID string, instanceName string) {
+	err := AssertCloudSQLInstanceExistsContextE(t, ctx, projectID, instanceName)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+// AssertCloudSQLInstanceExistsContextE checks if the given Cloud SQL instance exists and returns an error if it does not.
+// The ctx parameter supports cancellation and timeouts.
+func AssertCloudSQLInstanceExistsContextE(t testing.TestingT, ctx context.Context, projectID string, instanceName string) error {
+	logger.Default.Logf(t, "Verifying Cloud SQL instance %s exists in project %s", instanceName, projectID)
+
+	_, err := getCloudSQLInstanceE(ctx, projectID, instanceName)
+	return err
+}
+
+// GetCloudSQLInstanceDatabaseVersionContext returns the database version of the given Cloud SQL instance (e.g. MYSQL_8_0, POSTGRES_14, SQLSERVER_2019_STANDARD).
+// The ctx parameter supports cancellation and timeouts.
+func GetCloudSQLInstanceDatabaseVersionContext(t testing.TestingT, ctx context.Context, projectID string, instanceName string) string {
+	version, err := GetCloudSQLInstanceDatabaseVersionContextE(t, ctx, projectID, instanceName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return version
+}
+
+// GetCloudSQLInstanceDatabaseVersionContextE returns the database version of the given Cloud SQL instance and returns an error if it could not be retrieved.
+// The ctx parameter supports cancellation and timeouts.
+func GetCloudSQLInstanceDatabaseVersionContextE(t testing.TestingT, ctx context.Context, projectID string, instanceName string) (string, error) {
+	logger.Default.Logf(t, "Getting database version of Cloud SQL instance %s in project %s", instanceName, projectID)
+
+	instance, err := getCloudSQLInstanceE(ctx, projectID, instanceName)
+	if err != nil {
+		return "", err
+	}
+
+	return instance.DatabaseVersion, nil
+}
+
+// CreateCloudSQLInstanceContext creates a new Cloud SQL instance with the given database version and waits for it to be ready.
+// The ctx parameter supports cancellation and timeouts.
+func CreateCloudSQLInstanceContext(t testing.TestingT, ctx context.Context, projectID string, instanceName string, databaseVersion string) {
+	err := CreateCloudSQLInstanceContextE(t, ctx, projectID, instanceName, databaseVersion)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+// CreateCloudSQLInstanceContextE creates a new Cloud SQL instance and returns an error if it fails.
+// The ctx parameter supports cancellation and timeouts.
+func CreateCloudSQLInstanceContextE(t testing.TestingT, ctx context.Context, projectID string, instanceName string, databaseVersion string) error {
+	logger.Default.Logf(t, "Creating Cloud SQL instance %s in project %s", instanceName, projectID)
+
+	service, err := newCloudSQLService(ctx)
+	if err != nil {
+		return err
+	}
+
+	instance := &sqladmin.DatabaseInstance{
+		Name:            instanceName,
+		DatabaseVersion: databaseVersion,
+		Settings: &sqladmin.Settings{
+			Tier: "db-f1-micro",
+		},
+	}
+
+	op, err := service.Instances.Insert(projectID, instance).Context(ctx).Do()
+	if err != nil {
+		return fmt.Errorf("failed to create Cloud SQL instance %s in project %s: %w", instanceName, projectID, err)
+	}
+
+	return waitForCloudSQLOperation(t, ctx, service, projectID, op.Name)
+}
+
+// DeleteCloudSQLInstanceContext deletes the given Cloud SQL instance and waits for the operation to complete.
+// The ctx parameter supports cancellation and timeouts.
+func DeleteCloudSQLInstanceContext(t testing.TestingT, ctx context.Context, projectID string, instanceName string) {
+	err := DeleteCloudSQLInstanceContextE(t, ctx, projectID, instanceName)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+// DeleteCloudSQLInstanceContextE deletes the given Cloud SQL instance and returns an error if it fails.
+// The ctx parameter supports cancellation and timeouts.
+func DeleteCloudSQLInstanceContextE(t testing.TestingT, ctx context.Context, projectID string, instanceName string) error {
+	logger.Default.Logf(t, "Deleting Cloud SQL instance %s in project %s", instanceName, projectID)
+
+	service, err := newCloudSQLService(ctx)
+	if err != nil {
+		return err
+	}
+
+	op, err := service.Instances.Delete(projectID, instanceName).Context(ctx).Do()
+	if err != nil {
+		return fmt.Errorf("failed to delete Cloud SQL instance %s in project %s: %w", instanceName, projectID, err)
+	}
+
+	return waitForCloudSQLOperation(t, ctx, service, projectID, op.Name)
+}
+
+// getCloudSQLInstanceE is a helper that fetches the Cloud SQL instance details.
+func getCloudSQLInstanceE(ctx context.Context, projectID string, instanceName string) (*sqladmin.DatabaseInstance, error) {
+	service, err := newCloudSQLService(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	instance, err := service.Instances.Get(projectID, instanceName).Context(ctx).Do()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get Cloud SQL instance %s in project %s: %w", instanceName, projectID, err)
+	}
+
+	return instance, nil
+}
+
+// newCloudSQLService creates a new Cloud SQL Admin service using the global GCP auth options.
+func newCloudSQLService(ctx context.Context) (*sqladmin.Service, error) {
+	service, err := sqladmin.NewService(ctx, withOptions()...)
+	if err != nil {
+		return nil, err
+	}
+	return service, nil
+}
+
+// waitForCloudSQLOperation polls until the given Cloud SQL operation completes using the terratest retry module.
+func waitForCloudSQLOperation(t testing.TestingT, ctx context.Context, service *sqladmin.Service, projectID string, operationName string) error {
+	// Cloud SQL instances can take up to 20 minutes to provision; 120 retries x 15s = 30 minutes to be safe.
+	maxRetries := 120
+	sleepBetweenRetries := 15 * time.Second
+
+	_, err := retry.DoWithRetryE(t, fmt.Sprintf("Waiting for Cloud SQL operation %s", operationName), maxRetries, sleepBetweenRetries, func() (string, error) {
+		op, err := service.Operations.Get(projectID, operationName).Context(ctx).Do()
+		if err != nil {
+			return "", fmt.Errorf("failed to get Cloud SQL operation status: %w", err)
+		}
+
+		if op.Status != "DONE" {
+			return "", fmt.Errorf("operation %s not done yet, current status: %s", operationName, op.Status)
+		}
+
+		if op.Error != nil {
+			// Operation is DONE but failed — stop retrying immediately.
+			return "", retry.FatalError{Underlying: fmt.Errorf("Cloud SQL operation failed: %v", op.Error.Errors)}
+		}
+
+		return "DONE", nil
+	})
+
+	return err
+}

--- a/modules/gcp/cloudsql_test.go
+++ b/modules/gcp/cloudsql_test.go
@@ -1,0 +1,55 @@
+//go:build gcp
+// +build gcp
+
+// NOTE: We use build tags to differentiate GCP testing for better isolation and parallelism when executing our tests.
+
+package gcp
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/logger"
+	"github.com/gruntwork-io/terratest/modules/random"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAssertCloudSQLInstanceExistsNoFalseNegative(t *testing.T) {
+	t.Parallel()
+
+	projectID := GetGoogleProjectIDFromEnvVar(t)
+	instanceName := fmt.Sprintf("terratest-cloudsql-%s", random.UniqueId())
+	logger.Logf(t, "Creating Cloud SQL instance %s to verify existence check works", instanceName)
+
+	CreateCloudSQLInstanceContext(t, context.Background(), projectID, instanceName, "MYSQL_8_0")
+	defer DeleteCloudSQLInstanceContext(t, context.Background(), projectID, instanceName)
+
+	AssertCloudSQLInstanceExistsContext(t, context.Background(), projectID, instanceName)
+
+	version := GetCloudSQLInstanceDatabaseVersionContext(t, context.Background(), projectID, instanceName)
+	assert.Equal(t, "MYSQL_8_0", version)
+}
+
+func TestAssertCloudSQLInstanceExistsNoFalsePositive(t *testing.T) {
+	t.Parallel()
+
+	projectID := GetGoogleProjectIDFromEnvVar(t)
+	instanceName := fmt.Sprintf("terratest-cloudsql-%s", random.UniqueId())
+	logger.Logf(t, "Checking that non-existent Cloud SQL instance %s returns an error", instanceName)
+
+	err := AssertCloudSQLInstanceExistsContextE(t, context.Background(), projectID, instanceName)
+	require.Error(t, err, "Expected an error for non-existent Cloud SQL instance, but got none")
+}
+
+func TestGetCloudSQLInstanceDatabaseVersionNoFalsePositive(t *testing.T) {
+	t.Parallel()
+
+	projectID := GetGoogleProjectIDFromEnvVar(t)
+	instanceName := fmt.Sprintf("terratest-cloudsql-%s", random.UniqueId())
+	logger.Logf(t, "Checking that GetCloudSQLInstanceDatabaseVersionContextE returns an error for non-existent instance %s", instanceName)
+
+	_, err := GetCloudSQLInstanceDatabaseVersionContextE(t, context.Background(), projectID, instanceName)
+	require.Error(t, err, "Expected an error for non-existent Cloud SQL instance, but got none")
+}

--- a/test/gcp/terraform_gcp_cloudsql_example_test.go
+++ b/test/gcp/terraform_gcp_cloudsql_example_test.go
@@ -1,0 +1,85 @@
+//go:build gcp
+// +build gcp
+
+// NOTE: We use build tags to differentiate GCP testing for better isolation
+
+package test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/gcp"
+	"github.com/gruntwork-io/terratest/modules/random"
+	"github.com/gruntwork-io/terratest/modules/terraform"
+	test_structure "github.com/gruntwork-io/terratest/modules/test-structure"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTerraformGcpCloudSQLExample(t *testing.T) {
+	ttable := []struct {
+		name            string
+		databaseVersion string
+	}{
+		{
+			name:            "mysql",
+			databaseVersion: "MYSQL_8_0",
+		},
+		{
+			name:            "postgres",
+			databaseVersion: "POSTGRES_14",
+		},
+	}
+
+	for _, tt := range ttable {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Get the Project ID from the environment variable.
+			projectID := gcp.GetGoogleProjectIDFromEnvVar(t)
+
+			// Create a random unique name for the Cloud SQL instance
+			// so multiple tests running simultaneously don't collide.
+			expectedInstanceName := fmt.Sprintf("terratest-cloudsql-%s", random.UniqueId())
+
+			exampleDir := test_structure.CopyTerraformFolderToTemp(t, "../../", "examples/terraform-gcp-cloudsql-example")
+
+			terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
+				// The path to where our Terraform code is located
+				TerraformDir: exampleDir,
+
+				// Variables to pass to our Terraform code using -var options
+				Vars: map[string]interface{}{
+					"gcp_project_id":   projectID,
+					"instance_name":    expectedInstanceName,
+					"database_version": tt.databaseVersion,
+				},
+			})
+
+			// At the end of the test, run `terraform destroy` to clean up any resources that were created
+			defer terraform.Destroy(t, terraformOptions)
+
+			// This will run `terraform init` and `terraform apply` and fail the test if there are any errors
+			terraform.InitAndApply(t, terraformOptions)
+
+			// Pull out the outputs from the Terraform configuration
+			actualInstanceName := terraform.Output(t, terraformOptions, "instance_name")
+			actualDatabaseVersion := terraform.Output(t, terraformOptions, "database_version")
+
+			// Verify the instance name matches what we expected
+			assert.Equal(t, expectedInstanceName, actualInstanceName)
+
+			// Verify the instance exists in GCP
+			gcp.AssertCloudSQLInstanceExistsContext(t, context.Background(), projectID, actualInstanceName)
+
+			// Verify the database version from Terraform output matches what we deployed
+			assert.Equal(t, tt.databaseVersion, actualDatabaseVersion)
+
+			// Verify the database version from the GCP API matches what we deployed
+			actualVersionFromAPI := gcp.GetCloudSQLInstanceDatabaseVersionContext(t, context.Background(), projectID, actualInstanceName)
+			assert.Equal(t, tt.databaseVersion, actualVersionFromAPI)
+		})
+	}
+}


### PR DESCRIPTION
## Description

This PR adds support for **Google Cloud SQL** to the GCP module. It introduces helper functions to verify the existence of Cloud SQL instances and retrieve their database version, along with a complete Terraform example and automated integration tests covering both MySQL and PostgreSQL engines.

This is a new feature addition and does not introduce any backward-incompatible changes.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.
- [x] Make a plan for release of the functionality in this PR. If it delivers value to an end user, you are responsible for ensuring it is released promptly, and correctly. If you are not a maintainer, you are responsible for finding a maintainer to do this for you.

## Release Notes (draft)

Added support for verifying Google Cloud SQL instances in the GCP module, including database engine version validation for MySQL and PostgreSQL.

### Migration Guide
No backward incompatible changes were introduced.

---

### Verification Results
I have verified this PR locally against a real GCP project:
- **Linting**: Passed using `golangci-lint run`.
- **Formatting**: Passed `go fmt` and `terraform fmt`.
- **Integration Test**: Successfully ran `TestTerraformGcpCloudSQLExample` covering both MySQL and PostgreSQL engines in parallel.

**Test Output Snippet:**
```text
=== RUN   TestTerraformGcpCloudSQLExample
=== RUN   TestTerraformGcpCloudSQLExample/mysql
=== RUN   TestTerraformGcpCloudSQLExample/postgres
=== CONT  TestTerraformGcpCloudSQLExample/mysql
=== CONT  TestTerraformGcpCloudSQLExample/postgres
...
TestTerraformGcpCloudSQLExample/postgres 2026-03-09T22:22:07 cloudsql.go:22: Verifying Cloud SQL instance terratest-cloudsql-6k3njo exists in project amith-1772452782257
TestTerraformGcpCloudSQLExample/postgres 2026-03-09T22:22:08 cloudsql.go:39: Getting database version of Cloud SQL instance terratest-cloudsql-6k3njo in project amith-1772452782257
...
TestTerraformGcpCloudSQLExample/mysql 2026-03-09T22:26:27 cloudsql.go:22: Verifying Cloud SQL instance terratest-cloudsql-vloz53 exists in project amith-1772452782257
TestTerraformGcpCloudSQLExample/mysql 2026-03-09T22:26:28 cloudsql.go:39: Getting database version of Cloud SQL instance terratest-cloudsql-vloz53 in project amith-1772452782257
...
--- PASS: TestTerraformGcpCloudSQLExample/postgres (630.55s)
--- PASS: TestTerraformGcpCloudSQLExample/mysql (921.10s)
PASS
```
