### PR TITLE
fix(azure)!: migrate monitor, frontdoor, and loganalytics to new Azure SDK with inline client pattern

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -53,9 +53,12 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v6 v6.4.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cosmos/armcosmos/v3 v3.4.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/datafactory/armdatafactory/v9 v9.1.0
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/frontdoor/armfrontdoor v1.4.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/keyvault/armkeyvault v1.5.0
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/monitor/armmonitor v0.11.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/mysql/armmysql v1.2.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v6 v6.2.0
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/operationalinsights/armoperationalinsights/v2 v2.0.2
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/postgresql/armpostgresql v1.2.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/privatedns/armprivatedns v1.3.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -52,6 +52,8 @@ github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cosmos/armcosmos/v3 v3.4.0
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cosmos/armcosmos/v3 v3.4.0/go.mod h1:Bb7kqorvA2acMCNFac+2ldoQWi7QrcMdH+9Gg9C7fSM=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/datafactory/armdatafactory/v9 v9.1.0 h1:82oTC4oB/7AjVmPR8KMvlyHZgZ8PGdboh8c0Jol/XWY=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/datafactory/armdatafactory/v9 v9.1.0/go.mod h1:nuDWiSqiFv4Bo8LX99dl+Ecl9o1iNSLJDBsrl8iRWr4=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/frontdoor/armfrontdoor v1.4.0 h1:dz5II+dFuMkrdpIkO9f/Ht3f8hnRUURiQdLj1hwKO5Q=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/frontdoor/armfrontdoor v1.4.0/go.mod h1:0tuwjeZbMwLV7h1bcyfTlnXUH6GBKkPml8ukX6EoS3o=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal v1.1.2 h1:mLY+pNLjCUeKhgnAJWAKhEUQM+RJQo2H1fuGSw1Ky1E=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal v1.1.2/go.mod h1:FbdwsQ2EzwvXxOPcMFYO8ogEc9uMMIj3YkmCdXdAFmk=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal/v2 v2.0.0 h1:PTFGRSlMKCQelWwxUyYVEUqseBJVemLyqWJjvMyt0do=
@@ -62,10 +64,14 @@ github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/keyvault/armkeyvault v1.5.
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/keyvault/armkeyvault v1.5.0/go.mod h1:4YIVtzMFVsPwBvitCDX7J9sqthSj43QD1sP6fYc1egc=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/managementgroups/armmanagementgroups v1.0.0 h1:pPvTJ1dY0sA35JOeFq6TsY2xj6Z85Yo23Pj4wCCvu4o=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/managementgroups/armmanagementgroups v1.0.0/go.mod h1:mLfWfj8v3jfWKsL9G4eoBoXVcsqcIUTapmdKy7uGOp0=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/monitor/armmonitor v0.11.0 h1:Ds0KRF8ggpEGg4Vo42oX1cIt/IfOhHWJBikksZbVxeg=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/monitor/armmonitor v0.11.0/go.mod h1:jj6P8ybImR+5topJ+eH6fgcemSFBmU6/6bFF8KkwuDI=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/mysql/armmysql v1.2.0 h1:dhywcZH9yPDIje9aTqwy6psZSPzI6CJLYEprDahIBSQ=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/mysql/armmysql v1.2.0/go.mod h1:6z3b+JdBLH0eMzfBex/cvEIoEFVEwXuB0wbgdfN11iM=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v6 v6.2.0 h1:HYGD75g0bQ3VO/Omedm54v4LrD3B1cGImuRF3AJ5wLo=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v6 v6.2.0/go.mod h1:ulHyBFJOI0ONiRL4vcJTmS7rx18jQQlEPmAgo80cRdM=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/operationalinsights/armoperationalinsights/v2 v2.0.2 h1:SFLbQmpdytToYZQJw5NqrZRwHPIGJmf5ZgjStbLfUuU=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/operationalinsights/armoperationalinsights/v2 v2.0.2/go.mod h1:H3EFkhcVTisidszwtIkRDggjS2HmOIA26J3g8hDdHAY=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/postgresql/armpostgresql v1.2.0 h1:0hXKrsbh2M6CQyW0TDC9Bsyd99vQmrOxiBTUfQHZjPA=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/postgresql/armpostgresql v1.2.0/go.mod h1:bvZZor36Jg9q9kouuMyfJ+ay77+qK+YUfThXH1FdXjU=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/privatedns/armprivatedns v1.3.0 h1:yzrctSl9GMIQ5lHu7jc8olOsGjWDCsBpJhWqfGa/YIM=

--- a/modules/azure/actiongroup.go
+++ b/modules/azure/actiongroup.go
@@ -3,7 +3,7 @@ package azure
 import (
 	"context"
 
-	"github.com/Azure/azure-sdk-for-go/profiles/preview/preview/monitor/mgmt/insights"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/monitor/armmonitor"
 	"github.com/gruntwork-io/terratest/modules/testing"
 	"github.com/stretchr/testify/require"
 )
@@ -14,7 +14,7 @@ import (
 // ruleName - required to find the ActionGroupResource.
 // resGroupName - use an empty string if you have the AZURE_RES_GROUP_NAME environment variable set
 // subscriptionId - use an empty string if you have the ARM_SUBSCRIPTION_ID environment variable set
-func GetActionGroupResourceContext(t testing.TestingT, ctx context.Context, ruleName string, resGroupName string, subscriptionID string) *insights.ActionGroupResource {
+func GetActionGroupResourceContext(t testing.TestingT, ctx context.Context, ruleName string, resGroupName string, subscriptionID string) *armmonitor.ActionGroupResource {
 	actionGroupResource, err := GetActionGroupResourceContextE(ctx, ruleName, resGroupName, subscriptionID)
 	require.NoError(t, err)
 
@@ -26,23 +26,38 @@ func GetActionGroupResourceContext(t testing.TestingT, ctx context.Context, rule
 // ruleName - required to find the ActionGroupResource.
 // resGroupName - use an empty string if you have the AZURE_RES_GROUP_NAME environment variable set
 // subscriptionId - use an empty string if you have the ARM_SUBSCRIPTION_ID environment variable set
-func GetActionGroupResourceContextE(ctx context.Context, ruleName string, resGroupName string, subscriptionID string) (*insights.ActionGroupResource, error) {
+func GetActionGroupResourceContextE(ctx context.Context, ruleName string, resGroupName string, subscriptionID string) (*armmonitor.ActionGroupResource, error) { //nolint:dupl
 	rgName, err := getTargetAzureResourceGroupName(resGroupName)
 	if err != nil {
 		return nil, err
 	}
 
-	client, err := CreateActionGroupClient(subscriptionID)
+	subID, err := getTargetAzureSubscription(subscriptionID)
 	if err != nil {
 		return nil, err
 	}
 
-	actionGroup, err := client.Get(ctx, rgName, ruleName)
+	cred, err := newArmCredential()
 	if err != nil {
 		return nil, err
 	}
 
-	return &actionGroup, nil
+	opts, err := newArmClientOptions()
+	if err != nil {
+		return nil, err
+	}
+
+	client, err := armmonitor.NewActionGroupsClient(subID, cred, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := client.Get(ctx, rgName, ruleName, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return &resp.ActionGroupResource, nil
 }
 
 // GetActionGroupResource gets the ActionGroupResource.
@@ -52,7 +67,7 @@ func GetActionGroupResourceContextE(ctx context.Context, ruleName string, resGro
 // subscriptionId - use an empty string if you have the ARM_SUBSCRIPTION_ID environment variable set
 //
 // Deprecated: Use [GetActionGroupResourceContext] instead.
-func GetActionGroupResource(t testing.TestingT, ruleName string, resGroupName string, subscriptionID string) *insights.ActionGroupResource {
+func GetActionGroupResource(t testing.TestingT, ruleName string, resGroupName string, subscriptionID string) *armmonitor.ActionGroupResource {
 	return GetActionGroupResourceContext(t, context.Background(), ruleName, resGroupName, subscriptionID) //nolint:staticcheck
 }
 
@@ -62,6 +77,6 @@ func GetActionGroupResource(t testing.TestingT, ruleName string, resGroupName st
 // subscriptionId - use an empty string if you have the ARM_SUBSCRIPTION_ID environment variable set
 //
 // Deprecated: Use [GetActionGroupResourceContextE] instead.
-func GetActionGroupResourceE(ruleName string, resGroupName string, subscriptionID string) (*insights.ActionGroupResource, error) {
+func GetActionGroupResourceE(ruleName string, resGroupName string, subscriptionID string) (*armmonitor.ActionGroupResource, error) {
 	return GetActionGroupResourceContextE(context.Background(), ruleName, resGroupName, subscriptionID)
 }

--- a/modules/azure/actiongroup_test.go
+++ b/modules/azure/actiongroup_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 
 	"github.com/gruntwork-io/terratest/modules/azure"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -19,37 +18,26 @@ The below tests are currently stubbed out, with the expectation that they will t
 If/when methods to create and delete network resources are added, these tests can be extended.
 */
 
-func TestGetActionGroupResourceEWithMissingResourceGroupName(t *testing.T) {
+func TestGetActionGroupResourceContextEWithMissingResourceGroupName(t *testing.T) {
 	t.Parallel()
 
 	ruleName := "Hello"
 	resGroupName := ""
 	subscriptionID := ""
 
-	_, err := azure.GetActionGroupResourceE(ruleName, resGroupName, subscriptionID)
+	_, err := azure.GetActionGroupResourceContextE(t.Context(), ruleName, resGroupName, subscriptionID)
 
 	require.Error(t, err)
 }
 
-func TestGetActionGroupResourceEWithInvalidResourceGroupName(t *testing.T) {
+func TestGetActionGroupResourceContextEWithInvalidResourceGroupName(t *testing.T) {
 	t.Parallel()
 
 	ruleName := ""
 	resGroupName := "Hello"
 	subscriptionID := ""
 
-	_, err := azure.GetActionGroupResourceE(ruleName, resGroupName, subscriptionID)
+	_, err := azure.GetActionGroupResourceContextE(t.Context(), ruleName, resGroupName, subscriptionID)
 
 	require.Error(t, err)
-}
-
-func TestGetActionGroupClient(t *testing.T) {
-	t.Parallel()
-
-	subscriptionID := ""
-
-	client, err := azure.CreateActionGroupClient(subscriptionID)
-
-	require.NoError(t, err)
-	assert.NotEmpty(t, *client)
 }

--- a/modules/azure/frontdoor.go
+++ b/modules/azure/frontdoor.go
@@ -3,7 +3,7 @@ package azure
 import (
 	"context"
 
-	"github.com/Azure/azure-sdk-for-go/profiles/latest/frontdoor/mgmt/frontdoor"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/frontdoor/armfrontdoor"
 	"github.com/gruntwork-io/terratest/modules/testing"
 	"github.com/stretchr/testify/require"
 )
@@ -27,13 +27,13 @@ func FrontDoorExistsContext(t testing.TestingT, ctx context.Context, frontDoorNa
 func FrontDoorExists(t testing.TestingT, frontDoorName string, resourceGroupName string, subscriptionID string) bool {
 	t.Helper()
 
-	return FrontDoorExistsContext(t, context.Background(), frontDoorName, resourceGroupName, subscriptionID)
+	return FrontDoorExistsContext(t, context.Background(), frontDoorName, resourceGroupName, subscriptionID) //nolint:staticcheck
 }
 
 // GetFrontDoorContext gets a Front Door by name if it exists for the subscription.
 // This function would fail the test if there is an error.
 // The ctx parameter supports cancellation and timeouts.
-func GetFrontDoorContext(t testing.TestingT, ctx context.Context, frontDoorName string, resourceGroupName string, subscriptionID string) *frontdoor.FrontDoor {
+func GetFrontDoorContext(t testing.TestingT, ctx context.Context, frontDoorName string, resourceGroupName string, subscriptionID string) *armfrontdoor.FrontDoor {
 	t.Helper()
 
 	fd, err := GetFrontDoorContextE(ctx, frontDoorName, resourceGroupName, subscriptionID)
@@ -46,10 +46,10 @@ func GetFrontDoorContext(t testing.TestingT, ctx context.Context, frontDoorName 
 // This function would fail the test if there is an error.
 //
 // Deprecated: Use [GetFrontDoorContext] instead.
-func GetFrontDoor(t testing.TestingT, frontDoorName string, resourceGroupName string, subscriptionID string) *frontdoor.FrontDoor {
+func GetFrontDoor(t testing.TestingT, frontDoorName string, resourceGroupName string, subscriptionID string) *armfrontdoor.FrontDoor {
 	t.Helper()
 
-	return GetFrontDoorContext(t, context.Background(), frontDoorName, resourceGroupName, subscriptionID)
+	return GetFrontDoorContext(t, context.Background(), frontDoorName, resourceGroupName, subscriptionID) //nolint:staticcheck
 }
 
 // FrontDoorFrontendEndpointExistsContext indicates whether the frontend endpoint exists for the provided Front Door.
@@ -71,13 +71,13 @@ func FrontDoorFrontendEndpointExistsContext(t testing.TestingT, ctx context.Cont
 func FrontDoorFrontendEndpointExists(t testing.TestingT, endpointName string, frontDoorName string, resourceGroupName string, subscriptionID string) bool {
 	t.Helper()
 
-	return FrontDoorFrontendEndpointExistsContext(t, context.Background(), endpointName, frontDoorName, resourceGroupName, subscriptionID)
+	return FrontDoorFrontendEndpointExistsContext(t, context.Background(), endpointName, frontDoorName, resourceGroupName, subscriptionID) //nolint:staticcheck
 }
 
 // GetFrontDoorFrontendEndpointContext gets a frontend endpoint by name for the provided Front Door if it exists for the subscription.
 // This function would fail the test if there is an error.
 // The ctx parameter supports cancellation and timeouts.
-func GetFrontDoorFrontendEndpointContext(t testing.TestingT, ctx context.Context, endpointName string, frontDoorName string, resourceGroupName string, subscriptionID string) *frontdoor.FrontendEndpoint {
+func GetFrontDoorFrontendEndpointContext(t testing.TestingT, ctx context.Context, endpointName string, frontDoorName string, resourceGroupName string, subscriptionID string) *armfrontdoor.FrontendEndpoint {
 	t.Helper()
 
 	ep, err := GetFrontDoorFrontendEndpointContextE(ctx, endpointName, frontDoorName, resourceGroupName, subscriptionID)
@@ -90,10 +90,10 @@ func GetFrontDoorFrontendEndpointContext(t testing.TestingT, ctx context.Context
 // This function would fail the test if there is an error.
 //
 // Deprecated: Use [GetFrontDoorFrontendEndpointContext] instead.
-func GetFrontDoorFrontendEndpoint(t testing.TestingT, endpointName string, frontDoorName string, resourceGroupName string, subscriptionID string) *frontdoor.FrontendEndpoint {
+func GetFrontDoorFrontendEndpoint(t testing.TestingT, endpointName string, frontDoorName string, resourceGroupName string, subscriptionID string) *armfrontdoor.FrontendEndpoint {
 	t.Helper()
 
-	return GetFrontDoorFrontendEndpointContext(t, context.Background(), endpointName, frontDoorName, resourceGroupName, subscriptionID)
+	return GetFrontDoorFrontendEndpointContext(t, context.Background(), endpointName, frontDoorName, resourceGroupName, subscriptionID) //nolint:staticcheck
 }
 
 // FrontDoorExistsContextE indicates whether the specified Front Door exists.
@@ -142,80 +142,130 @@ func FrontDoorFrontendEndpointExistsE(endpointName string, frontDoorName string,
 
 // GetFrontDoorContextE gets the specified Front Door if it exists.
 // The ctx parameter supports cancellation and timeouts.
-func GetFrontDoorContextE(ctx context.Context, frontDoorName, resourceGroupName, subscriptionID string) (*frontdoor.FrontDoor, error) {
-	client, err := GetFrontDoorClientE(subscriptionID)
+func GetFrontDoorContextE(ctx context.Context, frontDoorName, resourceGroupName, subscriptionID string) (*armfrontdoor.FrontDoor, error) {
+	subID, err := getTargetAzureSubscription(subscriptionID)
 	if err != nil {
 		return nil, err
 	}
 
-	fd, err := client.Get(ctx, resourceGroupName, frontDoorName)
+	cred, err := newArmCredential()
 	if err != nil {
 		return nil, err
 	}
 
-	return &fd, nil
+	opts, err := newArmClientOptions()
+	if err != nil {
+		return nil, err
+	}
+
+	client, err := armfrontdoor.NewFrontDoorsClient(subID, cred, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := client.Get(ctx, resourceGroupName, frontDoorName, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return &resp.FrontDoor, nil
 }
 
 // GetFrontDoorE gets the specified Front Door if it exists.
 //
 // Deprecated: Use [GetFrontDoorContextE] instead.
-func GetFrontDoorE(frontDoorName, resourceGroupName, subscriptionID string) (*frontdoor.FrontDoor, error) {
+func GetFrontDoorE(frontDoorName, resourceGroupName, subscriptionID string) (*armfrontdoor.FrontDoor, error) {
 	return GetFrontDoorContextE(context.Background(), frontDoorName, resourceGroupName, subscriptionID)
 }
 
 // GetFrontDoorFrontendEndpointContextE gets the specified Frontend Endpoint for the provided Front Door if it exists.
 // The ctx parameter supports cancellation and timeouts.
-func GetFrontDoorFrontendEndpointContextE(ctx context.Context, endpointName, frontDoorName, resourceGroupName, subscriptionID string) (*frontdoor.FrontendEndpoint, error) {
-	client, err := GetFrontDoorFrontendEndpointClientE(subscriptionID)
+func GetFrontDoorFrontendEndpointContextE(ctx context.Context, endpointName, frontDoorName, resourceGroupName, subscriptionID string) (*armfrontdoor.FrontendEndpoint, error) {
+	subID, err := getTargetAzureSubscription(subscriptionID)
 	if err != nil {
 		return nil, err
 	}
 
-	endpoint, err := client.Get(ctx, resourceGroupName, frontDoorName, endpointName)
+	cred, err := newArmCredential()
 	if err != nil {
 		return nil, err
 	}
 
-	return &endpoint, nil
+	opts, err := newArmClientOptions()
+	if err != nil {
+		return nil, err
+	}
+
+	client, err := armfrontdoor.NewFrontendEndpointsClient(subID, cred, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := client.Get(ctx, resourceGroupName, frontDoorName, endpointName, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return &resp.FrontendEndpoint, nil
 }
 
 // GetFrontDoorFrontendEndpointE gets the specified Frontend Endpoint for the provided Front Door if it exists.
 //
 // Deprecated: Use [GetFrontDoorFrontendEndpointContextE] instead.
-func GetFrontDoorFrontendEndpointE(endpointName, frontDoorName, resourceGroupName, subscriptionID string) (*frontdoor.FrontendEndpoint, error) {
+func GetFrontDoorFrontendEndpointE(endpointName, frontDoorName, resourceGroupName, subscriptionID string) (*armfrontdoor.FrontendEndpoint, error) {
 	return GetFrontDoorFrontendEndpointContextE(context.Background(), endpointName, frontDoorName, resourceGroupName, subscriptionID)
 }
 
-// GetFrontDoorClientE returns a front door client; otherwise error.
-func GetFrontDoorClientE(subscriptionID string) (*frontdoor.FrontDoorsClient, error) {
-	client, err := CreateFrontDoorClientE(subscriptionID)
+// GetFrontDoorClientE returns a Front Door client; otherwise error.
+//
+// Deprecated: Use [GetFrontDoorContextE] instead, which manages client creation internally.
+func GetFrontDoorClientE(subscriptionID string) (*armfrontdoor.FrontDoorsClient, error) {
+	subID, err := getTargetAzureSubscription(subscriptionID)
 	if err != nil {
 		return nil, err
 	}
 
-	authorizer, err := NewAuthorizer()
+	cred, err := newArmCredential()
 	if err != nil {
 		return nil, err
 	}
 
-	client.Authorizer = *authorizer
+	opts, err := newArmClientOptions()
+	if err != nil {
+		return nil, err
+	}
+
+	client, err := armfrontdoor.NewFrontDoorsClient(subID, cred, opts)
+	if err != nil {
+		return nil, err
+	}
 
 	return client, nil
 }
 
-// GetFrontDoorFrontendEndpointClientE returns a front door frontend endpoints client; otherwise error.
-func GetFrontDoorFrontendEndpointClientE(subscriptionID string) (*frontdoor.FrontendEndpointsClient, error) {
-	client, err := CreateFrontDoorFrontendEndpointClientE(subscriptionID)
+// GetFrontDoorFrontendEndpointClientE returns a Front Door frontend endpoints client; otherwise error.
+//
+// Deprecated: Use [GetFrontDoorFrontendEndpointContextE] instead, which manages client creation internally.
+func GetFrontDoorFrontendEndpointClientE(subscriptionID string) (*armfrontdoor.FrontendEndpointsClient, error) {
+	subID, err := getTargetAzureSubscription(subscriptionID)
 	if err != nil {
 		return nil, err
 	}
 
-	authorizer, err := NewAuthorizer()
+	cred, err := newArmCredential()
 	if err != nil {
 		return nil, err
 	}
 
-	client.Authorizer = *authorizer
+	opts, err := newArmClientOptions()
+	if err != nil {
+		return nil, err
+	}
+
+	client, err := armfrontdoor.NewFrontendEndpointsClient(subID, cred, opts)
+	if err != nil {
+		return nil, err
+	}
 
 	return client, nil
 }

--- a/modules/azure/frontdoor_test.go
+++ b/modules/azure/frontdoor_test.go
@@ -18,33 +18,33 @@ The below tests are currently stubbed out, with the expectation that they will t
 If/when methods to create and delete front door are added, these tests can be extended.
 */
 
-func TestFrontDoorExists(t *testing.T) {
+func TestFrontDoorExistsContextE(t *testing.T) {
 	t.Parallel()
 
 	frontDoorName := "TestFrontDoor"
 	resourceGroupName := "TestResourceGroup"
 	subscriptionID := ""
 
-	exists, err := azure.FrontDoorExistsE(frontDoorName, resourceGroupName, subscriptionID)
+	exists, err := azure.FrontDoorExistsContextE(t.Context(), frontDoorName, resourceGroupName, subscriptionID)
 
 	require.False(t, exists)
 	require.Error(t, err)
 }
 
-func TestGetFrontDoor(t *testing.T) {
+func TestGetFrontDoorContextE(t *testing.T) {
 	t.Parallel()
 
 	frontDoorName := "TestFrontDoor"
 	resourceGroupName := "TestResourceGroup"
 	subscriptionID := ""
 
-	instance, err := azure.GetFrontDoorE(frontDoorName, resourceGroupName, subscriptionID)
+	instance, err := azure.GetFrontDoorContextE(t.Context(), frontDoorName, resourceGroupName, subscriptionID)
 
 	require.Nil(t, instance)
 	require.Error(t, err)
 }
 
-func TestFrontDoorFrontendEndpointExists(t *testing.T) {
+func TestFrontDoorFrontendEndpointExistsContextE(t *testing.T) {
 	t.Parallel()
 
 	endpointName := "TestFrontendEndpoint"
@@ -52,13 +52,13 @@ func TestFrontDoorFrontendEndpointExists(t *testing.T) {
 	resourceGroupName := "TestResourceGroup"
 	subscriptionID := ""
 
-	endpoint, err := azure.FrontDoorFrontendEndpointExistsE(endpointName, frontDoorName, resourceGroupName, subscriptionID)
+	endpoint, err := azure.FrontDoorFrontendEndpointExistsContextE(t.Context(), endpointName, frontDoorName, resourceGroupName, subscriptionID)
 
 	require.False(t, endpoint)
 	require.Error(t, err)
 }
 
-func TestGetFrontDoorFrontendEndpoint(t *testing.T) {
+func TestGetFrontDoorFrontendEndpointContextE(t *testing.T) {
 	t.Parallel()
 
 	endpointName := "TestFrontendEndpoint"
@@ -66,7 +66,7 @@ func TestGetFrontDoorFrontendEndpoint(t *testing.T) {
 	resourceGroupName := "TestResourceGroup"
 	subscriptionID := ""
 
-	endpoint, err := azure.GetFrontDoorFrontendEndpointE(endpointName, frontDoorName, resourceGroupName, subscriptionID)
+	endpoint, err := azure.GetFrontDoorFrontendEndpointContextE(t.Context(), endpointName, frontDoorName, resourceGroupName, subscriptionID)
 
 	require.Nil(t, endpoint)
 	require.Error(t, err)

--- a/modules/azure/loganalytics.go
+++ b/modules/azure/loganalytics.go
@@ -2,9 +2,8 @@ package azure
 
 import (
 	"context"
-	"fmt"
 
-	"github.com/Azure/azure-sdk-for-go/services/preview/operationalinsights/mgmt/2020-03-01-preview/operationalinsights"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/operationalinsights/armoperationalinsights/v2"
 	"github.com/gruntwork-io/terratest/modules/testing"
 	"github.com/stretchr/testify/require"
 )
@@ -34,7 +33,7 @@ func LogAnalyticsWorkspaceExists(t testing.TestingT, workspaceName string, resou
 // GetLogAnalyticsWorkspaceContext gets an operational insights workspace if it exists in a subscription.
 // This function would fail the test if there is an error.
 // The ctx parameter supports cancellation and timeouts.
-func GetLogAnalyticsWorkspaceContext(t testing.TestingT, ctx context.Context, workspaceName string, resourceGroupName string, subscriptionID string) *operationalinsights.Workspace {
+func GetLogAnalyticsWorkspaceContext(t testing.TestingT, ctx context.Context, workspaceName string, resourceGroupName string, subscriptionID string) *armoperationalinsights.Workspace {
 	t.Helper()
 
 	ws, err := GetLogAnalyticsWorkspaceContextE(ctx, workspaceName, resourceGroupName, subscriptionID)
@@ -47,7 +46,7 @@ func GetLogAnalyticsWorkspaceContext(t testing.TestingT, ctx context.Context, wo
 // This function would fail the test if there is an error.
 //
 // Deprecated: Use [GetLogAnalyticsWorkspaceContext] instead.
-func GetLogAnalyticsWorkspace(t testing.TestingT, workspaceName string, resourceGroupName string, subscriptionID string) *operationalinsights.Workspace {
+func GetLogAnalyticsWorkspace(t testing.TestingT, workspaceName string, resourceGroupName string, subscriptionID string) *armoperationalinsights.Workspace {
 	t.Helper()
 
 	return GetLogAnalyticsWorkspaceContext(t, context.Background(), workspaceName, resourceGroupName, subscriptionID) //nolint:staticcheck
@@ -55,25 +54,40 @@ func GetLogAnalyticsWorkspace(t testing.TestingT, workspaceName string, resource
 
 // GetLogAnalyticsWorkspaceContextE gets an operational insights workspace if it exists in a subscription.
 // The ctx parameter supports cancellation and timeouts.
-func GetLogAnalyticsWorkspaceContextE(ctx context.Context, workspaceName, resoureGroupName, subscriptionID string) (*operationalinsights.Workspace, error) {
-	client, err := GetLogAnalyticsWorkspacesClientE(subscriptionID)
+func GetLogAnalyticsWorkspaceContextE(ctx context.Context, workspaceName, resourceGroupName, subscriptionID string) (*armoperationalinsights.Workspace, error) {
+	subID, err := getTargetAzureSubscription(subscriptionID)
 	if err != nil {
 		return nil, err
 	}
 
-	ws, err := client.Get(ctx, resoureGroupName, workspaceName)
+	cred, err := newArmCredential()
 	if err != nil {
 		return nil, err
 	}
 
-	return &ws, nil
+	opts, err := newArmClientOptions()
+	if err != nil {
+		return nil, err
+	}
+
+	client, err := armoperationalinsights.NewWorkspacesClient(subID, cred, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := client.Get(ctx, resourceGroupName, workspaceName, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return &resp.Workspace, nil
 }
 
 // GetLogAnalyticsWorkspaceE gets an operational insights workspace if it exists in a subscription.
 //
 // Deprecated: Use [GetLogAnalyticsWorkspaceContextE] instead.
-func GetLogAnalyticsWorkspaceE(workspaceName, resoureGroupName, subscriptionID string) (*operationalinsights.Workspace, error) {
-	return GetLogAnalyticsWorkspaceContextE(context.Background(), workspaceName, resoureGroupName, subscriptionID)
+func GetLogAnalyticsWorkspaceE(workspaceName, resourceGroupName, subscriptionID string) (*armoperationalinsights.Workspace, error) {
+	return GetLogAnalyticsWorkspaceContextE(context.Background(), workspaceName, resourceGroupName, subscriptionID)
 }
 
 // LogAnalyticsWorkspaceExistsContextE indicates whether the operational insights workspace exists and may return an error.
@@ -99,24 +113,28 @@ func LogAnalyticsWorkspaceExistsE(workspaceName string, resourceGroupName string
 }
 
 // GetLogAnalyticsWorkspacesClientE returns a workspaces client; otherwise error.
-func GetLogAnalyticsWorkspacesClientE(subscriptionID string) (*operationalinsights.WorkspacesClient, error) {
-	subscriptionID, err := getTargetAzureSubscription(subscriptionID)
+//
+// Deprecated: Use [GetLogAnalyticsWorkspaceContextE] instead, which manages client creation internally.
+func GetLogAnalyticsWorkspacesClientE(subscriptionID string) (*armoperationalinsights.WorkspacesClient, error) {
+	subID, err := getTargetAzureSubscription(subscriptionID)
 	if err != nil {
-		fmt.Println("Workspace client error getting subscription")
-
 		return nil, err
 	}
 
-	client := operationalinsights.NewWorkspacesClient(subscriptionID)
-
-	authorizer, err := NewAuthorizer()
+	cred, err := newArmCredential()
 	if err != nil {
-		fmt.Println("authorizer error")
-
 		return nil, err
 	}
 
-	client.Authorizer = *authorizer
+	opts, err := newArmClientOptions()
+	if err != nil {
+		return nil, err
+	}
 
-	return &client, nil
+	client, err := armoperationalinsights.NewWorkspacesClient(subID, cred, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	return client, nil
 }

--- a/modules/azure/loganalytics_test.go
+++ b/modules/azure/loganalytics_test.go
@@ -1,12 +1,13 @@
+//go:build azure
+// +build azure
+
 package azure_test
 
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/gruntwork-io/terratest/modules/azure"
 	"github.com/stretchr/testify/require"
-
-	azure "github.com/gruntwork-io/terratest/modules/azure"
 )
 
 /*
@@ -14,20 +15,20 @@ The below tests are currently stubbed out, with the expectation that they will t
 If/when methods to create and delete log analytics resources are added, these tests can be extended.
 */
 
-func TestLogAnalyticsWorkspace(t *testing.T) {
+func TestLogAnalyticsWorkspaceExistsContextE(t *testing.T) {
 	t.Parallel()
 
-	_, err := azure.LogAnalyticsWorkspaceExistsE("fake", "", "")
-	assert.Error(t, err, "Workspace")
+	_, err := azure.LogAnalyticsWorkspaceExistsContextE(t.Context(), "fake", "", "")
+	require.Error(t, err)
 }
 
-func TestGetLogAnalyticsWorkspaceE(t *testing.T) {
+func TestGetLogAnalyticsWorkspaceContextE(t *testing.T) {
 	t.Parallel()
 
 	workspaceName := ""
 	resourceGroupName := ""
 	subscriptionID := ""
 
-	_, err := azure.GetLogAnalyticsWorkspaceE(workspaceName, resourceGroupName, subscriptionID)
+	_, err := azure.GetLogAnalyticsWorkspaceContextE(t.Context(), workspaceName, resourceGroupName, subscriptionID)
 	require.Error(t, err)
 }

--- a/modules/azure/monitor.go
+++ b/modules/azure/monitor.go
@@ -3,7 +3,7 @@ package azure
 import (
 	"context"
 
-	"github.com/Azure/azure-sdk-for-go/profiles/preview/preview/monitor/mgmt/insights"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/monitor/armmonitor"
 	"github.com/gruntwork-io/terratest/modules/testing"
 	"github.com/stretchr/testify/require"
 )
@@ -55,7 +55,7 @@ func DiagnosticSettingsResourceExistsE(diagnosticSettingsResourceName string, re
 // GetDiagnosticsSettingsResourceContext gets the diagnostics settings for a specified resource.
 // This function would fail the test if there is an error.
 // The ctx parameter supports cancellation and timeouts.
-func GetDiagnosticsSettingsResourceContext(t testing.TestingT, ctx context.Context, name string, resourceURI string, subscriptionID string) *insights.DiagnosticSettingsResource {
+func GetDiagnosticsSettingsResourceContext(t testing.TestingT, ctx context.Context, name string, resourceURI string, subscriptionID string) *armmonitor.DiagnosticSettingsResource {
 	t.Helper()
 
 	resource, err := GetDiagnosticsSettingsResourceContextE(ctx, name, resourceURI, subscriptionID)
@@ -68,7 +68,7 @@ func GetDiagnosticsSettingsResourceContext(t testing.TestingT, ctx context.Conte
 // This function would fail the test if there is an error.
 //
 // Deprecated: Use [GetDiagnosticsSettingsResourceContext] instead.
-func GetDiagnosticsSettingsResource(t testing.TestingT, name string, resourceURI string, subscriptionID string) *insights.DiagnosticSettingsResource {
+func GetDiagnosticsSettingsResource(t testing.TestingT, name string, resourceURI string, subscriptionID string) *armmonitor.DiagnosticSettingsResource {
 	t.Helper()
 
 	return GetDiagnosticsSettingsResourceContext(t, context.Background(), name, resourceURI, subscriptionID) //nolint:staticcheck
@@ -76,37 +76,47 @@ func GetDiagnosticsSettingsResource(t testing.TestingT, name string, resourceURI
 
 // GetDiagnosticsSettingsResourceContextE gets the diagnostics settings for a specified resource.
 // The ctx parameter supports cancellation and timeouts.
-func GetDiagnosticsSettingsResourceContextE(ctx context.Context, name string, resourceURI string, subscriptionID string) (*insights.DiagnosticSettingsResource, error) {
+func GetDiagnosticsSettingsResourceContextE(ctx context.Context, name string, resourceURI string, subscriptionID string) (*armmonitor.DiagnosticSettingsResource, error) {
 	// Validate Azure subscription ID
-	subscriptionID, err := getTargetAzureSubscription(subscriptionID)
+	_, err := getTargetAzureSubscription(subscriptionID)
 	if err != nil {
 		return nil, err
 	}
 
-	client, err := CreateDiagnosticsSettingsClientE(subscriptionID)
+	cred, err := newArmCredential()
 	if err != nil {
 		return nil, err
 	}
 
-	settings, err := client.Get(ctx, resourceURI, name)
+	opts, err := newArmClientOptions()
 	if err != nil {
 		return nil, err
 	}
 
-	return &settings, nil
+	client, err := armmonitor.NewDiagnosticSettingsClient(cred, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := client.Get(ctx, resourceURI, name, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return &resp.DiagnosticSettingsResource, nil
 }
 
 // GetDiagnosticsSettingsResourceE gets the diagnostics settings for a specified resource.
 //
 // Deprecated: Use [GetDiagnosticsSettingsResourceContextE] instead.
-func GetDiagnosticsSettingsResourceE(name string, resourceURI string, subscriptionID string) (*insights.DiagnosticSettingsResource, error) {
+func GetDiagnosticsSettingsResourceE(name string, resourceURI string, subscriptionID string) (*armmonitor.DiagnosticSettingsResource, error) {
 	return GetDiagnosticsSettingsResourceContextE(context.Background(), name, resourceURI, subscriptionID)
 }
 
 // GetVMInsightsOnboardingStatusContext gets diagnostics VM onboarding status.
 // This function would fail the test if there is an error.
 // The ctx parameter supports cancellation and timeouts.
-func GetVMInsightsOnboardingStatusContext(t testing.TestingT, ctx context.Context, resourceURI string, subscriptionID string) *insights.VMInsightsOnboardingStatus {
+func GetVMInsightsOnboardingStatusContext(t testing.TestingT, ctx context.Context, resourceURI string, subscriptionID string) *armmonitor.VMInsightsOnboardingStatus {
 	t.Helper()
 
 	status, err := GetVMInsightsOnboardingStatusContextE(t, ctx, resourceURI, subscriptionID)
@@ -119,7 +129,7 @@ func GetVMInsightsOnboardingStatusContext(t testing.TestingT, ctx context.Contex
 // This function would fail the test if there is an error.
 //
 // Deprecated: Use [GetVMInsightsOnboardingStatusContext] instead.
-func GetVMInsightsOnboardingStatus(t testing.TestingT, resourceURI string, subscriptionID string) *insights.VMInsightsOnboardingStatus {
+func GetVMInsightsOnboardingStatus(t testing.TestingT, resourceURI string, subscriptionID string) *armmonitor.VMInsightsOnboardingStatus {
 	t.Helper()
 
 	return GetVMInsightsOnboardingStatusContext(t, context.Background(), resourceURI, subscriptionID) //nolint:staticcheck
@@ -127,31 +137,41 @@ func GetVMInsightsOnboardingStatus(t testing.TestingT, resourceURI string, subsc
 
 // GetVMInsightsOnboardingStatusContextE gets diagnostics VM onboarding status.
 // The ctx parameter supports cancellation and timeouts.
-func GetVMInsightsOnboardingStatusContextE(t testing.TestingT, ctx context.Context, resourceURI string, subscriptionID string) (*insights.VMInsightsOnboardingStatus, error) {
-	client, err := CreateVMInsightsClientE(subscriptionID)
+func GetVMInsightsOnboardingStatusContextE(t testing.TestingT, ctx context.Context, resourceURI string, subscriptionID string) (*armmonitor.VMInsightsOnboardingStatus, error) {
+	cred, err := newArmCredential()
 	if err != nil {
 		return nil, err
 	}
 
-	status, err := client.GetOnboardingStatus(ctx, resourceURI)
+	opts, err := newArmClientOptions()
 	if err != nil {
 		return nil, err
 	}
 
-	return &status, nil
+	client, err := armmonitor.NewVMInsightsClient(cred, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := client.GetOnboardingStatus(ctx, resourceURI, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return &resp.VMInsightsOnboardingStatus, nil
 }
 
 // GetVMInsightsOnboardingStatusE gets diagnostics VM onboarding status.
 //
 // Deprecated: Use [GetVMInsightsOnboardingStatusContextE] instead.
-func GetVMInsightsOnboardingStatusE(t testing.TestingT, resourceURI string, subscriptionID string) (*insights.VMInsightsOnboardingStatus, error) {
+func GetVMInsightsOnboardingStatusE(t testing.TestingT, resourceURI string, subscriptionID string) (*armmonitor.VMInsightsOnboardingStatus, error) {
 	return GetVMInsightsOnboardingStatusContextE(t, context.Background(), resourceURI, subscriptionID)
 }
 
 // GetActivityLogAlertResourceContext gets an Activity Log Alert Resource in the specified Azure Resource Group.
 // This function would fail the test if there is an error.
 // The ctx parameter supports cancellation and timeouts.
-func GetActivityLogAlertResourceContext(t testing.TestingT, ctx context.Context, activityLogAlertName string, resGroupName string, subscriptionID string) *insights.ActivityLogAlertResource {
+func GetActivityLogAlertResourceContext(t testing.TestingT, ctx context.Context, activityLogAlertName string, resGroupName string, subscriptionID string) *armmonitor.ActivityLogAlertResource {
 	t.Helper()
 
 	activityLogAlertResource, err := GetActivityLogAlertResourceContextE(ctx, activityLogAlertName, resGroupName, subscriptionID)
@@ -164,7 +184,7 @@ func GetActivityLogAlertResourceContext(t testing.TestingT, ctx context.Context,
 // This function would fail the test if there is an error.
 //
 // Deprecated: Use [GetActivityLogAlertResourceContext] instead.
-func GetActivityLogAlertResource(t testing.TestingT, activityLogAlertName string, resGroupName string, subscriptionID string) *insights.ActivityLogAlertResource {
+func GetActivityLogAlertResource(t testing.TestingT, activityLogAlertName string, resGroupName string, subscriptionID string) *armmonitor.ActivityLogAlertResource {
 	t.Helper()
 
 	return GetActivityLogAlertResourceContext(t, context.Background(), activityLogAlertName, resGroupName, subscriptionID) //nolint:staticcheck
@@ -172,31 +192,44 @@ func GetActivityLogAlertResource(t testing.TestingT, activityLogAlertName string
 
 // GetActivityLogAlertResourceContextE gets an Activity Log Alert Resource in the specified Azure Resource Group.
 // The ctx parameter supports cancellation and timeouts.
-func GetActivityLogAlertResourceContextE(ctx context.Context, activityLogAlertName string, resGroupName string, subscriptionID string) (*insights.ActivityLogAlertResource, error) {
+func GetActivityLogAlertResourceContextE(ctx context.Context, activityLogAlertName string, resGroupName string, subscriptionID string) (*armmonitor.ActivityLogAlertResource, error) { //nolint:dupl
 	// Validate resource group name and subscription ID
 	_, err := getTargetAzureResourceGroupName(resGroupName)
 	if err != nil {
 		return nil, err
 	}
 
-	// Get the client reference
-	client, err := CreateActivityLogAlertsClientE(subscriptionID)
+	subID, err := getTargetAzureSubscription(subscriptionID)
 	if err != nil {
 		return nil, err
 	}
 
-	// Get the Activity Log Alert Resource
-	activityLogAlertResource, err := client.Get(ctx, resGroupName, activityLogAlertName)
+	cred, err := newArmCredential()
 	if err != nil {
 		return nil, err
 	}
 
-	return &activityLogAlertResource, nil
+	opts, err := newArmClientOptions()
+	if err != nil {
+		return nil, err
+	}
+
+	client, err := armmonitor.NewActivityLogAlertsClient(subID, cred, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := client.Get(ctx, resGroupName, activityLogAlertName, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return &resp.ActivityLogAlertResource, nil
 }
 
 // GetActivityLogAlertResourceE gets an Activity Log Alert Resource in the specified Azure Resource Group.
 //
 // Deprecated: Use [GetActivityLogAlertResourceContextE] instead.
-func GetActivityLogAlertResourceE(activityLogAlertName string, resGroupName string, subscriptionID string) (*insights.ActivityLogAlertResource, error) {
+func GetActivityLogAlertResourceE(activityLogAlertName string, resGroupName string, subscriptionID string) (*armmonitor.ActivityLogAlertResource, error) {
 	return GetActivityLogAlertResourceContextE(context.Background(), activityLogAlertName, resGroupName, subscriptionID)
 }

--- a/modules/azure/monitor_test.go
+++ b/modules/azure/monitor_test.go
@@ -10,13 +10,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestDiagnosticsSettingsResourceExists(t *testing.T) {
+func TestDiagnosticsSettingsResourceExistsContextE(t *testing.T) {
 	t.Parallel()
 
 	diagnosticsSettingResourceName := "fakename"
 	resGroupName := "fakeresgroup"
 	subscriptionID := "fakesubid"
 
-	_, err := azure.DiagnosticSettingsResourceExistsE(diagnosticsSettingResourceName, resGroupName, subscriptionID)
+	_, err := azure.DiagnosticSettingsResourceExistsContextE(t.Context(), diagnosticsSettingResourceName, resGroupName, subscriptionID)
 	require.Error(t, err)
 }

--- a/modules/azure/privatednszone.go
+++ b/modules/azure/privatednszone.go
@@ -23,7 +23,7 @@ func PrivateDNSZoneExistsContextE(ctx context.Context, zoneName string, resource
 
 // GetPrivateDNSZoneContextE gets the specified private DNS zone object.
 // The ctx parameter supports cancellation and timeouts.
-func GetPrivateDNSZoneContextE(ctx context.Context, zoneName string, resGroupName string, subscriptionID string) (*armprivatedns.PrivateZone, error) {
+func GetPrivateDNSZoneContextE(ctx context.Context, zoneName string, resGroupName string, subscriptionID string) (*armprivatedns.PrivateZone, error) { //nolint:dupl
 	rgName, err := getTargetAzureResourceGroupName(resGroupName)
 	if err != nil {
 		return nil, err

--- a/test/azure/terraform_azure_actiongroup_example_test.go
+++ b/test/azure/terraform_azure_actiongroup_example_test.go
@@ -54,7 +54,7 @@ func TestTerraformAzureActionGroupExample(t *testing.T) {
 	actionGroup := azure.GetActionGroupResourceContext(t, t.Context(), expectedAppName, expectedResourceGroupName, "")
 
 	assert.NotNil(actionGroup)
-	assert.Len(*actionGroup.EmailReceivers, 1)
-	assert.Empty(*actionGroup.SmsReceivers)
-	assert.Len(*actionGroup.WebhookReceivers, 1)
+	assert.Len(actionGroup.Properties.EmailReceivers, 1)
+	assert.Empty(actionGroup.Properties.SmsReceivers)
+	assert.Len(actionGroup.Properties.WebhookReceivers, 1)
 }

--- a/test/azure/terraform_azure_frontdoor_example_test.go
+++ b/test/azure/terraform_azure_frontdoor_example_test.go
@@ -56,6 +56,5 @@ func TestTerraformAzureFrontDoorExample(t *testing.T) {
 	assert.True(t, endpointExists)
 
 	actualFrontDoorEndpoint := azure.GetFrontDoorFrontendEndpointContext(t, t.Context(), frontendEndpointName, frontDoorName, resourceGroupName, subscriptionID)
-	endpointProperties := *actualFrontDoorEndpoint.FrontendEndpointProperties
-	assert.Equal(t, frontDoorURL, *endpointProperties.HostName)
+	assert.Equal(t, frontDoorURL, *actualFrontDoorEndpoint.Properties.HostName)
 }

--- a/test/azure/terraform_azure_loganalytics_example_test.go
+++ b/test/azure/terraform_azure_loganalytics_example_test.go
@@ -52,10 +52,10 @@ func TestTerraformAzureLogAnalyticsExample(t *testing.T) {
 
 	actualWorkspace := azure.GetLogAnalyticsWorkspaceContext(t, t.Context(), workspaceName, resourceGroupName, subscriptionID)
 
-	actualSku := string(actualWorkspace.Sku.Name)
+	actualSku := string(*actualWorkspace.Properties.SKU.Name)
 	assert.Equal(t, strings.ToLower(sku), strings.ToLower(actualSku), "log analytics sku mismatch")
 
-	actualRetentionPeriod := *actualWorkspace.RetentionInDays
+	actualRetentionPeriod := *actualWorkspace.Properties.RetentionInDays
 	expectedPeriod, _ := strconv.ParseInt(retentionPeriodString, 10, 32)
 	assert.Equal(t, int32(expectedPeriod), actualRetentionPeriod, "log analytics retention period mismatch")
 }


### PR DESCRIPTION
## Summary

Migrates actiongroup.go, monitor.go, frontdoor.go, and loganalytics.go from the deprecated `go-autorest` SDK to `azure-sdk-for-go/sdk/resourcemanager` with inline client creation. Deprecated wrappers are kept with updated return types for backward compatibility — removal deferred to a later release.

**Files changed:**
- `actiongroup.go` — migrated to `armmonitor`, inline client creation
- `actiongroup_test.go` — updated to Context variants
- `monitor.go` — migrated to `armmonitor`, inline client creation
- `monitor_test.go` — updated to Context variants
- `frontdoor.go` — migrated to `armfrontdoor`, inline client creation
- `frontdoor_test.go` — updated to Context variants
- `loganalytics.go` — migrated to `armoperationalinsights/v2`, inline client creation
- `loganalytics_test.go` — updated to Context variants
- `test/azure/terraform_azure_actiongroup_example_test.go` — field access updates
- `test/azure/terraform_azure_frontdoor_example_test.go` — field access updates
- `go.mod` / `go.sum` — added new SDK dependencies

## Breaking Changes

Return types changed to new SDK packages (deprecated wrappers kept but also return new types):
- `*insights.ActionGroupResource` → `*armmonitor.ActionGroupResource`
- `*insights.DiagnosticSettingsResource` → `*armmonitor.DiagnosticSettingsResource`
- `*insights.ActivityLogAlertResource` → `*armmonitor.ActivityLogAlertResource`
- `*insights.VMInsightsOnboardingStatus` → `*armmonitor.VMInsightsOnboardingStatus`
- `*frontdoor.FrontDoor` → `*armfrontdoor.FrontDoor`
- `*frontdoor.FrontendEndpoint` → `*armfrontdoor.FrontendEndpoint`
- `*operationalinsights.Workspace` → `*armoperationalinsights.Workspace`

SDK type access patterns changed:
- `ActionGroupResource.EmailReceivers` → `ActionGroupResource.Properties.EmailReceivers`
- `FrontendEndpoint.FrontendEndpointProperties` → `FrontendEndpoint.Properties`
- `Workspace.Sku.Name` → `*Workspace.Properties.SKU.Name`
- `Workspace.RetentionInDays` → `Workspace.Properties.RetentionInDays`

## Validated

- [x] `go build ./...`
- [x] `go test -tags azure -c -o /dev/null ./modules/azure/...`
- [x] `go test -tags azure -c -o /dev/null ./test/azure/...`
- [x] `go test ./modules/azure/...` — all unit tests pass
- [x] `make lint` — 0 issues