### PR TITLE
fix(azure): migrate subscription, resourcegroup, and recoveryservices to new Azure SDK

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -58,7 +58,10 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v6 v6.2.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/postgresql/armpostgresql v1.2.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/privatedns/armprivatedns v1.3.0
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/recoveryservices/armrecoveryservices/v2 v2.1.0
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/recoveryservices/armrecoveryservicesbackup/v4 v4.2.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.2.0
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions v1.3.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/servicebus/armservicebus/v2 v2.0.0-beta.3
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/sql/armsql v1.2.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -70,8 +70,14 @@ github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/postgresql/armpostgresql v
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/postgresql/armpostgresql v1.2.0/go.mod h1:bvZZor36Jg9q9kouuMyfJ+ay77+qK+YUfThXH1FdXjU=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/privatedns/armprivatedns v1.3.0 h1:yzrctSl9GMIQ5lHu7jc8olOsGjWDCsBpJhWqfGa/YIM=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/privatedns/armprivatedns v1.3.0/go.mod h1:GE4m0rnnfwLGX0Y9A9A25Zx5N/90jneT5ABevqzhuFQ=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/recoveryservices/armrecoveryservices/v2 v2.1.0 h1:1JdyrPv/UPMSAm+As/+fRqyRU6IP1KqiIm3NHuURSlQ=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/recoveryservices/armrecoveryservices/v2 v2.1.0/go.mod h1:u+oD8BX3AzcZs4wo/geQg2BysfY1qjtJDSuzrBSll1Y=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/recoveryservices/armrecoveryservicesbackup/v4 v4.2.0 h1:GOtQKZTIc4/HnWIEqGqtkMHLXIlwa4GpT8BB5JGH+tc=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/recoveryservices/armrecoveryservicesbackup/v4 v4.2.0/go.mod h1:o1BW30aoyqKYcQKAMNWs0UAkT30Z2FZzmCNo7hrGHjM=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.2.0 h1:Dd+RhdJn0OTtVGaeDLZpcumkIVCtA/3/Fo42+eoYvVM=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.2.0/go.mod h1:5kakwfW5CjC9KK+Q4wjXAg+ShuIm2mBMua0ZFj2C8PE=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions v1.3.0 h1:wxQx2Bt4xzPIKvW59WQf1tJNx/ZZKPfN+EhPX3Z6CYY=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions v1.3.0/go.mod h1:TpiwjwnW/khS0LKs4vW5UmmT9OWcxaveS8U7+tlknzo=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/servicebus/armservicebus/v2 v2.0.0-beta.3 h1:JLPf82byRFgfB0f2feJMmRfCCFV0W9/GayiiewTvjlw=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/servicebus/armservicebus/v2 v2.0.0-beta.3/go.mod h1:9sfaaa+UF5VVus+Tr/bd1qm1oRoltnewm3HpiT9l8VU=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/sql/armsql v1.2.0 h1:S087deZ0kP1RUg4pU7w9U9xpUedTCbOtz+mnd0+hrkQ=

--- a/modules/azure/recoveryservices.go
+++ b/modules/azure/recoveryservices.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/Azure/azure-sdk-for-go/services/recoveryservices/mgmt/2016-06-01/recoveryservices"
-	"github.com/Azure/azure-sdk-for-go/services/recoveryservices/mgmt/2020-02-02/backup"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/recoveryservices/armrecoveryservices/v2"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/recoveryservices/armrecoveryservicesbackup/v4"
 	"github.com/gruntwork-io/terratest/modules/testing"
 	"github.com/stretchr/testify/require"
 )
@@ -35,7 +35,7 @@ func RecoveryServicesVaultExists(t testing.TestingT, vaultName, resourceGroupNam
 // GetRecoveryServicesVaultBackupPolicyListContext returns a list of backup policies for the given vault.
 // This function would fail the test if there is an error.
 // The ctx parameter supports cancellation and timeouts.
-func GetRecoveryServicesVaultBackupPolicyListContext(t testing.TestingT, ctx context.Context, vaultName, resourceGroupName, subscriptionID string) map[string]backup.ProtectionPolicyResource {
+func GetRecoveryServicesVaultBackupPolicyListContext(t testing.TestingT, ctx context.Context, vaultName, resourceGroupName, subscriptionID string) map[string]armrecoveryservicesbackup.ProtectionPolicyResource {
 	t.Helper()
 
 	list, err := GetRecoveryServicesVaultBackupPolicyListContextE(ctx, vaultName, resourceGroupName, subscriptionID)
@@ -48,7 +48,7 @@ func GetRecoveryServicesVaultBackupPolicyListContext(t testing.TestingT, ctx con
 // This function would fail the test if there is an error.
 //
 // Deprecated: Use [GetRecoveryServicesVaultBackupPolicyListContext] instead.
-func GetRecoveryServicesVaultBackupPolicyList(t testing.TestingT, vaultName, resourceGroupName, subscriptionID string) map[string]backup.ProtectionPolicyResource {
+func GetRecoveryServicesVaultBackupPolicyList(t testing.TestingT, vaultName, resourceGroupName, subscriptionID string) map[string]armrecoveryservicesbackup.ProtectionPolicyResource {
 	t.Helper()
 
 	return GetRecoveryServicesVaultBackupPolicyListContext(t, context.Background(), vaultName, resourceGroupName, subscriptionID)
@@ -57,7 +57,7 @@ func GetRecoveryServicesVaultBackupPolicyList(t testing.TestingT, vaultName, res
 // GetRecoveryServicesVaultBackupProtectedVMListContext returns a list of protected VMs on the given vault and policy.
 // This function would fail the test if there is an error.
 // The ctx parameter supports cancellation and timeouts.
-func GetRecoveryServicesVaultBackupProtectedVMListContext(t testing.TestingT, ctx context.Context, policyName, vaultName, resourceGroupName, subscriptionID string) map[string]backup.AzureIaaSComputeVMProtectedItem {
+func GetRecoveryServicesVaultBackupProtectedVMListContext(t testing.TestingT, ctx context.Context, policyName, vaultName, resourceGroupName, subscriptionID string) map[string]armrecoveryservicesbackup.AzureIaaSComputeVMProtectedItem {
 	t.Helper()
 
 	list, err := GetRecoveryServicesVaultBackupProtectedVMListContextE(ctx, policyName, vaultName, resourceGroupName, subscriptionID)
@@ -70,7 +70,7 @@ func GetRecoveryServicesVaultBackupProtectedVMListContext(t testing.TestingT, ct
 // This function would fail the test if there is an error.
 //
 // Deprecated: Use [GetRecoveryServicesVaultBackupProtectedVMListContext] instead.
-func GetRecoveryServicesVaultBackupProtectedVMList(t testing.TestingT, policyName, vaultName, resourceGroupName, subscriptionID string) map[string]backup.AzureIaaSComputeVMProtectedItem {
+func GetRecoveryServicesVaultBackupProtectedVMList(t testing.TestingT, policyName, vaultName, resourceGroupName, subscriptionID string) map[string]armrecoveryservicesbackup.AzureIaaSComputeVMProtectedItem {
 	t.Helper()
 
 	return GetRecoveryServicesVaultBackupProtectedVMListContext(t, context.Background(), policyName, vaultName, resourceGroupName, subscriptionID)
@@ -100,7 +100,7 @@ func RecoveryServicesVaultExistsE(vaultName, resourceGroupName, subscriptionID s
 
 // GetRecoveryServicesVaultContextE returns a recovery services vault instance.
 // The ctx parameter supports cancellation and timeouts.
-func GetRecoveryServicesVaultContextE(ctx context.Context, vaultName, resourceGroupName, subscriptionID string) (*recoveryservices.Vault, error) {
+func GetRecoveryServicesVaultContextE(ctx context.Context, vaultName, resourceGroupName, subscriptionID string) (*armrecoveryservices.Vault, error) {
 	subscriptionID, err := getTargetAzureSubscription(subscriptionID)
 	if err != nil {
 		return nil, err
@@ -111,33 +111,34 @@ func GetRecoveryServicesVaultContextE(ctx context.Context, vaultName, resourceGr
 		return nil, err
 	}
 
-	client := recoveryservices.NewVaultsClient(subscriptionID)
-
-	authorizer, err := NewAuthorizer()
+	cred, err := newArmCredential()
 	if err != nil {
 		return nil, err
 	}
 
-	client.Authorizer = *authorizer
-
-	vault, err := client.Get(ctx, resourceGroupName, vaultName)
+	opts, err := newArmClientOptions()
 	if err != nil {
 		return nil, err
 	}
 
-	return &vault, nil
+	client, err := armrecoveryservices.NewVaultsClient(subscriptionID, cred, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	return FetchRecoveryServicesVault(ctx, client, resourceGroupName, vaultName)
 }
 
 // GetRecoveryServicesVaultE returns a vault instance.
 //
 // Deprecated: Use [GetRecoveryServicesVaultContextE] instead.
-func GetRecoveryServicesVaultE(vaultName, resourceGroupName, subscriptionID string) (*recoveryservices.Vault, error) {
+func GetRecoveryServicesVaultE(vaultName, resourceGroupName, subscriptionID string) (*armrecoveryservices.Vault, error) {
 	return GetRecoveryServicesVaultContextE(context.Background(), vaultName, resourceGroupName, subscriptionID)
 }
 
 // GetRecoveryServicesVaultBackupPolicyListContextE returns a list of backup policies for the given vault.
 // The ctx parameter supports cancellation and timeouts.
-func GetRecoveryServicesVaultBackupPolicyListContextE(ctx context.Context, vaultName, resourceGroupName, subscriptionID string) (map[string]backup.ProtectionPolicyResource, error) {
+func GetRecoveryServicesVaultBackupPolicyListContextE(ctx context.Context, vaultName, resourceGroupName, subscriptionID string) (map[string]armrecoveryservicesbackup.ProtectionPolicyResource, error) {
 	subscriptionID, err := getTargetAzureSubscription(subscriptionID)
 	if err != nil {
 		return nil, err
@@ -148,89 +149,120 @@ func GetRecoveryServicesVaultBackupPolicyListContextE(ctx context.Context, vault
 		return nil, err
 	}
 
-	client := backup.NewPoliciesClient(subscriptionID)
-
-	authorizer, err := NewAuthorizer()
+	cred, err := newArmCredential()
 	if err != nil {
 		return nil, err
 	}
 
-	client.Authorizer = *authorizer
-
-	listIter, err := client.ListComplete(ctx, vaultName, resourceGroupName, "")
+	opts, err := newArmClientOptions()
 	if err != nil {
 		return nil, err
 	}
 
-	policyMap := make(map[string]backup.ProtectionPolicyResource)
+	client, err := armrecoveryservicesbackup.NewBackupPoliciesClient(subscriptionID, cred, opts)
+	if err != nil {
+		return nil, err
+	}
 
-	for listIter.NotDone() {
-		v := listIter.Value()
-		policyMap[*v.Name] = v
+	return CollectBackupPolicies(ctx, client, vaultName, resourceGroupName)
+}
 
-		err := listIter.NextWithContext(ctx)
+// GetRecoveryServicesVaultBackupPolicyListE returns a list of backup policies for the given vault.
+//
+// Deprecated: Use [GetRecoveryServicesVaultBackupPolicyListContextE] instead.
+func GetRecoveryServicesVaultBackupPolicyListE(vaultName, resourceGroupName, subscriptionID string) (map[string]armrecoveryservicesbackup.ProtectionPolicyResource, error) {
+	return GetRecoveryServicesVaultBackupPolicyListContextE(context.Background(), vaultName, resourceGroupName, subscriptionID)
+}
+
+// GetRecoveryServicesVaultBackupProtectedVMListContextE returns a list of protected VMs on the given vault and policy.
+// The ctx parameter supports cancellation and timeouts.
+func GetRecoveryServicesVaultBackupProtectedVMListContextE(ctx context.Context, policyName, vaultName, resourceGroupName, subscriptionID string) (map[string]armrecoveryservicesbackup.AzureIaaSComputeVMProtectedItem, error) {
+	subscriptionID, err := getTargetAzureSubscription(subscriptionID)
+	if err != nil {
+		return nil, err
+	}
+
+	resourceGroupName, err = getTargetAzureResourceGroupName(resourceGroupName)
+	if err != nil {
+		return nil, err
+	}
+
+	cred, err := newArmCredential()
+	if err != nil {
+		return nil, err
+	}
+
+	opts, err := newArmClientOptions()
+	if err != nil {
+		return nil, err
+	}
+
+	client, err := armrecoveryservicesbackup.NewBackupProtectedItemsClient(subscriptionID, cred, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	return CollectBackupProtectedVMs(ctx, client, vaultName, resourceGroupName, policyName)
+}
+
+// GetRecoveryServicesVaultBackupProtectedVMListE returns a list of protected VM's on the given vault/policy.
+//
+// Deprecated: Use [GetRecoveryServicesVaultBackupProtectedVMListContextE] instead.
+func GetRecoveryServicesVaultBackupProtectedVMListE(policyName, vaultName, resourceGroupName, subscriptionID string) (map[string]armrecoveryservicesbackup.AzureIaaSComputeVMProtectedItem, error) {
+	return GetRecoveryServicesVaultBackupProtectedVMListContextE(context.Background(), policyName, vaultName, resourceGroupName, subscriptionID)
+}
+
+// FetchRecoveryServicesVault retrieves a recovery services vault using the provided client.
+func FetchRecoveryServicesVault(ctx context.Context, client *armrecoveryservices.VaultsClient, resourceGroupName, vaultName string) (*armrecoveryservices.Vault, error) {
+	resp, err := client.Get(ctx, resourceGroupName, vaultName, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return &resp.Vault, nil
+}
+
+// CollectBackupPolicies retrieves all backup policies for a vault using the provided client.
+func CollectBackupPolicies(ctx context.Context, client *armrecoveryservicesbackup.BackupPoliciesClient, vaultName, resourceGroupName string) (map[string]armrecoveryservicesbackup.ProtectionPolicyResource, error) {
+	pager := client.NewListPager(vaultName, resourceGroupName, nil)
+	policyMap := make(map[string]armrecoveryservicesbackup.ProtectionPolicyResource)
+
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
 		if err != nil {
 			return nil, err
+		}
+
+		for _, v := range page.Value {
+			policyMap[*v.Name] = *v
 		}
 	}
 
 	return policyMap, nil
 }
 
-// GetRecoveryServicesVaultBackupPolicyListE returns a list of backup policies for the given vault.
-//
-// Deprecated: Use [GetRecoveryServicesVaultBackupPolicyListContextE] instead.
-func GetRecoveryServicesVaultBackupPolicyListE(vaultName, resourceGroupName, subscriptionID string) (map[string]backup.ProtectionPolicyResource, error) {
-	return GetRecoveryServicesVaultBackupPolicyListContextE(context.Background(), vaultName, resourceGroupName, subscriptionID)
-}
-
-// GetRecoveryServicesVaultBackupProtectedVMListContextE returns a list of protected VMs on the given vault and policy.
-// The ctx parameter supports cancellation and timeouts.
-func GetRecoveryServicesVaultBackupProtectedVMListContextE(ctx context.Context, policyName, vaultName, resourceGroupName, subscriptionID string) (map[string]backup.AzureIaaSComputeVMProtectedItem, error) {
-	subscriptionID, err := getTargetAzureSubscription(subscriptionID)
-	if err != nil {
-		return nil, err
-	}
-
-	resourceGroupName, err = getTargetAzureResourceGroupName(resourceGroupName)
-	if err != nil {
-		return nil, err
-	}
-
-	client := backup.NewProtectedItemsGroupClient(subscriptionID)
-
-	authorizer, err := NewAuthorizer()
-	if err != nil {
-		return nil, err
-	}
-
-	client.Authorizer = *authorizer
-
+// CollectBackupProtectedVMs retrieves all protected VMs matching the given policy using the provided client.
+func CollectBackupProtectedVMs(ctx context.Context, client *armrecoveryservicesbackup.BackupProtectedItemsClient, vaultName, resourceGroupName, policyName string) (map[string]armrecoveryservicesbackup.AzureIaaSComputeVMProtectedItem, error) {
 	filter := fmt.Sprintf("backupManagementType eq 'AzureIaasVM' and itemType eq 'VM' and policyName eq '%s'", policyName)
 
-	listIter, err := client.ListComplete(ctx, vaultName, resourceGroupName, filter, "")
-	if err != nil {
-		return nil, err
-	}
+	pager := client.NewListPager(vaultName, resourceGroupName, &armrecoveryservicesbackup.BackupProtectedItemsClientListOptions{
+		Filter: &filter,
+	})
 
-	vmList := make(map[string]backup.AzureIaaSComputeVMProtectedItem)
+	vmList := make(map[string]armrecoveryservicesbackup.AzureIaaSComputeVMProtectedItem)
 
-	for listIter.NotDone() {
-		currentVM, _ := listIter.Value().Properties.AsAzureIaaSComputeVMProtectedItem()
-		vmList[*currentVM.FriendlyName] = *currentVM
-
-		err := listIter.NextWithContext(ctx)
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
 		if err != nil {
 			return nil, err
+		}
+
+		for _, item := range page.Value {
+			if vmItem, ok := item.Properties.(*armrecoveryservicesbackup.AzureIaaSComputeVMProtectedItem); ok {
+				vmList[*vmItem.FriendlyName] = *vmItem
+			}
 		}
 	}
 
 	return vmList, nil
-}
-
-// GetRecoveryServicesVaultBackupProtectedVMListE returns a list of protected VM's on the given vault/policy.
-//
-// Deprecated: Use [GetRecoveryServicesVaultBackupProtectedVMListContextE] instead.
-func GetRecoveryServicesVaultBackupProtectedVMListE(policyName, vaultName, resourceGroupName, subscriptionID string) (map[string]backup.AzureIaaSComputeVMProtectedItem, error) {
-	return GetRecoveryServicesVaultBackupProtectedVMListContextE(context.Background(), policyName, vaultName, resourceGroupName, subscriptionID)
 }

--- a/modules/azure/recoveryservices_test.go
+++ b/modules/azure/recoveryservices_test.go
@@ -1,42 +1,202 @@
 package azure_test
 
 import (
+	"context"
+	"net/http"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	azfake "github.com/Azure/azure-sdk-for-go/sdk/azcore/fake"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/recoveryservices/armrecoveryservices/v2"
+	recoveryfake "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/recoveryservices/armrecoveryservices/v2/fake"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/recoveryservices/armrecoveryservicesbackup/v4"
+	backupfake "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/recoveryservices/armrecoveryservicesbackup/v4/fake"
+	"github.com/gruntwork-io/terratest/modules/azure"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	azure "github.com/gruntwork-io/terratest/modules/azure"
 )
 
-/*
-The below tests are currently stubbed out, with the expectation that they will throw errors.
-If/when methods to create and delete recovery services resources are added, these tests can be extended.
-*/
+// ---------------------------------------------------------------------------
+// Fake client helpers
+// ---------------------------------------------------------------------------
 
-func TestRecoveryServicesVaultName(t *testing.T) {
-	t.Parallel()
+func newFakeVaultsClient(t *testing.T, srv recoveryfake.VaultsServer) *armrecoveryservices.VaultsClient {
+	t.Helper()
 
-	_, err := azure.GetRecoveryServicesVaultE("", "", "")
-	require.Error(t, err, "vault")
+	client, err := armrecoveryservices.NewVaultsClient("fake-sub", &azfake.TokenCredential{},
+		&arm.ClientOptions{ClientOptions: policy.ClientOptions{
+			Transport: recoveryfake.NewVaultsServerTransport(&srv),
+		}})
+	require.NoError(t, err)
+
+	return client
 }
 
-func TestRecoveryServicesVaultExists(t *testing.T) {
-	t.Parallel()
+func newFakeBackupPoliciesClient(t *testing.T, srv backupfake.BackupPoliciesServer) *armrecoveryservicesbackup.BackupPoliciesClient {
+	t.Helper()
 
-	_, err := azure.RecoveryServicesVaultExistsE("", "", "")
-	require.Error(t, err, "vault exists")
+	client, err := armrecoveryservicesbackup.NewBackupPoliciesClient("fake-sub", &azfake.TokenCredential{},
+		&arm.ClientOptions{ClientOptions: policy.ClientOptions{
+			Transport: backupfake.NewBackupPoliciesServerTransport(&srv),
+		}})
+	require.NoError(t, err)
+
+	return client
 }
 
-func TestRecoveryServicesVaultBackupPolicyList(t *testing.T) {
-	t.Parallel()
+func newFakeBackupProtectedItemsClient(t *testing.T, srv backupfake.BackupProtectedItemsServer) *armrecoveryservicesbackup.BackupProtectedItemsClient {
+	t.Helper()
 
-	_, err := azure.GetRecoveryServicesVaultBackupPolicyListE("", "", "")
-	require.Error(t, err, "Backup policy list not faulted")
+	client, err := armrecoveryservicesbackup.NewBackupProtectedItemsClient("fake-sub", &azfake.TokenCredential{},
+		&arm.ClientOptions{ClientOptions: policy.ClientOptions{
+			Transport: backupfake.NewBackupProtectedItemsServerTransport(&srv),
+		}})
+	require.NoError(t, err)
+
+	return client
 }
 
-func TestRecoveryServicesVaultBackupProtectedVMList(t *testing.T) {
+// ---------------------------------------------------------------------------
+// FetchRecoveryServicesVault tests
+// ---------------------------------------------------------------------------
+
+func TestFetchRecoveryServicesVault_Success(t *testing.T) {
 	t.Parallel()
 
-	_, err := azure.GetRecoveryServicesVaultBackupProtectedVMListE("", "", "", "")
-	require.Error(t, err, "Backup policy protected vm list not faulted")
+	srv := recoveryfake.VaultsServer{
+		Get: func(_ context.Context, _, _ string, _ *armrecoveryservices.VaultsClientGetOptions) (resp azfake.Responder[armrecoveryservices.VaultsClientGetResponse], errResp azfake.ErrorResponder) {
+			result := armrecoveryservices.VaultsClientGetResponse{
+				Vault: armrecoveryservices.Vault{
+					Name: to.Ptr("testvault"),
+				},
+			}
+			resp.SetResponse(http.StatusOK, result, nil)
+
+			return
+		},
+	}
+
+	client := newFakeVaultsClient(t, srv)
+	vault, err := azure.FetchRecoveryServicesVault(t.Context(), client, "rg", "testvault")
+
+	require.NoError(t, err)
+	assert.Equal(t, "testvault", *vault.Name)
+}
+
+func TestFetchRecoveryServicesVault_NotFound(t *testing.T) {
+	t.Parallel()
+
+	srv := recoveryfake.VaultsServer{
+		Get: func(_ context.Context, _, _ string, _ *armrecoveryservices.VaultsClientGetOptions) (resp azfake.Responder[armrecoveryservices.VaultsClientGetResponse], errResp azfake.ErrorResponder) {
+			errResp.SetResponseError(http.StatusNotFound, "ResourceNotFound")
+
+			return
+		},
+	}
+
+	client := newFakeVaultsClient(t, srv)
+	_, err := azure.FetchRecoveryServicesVault(t.Context(), client, "rg", "missing")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ResourceNotFound")
+}
+
+// ---------------------------------------------------------------------------
+// CollectBackupPolicies tests
+// ---------------------------------------------------------------------------
+
+func TestCollectBackupPolicies_OnePage(t *testing.T) {
+	t.Parallel()
+
+	srv := backupfake.BackupPoliciesServer{
+		NewListPager: func(_, _ string, _ *armrecoveryservicesbackup.BackupPoliciesClientListOptions) (resp azfake.PagerResponder[armrecoveryservicesbackup.BackupPoliciesClientListResponse]) {
+			resp.AddPage(http.StatusOK, armrecoveryservicesbackup.BackupPoliciesClientListResponse{
+				ProtectionPolicyResourceList: armrecoveryservicesbackup.ProtectionPolicyResourceList{
+					Value: []*armrecoveryservicesbackup.ProtectionPolicyResource{
+						{Name: to.Ptr("policy1")},
+						{Name: to.Ptr("policy2")},
+					},
+				},
+			}, nil)
+
+			return
+		},
+	}
+
+	client := newFakeBackupPoliciesClient(t, srv)
+	policies, err := azure.CollectBackupPolicies(t.Context(), client, "vault", "rg")
+
+	require.NoError(t, err)
+	assert.Len(t, policies, 2)
+	assert.Contains(t, policies, "policy1")
+	assert.Contains(t, policies, "policy2")
+}
+
+// ---------------------------------------------------------------------------
+// CollectBackupProtectedVMs tests
+// ---------------------------------------------------------------------------
+
+func TestCollectBackupProtectedVMs_WithVMItems(t *testing.T) {
+	t.Parallel()
+
+	srv := backupfake.BackupProtectedItemsServer{
+		NewListPager: func(_, _ string, _ *armrecoveryservicesbackup.BackupProtectedItemsClientListOptions) (resp azfake.PagerResponder[armrecoveryservicesbackup.BackupProtectedItemsClientListResponse]) {
+			resp.AddPage(http.StatusOK, armrecoveryservicesbackup.BackupProtectedItemsClientListResponse{
+				ProtectedItemResourceList: armrecoveryservicesbackup.ProtectedItemResourceList{
+					Value: []*armrecoveryservicesbackup.ProtectedItemResource{
+						{
+							Properties: &armrecoveryservicesbackup.AzureIaaSComputeVMProtectedItem{
+								FriendlyName: to.Ptr("myVM"),
+							},
+						},
+						{
+							Properties: &armrecoveryservicesbackup.AzureIaaSComputeVMProtectedItem{
+								FriendlyName: to.Ptr("myVM2"),
+							},
+						},
+					},
+				},
+			}, nil)
+
+			return
+		},
+	}
+
+	client := newFakeBackupProtectedItemsClient(t, srv)
+	vms, err := azure.CollectBackupProtectedVMs(t.Context(), client, "vault", "rg", "policy1")
+
+	require.NoError(t, err)
+	assert.Len(t, vms, 2)
+	assert.Contains(t, vms, "myVM")
+	assert.Contains(t, vms, "myVM2")
+}
+
+func TestCollectBackupProtectedVMs_NonVMItemsSkipped(t *testing.T) {
+	t.Parallel()
+
+	srv := backupfake.BackupProtectedItemsServer{
+		NewListPager: func(_, _ string, _ *armrecoveryservicesbackup.BackupProtectedItemsClientListOptions) (resp azfake.PagerResponder[armrecoveryservicesbackup.BackupProtectedItemsClientListResponse]) {
+			resp.AddPage(http.StatusOK, armrecoveryservicesbackup.BackupProtectedItemsClientListResponse{
+				ProtectedItemResourceList: armrecoveryservicesbackup.ProtectedItemResourceList{
+					Value: []*armrecoveryservicesbackup.ProtectedItemResource{
+						{
+							Properties: &armrecoveryservicesbackup.AzureFileshareProtectedItem{
+								FriendlyName: to.Ptr("myShare"),
+							},
+						},
+					},
+				},
+			}, nil)
+
+			return
+		},
+	}
+
+	client := newFakeBackupProtectedItemsClient(t, srv)
+	vms, err := azure.CollectBackupProtectedVMs(t.Context(), client, "vault", "rg", "policy1")
+
+	require.NoError(t, err)
+	assert.Empty(t, vms)
 }

--- a/modules/azure/region.go
+++ b/modules/azure/region.go
@@ -197,17 +197,20 @@ func GetAllAzureRegionsContextE(t testing.TestingT, ctx context.Context, subscri
 		return nil, err
 	}
 
-	// Get list of Azure locations
-	out, err := subscriptionClient.ListLocations(ctx, subscriptionID)
-	if err != nil {
-		return nil, err
-	}
+	// Get list of Azure locations via pager
+	pager := subscriptionClient.NewListLocationsPager(subscriptionID, nil)
 
-	// Populate a return slice
-	regions := make([]string, 0, len(*out.Value))
+	var regions []string
 
-	for _, region := range *out.Value {
-		regions = append(regions, *region.Name)
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, region := range page.Value {
+			regions = append(regions, *region.Name)
+		}
 	}
 
 	return regions, nil

--- a/modules/azure/resourcegroup.go
+++ b/modules/azure/resourcegroup.go
@@ -6,9 +6,9 @@ import (
 	"fmt"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2020-10-01/resources"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
 	"github.com/Azure/go-autorest/autorest"
-	"github.com/Azure/go-autorest/autorest/azure"
+	autorestAzure "github.com/Azure/go-autorest/autorest/azure"
 	"github.com/gruntwork-io/terratest/modules/testing"
 	"github.com/stretchr/testify/require"
 )
@@ -78,7 +78,7 @@ func GetResourceGroupE(resourceGroupName, subscriptionID string) (bool, error) {
 // GetAResourceGroupContext returns a resource group within a subscription.
 // This function would fail the test if there is an error.
 // The ctx parameter supports cancellation and timeouts.
-func GetAResourceGroupContext(t testing.TestingT, ctx context.Context, resourceGroupName string, subscriptionID string) *resources.Group {
+func GetAResourceGroupContext(t testing.TestingT, ctx context.Context, resourceGroupName string, subscriptionID string) *armresources.ResourceGroup {
 	t.Helper()
 
 	rg, err := GetAResourceGroupContextE(ctx, resourceGroupName, subscriptionID)
@@ -89,25 +89,40 @@ func GetAResourceGroupContext(t testing.TestingT, ctx context.Context, resourceG
 
 // GetAResourceGroupContextE gets a resource group within a subscription.
 // The ctx parameter supports cancellation and timeouts.
-func GetAResourceGroupContextE(ctx context.Context, resourceGroupName, subscriptionID string) (*resources.Group, error) {
-	client, err := CreateResourceGroupClientE(subscriptionID)
+func GetAResourceGroupContextE(ctx context.Context, resourceGroupName, subscriptionID string) (*armresources.ResourceGroup, error) {
+	subscriptionID, err := getTargetAzureSubscription(subscriptionID)
 	if err != nil {
 		return nil, err
 	}
 
-	rg, err := client.Get(ctx, resourceGroupName)
+	cred, err := newArmCredential()
 	if err != nil {
 		return nil, err
 	}
 
-	return &rg, nil
+	opts, err := newArmClientOptions()
+	if err != nil {
+		return nil, err
+	}
+
+	client, err := armresources.NewResourceGroupsClient(subscriptionID, cred, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := client.Get(ctx, resourceGroupName, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return &resp.ResourceGroup, nil
 }
 
 // GetAResourceGroup returns a resource group within a subscription.
 // This function would fail the test if there is an error.
 //
 // Deprecated: Use [GetAResourceGroupContext] instead.
-func GetAResourceGroup(t testing.TestingT, resourceGroupName string, subscriptionID string) *resources.Group {
+func GetAResourceGroup(t testing.TestingT, resourceGroupName string, subscriptionID string) *armresources.ResourceGroup {
 	t.Helper()
 
 	return GetAResourceGroupContext(t, context.Background(), resourceGroupName, subscriptionID)
@@ -116,14 +131,14 @@ func GetAResourceGroup(t testing.TestingT, resourceGroupName string, subscriptio
 // GetAResourceGroupE gets a resource group within a subscription.
 //
 // Deprecated: Use [GetAResourceGroupContextE] instead.
-func GetAResourceGroupE(resourceGroupName, subscriptionID string) (*resources.Group, error) {
+func GetAResourceGroupE(resourceGroupName, subscriptionID string) (*armresources.ResourceGroup, error) {
 	return GetAResourceGroupContextE(context.Background(), resourceGroupName, subscriptionID)
 }
 
 // ListResourceGroupsByTagContext returns a resource group list within a subscription based on a tag key.
 // This function would fail the test if there is an error.
 // The ctx parameter supports cancellation and timeouts.
-func ListResourceGroupsByTagContext(t testing.TestingT, ctx context.Context, tag, subscriptionID string) []resources.Group {
+func ListResourceGroupsByTagContext(t testing.TestingT, ctx context.Context, tag, subscriptionID string) []armresources.ResourceGroup {
 	t.Helper()
 
 	rg, err := ListResourceGroupsByTagContextE(ctx, tag, subscriptionID)
@@ -134,25 +149,53 @@ func ListResourceGroupsByTagContext(t testing.TestingT, ctx context.Context, tag
 
 // ListResourceGroupsByTagContextE returns a resource group list within a subscription based on a tag key.
 // The ctx parameter supports cancellation and timeouts.
-func ListResourceGroupsByTagContextE(ctx context.Context, tag string, subscriptionID string) ([]resources.Group, error) {
-	client, err := CreateResourceGroupClientE(subscriptionID)
+func ListResourceGroupsByTagContextE(ctx context.Context, tag string, subscriptionID string) ([]armresources.ResourceGroup, error) {
+	subscriptionID, err := getTargetAzureSubscription(subscriptionID)
 	if err != nil {
 		return nil, err
 	}
 
-	rg, err := client.List(ctx, fmt.Sprintf("tagName eq '%s'", tag), nil)
+	cred, err := newArmCredential()
 	if err != nil {
 		return nil, err
 	}
 
-	return rg.Values(), nil
+	opts, err := newArmClientOptions()
+	if err != nil {
+		return nil, err
+	}
+
+	client, err := armresources.NewResourceGroupsClient(subscriptionID, cred, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	filter := fmt.Sprintf("tagName eq '%s'", tag)
+	pager := client.NewListPager(&armresources.ResourceGroupsClientListOptions{
+		Filter: &filter,
+	})
+
+	var groups []armresources.ResourceGroup
+
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, rg := range page.Value {
+			groups = append(groups, *rg)
+		}
+	}
+
+	return groups, nil
 }
 
 // ListResourceGroupsByTag returns a resource group list within a subscription based on a tag key.
 // This function would fail the test if there is an error.
 //
 // Deprecated: Use [ListResourceGroupsByTagContext] instead.
-func ListResourceGroupsByTag(t testing.TestingT, tag, subscriptionID string) []resources.Group {
+func ListResourceGroupsByTag(t testing.TestingT, tag, subscriptionID string) []armresources.ResourceGroup {
 	t.Helper()
 
 	return ListResourceGroupsByTagContext(t, context.Background(), tag, subscriptionID)
@@ -161,23 +204,23 @@ func ListResourceGroupsByTag(t testing.TestingT, tag, subscriptionID string) []r
 // ListResourceGroupsByTagE returns a resource group list within a subscription based on a tag key.
 //
 // Deprecated: Use [ListResourceGroupsByTagContextE] instead.
-func ListResourceGroupsByTagE(tag string, subscriptionID string) ([]resources.Group, error) {
+func ListResourceGroupsByTagE(tag string, subscriptionID string) ([]armresources.ResourceGroup, error) {
 	return ListResourceGroupsByTagContextE(context.Background(), tag, subscriptionID)
 }
 
 func resourceGroupNotFoundError(err error) bool {
 	if err != nil {
-		var autorestError autorest.DetailedError
-		if errors.As(err, &autorestError) {
-			var requestError *azure.RequestError
-			if errors.As(autorestError.Original, &requestError) {
-				return (requestError.ServiceError.Code == "ResourceGroupNotFound")
-			}
-		}
-
 		var azcoreErr *azcore.ResponseError
 		if errors.As(err, &azcoreErr) {
 			return azcoreErr.ErrorCode == "ResourceGroupNotFound"
+		}
+
+		var autorestError autorest.DetailedError
+		if errors.As(err, &autorestError) {
+			var requestError *autorestAzure.RequestError
+			if errors.As(autorestError.Original, &requestError) {
+				return (requestError.ServiceError.Code == "ResourceGroupNotFound")
+			}
 		}
 	}
 

--- a/modules/azure/resourcegroup_test.go
+++ b/modules/azure/resourcegroup_test.go
@@ -22,7 +22,7 @@ func TestResourceGroupExists(t *testing.T) {
 	t.Parallel()
 
 	resourceGroupName := "fakeResourceGroupName"
-	exists, err := azure.ResourceGroupExistsE(resourceGroupName, "")
+	exists, err := azure.ResourceGroupExistsContextE(t.Context(), resourceGroupName, "")
 	require.NoError(t, err)
 	require.False(t, exists)
 }
@@ -32,6 +32,6 @@ func TestGetAResourceGroup(t *testing.T) {
 
 	resourceGroupName := "fakeResourceGroupName"
 
-	_, err := azure.GetAResourceGroupE(resourceGroupName, "")
+	_, err := azure.GetAResourceGroupContextE(t.Context(), resourceGroupName, "")
 	require.Error(t, err)
 }

--- a/modules/azure/subscription.go
+++ b/modules/azure/subscription.go
@@ -1,25 +1,20 @@
 package azure
 
 import (
-	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2019-06-01/subscriptions"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions"
 )
 
-// GetSubscriptionClientE is a helper function that will setup an Azure Subscription client on your behalf
-func GetSubscriptionClientE() (*subscriptions.Client, error) {
-	// Create a Subscription client
-	client, err := CreateSubscriptionsClientE()
+// GetSubscriptionClientE is a helper function that will setup an Azure Subscription client on your behalf.
+func GetSubscriptionClientE() (*armsubscriptions.Client, error) {
+	cred, err := newArmCredential()
 	if err != nil {
 		return nil, err
 	}
 
-	// Create an authorizer
-	authorizer, err := NewAuthorizer()
+	opts, err := newArmClientOptions()
 	if err != nil {
 		return nil, err
 	}
 
-	// Attach authorizer to the client
-	client.Authorizer = *authorizer
-
-	return &client, nil
+	return armsubscriptions.NewClient(cred, opts)
 }


### PR DESCRIPTION
## Summary
Migrate subscription.go, resourcegroup.go, and recoveryservices.go from the deprecated go-autorest SDK to the new ARM SDK packages (armsubscriptions, armresources, armrecoveryservices/v2, armrecoveryservicesbackup/v4). All deprecated wrapper functions are preserved with updated return types. Adds fake-server unit tests for recovery services business logic.

**Files changed (8):**
- `modules/azure/subscription.go` — migrated to armsubscriptions with inline client creation
- `modules/azure/resourcegroup.go` — migrated to armresources with inline client creation and NewListPager pagination
- `modules/azure/resourcegroup_test.go` — updated to use Context variants and t.Context()
- `modules/azure/recoveryservices.go` — migrated to armrecoveryservices/v2 + armrecoveryservicesbackup/v4 with inline client creation
- `modules/azure/recoveryservices_test.go` — rewritten with azfake fake-server tests for CollectBackupPolicies, CollectBackupProtectedVMs, and FetchRecoveryServicesVault
- `modules/azure/region.go` — updated to use new armsubscriptions NewListLocationsPager API
- `go.mod` — added armsubscriptions, armrecoveryservices/v2, armrecoveryservicesbackup/v4
- `go.sum` — updated checksums

## Breaking Changes
- `GetSubscriptionClientE()` now returns `*armsubscriptions.Client` (was `*subscriptions.Client`)
- `GetAResourceGroupContextE` / `GetAResourceGroupContext` / `GetAResourceGroup` / `GetAResourceGroupE` now return `*armresources.ResourceGroup` (was `*resources.Group`)
- `ListResourceGroupsByTagContextE` / `ListResourceGroupsByTagContext` / `ListResourceGroupsByTag` / `ListResourceGroupsByTagE` now return `[]armresources.ResourceGroup` (was `[]resources.Group`)
- `GetRecoveryServicesVaultContextE` / `GetRecoveryServicesVaultE` now return `*armrecoveryservices.Vault` (was `*recoveryservices.Vault`)
- `GetRecoveryServicesVaultBackupPolicyListContextE` and variants now return `map[string]armrecoveryservicesbackup.ProtectionPolicyResource` (was `map[string]backup.ProtectionPolicyResource`)
- `GetRecoveryServicesVaultBackupProtectedVMListContextE` and variants now return `map[string]armrecoveryservicesbackup.AzureIaaSComputeVMProtectedItem` (was `map[string]backup.AzureIaaSComputeVMProtectedItem`)
- All deprecated wrapper functions are kept but return the new SDK types

## Validated
- [x] `go mod tidy` — clean
- [x] `go build ./...` — compiles
- [x] `go test -tags azure -c -o /dev/null ./modules/azure/...` — test compilation with azure tag
- [x] `go test -count=1 -timeout 5m ./modules/azure/...` — fake-server tests pass
- [x] `make lint` — 0 issues