### PR TITLE
fix(azure)!: remove deprecated non-Context wrappers from data/SQL modules

### DIFF
--- a/modules/azure/mysql.go
+++ b/modules/azure/mysql.go
@@ -31,16 +31,6 @@ func GetMYSQLServerContext(t testing.TestingT, ctx context.Context, resGroupName
 	return mysqlServer
 }
 
-// GetMYSQLServer is a helper function that gets the server.
-// This function would fail the test if there is an error.
-//
-// Deprecated: Use [GetMYSQLServerContext] instead.
-func GetMYSQLServer(t testing.TestingT, resGroupName string, serverName string, subscriptionID string) *armmysql.Server {
-	t.Helper()
-
-	return GetMYSQLServerContext(t, context.Background(), resGroupName, serverName, subscriptionID) //nolint:staticcheck
-}
-
 // GetMYSQLServerContextE is a helper function that gets the server.
 // The ctx parameter supports cancellation and timeouts.
 func GetMYSQLServerContextE(t testing.TestingT, ctx context.Context, subscriptionID string, resGroupName string, serverName string) (*armmysql.Server, error) {
@@ -57,13 +47,6 @@ func GetMYSQLServerContextE(t testing.TestingT, ctx context.Context, subscriptio
 	}
 
 	return &resp.Server, nil
-}
-
-// GetMYSQLServerE is a helper function that gets the server.
-//
-// Deprecated: Use [GetMYSQLServerContextE] instead.
-func GetMYSQLServerE(t testing.TestingT, subscriptionID string, resGroupName string, serverName string) (*armmysql.Server, error) {
-	return GetMYSQLServerContextE(t, context.Background(), subscriptionID, resGroupName, serverName)
 }
 
 // GetMYSQLDBClientE is a helper function that will setup a mysql DB client.
@@ -88,16 +71,6 @@ func GetMYSQLDBContext(t testing.TestingT, ctx context.Context, resGroupName str
 	return database
 }
 
-// GetMYSQLDB is a helper function that gets the database.
-// This function would fail the test if there is an error.
-//
-// Deprecated: Use [GetMYSQLDBContext] instead.
-func GetMYSQLDB(t testing.TestingT, resGroupName string, serverName string, dbName string, subscriptionID string) *armmysql.Database {
-	t.Helper()
-
-	return GetMYSQLDBContext(t, context.Background(), resGroupName, serverName, dbName, subscriptionID) //nolint:staticcheck
-}
-
 // GetMYSQLDBContextE is a helper function that gets the database.
 // The ctx parameter supports cancellation and timeouts.
 func GetMYSQLDBContextE(t testing.TestingT, ctx context.Context, subscriptionID string, resGroupName string, serverName string, dbName string) (*armmysql.Database, error) {
@@ -116,13 +89,6 @@ func GetMYSQLDBContextE(t testing.TestingT, ctx context.Context, subscriptionID 
 	return &resp.Database, nil
 }
 
-// GetMYSQLDBE is a helper function that gets the database.
-//
-// Deprecated: Use [GetMYSQLDBContextE] instead.
-func GetMYSQLDBE(t testing.TestingT, subscriptionID string, resGroupName string, serverName string, dbName string) (*armmysql.Database, error) {
-	return GetMYSQLDBContextE(t, context.Background(), subscriptionID, resGroupName, serverName, dbName)
-}
-
 // ListMySQLDBContext is a helper function that gets all databases per server.
 // This function would fail the test if there is an error.
 // The ctx parameter supports cancellation and timeouts.
@@ -133,16 +99,6 @@ func ListMySQLDBContext(t testing.TestingT, ctx context.Context, resGroupName st
 	require.NoError(t, err)
 
 	return dblist
-}
-
-// ListMySQLDB is a helper function that gets all databases per server.
-// This function would fail the test if there is an error.
-//
-// Deprecated: Use [ListMySQLDBContext] instead.
-func ListMySQLDB(t testing.TestingT, resGroupName string, serverName string, subscriptionID string) []*armmysql.Database {
-	t.Helper()
-
-	return ListMySQLDBContext(t, context.Background(), resGroupName, serverName, subscriptionID) //nolint:staticcheck
 }
 
 // ListMySQLDBContextE is a helper function that gets all databases per server.
@@ -169,11 +125,4 @@ func ListMySQLDBContextE(t testing.TestingT, ctx context.Context, subscriptionID
 	}
 
 	return databases, nil
-}
-
-// ListMySQLDBE is a helper function that gets all databases per server.
-//
-// Deprecated: Use [ListMySQLDBContextE] instead.
-func ListMySQLDBE(t testing.TestingT, subscriptionID string, resGroupName string, serverName string) ([]*armmysql.Database, error) {
-	return ListMySQLDBContextE(t, context.Background(), subscriptionID, resGroupName, serverName)
 }

--- a/modules/azure/mysql_test.go
+++ b/modules/azure/mysql_test.go
@@ -18,18 +18,18 @@ The below tests are currently stubbed out, with the expectation that they will t
 If/when CRUD methods are introduced for Azure MySQL server and database, these tests can be extended
 */
 
-func TestGetMYSQLServerE(t *testing.T) {
+func TestGetMYSQLServerContextE(t *testing.T) {
 	t.Parallel()
 
 	resGroupName := ""
 	serverName := ""
 	subscriptionID := ""
 
-	_, err := azure.GetMYSQLServerE(t, subscriptionID, resGroupName, serverName)
+	_, err := azure.GetMYSQLServerContextE(t, t.Context(), subscriptionID, resGroupName, serverName)
 	require.Error(t, err)
 }
 
-func TestGetMYSQLDBE(t *testing.T) {
+func TestGetMYSQLDBContextE(t *testing.T) {
 	t.Parallel()
 
 	resGroupName := ""
@@ -37,6 +37,6 @@ func TestGetMYSQLDBE(t *testing.T) {
 	subscriptionID := ""
 	dbName := ""
 
-	_, err := azure.GetMYSQLDBE(t, subscriptionID, resGroupName, serverName, dbName)
+	_, err := azure.GetMYSQLDBContextE(t, t.Context(), subscriptionID, resGroupName, serverName, dbName)
 	require.Error(t, err)
 }

--- a/modules/azure/postgresql.go
+++ b/modules/azure/postgresql.go
@@ -31,16 +31,6 @@ func GetPostgreSQLServerContext(t testing.TestingT, ctx context.Context, resGrou
 	return postgresqlServer
 }
 
-// GetPostgreSQLServer is a helper function that gets the server.
-// This function would fail the test if there is an error.
-//
-// Deprecated: Use [GetPostgreSQLServerContext] instead.
-func GetPostgreSQLServer(t testing.TestingT, resGroupName string, serverName string, subscriptionID string) *armpostgresql.Server {
-	t.Helper()
-
-	return GetPostgreSQLServerContext(t, context.Background(), resGroupName, serverName, subscriptionID) //nolint:staticcheck
-}
-
 // GetPostgreSQLServerContextE is a helper function that gets the server.
 // The ctx parameter supports cancellation and timeouts.
 func GetPostgreSQLServerContextE(t testing.TestingT, ctx context.Context, subscriptionID string, resGroupName string, serverName string) (*armpostgresql.Server, error) {
@@ -57,13 +47,6 @@ func GetPostgreSQLServerContextE(t testing.TestingT, ctx context.Context, subscr
 	}
 
 	return &resp.Server, nil
-}
-
-// GetPostgreSQLServerE is a helper function that gets the server.
-//
-// Deprecated: Use [GetPostgreSQLServerContextE] instead.
-func GetPostgreSQLServerE(t testing.TestingT, subscriptionID string, resGroupName string, serverName string) (*armpostgresql.Server, error) {
-	return GetPostgreSQLServerContextE(t, context.Background(), subscriptionID, resGroupName, serverName)
 }
 
 // GetPostgreSQLDBClientE is a helper function that will setup a postgresql DB client.
@@ -88,16 +71,6 @@ func GetPostgreSQLDBContext(t testing.TestingT, ctx context.Context, resGroupNam
 	return database
 }
 
-// GetPostgreSQLDB is a helper function that gets the database.
-// This function would fail the test if there is an error.
-//
-// Deprecated: Use [GetPostgreSQLDBContext] instead.
-func GetPostgreSQLDB(t testing.TestingT, resGroupName string, serverName string, dbName string, subscriptionID string) *armpostgresql.Database {
-	t.Helper()
-
-	return GetPostgreSQLDBContext(t, context.Background(), resGroupName, serverName, dbName, subscriptionID) //nolint:staticcheck
-}
-
 // GetPostgreSQLDBContextE is a helper function that gets the database.
 // The ctx parameter supports cancellation and timeouts.
 func GetPostgreSQLDBContextE(t testing.TestingT, ctx context.Context, subscriptionID string, resGroupName string, serverName string, dbName string) (*armpostgresql.Database, error) {
@@ -116,13 +89,6 @@ func GetPostgreSQLDBContextE(t testing.TestingT, ctx context.Context, subscripti
 	return &resp.Database, nil
 }
 
-// GetPostgreSQLDBE is a helper function that gets the database.
-//
-// Deprecated: Use [GetPostgreSQLDBContextE] instead.
-func GetPostgreSQLDBE(t testing.TestingT, subscriptionID string, resGroupName string, serverName string, dbName string) (*armpostgresql.Database, error) {
-	return GetPostgreSQLDBContextE(t, context.Background(), subscriptionID, resGroupName, serverName, dbName)
-}
-
 // ListPostgreSQLDBContext is a helper function that gets all databases per server.
 // This function would fail the test if there is an error.
 // The ctx parameter supports cancellation and timeouts.
@@ -133,16 +99,6 @@ func ListPostgreSQLDBContext(t testing.TestingT, ctx context.Context, subscripti
 	require.NoError(t, err)
 
 	return dblist
-}
-
-// ListPostgreSQLDB is a helper function that gets all databases per server.
-// This function would fail the test if there is an error.
-//
-// Deprecated: Use [ListPostgreSQLDBContext] instead.
-func ListPostgreSQLDB(t testing.TestingT, subscriptionID string, resGroupName string, serverName string) []*armpostgresql.Database {
-	t.Helper()
-
-	return ListPostgreSQLDBContext(t, context.Background(), subscriptionID, resGroupName, serverName) //nolint:staticcheck
 }
 
 // ListPostgreSQLDBContextE is a helper function that gets all databases per server.
@@ -169,11 +125,4 @@ func ListPostgreSQLDBContextE(t testing.TestingT, ctx context.Context, subscript
 	}
 
 	return databases, nil
-}
-
-// ListPostgreSQLDBE is a helper function that gets all databases per server.
-//
-// Deprecated: Use [ListPostgreSQLDBContextE] instead.
-func ListPostgreSQLDBE(t testing.TestingT, subscriptionID string, resGroupName string, serverName string) ([]*armpostgresql.Database, error) {
-	return ListPostgreSQLDBContextE(t, context.Background(), subscriptionID, resGroupName, serverName)
 }

--- a/modules/azure/postgresql_test.go
+++ b/modules/azure/postgresql_test.go
@@ -18,18 +18,18 @@ The below tests are currently stubbed out, with the expectation that they will t
 If/when CRUD methods are introduced for Azure PostgreSQL server and database, these tests can be extended
 */
 
-func TestGetPostgreSQLServerE(t *testing.T) {
+func TestGetPostgreSQLServerContextE(t *testing.T) {
 	t.Parallel()
 
 	resGroupName := ""
 	serverName := ""
 	subscriptionID := ""
 
-	_, err := azure.GetPostgreSQLServerE(t, subscriptionID, resGroupName, serverName)
+	_, err := azure.GetPostgreSQLServerContextE(t, t.Context(), subscriptionID, resGroupName, serverName)
 	require.Error(t, err)
 }
 
-func TestGetPostgreSQLDBE(t *testing.T) {
+func TestGetPostgreSQLDBContextE(t *testing.T) {
 	t.Parallel()
 
 	resGroupName := ""
@@ -37,6 +37,6 @@ func TestGetPostgreSQLDBE(t *testing.T) {
 	subscriptionID := ""
 	dbName := ""
 
-	_, err := azure.GetPostgreSQLDBE(t, subscriptionID, resGroupName, serverName, dbName)
+	_, err := azure.GetPostgreSQLDBContextE(t, t.Context(), subscriptionID, resGroupName, serverName, dbName)
 	require.Error(t, err)
 }

--- a/modules/azure/sql.go
+++ b/modules/azure/sql.go
@@ -25,16 +25,6 @@ func GetSQLServerContext(t testing.TestingT, ctx context.Context, resGroupName s
 	return sqlServer
 }
 
-// GetSQLServer is a helper function that gets the sql server object.
-// This function would fail the test if there is an error.
-//
-// Deprecated: Use [GetSQLServerContext] instead.
-func GetSQLServer(t testing.TestingT, resGroupName string, serverName string, subscriptionID string) *armsql.Server {
-	t.Helper()
-
-	return GetSQLServerContext(t, context.Background(), resGroupName, serverName, subscriptionID)
-}
-
 // GetSQLServerContextE is a helper function that gets the sql server object.
 // The ctx parameter supports cancellation and timeouts.
 func GetSQLServerContextE(t testing.TestingT, ctx context.Context, subscriptionID string, resGroupName string, serverName string) (*armsql.Server, error) {
@@ -53,13 +43,6 @@ func GetSQLServerContextE(t testing.TestingT, ctx context.Context, subscriptionI
 	return &resp.Server, nil
 }
 
-// GetSQLServerE is a helper function that gets the sql server object.
-//
-// Deprecated: Use [GetSQLServerContextE] instead.
-func GetSQLServerE(t testing.TestingT, subscriptionID string, resGroupName string, serverName string) (*armsql.Server, error) {
-	return GetSQLServerContextE(t, context.Background(), subscriptionID, resGroupName, serverName)
-}
-
 // GetDatabaseClient is a helper function that will setup a sql DB client.
 func GetDatabaseClient(subscriptionID string) (*armsql.DatabasesClient, error) {
 	return CreateDatabaseClient(subscriptionID)
@@ -75,16 +58,6 @@ func ListSQLServerDatabasesContext(t testing.TestingT, ctx context.Context, resG
 	require.NoError(t, err)
 
 	return dbList
-}
-
-// ListSQLServerDatabases is a helper function that gets a list of databases on a sql server.
-// This function would fail the test if there is an error.
-//
-// Deprecated: Use [ListSQLServerDatabasesContext] instead.
-func ListSQLServerDatabases(t testing.TestingT, resGroupName string, serverName string, subscriptionID string) []*armsql.Database {
-	t.Helper()
-
-	return ListSQLServerDatabasesContext(t, context.Background(), resGroupName, serverName, subscriptionID)
 }
 
 // ListSQLServerDatabasesContextE is a helper function that gets a list of databases on a sql server.
@@ -113,13 +86,6 @@ func ListSQLServerDatabasesContextE(t testing.TestingT, ctx context.Context, res
 	return databases, nil
 }
 
-// ListSQLServerDatabasesE is a helper function that gets a list of databases on a sql server.
-//
-// Deprecated: Use [ListSQLServerDatabasesContextE] instead.
-func ListSQLServerDatabasesE(t testing.TestingT, resGroupName string, serverName string, subscriptionID string) ([]*armsql.Database, error) {
-	return ListSQLServerDatabasesContextE(t, context.Background(), resGroupName, serverName, subscriptionID)
-}
-
 // GetSQLDatabaseContext is a helper function that gets the sql db.
 // This function would fail the test if there is an error.
 // The ctx parameter supports cancellation and timeouts.
@@ -130,16 +96,6 @@ func GetSQLDatabaseContext(t testing.TestingT, ctx context.Context, resGroupName
 	require.NoError(t, err)
 
 	return database
-}
-
-// GetSQLDatabase is a helper function that gets the sql db.
-// This function would fail the test if there is an error.
-//
-// Deprecated: Use [GetSQLDatabaseContext] instead.
-func GetSQLDatabase(t testing.TestingT, resGroupName string, serverName string, dbName string, subscriptionID string) *armsql.Database {
-	t.Helper()
-
-	return GetSQLDatabaseContext(t, context.Background(), resGroupName, serverName, dbName, subscriptionID)
 }
 
 // GetSQLDatabaseContextE is a helper function that gets the sql db.
@@ -158,11 +114,4 @@ func GetSQLDatabaseContextE(t testing.TestingT, ctx context.Context, subscriptio
 	}
 
 	return &resp.Database, nil
-}
-
-// GetSQLDatabaseE is a helper function that gets the sql db.
-//
-// Deprecated: Use [GetSQLDatabaseContextE] instead.
-func GetSQLDatabaseE(t testing.TestingT, subscriptionID string, resGroupName string, serverName string, dbName string) (*armsql.Database, error) {
-	return GetSQLDatabaseContextE(t, context.Background(), subscriptionID, resGroupName, serverName, dbName)
 }

--- a/modules/azure/sql_managedinstance.go
+++ b/modules/azure/sql_managedinstance.go
@@ -35,23 +35,6 @@ func SQLManagedInstanceExistsContextE(ctx context.Context, managedInstanceName s
 	return true, nil
 }
 
-// SQLManagedInstanceExists indicates whether the SQL Managed Instance exists for the subscription.
-// This function would fail the test if there is an error.
-//
-// Deprecated: Use [SQLManagedInstanceExistsContext] instead.
-func SQLManagedInstanceExists(t testing.TestingT, managedInstanceName string, resourceGroupName string, subscriptionID string) bool {
-	t.Helper()
-
-	return SQLManagedInstanceExistsContext(t, context.Background(), managedInstanceName, resourceGroupName, subscriptionID)
-}
-
-// SQLManagedInstanceExistsE indicates whether the specified SQL Managed Instance exists and may return an error.
-//
-// Deprecated: Use [SQLManagedInstanceExistsContextE] instead.
-func SQLManagedInstanceExistsE(managedInstanceName string, resourceGroupName string, subscriptionID string) (bool, error) {
-	return SQLManagedInstanceExistsContextE(context.Background(), managedInstanceName, resourceGroupName, subscriptionID)
-}
-
 // GetManagedInstanceContext retrieves the SQL managed instance object for the given subscription.
 // This function would fail the test if there is an error.
 // The ctx parameter supports cancellation and timeouts.
@@ -80,23 +63,6 @@ func GetManagedInstanceContextE(ctx context.Context, subscriptionID string, resG
 	return &resp.ManagedInstance, nil
 }
 
-// GetManagedInstance retrieves the SQL managed instance object for the given subscription.
-// This function would fail the test if there is an error.
-//
-// Deprecated: Use [GetManagedInstanceContext] instead.
-func GetManagedInstance(t testing.TestingT, resGroupName string, managedInstanceName string, subscriptionID string) *armsql.ManagedInstance {
-	t.Helper()
-
-	return GetManagedInstanceContext(t, context.Background(), resGroupName, managedInstanceName, subscriptionID)
-}
-
-// GetManagedInstanceE retrieves the SQL managed instance object for the given subscription.
-//
-// Deprecated: Use [GetManagedInstanceContextE] instead.
-func GetManagedInstanceE(subscriptionID string, resGroupName string, managedInstanceName string) (*armsql.ManagedInstance, error) {
-	return GetManagedInstanceContextE(context.Background(), subscriptionID, resGroupName, managedInstanceName)
-}
-
 // GetManagedInstanceDatabaseContext retrieves the SQL managed database object for the given subscription.
 // This function would fail the test if there is an error.
 // The ctx parameter supports cancellation and timeouts.
@@ -123,21 +89,4 @@ func GetManagedInstanceDatabaseContextE(ctx context.Context, subscriptionID stri
 	}
 
 	return &resp.ManagedDatabase, nil
-}
-
-// GetManagedInstanceDatabase retrieves the SQL managed database object for the given subscription.
-// This function would fail the test if there is an error.
-//
-// Deprecated: Use [GetManagedInstanceDatabaseContext] instead.
-func GetManagedInstanceDatabase(t testing.TestingT, resGroupName string, managedInstanceName string, databaseName string, subscriptionID string) *armsql.ManagedDatabase {
-	t.Helper()
-
-	return GetManagedInstanceDatabaseContext(t, context.Background(), resGroupName, managedInstanceName, databaseName, subscriptionID)
-}
-
-// GetManagedInstanceDatabaseE retrieves the SQL managed database object for the given subscription.
-//
-// Deprecated: Use [GetManagedInstanceDatabaseContextE] instead.
-func GetManagedInstanceDatabaseE(t testing.TestingT, subscriptionID string, resGroupName string, managedInstanceName string, databaseName string) (*armsql.ManagedDatabase, error) { //nolint:unparam // t kept for API compatibility
-	return GetManagedInstanceDatabaseContextE(context.Background(), subscriptionID, resGroupName, managedInstanceName, databaseName)
 }

--- a/modules/azure/sql_managedinstance_test.go
+++ b/modules/azure/sql_managedinstance_test.go
@@ -18,31 +18,31 @@ The below tests are currently stubbed out, with the expectation that they will t
 If/when CRUD methods are introduced for Azure SQL DB, these tests can be extended
 */
 
-func TestSQLManagedInstanceExists(t *testing.T) {
+func TestSQLManagedInstanceExistsContextE(t *testing.T) {
 	t.Parallel()
 
 	managedInstanceName := ""
 	resourceGroupName := ""
 	subscriptionID := ""
 
-	exists, err := azure.SQLManagedInstanceExistsE(managedInstanceName, resourceGroupName, subscriptionID)
+	exists, err := azure.SQLManagedInstanceExistsContextE(t.Context(), managedInstanceName, resourceGroupName, subscriptionID)
 
 	require.False(t, exists)
 	require.Error(t, err)
 }
 
-func TestGetManagedInstanceE(t *testing.T) {
+func TestGetManagedInstanceContextE(t *testing.T) {
 	t.Parallel()
 
 	resGroupName := ""
 	managedInstanceName := ""
 	subscriptionID := ""
 
-	_, err := azure.GetManagedInstanceE(subscriptionID, resGroupName, managedInstanceName)
+	_, err := azure.GetManagedInstanceContextE(t.Context(), subscriptionID, resGroupName, managedInstanceName)
 	require.Error(t, err)
 }
 
-func TestGetManagedInstanceDatabasesE(t *testing.T) {
+func TestGetManagedInstanceDatabaseContextE(t *testing.T) {
 	t.Parallel()
 
 	resGroupName := ""
@@ -50,6 +50,6 @@ func TestGetManagedInstanceDatabasesE(t *testing.T) {
 	databaseName := ""
 	subscriptionID := ""
 
-	_, err := azure.GetManagedInstanceDatabaseE(t, subscriptionID, resGroupName, managedInstanceName, databaseName)
+	_, err := azure.GetManagedInstanceDatabaseContextE(t.Context(), subscriptionID, resGroupName, managedInstanceName, databaseName)
 	require.Error(t, err)
 }

--- a/modules/azure/sql_test.go
+++ b/modules/azure/sql_test.go
@@ -18,18 +18,18 @@ The below tests are currently stubbed out, with the expectation that they will t
 If/when CRUD methods are introduced for Azure SQL DB, these tests can be extended
 */
 
-func TestGetSQLServerE(t *testing.T) {
+func TestGetSQLServerContextE(t *testing.T) {
 	t.Parallel()
 
 	resGroupName := ""
 	serverName := ""
 	subscriptionID := ""
 
-	_, err := azure.GetSQLServerE(t, resGroupName, serverName, subscriptionID)
+	_, err := azure.GetSQLServerContextE(t, t.Context(), subscriptionID, resGroupName, serverName)
 	require.Error(t, err)
 }
 
-func TestGetSQLDatabaseE(t *testing.T) {
+func TestGetSQLDatabaseContextE(t *testing.T) {
 	t.Parallel()
 
 	resGroupName := ""
@@ -37,6 +37,6 @@ func TestGetSQLDatabaseE(t *testing.T) {
 	dbName := ""
 	subscriptionID := ""
 
-	_, err := azure.GetSQLDatabaseE(t, resGroupName, serverName, dbName, subscriptionID)
+	_, err := azure.GetSQLDatabaseContextE(t, t.Context(), subscriptionID, resGroupName, serverName, dbName)
 	require.Error(t, err)
 }

--- a/modules/azure/synapse.go
+++ b/modules/azure/synapse.go
@@ -36,23 +36,6 @@ func GetSynapseWorkspaceContextE(ctx context.Context, subscriptionID string, res
 	return &resp.Workspace, nil
 }
 
-// GetSynapseWorkspace retrieves the synapse workspace for the given subscription.
-// This function would fail the test if there is an error.
-//
-// Deprecated: Use [GetSynapseWorkspaceContext] instead.
-func GetSynapseWorkspace(t testing.TestingT, resGroupName string, workspaceName string, subscriptionID string) *armsynapse.Workspace {
-	t.Helper()
-
-	return GetSynapseWorkspaceContext(t, context.Background(), resGroupName, workspaceName, subscriptionID)
-}
-
-// GetSynapseWorkspaceE retrieves the synapse workspace for the given subscription.
-//
-// Deprecated: Use [GetSynapseWorkspaceContextE] instead.
-func GetSynapseWorkspaceE(t testing.TestingT, subscriptionID string, resGroupName string, workspaceName string) (*armsynapse.Workspace, error) { //nolint:unparam // t kept for API compatibility
-	return GetSynapseWorkspaceContextE(context.Background(), subscriptionID, resGroupName, workspaceName)
-}
-
 // GetSynapseSQLPoolContext retrieves the synapse SQL pool for the given subscription.
 // This function would fail the test if there is an error.
 // The ctx parameter supports cancellation and timeouts.
@@ -79,38 +62,4 @@ func GetSynapseSQLPoolContextE(ctx context.Context, subscriptionID string, resGr
 	}
 
 	return &resp.SQLPool, nil
-}
-
-// GetSynapseSQLPool retrieves the synapse SQL pool for the given subscription.
-// This function would fail the test if there is an error.
-//
-// Deprecated: Use [GetSynapseSQLPoolContext] instead.
-func GetSynapseSQLPool(t testing.TestingT, resGroupName string, workspaceName string, sqlPoolName string, subscriptionID string) *armsynapse.SQLPool {
-	t.Helper()
-
-	return GetSynapseSQLPoolContext(t, context.Background(), resGroupName, workspaceName, sqlPoolName, subscriptionID)
-}
-
-// GetSynapseSQLPoolE retrieves the synapse SQL pool for the given subscription.
-//
-// Deprecated: Use [GetSynapseSQLPoolContextE] instead.
-func GetSynapseSQLPoolE(subscriptionID string, resGroupName string, workspaceName string, sqlPoolName string) (*armsynapse.SQLPool, error) {
-	return GetSynapseSQLPoolContextE(context.Background(), subscriptionID, resGroupName, workspaceName, sqlPoolName)
-}
-
-// GetSynapseSqlPool retrieves the synapse SQL pool for the given subscription.
-// This function would fail the test if there is an error.
-//
-//nolint:staticcheck,revive // Deprecated: Use [GetSynapseSQLPoolContext] instead.
-func GetSynapseSqlPool(t testing.TestingT, resGroupName string, workspaceName string, sqlPoolName string, subscriptionID string) *armsynapse.SQLPool {
-	t.Helper()
-
-	return GetSynapseSQLPoolContext(t, context.Background(), resGroupName, workspaceName, sqlPoolName, subscriptionID)
-}
-
-// GetSynapseSqlPoolE retrieves the synapse SQL pool for the given subscription.
-//
-//nolint:staticcheck,revive // Deprecated: Use [GetSynapseSQLPoolContextE] instead.
-func GetSynapseSqlPoolE(t testing.TestingT, subscriptionID string, resGroupName string, workspaceName string, sqlPoolName string) (*armsynapse.SQLPool, error) { //nolint:unparam // t kept for API compatibility
-	return GetSynapseSQLPoolContextE(context.Background(), subscriptionID, resGroupName, workspaceName, sqlPoolName)
 }

--- a/modules/azure/synapse_test.go
+++ b/modules/azure/synapse_test.go
@@ -1,3 +1,9 @@
+//go:build azure
+// +build azure
+
+// NOTE: We use build tags to differentiate azure testing because we currently do not have azure access setup for
+// CircleCI.
+
 package azure_test
 
 import (
@@ -5,7 +11,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	azure "github.com/gruntwork-io/terratest/modules/azure"
+	"github.com/gruntwork-io/terratest/modules/azure"
 )
 
 /*
@@ -13,18 +19,18 @@ The below tests are currently stubbed out, with the expectation that they will t
 If/when CRUD methods are introduced for Azure Synapse, these tests can be extended
 */
 
-func TestGetSynapseWorkspaceE(t *testing.T) {
+func TestGetSynapseWorkspaceContextE(t *testing.T) {
 	t.Parallel()
 
 	resGroupName := ""
 	subscriptionID := ""
 	workspaceName := ""
 
-	_, err := azure.GetSynapseWorkspaceE(t, subscriptionID, resGroupName, workspaceName)
+	_, err := azure.GetSynapseWorkspaceContextE(t.Context(), subscriptionID, resGroupName, workspaceName)
 	require.Error(t, err)
 }
 
-func TestGetSynapseSqlPoolE(t *testing.T) {
+func TestGetSynapseSQLPoolContextE(t *testing.T) {
 	t.Parallel()
 
 	resGroupName := ""
@@ -32,6 +38,6 @@ func TestGetSynapseSqlPoolE(t *testing.T) {
 	workspaceName := ""
 	sqlPoolName := ""
 
-	_, err := azure.GetSynapseSqlPoolE(t, subscriptionID, resGroupName, workspaceName, sqlPoolName)
+	_, err := azure.GetSynapseSQLPoolContextE(t.Context(), subscriptionID, resGroupName, workspaceName, sqlPoolName)
 	require.Error(t, err)
 }


### PR DESCRIPTION
## Summary
Remove all deprecated non-Context wrapper functions from the data/SQL Azure modules (mysql, postgresql, sql, sql_managedinstance, synapse) and update tests to use the Context variants with `t.Context()`.

**Files changed (10):**
- `modules/azure/mysql.go` -- removed 6 deprecated wrappers
- `modules/azure/mysql_test.go` -- updated to Context variants
- `modules/azure/postgresql.go` -- removed 6 deprecated wrappers
- `modules/azure/postgresql_test.go` -- updated to Context variants
- `modules/azure/sql.go` -- removed 6 deprecated wrappers
- `modules/azure/sql_test.go` -- updated to Context variants
- `modules/azure/sql_managedinstance.go` -- removed 6 deprecated wrappers
- `modules/azure/sql_managedinstance_test.go` -- updated to Context variants
- `modules/azure/synapse.go` -- removed 6 deprecated wrappers
- `modules/azure/synapse_test.go` -- updated to Context variants

## Breaking Changes
- **mysql**: Removed `GetMYSQLServer`, `GetMYSQLServerE`, `GetMYSQLDB`, `GetMYSQLDBE`, `ListMySQLDB`, `ListMySQLDBE`
- **postgresql**: Removed `GetPostgreSQLServer`, `GetPostgreSQLServerE`, `GetPostgreSQLDB`, `GetPostgreSQLDBE`, `ListPostgreSQLDB`, `ListPostgreSQLDBE`
- **sql**: Removed `GetSQLServer`, `GetSQLServerE`, `ListSQLServerDatabases`, `ListSQLServerDatabasesE`, `GetSQLDatabase`, `GetSQLDatabaseE`
- **sql_managedinstance**: Removed `SQLManagedInstanceExists`, `SQLManagedInstanceExistsE`, `GetManagedInstance`, `GetManagedInstanceE`, `GetManagedInstanceDatabase`, `GetManagedInstanceDatabaseE`
- **synapse**: Removed `GetSynapseWorkspace`, `GetSynapseWorkspaceE`, `GetSynapseSQLPool`, `GetSynapseSQLPoolE`, `GetSynapseSqlPool`, `GetSynapseSqlPoolE`

## Validated
- [x] `go build ./...`
- [x] `go test -tags azure -c -o /dev/null ./modules/azure/...`
- [x] `go test -count=1 -timeout 5m ./modules/azure/...`
- [x] `make lint` (0 issues)