### PR TITLE
chore: shell package simplifications

### DIFF
--- a/modules/gcp/pubsub.go
+++ b/modules/gcp/pubsub.go
@@ -27,6 +27,7 @@ func AssertTopicExistsContextE(t testing.TestingT, ctx context.Context, projectI
 	if err != nil {
 		return err
 	}
+
 	defer func() { _ = client.Close() }()
 
 	exists, err := client.Topic(topicName).Exists(ctx)
@@ -59,6 +60,7 @@ func AssertSubscriptionExistsContextE(t testing.TestingT, ctx context.Context, p
 	if err != nil {
 		return err
 	}
+
 	defer func() { _ = client.Close() }()
 
 	exists, err := client.Subscription(subscriptionName).Exists(ctx)
@@ -91,6 +93,7 @@ func CreateTopicContextE(t testing.TestingT, ctx context.Context, projectID stri
 	if err != nil {
 		return err
 	}
+
 	defer func() { _ = client.Close() }()
 
 	_, err = client.CreateTopic(ctx, topicName)
@@ -119,6 +122,7 @@ func DeleteTopicContextE(t testing.TestingT, ctx context.Context, projectID stri
 	if err != nil {
 		return err
 	}
+
 	defer func() { _ = client.Close() }()
 
 	if err := client.Topic(topicName).Delete(ctx); err != nil {
@@ -146,6 +150,7 @@ func CreateSubscriptionContextE(t testing.TestingT, ctx context.Context, project
 	if err != nil {
 		return err
 	}
+
 	defer func() { _ = client.Close() }()
 
 	_, err = client.CreateSubscription(ctx, subscriptionName, pubsub.SubscriptionConfig{
@@ -176,6 +181,7 @@ func DeleteSubscriptionContextE(t testing.TestingT, ctx context.Context, project
 	if err != nil {
 		return err
 	}
+
 	defer func() { _ = client.Close() }()
 
 	if err := client.Subscription(subscriptionName).Delete(ctx); err != nil {
@@ -191,5 +197,6 @@ func newPubSubClient(ctx context.Context, projectID string) (*pubsub.Client, err
 	if err != nil {
 		return nil, err
 	}
+
 	return client, nil
 }

--- a/modules/shell/command.go
+++ b/modules/shell/command.go
@@ -10,7 +10,6 @@ import (
 	"os/exec"
 	"strings"
 	"sync"
-	"syscall"
 
 	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/testing"
@@ -239,7 +238,7 @@ func readStdoutAndStderr(t testing.TestingT, log *logger.Logger, stdout, stderr 
 	stdoutReader := bufio.NewReader(stdout)
 	stderrReader := bufio.NewReader(stderr)
 
-	wg := &sync.WaitGroup{}
+	var wg sync.WaitGroup
 
 	wg.Add(2) //nolint:mnd // 2 goroutines: one for stdout, one for stderr
 
@@ -259,15 +258,7 @@ func readStdoutAndStderr(t testing.TestingT, log *logger.Logger, stdout, stderr 
 
 	wg.Wait()
 
-	if stdoutErr != nil {
-		return out, stdoutErr
-	}
-
-	if stderrErr != nil {
-		return out, stderrErr
-	}
-
-	return out, nil
+	return out, errors.Join(stdoutErr, stderrErr)
 }
 
 func readData(t testing.TestingT, log *logger.Logger, reader *bufio.Reader, writer io.StringWriter) error {
@@ -315,28 +306,16 @@ func readData(t testing.TestingT, log *logger.Logger, reader *bufio.Reader, writ
 	return nil
 }
 
-// GetExitCodeForRunCommandError tries to read the exit code for the error object returned from running a shell command. This is a bit tricky to do
-// in a way that works across platforms.
+// GetExitCodeForRunCommandError tries to read the exit code for the error object returned from running a shell command.
 func GetExitCodeForRunCommandError(err error) (int, error) {
 	var errWithOutput *ErrWithCmdOutput
 	if errors.As(err, &errWithOutput) {
 		err = errWithOutput.Underlying
 	}
 
-	// http://stackoverflow.com/a/10385867/483528
 	var exitErr *exec.ExitError
 	if errors.As(err, &exitErr) {
-		// The program has exited with an exit code != 0
-
-		// This works on both Unix and Windows. Although package
-		// syscall is generally platform dependent, WaitStatus is
-		// defined for both Unix and Windows and in both cases has
-		// an ExitStatus() method with the same signature.
-		if status, ok := exitErr.Sys().(syscall.WaitStatus); ok {
-			return status.ExitStatus(), nil
-		}
-
-		return 1, errors.New("could not determine exit code")
+		return exitErr.ExitCode(), nil
 	}
 
 	return 0, nil
@@ -345,7 +324,7 @@ func GetExitCodeForRunCommandError(err error) (int, error) {
 func formatEnvVars(command *Command) []string {
 	env := os.Environ()
 	for key, value := range command.Env {
-		env = append(env, fmt.Sprintf("%s=%s", key, value))
+		env = append(env, key+"="+value)
 	}
 
 	return env

--- a/modules/shell/output.go
+++ b/modules/shell/output.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 )
 
-// output contains the output after runnig a command.
+// output contains the output after running a command.
 type output struct {
 	stdout *outputStream
 	stderr *outputStream
@@ -52,12 +52,12 @@ func (o *output) Combined() string {
 }
 
 type outputStream struct {
-	*merged
-	Lines []string
+	merged *merged
+	lines  []string
 }
 
 func (st *outputStream) WriteString(s string) (n int, err error) {
-	st.Lines = append(st.Lines, s)
+	st.lines = append(st.lines, s)
 
 	return st.merged.WriteString(s)
 }
@@ -67,11 +67,11 @@ func (st *outputStream) String() string {
 		return ""
 	}
 
-	return strings.Join(st.Lines, "\n")
+	return strings.Join(st.lines, "\n")
 }
 
 type merged struct {
-	Lines []string
+	lines []string
 	// ensure that there are no parallel writes
 	sync.Mutex
 }
@@ -81,14 +81,14 @@ func (m *merged) String() string {
 		return ""
 	}
 
-	return strings.Join(m.Lines, "\n")
+	return strings.Join(m.lines, "\n")
 }
 
 func (m *merged) WriteString(s string) (n int, err error) {
 	m.Lock()
 	defer m.Unlock()
 
-	m.Lines = append(m.Lines, s)
+	m.lines = append(m.lines, s)
 
 	return len(s), nil
 }


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Simplified shell package:

* Replaced syscall.WaitStatus type assertion with exitErr.ExitCode() in GetExitCodeForRunCommandError, remove syscall import
* Use errors.Join instead of sequential nil checks in readStdoutAndStderr
* Use var wg sync.WaitGroup instead of pointer allocation
* Use string concat instead of fmt.Sprintf in formatEnvVars
* Unexport Lines to lines on private structs outputStream / merged
* Fixed lint issues

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.
- [x] Make a plan for release of the functionality in this PR. If it delivers value to an end user, you are responsible for ensuring it is released promptly, and correctly. If you are not a maintainer, you are responsible for finding a maintainer to do this for you.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->
