### PR TITLE
fix(azure)!: remove deprecated non-Context wrappers from appService, keyvault, datafactory, region, and resourcegroupv2

### DIFF
--- a/modules/azure/appService.go
+++ b/modules/azure/appService.go
@@ -20,16 +20,6 @@ func AppExistsContext(t testing.TestingT, ctx context.Context, appName string, r
 	return exists
 }
 
-// AppExists indicates whether the specified application exists.
-// This function would fail the test if there is an error.
-//
-// Deprecated: Use [AppExistsContext] instead.
-func AppExists(t testing.TestingT, appName string, resourceGroupName string, subscriptionID string) bool {
-	t.Helper()
-
-	return AppExistsContext(t, context.Background(), appName, resourceGroupName, subscriptionID)
-}
-
 // AppExistsContextE indicates whether the specified application exists.
 // The ctx parameter supports cancellation and timeouts.
 func AppExistsContextE(ctx context.Context, appName string, resourceGroupName string, subscriptionID string) (bool, error) {
@@ -45,13 +35,6 @@ func AppExistsContextE(ctx context.Context, appName string, resourceGroupName st
 	return true, nil
 }
 
-// AppExistsE indicates whether the specified application exists.
-//
-// Deprecated: Use [AppExistsContextE] instead.
-func AppExistsE(appName string, resourceGroupName string, subscriptionID string) (bool, error) {
-	return AppExistsContextE(context.Background(), appName, resourceGroupName, subscriptionID)
-}
-
 // GetAppServiceContext gets the App service object for the specified application.
 // This function would fail the test if there is an error.
 // The ctx parameter supports cancellation and timeouts.
@@ -62,16 +45,6 @@ func GetAppServiceContext(t testing.TestingT, ctx context.Context, appName strin
 	require.NoError(t, err)
 
 	return site
-}
-
-// GetAppService gets the App service object for the specified application.
-// This function would fail the test if there is an error.
-//
-// Deprecated: Use [GetAppServiceContext] instead.
-func GetAppService(t testing.TestingT, appName string, resGroupName string, subscriptionID string) *armappservice.Site {
-	t.Helper()
-
-	return GetAppServiceContext(t, context.Background(), appName, resGroupName, subscriptionID)
 }
 
 // GetAppServiceContextE gets the App service object for the specified application.
@@ -93,13 +66,6 @@ func GetAppServiceContextE(ctx context.Context, appName string, resGroupName str
 	}
 
 	return &resp.Site, nil
-}
-
-// GetAppServiceE gets the App service object for the specified application.
-//
-// Deprecated: Use [GetAppServiceContextE] instead.
-func GetAppServiceE(appName string, resGroupName string, subscriptionID string) (*armappservice.Site, error) {
-	return GetAppServiceContextE(context.Background(), appName, resGroupName, subscriptionID)
 }
 
 // GetAppServiceClientE creates and returns an App Service web apps client.

--- a/modules/azure/appService_test.go
+++ b/modules/azure/appService_test.go
@@ -18,25 +18,25 @@ The below tests are currently stubbed out, with the expectation that they will t
 If/when CRUD methods are introduced for Azure MySQL server and database, these tests can be extended
 */
 
-func TestAppExistsE(t *testing.T) {
+func TestAppExistsContextE(t *testing.T) {
 	t.Parallel()
 
 	resGroupName := ""
 	appName := ""
 	subscriptionID := ""
 
-	_, err := azure.AppExistsE(appName, resGroupName, subscriptionID)
+	_, err := azure.AppExistsContextE(t.Context(), appName, resGroupName, subscriptionID)
 	require.Error(t, err)
 }
 
-func TestGetAppServiceE(t *testing.T) {
+func TestGetAppServiceContextE(t *testing.T) {
 	t.Parallel()
 
 	resGroupName := ""
 	appName := ""
 	subscriptionID := ""
 
-	_, err := azure.GetAppServiceE(appName, resGroupName, subscriptionID)
+	_, err := azure.GetAppServiceContextE(t.Context(), appName, resGroupName, subscriptionID)
 	require.Error(t, err)
 }
 

--- a/modules/azure/datafactory.go
+++ b/modules/azure/datafactory.go
@@ -20,16 +20,6 @@ func DataFactoryExistsContext(t testing.TestingT, ctx context.Context, dataFacto
 	return exists
 }
 
-// DataFactoryExists indicates whether the Data Factory exists for the subscription.
-// This function would fail the test if there is an error.
-//
-// Deprecated: Use [DataFactoryExistsContext] instead.
-func DataFactoryExists(t testing.TestingT, dataFactoryName string, resourceGroupName string, subscriptionID string) bool {
-	t.Helper()
-
-	return DataFactoryExistsContext(t, context.Background(), dataFactoryName, resourceGroupName, subscriptionID) //nolint:staticcheck
-}
-
 // DataFactoryExistsContextE indicates whether the specified Data Factory exists and may return an error.
 // The ctx parameter supports cancellation and timeouts.
 func DataFactoryExistsContextE(ctx context.Context, dataFactoryName string, resourceGroupName string, subscriptionID string) (bool, error) {
@@ -45,13 +35,6 @@ func DataFactoryExistsContextE(ctx context.Context, dataFactoryName string, reso
 	return true, nil
 }
 
-// DataFactoryExistsE indicates whether the specified Data Factory exists and may return an error.
-//
-// Deprecated: Use [DataFactoryExistsContextE] instead.
-func DataFactoryExistsE(dataFactoryName string, resourceGroupName string, subscriptionID string) (bool, error) {
-	return DataFactoryExistsContextE(context.Background(), dataFactoryName, resourceGroupName, subscriptionID)
-}
-
 // GetDataFactoryContext returns the Data Factory object.
 // This function would fail the test if there is an error.
 // The ctx parameter supports cancellation and timeouts.
@@ -62,16 +45,6 @@ func GetDataFactoryContext(t testing.TestingT, ctx context.Context, resGroupName
 	require.NoError(t, err)
 
 	return factory
-}
-
-// GetDataFactory is a helper function that gets the data factory.
-// This function would fail the test if there is an error.
-//
-// Deprecated: Use [GetDataFactoryContext] instead.
-func GetDataFactory(t testing.TestingT, resGroupName string, factoryName string, subscriptionID string) *armdatafactory.Factory {
-	t.Helper()
-
-	return GetDataFactoryContext(t, context.Background(), resGroupName, factoryName, subscriptionID) //nolint:staticcheck
 }
 
 // GetDataFactoryContextE returns the Data Factory object.
@@ -91,11 +64,4 @@ func GetDataFactoryContextE(ctx context.Context, subscriptionID string, resGroup
 
 	// Return data factory
 	return &resp.Factory, nil
-}
-
-// GetDataFactoryE is a helper function that gets the data factory.
-//
-// Deprecated: Use [GetDataFactoryContextE] instead.
-func GetDataFactoryE(subscriptionID string, resGroupName string, factoryName string) (*armdatafactory.Factory, error) {
-	return GetDataFactoryContextE(context.Background(), subscriptionID, resGroupName, factoryName)
 }

--- a/modules/azure/datafactory_test.go
+++ b/modules/azure/datafactory_test.go
@@ -19,19 +19,19 @@ func TestDataFactoryExists(t *testing.T) {
 	resourceGroupName := ""
 	subscriptionID := ""
 
-	exists, err := azure.DataFactoryExistsE(dataFactoryName, resourceGroupName, subscriptionID)
+	exists, err := azure.DataFactoryExistsContextE(t.Context(), dataFactoryName, resourceGroupName, subscriptionID)
 
 	require.False(t, exists)
 	require.Error(t, err)
 }
 
-func TestGetDataFactoryE(t *testing.T) {
+func TestGetDataFactoryContextE(t *testing.T) {
 	t.Parallel()
 
 	resGroupName := ""
 	subscriptionID := ""
 	dataFactoryName := ""
 
-	_, err := azure.GetDataFactoryE(subscriptionID, resGroupName, dataFactoryName)
+	_, err := azure.GetDataFactoryContextE(t.Context(), subscriptionID, resGroupName, dataFactoryName)
 	require.Error(t, err)
 }

--- a/modules/azure/keyvault.go
+++ b/modules/azure/keyvault.go
@@ -30,16 +30,6 @@ func KeyVaultSecretExistsContext(t testing.TestingT, ctx context.Context, keyVau
 	return result
 }
 
-// KeyVaultSecretExists indicates whether a key vault secret exists; otherwise false.
-// This function would fail the test if there is an error.
-//
-// Deprecated: Use [KeyVaultSecretExistsContext] instead.
-func KeyVaultSecretExists(t testing.TestingT, keyVaultName string, secretName string) bool {
-	t.Helper()
-
-	return KeyVaultSecretExistsContext(t, context.Background(), keyVaultName, secretName) //nolint:staticcheck
-}
-
 // KeyVaultKeyExistsContext indicates whether a key vault key exists; otherwise false.
 // This function would fail the test if there is an error.
 // The ctx parameter supports cancellation and timeouts.
@@ -52,16 +42,6 @@ func KeyVaultKeyExistsContext(t testing.TestingT, ctx context.Context, keyVaultN
 	return result
 }
 
-// KeyVaultKeyExists indicates whether a key vault key exists; otherwise false.
-// This function would fail the test if there is an error.
-//
-// Deprecated: Use [KeyVaultKeyExistsContext] instead.
-func KeyVaultKeyExists(t testing.TestingT, keyVaultName string, keyName string) bool {
-	t.Helper()
-
-	return KeyVaultKeyExistsContext(t, context.Background(), keyVaultName, keyName) //nolint:staticcheck
-}
-
 // KeyVaultCertificateExistsContext indicates whether a key vault certificate exists; otherwise false.
 // This function would fail the test if there is an error.
 // The ctx parameter supports cancellation and timeouts.
@@ -72,16 +52,6 @@ func KeyVaultCertificateExistsContext(t testing.TestingT, ctx context.Context, k
 	require.NoError(t, err)
 
 	return result
-}
-
-// KeyVaultCertificateExists indicates whether a key vault certificate exists; otherwise false.
-// This function would fail the test if there is an error.
-//
-// Deprecated: Use [KeyVaultCertificateExistsContext] instead.
-func KeyVaultCertificateExists(t testing.TestingT, keyVaultName string, certificateName string) bool {
-	t.Helper()
-
-	return KeyVaultCertificateExistsContext(t, context.Background(), keyVaultName, certificateName) //nolint:staticcheck
 }
 
 // KeyVaultCertificateExistsContextE indicates whether a certificate exists in key vault; otherwise false.
@@ -110,13 +80,6 @@ func KeyVaultCertificateExistsContextE(ctx context.Context, keyVaultName, certif
 	return false, nil
 }
 
-// KeyVaultCertificateExistsE indicates whether a certificate exists in key vault; otherwise false.
-//
-// Deprecated: Use [KeyVaultCertificateExistsContextE] instead.
-func KeyVaultCertificateExistsE(keyVaultName, certificateName string) (bool, error) {
-	return KeyVaultCertificateExistsContextE(context.Background(), keyVaultName, certificateName)
-}
-
 // KeyVaultKeyExistsContextE indicates whether a key exists in the key vault; otherwise false.
 // The ctx parameter supports cancellation and timeouts.
 func KeyVaultKeyExistsContextE(ctx context.Context, keyVaultName, keyName string) (bool, error) {
@@ -143,13 +106,6 @@ func KeyVaultKeyExistsContextE(ctx context.Context, keyVaultName, keyName string
 	return false, nil
 }
 
-// KeyVaultKeyExistsE indicates whether a key exists in the key vault; otherwise false.
-//
-// Deprecated: Use [KeyVaultKeyExistsContextE] instead.
-func KeyVaultKeyExistsE(keyVaultName, keyName string) (bool, error) {
-	return KeyVaultKeyExistsContextE(context.Background(), keyVaultName, keyName)
-}
-
 // KeyVaultSecretExistsContextE indicates whether a secret exists in the key vault; otherwise false.
 // The ctx parameter supports cancellation and timeouts.
 func KeyVaultSecretExistsContextE(ctx context.Context, keyVaultName, secretName string) (bool, error) {
@@ -174,13 +130,6 @@ func KeyVaultSecretExistsContextE(ctx context.Context, keyVaultName, secretName 
 	}
 
 	return false, nil
-}
-
-// KeyVaultSecretExistsE indicates whether a secret exists in the key vault; otherwise false.
-//
-// Deprecated: Use [KeyVaultSecretExistsContextE] instead.
-func KeyVaultSecretExistsE(keyVaultName, secretName string) (bool, error) {
-	return KeyVaultSecretExistsContextE(context.Background(), keyVaultName, secretName)
 }
 
 // GetKeyVaultSecretsClientE creates a KeyVault secrets client.
@@ -246,16 +195,6 @@ func GetKeyVaultContext(t testing.TestingT, ctx context.Context, resGroupName st
 	return keyVault
 }
 
-// GetKeyVault is a helper function that gets the keyvault management object.
-// This function would fail the test if there is an error.
-//
-// Deprecated: Use [GetKeyVaultContext] instead.
-func GetKeyVault(t testing.TestingT, resGroupName string, keyVaultName string, subscriptionID string) *armkeyvault.Vault {
-	t.Helper()
-
-	return GetKeyVaultContext(t, context.Background(), resGroupName, keyVaultName, subscriptionID) //nolint:staticcheck
-}
-
 // GetKeyVaultContextE is a helper function that gets the keyvault management object.
 // The ctx parameter supports cancellation and timeouts.
 func GetKeyVaultContextE(t testing.TestingT, ctx context.Context, resGroupName string, keyVaultName string, subscriptionID string) (*armkeyvault.Vault, error) {
@@ -274,15 +213,6 @@ func GetKeyVaultContextE(t testing.TestingT, ctx context.Context, resGroupName s
 	}
 
 	return &resp.Vault, nil
-}
-
-// GetKeyVaultE is a helper function that gets the keyvault management object.
-//
-// Deprecated: Use [GetKeyVaultContextE] instead.
-func GetKeyVaultE(t testing.TestingT, resGroupName string, keyVaultName string, subscriptionID string) (*armkeyvault.Vault, error) {
-	t.Helper()
-
-	return GetKeyVaultContextE(t, context.Background(), resGroupName, keyVaultName, subscriptionID)
 }
 
 // GetKeyVaultManagementClientE is a helper function that will setup a key vault management client.

--- a/modules/azure/keyvault_test.go
+++ b/modules/azure/keyvault_test.go
@@ -18,7 +18,7 @@ func TestKeyVaultSecretExists(t *testing.T) {
 
 	testKeyVaultName := "fakeKeyVault"
 	testKeyVaultSecretName := "fakeSecretName"
-	_, err := azure.KeyVaultSecretExistsE(testKeyVaultName, testKeyVaultSecretName)
+	_, err := azure.KeyVaultSecretExistsContextE(t.Context(), testKeyVaultName, testKeyVaultSecretName)
 	require.Error(t, err)
 }
 
@@ -27,7 +27,7 @@ func TestKeyVaultKeyExists(t *testing.T) {
 
 	testKeyVaultName := "fakeKeyVault"
 	testKeyVaultKeyName := "fakeKeyName"
-	_, err := azure.KeyVaultKeyExistsE(testKeyVaultName, testKeyVaultKeyName)
+	_, err := azure.KeyVaultKeyExistsContextE(t.Context(), testKeyVaultName, testKeyVaultKeyName)
 	require.Error(t, err)
 }
 
@@ -36,7 +36,7 @@ func TestKeyVaultCertificateExists(t *testing.T) {
 
 	testKeyVaultName := "fakeKeyVault"
 	testKeyVaultCertName := "fakeCertName"
-	_, err := azure.KeyVaultCertificateExistsE(testKeyVaultName, testKeyVaultCertName)
+	_, err := azure.KeyVaultCertificateExistsContextE(t.Context(), testKeyVaultName, testKeyVaultCertName)
 	require.Error(t, err)
 }
 
@@ -47,6 +47,6 @@ func TestGetKeyVault(t *testing.T) {
 	keyVaultName := ""
 	subscriptionID := ""
 
-	_, err := azure.GetKeyVaultE(t, resGroupName, keyVaultName, subscriptionID)
+	_, err := azure.GetKeyVaultContextE(t, t.Context(), resGroupName, keyVaultName, subscriptionID)
 	require.Error(t, err)
 }

--- a/modules/azure/region.go
+++ b/modules/azure/region.go
@@ -82,19 +82,6 @@ func GetRandomStableRegionContext(t testing.TestingT, ctx context.Context, appro
 	return GetRandomRegionContext(t, ctx, regionsToPickFrom, nil, subscriptionID) //nolint:staticcheck
 }
 
-// GetRandomStableRegion gets a randomly chosen Azure region that is considered stable. Like GetRandomRegion, you can
-// further restrict the stable region list using approvedRegions and forbiddenRegions. We consider stable regions to be
-// those that have been around for at least 1 year.
-// Note that regions in the approvedRegions list that are not considered stable are ignored.
-// This function would fail the test if there is an error.
-//
-// Deprecated: Use [GetRandomStableRegionContext] instead.
-func GetRandomStableRegion(t testing.TestingT, approvedRegions []string, forbiddenRegions []string, subscriptionID string) string {
-	t.Helper()
-
-	return GetRandomStableRegionContext(t, context.Background(), approvedRegions, forbiddenRegions, subscriptionID)
-}
-
 // GetRandomRegionContext gets a randomly chosen Azure region.
 // If approvedRegions is not empty, this will be a region from the approvedRegions list; otherwise,
 // this method will fetch the latest list of regions from the Azure APIs and pick one of those.
@@ -108,18 +95,6 @@ func GetRandomRegionContext(t testing.TestingT, ctx context.Context, approvedReg
 	require.NoError(t, err)
 
 	return region
-}
-
-// GetRandomRegion gets a randomly chosen Azure region. If approvedRegions is not empty, this will be a region from the approvedRegions
-// list; otherwise, this method will fetch the latest list of regions from the Azure APIs and pick one of those. If
-// forbiddenRegions is not empty, this method will make sure the returned region is not in the forbiddenRegions list.
-// This function would fail the test if there is an error.
-//
-// Deprecated: Use [GetRandomRegionContext] instead.
-func GetRandomRegion(t testing.TestingT, approvedRegions []string, forbiddenRegions []string, subscriptionID string) string {
-	t.Helper()
-
-	return GetRandomRegionContext(t, context.Background(), approvedRegions, forbiddenRegions, subscriptionID) //nolint:staticcheck
 }
 
 // GetRandomRegionContextE gets a randomly chosen Azure region.
@@ -151,15 +126,6 @@ func GetRandomRegionContextE(t testing.TestingT, ctx context.Context, approvedRe
 	return region, nil
 }
 
-// GetRandomRegionE gets a randomly chosen Azure region. If approvedRegions is not empty, this will be a region from the approvedRegions
-// list; otherwise, this method will fetch the latest list of regions from the Azure APIs and pick one of those. If
-// forbiddenRegions is not empty, this method will make sure the returned region is not in the forbiddenRegions list.
-//
-// Deprecated: Use [GetRandomRegionContextE] instead.
-func GetRandomRegionE(t testing.TestingT, approvedRegions []string, forbiddenRegions []string, subscriptionID string) (string, error) {
-	return GetRandomRegionContextE(t, context.Background(), approvedRegions, forbiddenRegions, subscriptionID)
-}
-
 // GetAllAzureRegionsContext gets the list of Azure regions available in this subscription.
 // This function would fail the test if there is an error.
 // The ctx parameter supports cancellation and timeouts.
@@ -170,16 +136,6 @@ func GetAllAzureRegionsContext(t testing.TestingT, ctx context.Context, subscrip
 	require.NoError(t, err)
 
 	return out
-}
-
-// GetAllAzureRegions gets the list of Azure regions available in this subscription.
-// This function would fail the test if there is an error.
-//
-// Deprecated: Use [GetAllAzureRegionsContext] instead.
-func GetAllAzureRegions(t testing.TestingT, subscriptionID string) []string {
-	t.Helper()
-
-	return GetAllAzureRegionsContext(t, context.Background(), subscriptionID)
 }
 
 // GetAllAzureRegionsContextE gets the list of Azure regions available in this subscription.
@@ -211,11 +167,4 @@ func GetAllAzureRegionsContextE(t testing.TestingT, ctx context.Context, subscri
 	}
 
 	return regions, nil
-}
-
-// GetAllAzureRegionsE gets the list of Azure regions available in this subscription.
-//
-// Deprecated: Use [GetAllAzureRegionsContextE] instead.
-func GetAllAzureRegionsE(t testing.TestingT, subscriptionID string) ([]string, error) {
-	return GetAllAzureRegionsContextE(t, context.Background(), subscriptionID)
 }

--- a/modules/azure/region_test.go
+++ b/modules/azure/region_test.go
@@ -15,7 +15,7 @@ import (
 func TestGetRandomRegion(t *testing.T) {
 	t.Parallel()
 
-	randomRegion := GetRandomRegion(t, nil, nil, "")
+	randomRegion := GetRandomRegionContext(t, t.Context(), nil, nil, "")
 	assertLooksLikeRegionName(t, randomRegion)
 }
 
@@ -26,7 +26,7 @@ func TestGetRandomRegionExcludesForbiddenRegions(t *testing.T) {
 	forbiddenRegions := []string{"westus2", "japaneast"}
 
 	for i := 0; i < 48; i++ {
-		randomRegion := GetRandomRegion(t, approvedRegions, forbiddenRegions, "")
+		randomRegion := GetRandomRegionContext(t, t.Context(), approvedRegions, forbiddenRegions, "")
 		assert.NotContains(t, forbiddenRegions, randomRegion)
 	}
 }
@@ -34,7 +34,7 @@ func TestGetRandomRegionExcludesForbiddenRegions(t *testing.T) {
 func TestGetAllAzureRegions(t *testing.T) {
 	t.Parallel()
 
-	regions := GetAllAzureRegions(t, "")
+	regions := GetAllAzureRegionsContext(t, t.Context(), "")
 
 	// The typical subscription had access to 30+ live regions as of
 	// July 2019: https://azure.microsoft.com/en-us/global-infrastructure/regions/

--- a/modules/azure/resourcegroupv2.go
+++ b/modules/azure/resourcegroupv2.go
@@ -36,23 +36,6 @@ func ResourceGroupExistsV2ContextE(ctx context.Context, resourceGroupName, subsc
 	return exists, nil
 }
 
-// ResourceGroupExistsV2 indicates whether a resource group exists within a subscription; otherwise false.
-// This function would fail the test if there is an error.
-//
-// Deprecated: Use [ResourceGroupExistsV2Context] instead.
-func ResourceGroupExistsV2(t testing.TestingT, resourceGroupName string, subscriptionID string) bool {
-	t.Helper()
-
-	return ResourceGroupExistsV2Context(t, context.Background(), resourceGroupName, subscriptionID)
-}
-
-// ResourceGroupExistsV2E indicates whether a resource group exists within a subscription.
-//
-// Deprecated: Use [ResourceGroupExistsV2ContextE] instead.
-func ResourceGroupExistsV2E(resourceGroupName, subscriptionID string) (bool, error) {
-	return ResourceGroupExistsV2ContextE(context.Background(), resourceGroupName, subscriptionID)
-}
-
 // GetResourceGroupV2ContextE checks whether a resource group name matches the one retrieved from the subscription.
 // The ctx parameter supports cancellation and timeouts.
 func GetResourceGroupV2ContextE(ctx context.Context, resourceGroupName, subscriptionID string) (bool, error) {
@@ -62,13 +45,6 @@ func GetResourceGroupV2ContextE(ctx context.Context, resourceGroupName, subscrip
 	}
 
 	return (resourceGroupName == *rg.Name), nil
-}
-
-// GetResourceGroupV2E checks whether a resource group name matches the one retrieved from the subscription.
-//
-// Deprecated: Use [GetResourceGroupV2ContextE] instead.
-func GetResourceGroupV2E(resourceGroupName, subscriptionID string) (bool, error) {
-	return GetResourceGroupV2ContextE(context.Background(), resourceGroupName, subscriptionID)
 }
 
 // GetAResourceGroupV2Context returns a resource group within a subscription.
@@ -97,23 +73,6 @@ func GetAResourceGroupV2ContextE(ctx context.Context, resourceGroupName, subscri
 	}
 
 	return &rg.ResourceGroup, nil
-}
-
-// GetAResourceGroupV2 returns a resource group within a subscription.
-// This function would fail the test if there is an error.
-//
-// Deprecated: Use [GetAResourceGroupV2Context] instead.
-func GetAResourceGroupV2(t testing.TestingT, resourceGroupName string, subscriptionID string) *armresources.ResourceGroup {
-	t.Helper()
-
-	return GetAResourceGroupV2Context(t, context.Background(), resourceGroupName, subscriptionID)
-}
-
-// GetAResourceGroupV2E gets a resource group within a subscription.
-//
-// Deprecated: Use [GetAResourceGroupV2ContextE] instead.
-func GetAResourceGroupV2E(resourceGroupName, subscriptionID string) (*armresources.ResourceGroup, error) {
-	return GetAResourceGroupV2ContextE(context.Background(), resourceGroupName, subscriptionID)
 }
 
 // ListResourceGroupsByTagV2Context returns a resource group list within a subscription based on a tag key.
@@ -151,21 +110,4 @@ func ListResourceGroupsByTagV2ContextE(ctx context.Context, tag string, subscrip
 	}
 
 	return
-}
-
-// ListResourceGroupsByTagV2 returns a resource group list within a subscription based on a tag key.
-// This function would fail the test if there is an error.
-//
-// Deprecated: Use [ListResourceGroupsByTagV2Context] instead.
-func ListResourceGroupsByTagV2(t testing.TestingT, tag, subscriptionID string) []*armresources.ResourceGroup {
-	t.Helper()
-
-	return ListResourceGroupsByTagV2Context(t, context.Background(), tag, subscriptionID)
-}
-
-// ListResourceGroupsByTagV2E returns a resource group list within a subscription based on a tag key.
-//
-// Deprecated: Use [ListResourceGroupsByTagV2ContextE] instead.
-func ListResourceGroupsByTagV2E(tag string, subscriptionID string) (rg []*armresources.ResourceGroup, err error) {
-	return ListResourceGroupsByTagV2ContextE(context.Background(), tag, subscriptionID)
 }

--- a/modules/azure/resourcegroupv2_test.go
+++ b/modules/azure/resourcegroupv2_test.go
@@ -24,7 +24,7 @@ func TestResourceGroupExistsV2(t *testing.T) {
 	t.Parallel()
 
 	resourceGroupName := "fakeResourceGroupName"
-	exists, err := azure.ResourceGroupExistsV2E(resourceGroupName, "")
+	exists, err := azure.ResourceGroupExistsV2ContextE(t.Context(), resourceGroupName, "")
 	require.NoError(t, err)
 	assert.False(t, exists)
 }
@@ -34,7 +34,7 @@ func TestGetAResourceGroupV2(t *testing.T) {
 
 	resourceGroupName := "fakeResourceGroupName"
 
-	_, err := azure.GetAResourceGroupV2E(resourceGroupName, "")
+	_, err := azure.GetAResourceGroupV2ContextE(t.Context(), resourceGroupName, "")
 	errAzure := &azcore.ResponseError{}
 	require.ErrorAs(t, err, &errAzure)
 	assert.Equal(t, 404, errAzure.StatusCode)


### PR DESCRIPTION
## Summary
Remove all deprecated non-Context wrapper functions from five Azure modules that have already been migrated to the new Azure SDK. Tests are updated to call the Context variants directly using `t.Context()`.

**Files changed (10):**
- `modules/azure/appService.go` -- removed `AppExists`, `AppExistsE`, `GetAppService`, `GetAppServiceE`
- `modules/azure/appService_test.go` -- updated to use `AppExistsContextE`, `GetAppServiceContextE`
- `modules/azure/keyvault.go` -- removed `KeyVaultSecretExists`, `KeyVaultSecretExistsE`, `KeyVaultKeyExists`, `KeyVaultKeyExistsE`, `KeyVaultCertificateExists`, `KeyVaultCertificateExistsE`, `GetKeyVault`, `GetKeyVaultE`
- `modules/azure/keyvault_test.go` -- updated to use `KeyVaultSecretExistsContextE`, `KeyVaultKeyExistsContextE`, `KeyVaultCertificateExistsContextE`, `GetKeyVaultContextE`
- `modules/azure/datafactory.go` -- removed `DataFactoryExists`, `DataFactoryExistsE`, `GetDataFactory`, `GetDataFactoryE`
- `modules/azure/datafactory_test.go` -- updated to use `DataFactoryExistsContextE`, `GetDataFactoryContextE`
- `modules/azure/region.go` -- removed `GetRandomStableRegion`, `GetRandomRegion`, `GetRandomRegionE`, `GetAllAzureRegions`, `GetAllAzureRegionsE`
- `modules/azure/region_test.go` -- updated to use `GetRandomRegionContext`, `GetAllAzureRegionsContext`
- `modules/azure/resourcegroupv2.go` -- removed `ResourceGroupExistsV2`, `ResourceGroupExistsV2E`, `GetResourceGroupV2E`, `GetAResourceGroupV2`, `GetAResourceGroupV2E`, `ListResourceGroupsByTagV2`, `ListResourceGroupsByTagV2E`
- `modules/azure/resourcegroupv2_test.go` -- updated to use `ResourceGroupExistsV2ContextE`, `GetAResourceGroupV2ContextE`

## Breaking Changes
- **appService**: removed `AppExists`, `AppExistsE`, `GetAppService`, `GetAppServiceE`
- **keyvault**: removed `KeyVaultSecretExists`, `KeyVaultSecretExistsE`, `KeyVaultKeyExists`, `KeyVaultKeyExistsE`, `KeyVaultCertificateExists`, `KeyVaultCertificateExistsE`, `GetKeyVault`, `GetKeyVaultE`
- **datafactory**: removed `DataFactoryExists`, `DataFactoryExistsE`, `GetDataFactory`, `GetDataFactoryE`
- **region**: removed `GetRandomStableRegion`, `GetRandomRegion`, `GetRandomRegionE`, `GetAllAzureRegions`, `GetAllAzureRegionsE`
- **resourcegroupv2**: removed `ResourceGroupExistsV2`, `ResourceGroupExistsV2E`, `GetResourceGroupV2E`, `GetAResourceGroupV2`, `GetAResourceGroupV2E`, `ListResourceGroupsByTagV2`, `ListResourceGroupsByTagV2E`

## Validated
- [x] `go build ./...` passes
- [x] `go test -tags azure -c -o /dev/null ./modules/azure/...` compiles
- [x] `go test -count=1 -timeout 5m ./modules/azure/...` passes
- [x] `make lint` reports 0 issues