### PR TITLE
feat(k8s): add Context variants for KubectlApply and KubectlDelete functions

### DIFF
--- a/modules/k8s/kubectl.go
+++ b/modules/k8s/kubectl.go
@@ -83,7 +83,20 @@ func KubectlDelete(t testing.TestingT, options *KubectlOptions, configPath strin
 
 // KubectlDeleteE will take in a file path and delete it from the cluster targeted by KubectlOptions.
 func KubectlDeleteE(t testing.TestingT, options *KubectlOptions, configPath string) error {
-	return RunKubectlE(t, options, "delete", "-f", configPath)
+	return KubectlDeleteContextE(t, context.Background(), options, configPath)
+}
+
+// KubectlDeleteContext will take in a file path and delete it from the cluster targeted by KubectlOptions.
+// The context argument can be used for cancellation or timeout control.
+// If there are any errors, fail the test immediately.
+func KubectlDeleteContext(t testing.TestingT, ctx context.Context, options *KubectlOptions, configPath string) {
+	require.NoError(t, KubectlDeleteContextE(t, ctx, options, configPath))
+}
+
+// KubectlDeleteContextE will take in a file path and delete it from the cluster targeted by KubectlOptions.
+// The context argument can be used for cancellation or timeout control.
+func KubectlDeleteContextE(t testing.TestingT, ctx context.Context, options *KubectlOptions, configPath string) error {
+	return RunKubectlContextE(t, ctx, options, "delete", "-f", configPath)
 }
 
 // KubectlDeleteFromKustomize will take in a kustomization directory path and delete it from the cluster targeted by KubectlOptions. If there are any
@@ -94,7 +107,20 @@ func KubectlDeleteFromKustomize(t testing.TestingT, options *KubectlOptions, con
 
 // KubectlDeleteFromKustomizeE will take in a kustomization directory path and delete it from the cluster targeted by KubectlOptions.
 func KubectlDeleteFromKustomizeE(t testing.TestingT, options *KubectlOptions, configPath string) error {
-	return RunKubectlE(t, options, "delete", "-k", configPath)
+	return KubectlDeleteFromKustomizeContextE(t, context.Background(), options, configPath)
+}
+
+// KubectlDeleteFromKustomizeContext will take in a kustomization directory path and delete it from the cluster targeted by KubectlOptions.
+// The context argument can be used for cancellation or timeout control.
+// If there are any errors, fail the test immediately.
+func KubectlDeleteFromKustomizeContext(t testing.TestingT, ctx context.Context, options *KubectlOptions, configPath string) {
+	require.NoError(t, KubectlDeleteFromKustomizeContextE(t, ctx, options, configPath))
+}
+
+// KubectlDeleteFromKustomizeContextE will take in a kustomization directory path and delete it from the cluster targeted by KubectlOptions.
+// The context argument can be used for cancellation or timeout control.
+func KubectlDeleteFromKustomizeContextE(t testing.TestingT, ctx context.Context, options *KubectlOptions, configPath string) error {
+	return RunKubectlContextE(t, ctx, options, "delete", "-k", configPath)
 }
 
 // KubectlDeleteFromString will take in a kubernetes resource config as a string and delete it on the cluster specified
@@ -106,6 +132,20 @@ func KubectlDeleteFromString(t testing.TestingT, options *KubectlOptions, config
 // KubectlDeleteFromStringE will take in a kubernetes resource config as a string and delete it on the cluster specified
 // by the provided kubectl options. If it fails, this will return the error.
 func KubectlDeleteFromStringE(t testing.TestingT, options *KubectlOptions, configData string) error {
+	return KubectlDeleteFromStringContextE(t, context.Background(), options, configData)
+}
+
+// KubectlDeleteFromStringContext will take in a kubernetes resource config as a string and delete it on the cluster
+// specified by the provided kubectl options. The context argument can be used for cancellation or timeout control.
+// If there are any errors, fail the test immediately.
+func KubectlDeleteFromStringContext(t testing.TestingT, ctx context.Context, options *KubectlOptions, configData string) {
+	require.NoError(t, KubectlDeleteFromStringContextE(t, ctx, options, configData))
+}
+
+// KubectlDeleteFromStringContextE will take in a kubernetes resource config as a string and delete it on the cluster
+// specified by the provided kubectl options. The context argument can be used for cancellation or timeout control.
+// If it fails, this will return the error.
+func KubectlDeleteFromStringContextE(t testing.TestingT, ctx context.Context, options *KubectlOptions, configData string) error {
 	tmpfile, err := StoreConfigToTempFileE(t, configData)
 	if err != nil {
 		return err
@@ -113,7 +153,7 @@ func KubectlDeleteFromStringE(t testing.TestingT, options *KubectlOptions, confi
 
 	defer func() { _ = os.Remove(tmpfile) }()
 
-	return KubectlDeleteE(t, options, tmpfile)
+	return KubectlDeleteContextE(t, ctx, options, tmpfile)
 }
 
 // KubectlApply will take in a file path and apply it to the cluster targeted by KubectlOptions. If there are any
@@ -124,7 +164,20 @@ func KubectlApply(t testing.TestingT, options *KubectlOptions, configPath string
 
 // KubectlApplyE will take in a file path and apply it to the cluster targeted by KubectlOptions.
 func KubectlApplyE(t testing.TestingT, options *KubectlOptions, configPath string) error {
-	return RunKubectlE(t, options, "apply", "-f", configPath)
+	return KubectlApplyContextE(t, context.Background(), options, configPath)
+}
+
+// KubectlApplyContext will take in a file path and apply it to the cluster targeted by KubectlOptions.
+// The context argument can be used for cancellation or timeout control.
+// If there are any errors, fail the test immediately.
+func KubectlApplyContext(t testing.TestingT, ctx context.Context, options *KubectlOptions, configPath string) {
+	require.NoError(t, KubectlApplyContextE(t, ctx, options, configPath))
+}
+
+// KubectlApplyContextE will take in a file path and apply it to the cluster targeted by KubectlOptions.
+// The context argument can be used for cancellation or timeout control.
+func KubectlApplyContextE(t testing.TestingT, ctx context.Context, options *KubectlOptions, configPath string) error {
+	return RunKubectlContextE(t, ctx, options, "apply", "-f", configPath)
 }
 
 // KubectlApplyFromKustomize will take in a kustomization directory path and apply it to the cluster targeted by KubectlOptions. If there are any
@@ -135,7 +188,20 @@ func KubectlApplyFromKustomize(t testing.TestingT, options *KubectlOptions, conf
 
 // KubectlApplyFromKustomizeE will take in a kustomization directory path and apply it to the cluster targeted by KubectlOptions.
 func KubectlApplyFromKustomizeE(t testing.TestingT, options *KubectlOptions, configPath string) error {
-	return RunKubectlE(t, options, "apply", "-k", configPath)
+	return KubectlApplyFromKustomizeContextE(t, context.Background(), options, configPath)
+}
+
+// KubectlApplyFromKustomizeContext will take in a kustomization directory path and apply it to the cluster targeted by KubectlOptions.
+// The context argument can be used for cancellation or timeout control.
+// If there are any errors, fail the test immediately.
+func KubectlApplyFromKustomizeContext(t testing.TestingT, ctx context.Context, options *KubectlOptions, configPath string) {
+	require.NoError(t, KubectlApplyFromKustomizeContextE(t, ctx, options, configPath))
+}
+
+// KubectlApplyFromKustomizeContextE will take in a kustomization directory path and apply it to the cluster targeted by KubectlOptions.
+// The context argument can be used for cancellation or timeout control.
+func KubectlApplyFromKustomizeContextE(t testing.TestingT, ctx context.Context, options *KubectlOptions, configPath string) error {
+	return RunKubectlContextE(t, ctx, options, "apply", "-k", configPath)
 }
 
 // KubectlApplyFromString will take in a kubernetes resource config as a string and apply it on the cluster specified
@@ -147,6 +213,20 @@ func KubectlApplyFromString(t testing.TestingT, options *KubectlOptions, configD
 // KubectlApplyFromStringE will take in a kubernetes resource config as a string and apply it on the cluster specified
 // by the provided kubectl options. If it fails, this will return the error.
 func KubectlApplyFromStringE(t testing.TestingT, options *KubectlOptions, configData string) error {
+	return KubectlApplyFromStringContextE(t, context.Background(), options, configData)
+}
+
+// KubectlApplyFromStringContext will take in a kubernetes resource config as a string and apply it on the cluster
+// specified by the provided kubectl options. The context argument can be used for cancellation or timeout control.
+// If there are any errors, fail the test immediately.
+func KubectlApplyFromStringContext(t testing.TestingT, ctx context.Context, options *KubectlOptions, configData string) {
+	require.NoError(t, KubectlApplyFromStringContextE(t, ctx, options, configData))
+}
+
+// KubectlApplyFromStringContextE will take in a kubernetes resource config as a string and apply it on the cluster
+// specified by the provided kubectl options. The context argument can be used for cancellation or timeout control.
+// If it fails, this will return the error.
+func KubectlApplyFromStringContextE(t testing.TestingT, ctx context.Context, options *KubectlOptions, configData string) error {
 	tmpfile, err := StoreConfigToTempFileE(t, configData)
 	if err != nil {
 		return err
@@ -154,7 +234,7 @@ func KubectlApplyFromStringE(t testing.TestingT, options *KubectlOptions, config
 
 	defer func() { _ = os.Remove(tmpfile) }()
 
-	return KubectlApplyE(t, options, tmpfile)
+	return KubectlApplyContextE(t, ctx, options, tmpfile)
 }
 
 // StoreConfigToTempFile will store the provided config data to a temporary file created on the os and return the

--- a/modules/k8s/kubectl.go
+++ b/modules/k8s/kubectl.go
@@ -82,6 +82,8 @@ func KubectlDelete(t testing.TestingT, options *KubectlOptions, configPath strin
 }
 
 // KubectlDeleteE will take in a file path and delete it from the cluster targeted by KubectlOptions.
+//
+// Deprecated: Use KubectlDeleteContextE instead.
 func KubectlDeleteE(t testing.TestingT, options *KubectlOptions, configPath string) error {
 	return KubectlDeleteContextE(t, context.Background(), options, configPath)
 }
@@ -106,6 +108,8 @@ func KubectlDeleteFromKustomize(t testing.TestingT, options *KubectlOptions, con
 }
 
 // KubectlDeleteFromKustomizeE will take in a kustomization directory path and delete it from the cluster targeted by KubectlOptions.
+//
+// Deprecated: Use KubectlDeleteFromKustomizeContextE instead.
 func KubectlDeleteFromKustomizeE(t testing.TestingT, options *KubectlOptions, configPath string) error {
 	return KubectlDeleteFromKustomizeContextE(t, context.Background(), options, configPath)
 }
@@ -131,6 +135,8 @@ func KubectlDeleteFromString(t testing.TestingT, options *KubectlOptions, config
 
 // KubectlDeleteFromStringE will take in a kubernetes resource config as a string and delete it on the cluster specified
 // by the provided kubectl options. If it fails, this will return the error.
+//
+// Deprecated: Use KubectlDeleteFromStringContextE instead.
 func KubectlDeleteFromStringE(t testing.TestingT, options *KubectlOptions, configData string) error {
 	return KubectlDeleteFromStringContextE(t, context.Background(), options, configData)
 }
@@ -163,6 +169,8 @@ func KubectlApply(t testing.TestingT, options *KubectlOptions, configPath string
 }
 
 // KubectlApplyE will take in a file path and apply it to the cluster targeted by KubectlOptions.
+//
+// Deprecated: Use KubectlApplyContextE instead.
 func KubectlApplyE(t testing.TestingT, options *KubectlOptions, configPath string) error {
 	return KubectlApplyContextE(t, context.Background(), options, configPath)
 }
@@ -187,6 +195,8 @@ func KubectlApplyFromKustomize(t testing.TestingT, options *KubectlOptions, conf
 }
 
 // KubectlApplyFromKustomizeE will take in a kustomization directory path and apply it to the cluster targeted by KubectlOptions.
+//
+// Deprecated: Use KubectlApplyFromKustomizeContextE instead.
 func KubectlApplyFromKustomizeE(t testing.TestingT, options *KubectlOptions, configPath string) error {
 	return KubectlApplyFromKustomizeContextE(t, context.Background(), options, configPath)
 }
@@ -212,6 +222,8 @@ func KubectlApplyFromString(t testing.TestingT, options *KubectlOptions, configD
 
 // KubectlApplyFromStringE will take in a kubernetes resource config as a string and apply it on the cluster specified
 // by the provided kubectl options. If it fails, this will return the error.
+//
+// Deprecated: Use KubectlApplyFromStringContextE instead.
 func KubectlApplyFromStringE(t testing.TestingT, options *KubectlOptions, configData string) error {
 	return KubectlApplyFromStringContextE(t, context.Background(), options, configData)
 }


### PR DESCRIPTION
## Description

Closes #1720

The `k8s` module has a clear API pattern where every kubectl operation should have four variants: basic, `E`, `Context`, and `ContextE`. However, `KubectlApply`, `KubectlDelete`, and their `FromKustomize`/`FromString` counterparts were missing the `Context` and `ContextE` variants, and their internal implementations were calling the deprecated `RunKubectlE` instead of `RunKubectlContextE`.

## Changes

- Added `KubectlApplyContext` / `KubectlApplyContextE`
- Added `KubectlDeleteContext` / `KubectlDeleteContextE`
- Added `KubectlApplyFromKustomizeContext` / `KubectlApplyFromKustomizeContextE`
- Added `KubectlDeleteFromKustomizeContext` / `KubectlDeleteFromKustomizeContextE`
- Added `KubectlApplyFromStringContext` / `KubectlApplyFromStringContextE`
- Added `KubectlDeleteFromStringContext` / `KubectlDeleteFromStringContextE`
- Updated existing `E` variants to delegate to the new `ContextE` functions via `context.Background()`, eliminating all internal calls to the deprecated `RunKubectlE`

## Backward Compatibility

All existing function signatures are unchanged. The `E` variants now delegate to `ContextE` with `context.Background()`, so behavior is identical for existing callers.

## Test plan

- [ ] Existing k8s tests pass
- [ ] `go build ./modules/k8s/...` succeeds