### PR TITLE
fix(azure): restore deprecated non-Context wrappers for backward compatibility

### DIFF
--- a/modules/azure/availabilityset.go
+++ b/modules/azure/availabilityset.go
@@ -9,6 +9,25 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// AvailabilitySetExists indicates whether the specified Azure Availability Set exists.
+// This function would fail the test if there is an error.
+//
+// Deprecated: Use [AvailabilitySetExistsContext] instead.
+func AvailabilitySetExists(t testing.TestingT, avsName string, resGroupName string, subscriptionID string) bool {
+	t.Helper()
+
+	return AvailabilitySetExistsContext(t, context.Background(), avsName, resGroupName, subscriptionID)
+}
+
+// AvailabilitySetExistsE indicates whether the specified Azure Availability Set exists.
+//
+// Deprecated: Use [AvailabilitySetExistsContextE] instead.
+func AvailabilitySetExistsE(t testing.TestingT, avsName string, resGroupName string, subscriptionID string) (bool, error) {
+	t.Helper()
+
+	return AvailabilitySetExistsContextE(t, context.Background(), avsName, resGroupName, subscriptionID)
+}
+
 // AvailabilitySetExistsContext indicates whether the specified Azure Availability Set exists.
 // This function would fail the test if there is an error.
 // The ctx parameter supports cancellation and timeouts.
@@ -34,6 +53,25 @@ func AvailabilitySetExistsContextE(t testing.TestingT, ctx context.Context, avsN
 	}
 
 	return true, nil
+}
+
+// CheckAvailabilitySetContainsVM checks if the Virtual Machine is contained in the Availability Set VMs.
+// This function would fail the test if there is an error.
+//
+// Deprecated: Use [CheckAvailabilitySetContainsVMContext] instead.
+func CheckAvailabilitySetContainsVM(t testing.TestingT, vmName string, avsName string, resGroupName string, subscriptionID string) bool {
+	t.Helper()
+
+	return CheckAvailabilitySetContainsVMContext(t, context.Background(), vmName, avsName, resGroupName, subscriptionID)
+}
+
+// CheckAvailabilitySetContainsVME checks if the Virtual Machine is contained in the Availability Set VMs.
+//
+// Deprecated: Use [CheckAvailabilitySetContainsVMContextE] instead.
+func CheckAvailabilitySetContainsVME(t testing.TestingT, vmName string, avsName string, resGroupName string, subscriptionID string) (bool, error) {
+	t.Helper()
+
+	return CheckAvailabilitySetContainsVMContextE(t, context.Background(), vmName, avsName, resGroupName, subscriptionID)
 }
 
 // CheckAvailabilitySetContainsVMContext checks if the Virtual Machine is contained in the Availability Set VMs.
@@ -69,6 +107,25 @@ func CheckAvailabilitySetContainsVMContextE(t testing.TestingT, ctx context.Cont
 	}
 
 	return false, NewNotFoundError("Virtual Machine", vmName, avsName)
+}
+
+// GetAvailabilitySetVMNamesInCaps gets a list of VM names in the specified Azure Availability Set.
+// This function would fail the test if there is an error.
+//
+// Deprecated: Use [GetAvailabilitySetVMNamesInCapsContext] instead.
+func GetAvailabilitySetVMNamesInCaps(t testing.TestingT, avsName string, resGroupName string, subscriptionID string) []string {
+	t.Helper()
+
+	return GetAvailabilitySetVMNamesInCapsContext(t, context.Background(), avsName, resGroupName, subscriptionID)
+}
+
+// GetAvailabilitySetVMNamesInCapsE gets a list of VM names in the specified Azure Availability Set.
+//
+// Deprecated: Use [GetAvailabilitySetVMNamesInCapsContextE] instead.
+func GetAvailabilitySetVMNamesInCapsE(t testing.TestingT, avsName string, resGroupName string, subscriptionID string) ([]string, error) {
+	t.Helper()
+
+	return GetAvailabilitySetVMNamesInCapsContextE(t, context.Background(), avsName, resGroupName, subscriptionID)
 }
 
 // GetAvailabilitySetVMNamesInCapsContext gets a list of VM names in the specified Azure Availability Set.
@@ -108,6 +165,25 @@ func GetAvailabilitySetVMNamesInCapsContextE(t testing.TestingT, ctx context.Con
 	return vms, nil
 }
 
+// GetAvailabilitySetFaultDomainCount gets the Fault Domain Count for the specified Azure Availability Set.
+// This function would fail the test if there is an error.
+//
+// Deprecated: Use [GetAvailabilitySetFaultDomainCountContext] instead.
+func GetAvailabilitySetFaultDomainCount(t testing.TestingT, avsName string, resGroupName string, subscriptionID string) int32 {
+	t.Helper()
+
+	return GetAvailabilitySetFaultDomainCountContext(t, context.Background(), avsName, resGroupName, subscriptionID)
+}
+
+// GetAvailabilitySetFaultDomainCountE gets the Fault Domain Count for the specified Azure Availability Set.
+//
+// Deprecated: Use [GetAvailabilitySetFaultDomainCountContextE] instead.
+func GetAvailabilitySetFaultDomainCountE(t testing.TestingT, avsName string, resGroupName string, subscriptionID string) (int32, error) {
+	t.Helper()
+
+	return GetAvailabilitySetFaultDomainCountContextE(t, context.Background(), avsName, resGroupName, subscriptionID)
+}
+
 // GetAvailabilitySetFaultDomainCountContext gets the Fault Domain Count for the specified Azure Availability Set.
 // This function would fail the test if there is an error.
 // The ctx parameter supports cancellation and timeouts.
@@ -129,6 +205,15 @@ func GetAvailabilitySetFaultDomainCountContextE(t testing.TestingT, ctx context.
 	}
 
 	return *avs.Properties.PlatformFaultDomainCount, nil
+}
+
+// GetAvailabilitySetE gets an Availability Set in the specified Azure Resource Group.
+//
+// Deprecated: Use [GetAvailabilitySetContextE] instead.
+func GetAvailabilitySetE(t testing.TestingT, avsName string, resGroupName string, subscriptionID string) (*armcompute.AvailabilitySet, error) {
+	t.Helper()
+
+	return GetAvailabilitySetContextE(t, context.Background(), avsName, resGroupName, subscriptionID)
 }
 
 // GetAvailabilitySetContextE gets an Availability Set in the specified Azure Resource Group.

--- a/modules/azure/compute.go
+++ b/modules/azure/compute.go
@@ -52,6 +52,23 @@ func GetVirtualMachineClientE(subscriptionID string) (*armcompute.VirtualMachine
 	return GetVirtualMachineClientContextE(context.Background(), subscriptionID)
 }
 
+// VirtualMachineExists indicates whether the specified Azure Virtual Machine exists.
+// This function would fail the test if there is an error.
+//
+// Deprecated: Use [VirtualMachineExistsContext] instead.
+func VirtualMachineExists(t testing.TestingT, vmName string, resGroupName string, subscriptionID string) bool {
+	t.Helper()
+
+	return VirtualMachineExistsContext(t, context.Background(), vmName, resGroupName, subscriptionID)
+}
+
+// VirtualMachineExistsE indicates whether the specified Azure Virtual Machine exists.
+//
+// Deprecated: Use [VirtualMachineExistsContextE] instead.
+func VirtualMachineExistsE(vmName string, resGroupName string, subscriptionID string) (bool, error) {
+	return VirtualMachineExistsContextE(context.Background(), vmName, resGroupName, subscriptionID)
+}
+
 // VirtualMachineExistsContext indicates whether the specified Azure Virtual Machine exists.
 // This function would fail the test if there is an error.
 // The ctx parameter supports cancellation and timeouts.
@@ -77,6 +94,23 @@ func VirtualMachineExistsContextE(ctx context.Context, vmName string, resGroupNa
 	}
 
 	return true, nil
+}
+
+// GetVirtualMachineNics gets a list of Network Interface names for a specified Azure Virtual Machine.
+// This function would fail the test if there is an error.
+//
+// Deprecated: Use [GetVirtualMachineNicsContext] instead.
+func GetVirtualMachineNics(t testing.TestingT, vmName string, resGroupName string, subscriptionID string) []string {
+	t.Helper()
+
+	return GetVirtualMachineNicsContext(t, context.Background(), vmName, resGroupName, subscriptionID)
+}
+
+// GetVirtualMachineNicsE gets a list of Network Interface names for a specified Azure Virtual Machine.
+//
+// Deprecated: Use [GetVirtualMachineNicsContextE] instead.
+func GetVirtualMachineNicsE(vmName string, resGroupName string, subscriptionID string) ([]string, error) {
+	return GetVirtualMachineNicsContextE(context.Background(), vmName, resGroupName, subscriptionID)
 }
 
 // GetVirtualMachineNicsContext gets a list of Network Interface names for a specified Azure Virtual Machine.
@@ -124,6 +158,23 @@ func extractVMNics(vm *armcompute.VirtualMachine) ([]string, error) {
 	return nics, nil
 }
 
+// GetVirtualMachineManagedDisks gets the list of Managed Disk names of the specified Azure Virtual Machine.
+// This function would fail the test if there is an error.
+//
+// Deprecated: Use [GetVirtualMachineManagedDisksContext] instead.
+func GetVirtualMachineManagedDisks(t testing.TestingT, vmName string, resGroupName string, subscriptionID string) []string {
+	t.Helper()
+
+	return GetVirtualMachineManagedDisksContext(t, context.Background(), vmName, resGroupName, subscriptionID)
+}
+
+// GetVirtualMachineManagedDisksE gets the list of Managed Disk names of the specified Azure Virtual Machine.
+//
+// Deprecated: Use [GetVirtualMachineManagedDisksContextE] instead.
+func GetVirtualMachineManagedDisksE(vmName string, resGroupName string, subscriptionID string) ([]string, error) {
+	return GetVirtualMachineManagedDisksContextE(context.Background(), vmName, resGroupName, subscriptionID)
+}
+
 // GetVirtualMachineManagedDisksContext gets the list of Managed Disk names of the specified Azure Virtual Machine.
 // This function would fail the test if there is an error.
 // The ctx parameter supports cancellation and timeouts.
@@ -159,6 +210,23 @@ func extractVMManagedDisks(vm *armcompute.VirtualMachine) []string {
 	return diskNames
 }
 
+// GetVirtualMachineOSDiskName gets the OS Disk name of the specified Azure Virtual Machine.
+// This function would fail the test if there is an error.
+//
+// Deprecated: Use [GetVirtualMachineOSDiskNameContext] instead.
+func GetVirtualMachineOSDiskName(t testing.TestingT, vmName string, resGroupName string, subscriptionID string) string {
+	t.Helper()
+
+	return GetVirtualMachineOSDiskNameContext(t, context.Background(), vmName, resGroupName, subscriptionID)
+}
+
+// GetVirtualMachineOSDiskNameE gets the OS Disk name of the specified Azure Virtual Machine.
+//
+// Deprecated: Use [GetVirtualMachineOSDiskNameContextE] instead.
+func GetVirtualMachineOSDiskNameE(vmName string, resGroupName string, subscriptionID string) (string, error) {
+	return GetVirtualMachineOSDiskNameContextE(context.Background(), vmName, resGroupName, subscriptionID)
+}
+
 // GetVirtualMachineOSDiskNameContext gets the OS Disk name of the specified Azure Virtual Machine.
 // This function would fail the test if there is an error.
 // The ctx parameter supports cancellation and timeouts.
@@ -185,6 +253,23 @@ func GetVirtualMachineOSDiskNameContextE(ctx context.Context, vmName string, res
 // extractVMOSDiskName extracts the OS Disk name from a Virtual Machine object.
 func extractVMOSDiskName(vm *armcompute.VirtualMachine) string {
 	return *vm.Properties.StorageProfile.OSDisk.Name
+}
+
+// GetVirtualMachineAvailabilitySetID gets the Availability Set ID of the specified Azure Virtual Machine.
+// This function would fail the test if there is an error.
+//
+// Deprecated: Use [GetVirtualMachineAvailabilitySetIDContext] instead.
+func GetVirtualMachineAvailabilitySetID(t testing.TestingT, vmName string, resGroupName string, subscriptionID string) string {
+	t.Helper()
+
+	return GetVirtualMachineAvailabilitySetIDContext(t, context.Background(), vmName, resGroupName, subscriptionID)
+}
+
+// GetVirtualMachineAvailabilitySetIDE gets the Availability Set ID of the specified Azure Virtual Machine.
+//
+// Deprecated: Use [GetVirtualMachineAvailabilitySetIDContextE] instead.
+func GetVirtualMachineAvailabilitySetIDE(vmName string, resGroupName string, subscriptionID string) (string, error) {
+	return GetVirtualMachineAvailabilitySetIDContextE(context.Background(), vmName, resGroupName, subscriptionID)
 }
 
 // GetVirtualMachineAvailabilitySetIDContext gets the Availability Set ID of the specified Azure Virtual Machine.
@@ -230,6 +315,23 @@ type VMImage struct {
 	Offer     string
 	SKU       string
 	Version   string
+}
+
+// GetVirtualMachineImage gets the Image of the specified Azure Virtual Machine.
+// This function would fail the test if there is an error.
+//
+// Deprecated: Use [GetVirtualMachineImageContext] instead.
+func GetVirtualMachineImage(t testing.TestingT, vmName string, resGroupName string, subscriptionID string) VMImage {
+	t.Helper()
+
+	return GetVirtualMachineImageContext(t, context.Background(), vmName, resGroupName, subscriptionID)
+}
+
+// GetVirtualMachineImageE gets the Image of the specified Azure Virtual Machine.
+//
+// Deprecated: Use [GetVirtualMachineImageContextE] instead.
+func GetVirtualMachineImageE(vmName string, resGroupName string, subscriptionID string) (VMImage, error) {
+	return GetVirtualMachineImageContextE(context.Background(), vmName, resGroupName, subscriptionID)
 }
 
 // GetVirtualMachineImageContext gets the Image of the specified Azure Virtual Machine.
@@ -281,6 +383,23 @@ func extractVMImage(vm *armcompute.VirtualMachine) VMImage {
 	return img
 }
 
+// GetSizeOfVirtualMachine gets the Size Type of the specified Azure Virtual Machine.
+// This function would fail the test if there is an error.
+//
+// Deprecated: Use [GetSizeOfVirtualMachineContext] instead.
+func GetSizeOfVirtualMachine(t testing.TestingT, vmName string, resGroupName string, subscriptionID string) armcompute.VirtualMachineSizeTypes {
+	t.Helper()
+
+	return GetSizeOfVirtualMachineContext(t, context.Background(), vmName, resGroupName, subscriptionID)
+}
+
+// GetSizeOfVirtualMachineE gets the Size Type of the specified Azure Virtual Machine.
+//
+// Deprecated: Use [GetSizeOfVirtualMachineContextE] instead.
+func GetSizeOfVirtualMachineE(vmName string, resGroupName string, subscriptionID string) (armcompute.VirtualMachineSizeTypes, error) {
+	return GetSizeOfVirtualMachineContextE(context.Background(), vmName, resGroupName, subscriptionID)
+}
+
 // GetSizeOfVirtualMachineContext gets the Size Type of the specified Azure Virtual Machine.
 // This function would fail the test if there is an error.
 // The ctx parameter supports cancellation and timeouts.
@@ -307,6 +426,23 @@ func GetSizeOfVirtualMachineContextE(ctx context.Context, vmName string, resGrou
 // extractVMSize extracts the VM size from a Virtual Machine object.
 func extractVMSize(vm *armcompute.VirtualMachine) armcompute.VirtualMachineSizeTypes {
 	return *vm.Properties.HardwareProfile.VMSize
+}
+
+// GetVirtualMachineTags gets the Tags of the specified Virtual Machine as a map.
+// This function would fail the test if there is an error.
+//
+// Deprecated: Use [GetVirtualMachineTagsContext] instead.
+func GetVirtualMachineTags(t testing.TestingT, vmName string, resGroupName string, subscriptionID string) map[string]string {
+	t.Helper()
+
+	return GetVirtualMachineTagsContext(t, context.Background(), vmName, resGroupName, subscriptionID)
+}
+
+// GetVirtualMachineTagsE gets the Tags of the specified Virtual Machine as a map.
+//
+// Deprecated: Use [GetVirtualMachineTagsContextE] instead.
+func GetVirtualMachineTagsE(vmName string, resGroupName string, subscriptionID string) (map[string]string, error) {
+	return GetVirtualMachineTagsContextE(context.Background(), vmName, resGroupName, subscriptionID)
 }
 
 // GetVirtualMachineTagsContext gets the Tags of the specified Virtual Machine as a map.
@@ -351,6 +487,23 @@ func extractVMTags(vm *armcompute.VirtualMachine) map[string]string {
 // Get multiple Virtual Machines from a Resource Group
 // ***************************************************** //
 
+// ListVirtualMachinesForResourceGroup gets a list of all Virtual Machine names in the specified Resource Group.
+// This function would fail the test if there is an error.
+//
+// Deprecated: Use [ListVirtualMachinesForResourceGroupContext] instead.
+func ListVirtualMachinesForResourceGroup(t testing.TestingT, resGroupName string, subscriptionID string) []string {
+	t.Helper()
+
+	return ListVirtualMachinesForResourceGroupContext(t, context.Background(), resGroupName, subscriptionID)
+}
+
+// ListVirtualMachinesForResourceGroupE gets a list of all Virtual Machine names in the specified Resource Group.
+//
+// Deprecated: Use [ListVirtualMachinesForResourceGroupContextE] instead.
+func ListVirtualMachinesForResourceGroupE(resGroupName string, subscriptionID string) ([]string, error) {
+	return ListVirtualMachinesForResourceGroupContextE(context.Background(), resGroupName, subscriptionID)
+}
+
 // ListVirtualMachinesForResourceGroupContext gets a list of all Virtual Machine names in the specified Resource Group.
 // This function would fail the test if there is an error.
 // The ctx parameter supports cancellation and timeouts.
@@ -391,6 +544,25 @@ func listVirtualMachineNames(ctx context.Context, client *armcompute.VirtualMach
 	}
 
 	return vmDetails, nil
+}
+
+// GetVirtualMachinesForResourceGroup gets all Virtual Machine objects in the specified Resource Group. Each
+// VM Object represents the entire set of VM compute properties accessible by using the VM name as the map key.
+// This function would fail the test if there is an error.
+//
+// Deprecated: Use [GetVirtualMachinesForResourceGroupContext] instead.
+func GetVirtualMachinesForResourceGroup(t testing.TestingT, resGroupName string, subscriptionID string) map[string]armcompute.VirtualMachineProperties {
+	t.Helper()
+
+	return GetVirtualMachinesForResourceGroupContext(t, context.Background(), resGroupName, subscriptionID)
+}
+
+// GetVirtualMachinesForResourceGroupE gets all Virtual Machine objects in the specified Resource Group. Each
+// VM Object represents the entire set of VM compute properties accessible by using the VM name as the map key.
+//
+// Deprecated: Use [GetVirtualMachinesForResourceGroupContextE] instead.
+func GetVirtualMachinesForResourceGroupE(resGroupName string, subscriptionID string) (map[string]armcompute.VirtualMachineProperties, error) {
+	return GetVirtualMachinesForResourceGroupContextE(context.Background(), resGroupName, subscriptionID)
 }
 
 // GetVirtualMachinesForResourceGroupContext gets all Virtual Machine objects in the specified Resource Group. Each
@@ -465,6 +637,23 @@ func GetVirtualMachineContext(t testing.TestingT, ctx context.Context, vmName st
 	require.NoError(t, err)
 
 	return vm
+}
+
+// GetVirtualMachine gets a Virtual Machine in the specified Azure Resource Group.
+// This function would fail the test if there is an error.
+//
+// Deprecated: Use [GetVirtualMachineContext] instead.
+func GetVirtualMachine(t testing.TestingT, vmName string, resGroupName string, subscriptionID string) *armcompute.VirtualMachine {
+	t.Helper()
+
+	return GetVirtualMachineContext(t, context.Background(), vmName, resGroupName, subscriptionID)
+}
+
+// GetVirtualMachineE gets a Virtual Machine in the specified Azure Resource Group.
+//
+// Deprecated: Use [GetVirtualMachineContextE] instead.
+func GetVirtualMachineE(vmName string, resGroupName string, subscriptionID string) (*armcompute.VirtualMachine, error) {
+	return GetVirtualMachineContextE(context.Background(), vmName, resGroupName, subscriptionID)
 }
 
 // GetVirtualMachineContextE gets a Virtual Machine in the specified Azure Resource Group.

--- a/modules/azure/cosmosdb.go
+++ b/modules/azure/cosmosdb.go
@@ -39,6 +39,21 @@ func GetCosmosDBAccountClient(t testing.TestingT, subscriptionID string) *armcos
 	return GetCosmosDBAccountClientContext(t, context.Background(), subscriptionID) //nolint:staticcheck
 }
 
+// GetCosmosDBAccount is a helper function that gets the database account.
+// This function would fail the test if there is an error.
+//
+// Deprecated: Use [GetCosmosDBAccountContext] instead.
+func GetCosmosDBAccount(t testing.TestingT, subscriptionID string, resourceGroupName string, accountName string) *armcosmos.DatabaseAccountGetResults {
+	return GetCosmosDBAccountContext(t, context.Background(), subscriptionID, resourceGroupName, accountName)
+}
+
+// GetCosmosDBAccountE is a helper function that gets the database account.
+//
+// Deprecated: Use [GetCosmosDBAccountContextE] instead.
+func GetCosmosDBAccountE(subscriptionID string, resourceGroupName string, accountName string) (*armcosmos.DatabaseAccountGetResults, error) {
+	return GetCosmosDBAccountContextE(context.Background(), subscriptionID, resourceGroupName, accountName)
+}
+
 // GetCosmosDBAccountContext is a helper function that gets the database account.
 // This function would fail the test if there is an error.
 // The ctx parameter supports cancellation and timeouts.
@@ -99,6 +114,21 @@ func GetCosmosDBSQLClient(t testing.TestingT, subscriptionID string) *armcosmos.
 	return GetCosmosDBSQLClientContext(t, context.Background(), subscriptionID) //nolint:staticcheck
 }
 
+// GetCosmosDBSQLDatabase is a helper function that gets a SQL database.
+// This function would fail the test if there is an error.
+//
+// Deprecated: Use [GetCosmosDBSQLDatabaseContext] instead.
+func GetCosmosDBSQLDatabase(t testing.TestingT, subscriptionID string, resourceGroupName string, accountName string, databaseName string) *armcosmos.SQLDatabaseGetResults {
+	return GetCosmosDBSQLDatabaseContext(t, context.Background(), subscriptionID, resourceGroupName, accountName, databaseName)
+}
+
+// GetCosmosDBSQLDatabaseE is a helper function that gets a SQL database.
+//
+// Deprecated: Use [GetCosmosDBSQLDatabaseContextE] instead.
+func GetCosmosDBSQLDatabaseE(subscriptionID string, resourceGroupName string, accountName string, databaseName string) (*armcosmos.SQLDatabaseGetResults, error) {
+	return GetCosmosDBSQLDatabaseContextE(context.Background(), subscriptionID, resourceGroupName, accountName, databaseName)
+}
+
 // GetCosmosDBSQLDatabaseContext is a helper function that gets a SQL database.
 // This function would fail the test if there is an error.
 // The ctx parameter supports cancellation and timeouts.
@@ -126,6 +156,21 @@ func GetCosmosDBSQLDatabaseContextE(ctx context.Context, subscriptionID string, 
 
 	// Return DB
 	return &resp.SQLDatabaseGetResults, nil
+}
+
+// GetCosmosDBSQLContainer is a helper function that gets a SQL container.
+// This function would fail the test if there is an error.
+//
+// Deprecated: Use [GetCosmosDBSQLContainerContext] instead.
+func GetCosmosDBSQLContainer(t testing.TestingT, subscriptionID string, resourceGroupName string, accountName string, databaseName string, containerName string) *armcosmos.SQLContainerGetResults {
+	return GetCosmosDBSQLContainerContext(t, context.Background(), subscriptionID, resourceGroupName, accountName, databaseName, containerName)
+}
+
+// GetCosmosDBSQLContainerE is a helper function that gets a SQL container.
+//
+// Deprecated: Use [GetCosmosDBSQLContainerContextE] instead.
+func GetCosmosDBSQLContainerE(subscriptionID string, resourceGroupName string, accountName string, databaseName string, containerName string) (*armcosmos.SQLContainerGetResults, error) {
+	return GetCosmosDBSQLContainerContextE(context.Background(), subscriptionID, resourceGroupName, accountName, databaseName, containerName)
 }
 
 // GetCosmosDBSQLContainerContext is a helper function that gets a SQL container.
@@ -157,6 +202,21 @@ func GetCosmosDBSQLContainerContextE(ctx context.Context, subscriptionID string,
 	return &resp.SQLContainerGetResults, nil
 }
 
+// GetCosmosDBSQLDatabaseThroughput is a helper function that gets a SQL database throughput configuration.
+// This function would fail the test if there is an error.
+//
+// Deprecated: Use [GetCosmosDBSQLDatabaseThroughputContext] instead.
+func GetCosmosDBSQLDatabaseThroughput(t testing.TestingT, subscriptionID string, resourceGroupName string, accountName string, databaseName string) *armcosmos.ThroughputSettingsGetResults {
+	return GetCosmosDBSQLDatabaseThroughputContext(t, context.Background(), subscriptionID, resourceGroupName, accountName, databaseName)
+}
+
+// GetCosmosDBSQLDatabaseThroughputE is a helper function that gets a SQL database throughput configuration.
+//
+// Deprecated: Use [GetCosmosDBSQLDatabaseThroughputContextE] instead.
+func GetCosmosDBSQLDatabaseThroughputE(subscriptionID string, resourceGroupName string, accountName string, databaseName string) (*armcosmos.ThroughputSettingsGetResults, error) {
+	return GetCosmosDBSQLDatabaseThroughputContextE(context.Background(), subscriptionID, resourceGroupName, accountName, databaseName)
+}
+
 // GetCosmosDBSQLDatabaseThroughputContext is a helper function that gets a SQL database throughput configuration.
 // This function would fail the test if there is an error.
 // The ctx parameter supports cancellation and timeouts.
@@ -184,6 +244,21 @@ func GetCosmosDBSQLDatabaseThroughputContextE(ctx context.Context, subscriptionI
 
 	// Return throughput config
 	return &resp.ThroughputSettingsGetResults, nil
+}
+
+// GetCosmosDBSQLContainerThroughput is a helper function that gets a SQL container throughput configuration.
+// This function would fail the test if there is an error.
+//
+// Deprecated: Use [GetCosmosDBSQLContainerThroughputContext] instead.
+func GetCosmosDBSQLContainerThroughput(t testing.TestingT, subscriptionID string, resourceGroupName string, accountName string, databaseName string, containerName string) *armcosmos.ThroughputSettingsGetResults {
+	return GetCosmosDBSQLContainerThroughputContext(t, context.Background(), subscriptionID, resourceGroupName, accountName, databaseName, containerName)
+}
+
+// GetCosmosDBSQLContainerThroughputE is a helper function that gets a SQL container throughput configuration.
+//
+// Deprecated: Use [GetCosmosDBSQLContainerThroughputContextE] instead.
+func GetCosmosDBSQLContainerThroughputE(subscriptionID string, resourceGroupName string, accountName string, databaseName string, containerName string) (*armcosmos.ThroughputSettingsGetResults, error) {
+	return GetCosmosDBSQLContainerThroughputContextE(context.Background(), subscriptionID, resourceGroupName, accountName, databaseName, containerName)
 }
 
 // GetCosmosDBSQLContainerThroughputContext is a helper function that gets a SQL container throughput configuration.

--- a/modules/azure/disk.go
+++ b/modules/azure/disk.go
@@ -8,6 +8,23 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// DiskExists indicates whether the specified Azure Managed Disk exists.
+// This function would fail the test if there is an error.
+//
+// Deprecated: Use [DiskExistsContext] instead.
+func DiskExists(t testing.TestingT, diskName string, resGroupName string, subscriptionID string) bool {
+	t.Helper()
+
+	return DiskExistsContext(t, context.Background(), diskName, resGroupName, subscriptionID)
+}
+
+// DiskExistsE indicates whether the specified Azure Managed Disk exists in the specified Azure Resource Group.
+//
+// Deprecated: Use [DiskExistsContextE] instead.
+func DiskExistsE(diskName string, resGroupName string, subscriptionID string) (bool, error) {
+	return DiskExistsContextE(context.Background(), diskName, resGroupName, subscriptionID)
+}
+
 // DiskExistsContext indicates whether the specified Azure Managed Disk exists.
 // This function would fail the test if there is an error.
 // The ctx parameter supports cancellation and timeouts.
@@ -33,6 +50,23 @@ func DiskExistsContextE(ctx context.Context, diskName string, resGroupName strin
 	}
 
 	return true, nil
+}
+
+// GetDisk returns a Disk in the specified Azure Resource Group.
+// This function would fail the test if there is an error.
+//
+// Deprecated: Use [GetDiskContext] instead.
+func GetDisk(t testing.TestingT, diskName string, resGroupName string, subscriptionID string) *armcompute.Disk {
+	t.Helper()
+
+	return GetDiskContext(t, context.Background(), diskName, resGroupName, subscriptionID)
+}
+
+// GetDiskE returns a Disk in the specified Azure Resource Group.
+//
+// Deprecated: Use [GetDiskContextE] instead.
+func GetDiskE(diskName string, resGroupName string, subscriptionID string) (*armcompute.Disk, error) {
+	return GetDiskContextE(context.Background(), diskName, resGroupName, subscriptionID)
 }
 
 // GetDiskContext returns a Disk in the specified Azure Resource Group.

--- a/modules/azure/loadbalancer.go
+++ b/modules/azure/loadbalancer.go
@@ -8,6 +8,23 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// LoadBalancerExists indicates whether the specified Load Balancer exists.
+// This function would fail the test if there is an error.
+//
+// Deprecated: Use [LoadBalancerExistsContext] instead.
+func LoadBalancerExists(t testing.TestingT, loadBalancerName string, resourceGroupName string, subscriptionID string) bool {
+	t.Helper()
+
+	return LoadBalancerExistsContext(t, context.Background(), loadBalancerName, resourceGroupName, subscriptionID)
+}
+
+// LoadBalancerExistsE indicates whether the specified Load Balancer exists.
+//
+// Deprecated: Use [LoadBalancerExistsContextE] instead.
+func LoadBalancerExistsE(loadBalancerName string, resourceGroupName string, subscriptionID string) (bool, error) {
+	return LoadBalancerExistsContextE(context.Background(), loadBalancerName, resourceGroupName, subscriptionID)
+}
+
 // LoadBalancerExistsContext indicates whether the specified Load Balancer exists.
 // This function would fail the test if there is an error.
 // The ctx parameter supports cancellation and timeouts.
@@ -33,6 +50,23 @@ func LoadBalancerExistsContextE(ctx context.Context, loadBalancerName string, re
 	}
 
 	return true, nil
+}
+
+// GetLoadBalancerFrontendIPConfigNames gets a list of the Frontend IP Configuration Names for the Load Balancer.
+// This function would fail the test if there is an error.
+//
+// Deprecated: Use [GetLoadBalancerFrontendIPConfigNamesContext] instead.
+func GetLoadBalancerFrontendIPConfigNames(t testing.TestingT, loadBalancerName string, resourceGroupName string, subscriptionID string) []string {
+	t.Helper()
+
+	return GetLoadBalancerFrontendIPConfigNamesContext(t, context.Background(), loadBalancerName, resourceGroupName, subscriptionID)
+}
+
+// GetLoadBalancerFrontendIPConfigNamesE gets a list of the Frontend IP Configuration Names for the Load Balancer.
+//
+// Deprecated: Use [GetLoadBalancerFrontendIPConfigNamesContextE] instead.
+func GetLoadBalancerFrontendIPConfigNamesE(loadBalancerName string, resourceGroupName string, subscriptionID string) ([]string, error) {
+	return GetLoadBalancerFrontendIPConfigNamesContextE(context.Background(), loadBalancerName, resourceGroupName, subscriptionID)
 }
 
 // GetLoadBalancerFrontendIPConfigNamesContext gets a list of the Frontend IP Configuration Names for the Load Balancer.
@@ -71,6 +105,23 @@ func GetLoadBalancerFrontendIPConfigNamesContextE(ctx context.Context, loadBalan
 	}
 
 	return configNames, nil
+}
+
+// GetIPOfLoadBalancerFrontendIPConfig gets the IP and LoadBalancerIPType for the specified Load Balancer Frontend IP Configuration.
+// This function would fail the test if there is an error.
+//
+// Deprecated: Use [GetIPOfLoadBalancerFrontendIPConfigContext] instead.
+func GetIPOfLoadBalancerFrontendIPConfig(t testing.TestingT, feConfigName string, loadBalancerName string, resourceGroupName string, subscriptionID string) (ipAddress string, publicOrPrivate LoadBalancerIPType) {
+	t.Helper()
+
+	return GetIPOfLoadBalancerFrontendIPConfigContext(t, context.Background(), feConfigName, loadBalancerName, resourceGroupName, subscriptionID)
+}
+
+// GetIPOfLoadBalancerFrontendIPConfigE gets the IP and LoadBalancerIPType for the specified Load Balancer Frontend IP Configuration.
+//
+// Deprecated: Use [GetIPOfLoadBalancerFrontendIPConfigContextE] instead.
+func GetIPOfLoadBalancerFrontendIPConfigE(feConfigName string, loadBalancerName string, resourceGroupName string, subscriptionID string) (ipAddress string, publicOrPrivate LoadBalancerIPType, err1 error) {
+	return GetIPOfLoadBalancerFrontendIPConfigContextE(context.Background(), feConfigName, loadBalancerName, resourceGroupName, subscriptionID)
 }
 
 // GetIPOfLoadBalancerFrontendIPConfigContext gets the IP and LoadBalancerIPType for the specified Load Balancer Frontend IP Configuration.
@@ -113,6 +164,23 @@ func GetIPOfLoadBalancerFrontendIPConfigContextE(ctx context.Context, feConfigNa
 
 	// Return the Private IP as there are no other option available
 	return *feProps.PrivateIPAddress, PrivateIP, nil
+}
+
+// GetLoadBalancerFrontendIPConfig gets the specified Load Balancer Frontend IP Configuration network resource.
+// This function would fail the test if there is an error.
+//
+// Deprecated: Use [GetLoadBalancerFrontendIPConfigContext] instead.
+func GetLoadBalancerFrontendIPConfig(t testing.TestingT, feConfigName string, loadBalancerName string, resourceGroupName string, subscriptionID string) *armnetwork.FrontendIPConfiguration {
+	t.Helper()
+
+	return GetLoadBalancerFrontendIPConfigContext(t, context.Background(), feConfigName, loadBalancerName, resourceGroupName, subscriptionID)
+}
+
+// GetLoadBalancerFrontendIPConfigE gets the specified Load Balancer Frontend IP Configuration network resource.
+//
+// Deprecated: Use [GetLoadBalancerFrontendIPConfigContextE] instead.
+func GetLoadBalancerFrontendIPConfigE(feConfigName string, loadBalancerName string, resourceGroupName string, subscriptionID string) (*armnetwork.FrontendIPConfiguration, error) {
+	return GetLoadBalancerFrontendIPConfigContextE(context.Background(), feConfigName, loadBalancerName, resourceGroupName, subscriptionID)
 }
 
 // GetLoadBalancerFrontendIPConfigContext gets the specified Load Balancer Frontend IP Configuration network resource.
@@ -162,6 +230,23 @@ func GetLoadBalancerFrontendIPConfigClientContextE(ctx context.Context, subscrip
 // Deprecated: Use [GetLoadBalancerFrontendIPConfigClientContextE] instead.
 func GetLoadBalancerFrontendIPConfigClientE(subscriptionID string) (*armnetwork.LoadBalancerFrontendIPConfigurationsClient, error) {
 	return GetLoadBalancerFrontendIPConfigClientContextE(context.Background(), subscriptionID)
+}
+
+// GetLoadBalancer gets a Load Balancer network resource in the specified Azure Resource Group.
+// This function would fail the test if there is an error.
+//
+// Deprecated: Use [GetLoadBalancerContext] instead.
+func GetLoadBalancer(t testing.TestingT, loadBalancerName string, resourceGroupName string, subscriptionID string) *armnetwork.LoadBalancer {
+	t.Helper()
+
+	return GetLoadBalancerContext(t, context.Background(), loadBalancerName, resourceGroupName, subscriptionID)
+}
+
+// GetLoadBalancerE gets a Load Balancer network resource in the specified Azure Resource Group.
+//
+// Deprecated: Use [GetLoadBalancerContextE] instead.
+func GetLoadBalancerE(loadBalancerName string, resourceGroupName string, subscriptionID string) (*armnetwork.LoadBalancer, error) {
+	return GetLoadBalancerContextE(context.Background(), loadBalancerName, resourceGroupName, subscriptionID)
 }
 
 // GetLoadBalancerContext gets a Load Balancer network resource in the specified Azure Resource Group.

--- a/modules/azure/networkinterface.go
+++ b/modules/azure/networkinterface.go
@@ -8,6 +8,23 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// NetworkInterfaceExists indicates whether the specified Azure Network Interface exists.
+// This function would fail the test if there is an error.
+//
+// Deprecated: Use [NetworkInterfaceExistsContext] instead.
+func NetworkInterfaceExists(t testing.TestingT, nicName string, resGroupName string, subscriptionID string) bool {
+	t.Helper()
+
+	return NetworkInterfaceExistsContext(t, context.Background(), nicName, resGroupName, subscriptionID)
+}
+
+// NetworkInterfaceExistsE indicates whether the specified Azure Network Interface exists.
+//
+// Deprecated: Use [NetworkInterfaceExistsContextE] instead.
+func NetworkInterfaceExistsE(nicName string, resGroupName string, subscriptionID string) (bool, error) {
+	return NetworkInterfaceExistsContextE(context.Background(), nicName, resGroupName, subscriptionID)
+}
+
 // NetworkInterfaceExistsContext indicates whether the specified Azure Network Interface exists.
 // This function would fail the test if there is an error.
 // The ctx parameter supports cancellation and timeouts.
@@ -34,6 +51,23 @@ func NetworkInterfaceExistsContextE(ctx context.Context, nicName string, resGrou
 	}
 
 	return true, nil
+}
+
+// GetNetworkInterfacePrivateIPs gets a list of the Private IPs of a Network Interface configs.
+// This function would fail the test if there is an error.
+//
+// Deprecated: Use [GetNetworkInterfacePrivateIPsContext] instead.
+func GetNetworkInterfacePrivateIPs(t testing.TestingT, nicName string, resGroupName string, subscriptionID string) []string {
+	t.Helper()
+
+	return GetNetworkInterfacePrivateIPsContext(t, context.Background(), nicName, resGroupName, subscriptionID)
+}
+
+// GetNetworkInterfacePrivateIPsE gets a list of the Private IPs of a Network Interface configs.
+//
+// Deprecated: Use [GetNetworkInterfacePrivateIPsContextE] instead.
+func GetNetworkInterfacePrivateIPsE(nicName string, resGroupName string, subscriptionID string) ([]string, error) {
+	return GetNetworkInterfacePrivateIPsContextE(context.Background(), nicName, resGroupName, subscriptionID)
 }
 
 // GetNetworkInterfacePrivateIPsContext gets a list of the Private IPs of a Network Interface configs.
@@ -65,6 +99,23 @@ func GetNetworkInterfacePrivateIPsContextE(ctx context.Context, nicName string, 
 	}
 
 	return privateIPs, nil
+}
+
+// GetNetworkInterfacePublicIPs returns a list of all the Public IPs found in the Network Interface configurations.
+// This function would fail the test if there is an error.
+//
+// Deprecated: Use [GetNetworkInterfacePublicIPsContext] instead.
+func GetNetworkInterfacePublicIPs(t testing.TestingT, nicName string, resGroupName string, subscriptionID string) []string {
+	t.Helper()
+
+	return GetNetworkInterfacePublicIPsContext(t, context.Background(), nicName, resGroupName, subscriptionID)
+}
+
+// GetNetworkInterfacePublicIPsE returns a list of all the Public IPs found in the Network Interface configurations.
+//
+// Deprecated: Use [GetNetworkInterfacePublicIPsContextE] instead.
+func GetNetworkInterfacePublicIPsE(nicName string, resGroupName string, subscriptionID string) ([]string, error) {
+	return GetNetworkInterfacePublicIPsContextE(context.Background(), nicName, resGroupName, subscriptionID)
 }
 
 // GetNetworkInterfacePublicIPsContext returns a list of all the Public IPs found in the Network Interface configurations.
@@ -110,6 +161,13 @@ func GetNetworkInterfacePublicIPsContextE(ctx context.Context, nicName string, r
 	return publicIPs, nil
 }
 
+// GetNetworkInterfaceConfigurationE gets a Network Interface IP Configuration in the specified Azure Resource Group.
+//
+// Deprecated: Use [GetNetworkInterfaceConfigurationContextE] instead.
+func GetNetworkInterfaceConfigurationE(nicName string, nicConfigName string, resGroupName string, subscriptionID string) (*armnetwork.InterfaceIPConfiguration, error) {
+	return GetNetworkInterfaceConfigurationContextE(context.Background(), nicName, nicConfigName, resGroupName, subscriptionID)
+}
+
 // GetNetworkInterfaceConfigurationContextE gets a Network Interface Configuration in the specified Azure Resource Group.
 // The ctx parameter supports cancellation and timeouts.
 func GetNetworkInterfaceConfigurationContextE(ctx context.Context, nicName string, nicConfigName string, resGroupName string, subscriptionID string) (*armnetwork.InterfaceIPConfiguration, error) {
@@ -145,6 +203,13 @@ func GetNetworkInterfaceConfigurationClientContextE(ctx context.Context, subscri
 // Deprecated: Use [GetNetworkInterfaceConfigurationClientContextE] instead.
 func GetNetworkInterfaceConfigurationClientE(subscriptionID string) (*armnetwork.InterfaceIPConfigurationsClient, error) {
 	return GetNetworkInterfaceConfigurationClientContextE(context.Background(), subscriptionID)
+}
+
+// GetNetworkInterfaceE gets a Network Interface in the specified Azure Resource Group.
+//
+// Deprecated: Use [GetNetworkInterfaceContextE] instead.
+func GetNetworkInterfaceE(nicName string, resGroupName string, subscriptionID string) (*armnetwork.Interface, error) {
+	return GetNetworkInterfaceContextE(context.Background(), nicName, resGroupName, subscriptionID)
 }
 
 // GetNetworkInterfaceContextE gets a Network Interface in the specified Azure Resource Group.

--- a/modules/azure/nsg.go
+++ b/modules/azure/nsg.go
@@ -130,6 +130,25 @@ func GetCustomNsgRulesClientE(subscriptionID string) (*armnetwork.SecurityRulesC
 	return GetCustomNsgRulesClientContextE(context.Background(), subscriptionID)
 }
 
+// GetAllNSGRules returns an NsgRuleSummaryList instance containing the combined "default" and "custom" rules
+// from a network security group.
+// This function would fail the test if there is an error.
+//
+// Deprecated: Use [GetAllNSGRulesContext] instead.
+func GetAllNSGRules(t testing.TestingT, resourceGroupName, nsgName, subscriptionID string) NsgRuleSummaryList {
+	t.Helper()
+
+	return GetAllNSGRulesContext(t, context.Background(), resourceGroupName, nsgName, subscriptionID)
+}
+
+// GetAllNSGRulesE returns an NsgRuleSummaryList instance containing the combined "default" and "custom" rules
+// from a network security group.
+//
+// Deprecated: Use [GetAllNSGRulesContextE] instead.
+func GetAllNSGRulesE(resourceGroupName, nsgName, subscriptionID string) (NsgRuleSummaryList, error) {
+	return GetAllNSGRulesContextE(context.Background(), resourceGroupName, nsgName, subscriptionID)
+}
+
 // GetAllNSGRulesContext returns an NsgRuleSummaryList instance containing the combined "default" and "custom" rules
 // from a network security group. The ctx parameter supports cancellation and timeouts.
 // This function would fail the test if there is an error.

--- a/modules/azure/publicaddress.go
+++ b/modules/azure/publicaddress.go
@@ -9,6 +9,23 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// PublicAddressExists indicates whether the specified Azure Public Address exists.
+// This function would fail the test if there is an error.
+//
+// Deprecated: Use [PublicAddressExistsContext] instead.
+func PublicAddressExists(t testing.TestingT, publicAddressName string, resGroupName string, subscriptionID string) bool {
+	t.Helper()
+
+	return PublicAddressExistsContext(t, context.Background(), publicAddressName, resGroupName, subscriptionID)
+}
+
+// PublicAddressExistsE indicates whether the specified Azure Public Address exists.
+//
+// Deprecated: Use [PublicAddressExistsContextE] instead.
+func PublicAddressExistsE(publicAddressName string, resGroupName string, subscriptionID string) (bool, error) {
+	return PublicAddressExistsContextE(context.Background(), publicAddressName, resGroupName, subscriptionID)
+}
+
 // PublicAddressExistsContext indicates whether the specified Azure Public Address exists.
 // This function would fail the test if there is an error.
 // The ctx parameter supports cancellation and timeouts.
@@ -36,6 +53,23 @@ func PublicAddressExistsContextE(ctx context.Context, publicAddressName string, 
 	return true, nil
 }
 
+// GetIPOfPublicIPAddressByName gets the IP of the specified Public IP Address.
+// This function would fail the test if there is an error.
+//
+// Deprecated: Use [GetIPOfPublicIPAddressByNameContext] instead.
+func GetIPOfPublicIPAddressByName(t testing.TestingT, publicAddressName string, resGroupName string, subscriptionID string) string {
+	t.Helper()
+
+	return GetIPOfPublicIPAddressByNameContext(t, context.Background(), publicAddressName, resGroupName, subscriptionID)
+}
+
+// GetIPOfPublicIPAddressByNameE gets the IP of the specified Public IP Address.
+//
+// Deprecated: Use [GetIPOfPublicIPAddressByNameContextE] instead.
+func GetIPOfPublicIPAddressByNameE(publicAddressName string, resGroupName string, subscriptionID string) (string, error) {
+	return GetIPOfPublicIPAddressByNameContextE(context.Background(), publicAddressName, resGroupName, subscriptionID)
+}
+
 // GetIPOfPublicIPAddressByNameContext gets the IP of the specified Public IP Address.
 // This function would fail the test if there is an error.
 // The ctx parameter supports cancellation and timeouts.
@@ -61,6 +95,24 @@ func GetIPOfPublicIPAddressByNameContextE(ctx context.Context, publicAddressName
 	}
 
 	return *pip.Properties.IPAddress, nil
+}
+
+// CheckPublicDNSNameAvailability checks whether a domain name in the cloudapp.azure.com zone
+// is available for use. This function would fail the test if there is an error.
+//
+// Deprecated: Use [CheckPublicDNSNameAvailabilityContext] instead.
+func CheckPublicDNSNameAvailability(t testing.TestingT, location string, domainNameLabel string, subscriptionID string) bool {
+	t.Helper()
+
+	return CheckPublicDNSNameAvailabilityContext(t, context.Background(), location, domainNameLabel, subscriptionID)
+}
+
+// CheckPublicDNSNameAvailabilityE checks whether a domain name in the cloudapp.azure.com zone
+// is available for use.
+//
+// Deprecated: Use [CheckPublicDNSNameAvailabilityContextE] instead.
+func CheckPublicDNSNameAvailabilityE(location string, domainNameLabel string, subscriptionID string) (bool, error) {
+	return CheckPublicDNSNameAvailabilityContextE(context.Background(), location, domainNameLabel, subscriptionID)
 }
 
 // CheckPublicDNSNameAvailabilityContext checks whether a domain name in the cloudapp.azure.com zone
@@ -92,6 +144,13 @@ func CheckPublicDNSNameAvailabilityContextE(ctx context.Context, location string
 	}
 
 	return *res.Available, nil
+}
+
+// GetPublicIPAddressE gets a Public IP Address in the specified Azure Resource Group.
+//
+// Deprecated: Use [GetPublicIPAddressContextE] instead.
+func GetPublicIPAddressE(publicIPAddressName string, resGroupName string, subscriptionID string) (*armnetwork.PublicIPAddress, error) {
+	return GetPublicIPAddressContextE(context.Background(), publicIPAddressName, resGroupName, subscriptionID)
 }
 
 // GetPublicIPAddressContextE gets a Public IP Address in the specified Azure Resource Group.

--- a/modules/azure/storage.go
+++ b/modules/azure/storage.go
@@ -9,6 +9,23 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// StorageAccountExists indicates whether the storage account name exactly matches; otherwise false.
+// This function would fail the test if there is an error.
+//
+// Deprecated: Use [StorageAccountExistsContext] instead.
+func StorageAccountExists(t testing.TestingT, storageAccountName string, resourceGroupName string, subscriptionID string) bool {
+	t.Helper()
+
+	return StorageAccountExistsContext(t, context.Background(), storageAccountName, resourceGroupName, subscriptionID)
+}
+
+// StorageAccountExistsE indicates whether the storage account name exactly matches; otherwise false.
+//
+// Deprecated: Use [StorageAccountExistsContextE] instead.
+func StorageAccountExistsE(storageAccountName string, resourceGroupName string, subscriptionID string) (bool, error) {
+	return StorageAccountExistsContextE(context.Background(), storageAccountName, resourceGroupName, subscriptionID)
+}
+
 // StorageAccountExistsContext indicates whether the storage account name exactly matches; otherwise false.
 // This function would fail the test if there is an error.
 // The ctx parameter supports cancellation and timeouts.
@@ -21,6 +38,23 @@ func StorageAccountExistsContext(t testing.TestingT, ctx context.Context, storag
 	return result
 }
 
+// StorageBlobContainerExists returns true if the container name exactly matches; otherwise false.
+// This function would fail the test if there is an error.
+//
+// Deprecated: Use [StorageBlobContainerExistsContext] instead.
+func StorageBlobContainerExists(t testing.TestingT, containerName string, storageAccountName string, resourceGroupName string, subscriptionID string) bool {
+	t.Helper()
+
+	return StorageBlobContainerExistsContext(t, context.Background(), containerName, storageAccountName, resourceGroupName, subscriptionID)
+}
+
+// StorageBlobContainerExistsE returns true if the container name exactly matches; otherwise false.
+//
+// Deprecated: Use [StorageBlobContainerExistsContextE] instead.
+func StorageBlobContainerExistsE(containerName string, storageAccountName string, resourceGroupName string, subscriptionID string) (bool, error) {
+	return StorageBlobContainerExistsContextE(context.Background(), containerName, storageAccountName, resourceGroupName, subscriptionID)
+}
+
 // StorageBlobContainerExistsContext returns true if the container name exactly matches; otherwise false.
 // This function would fail the test if there is an error.
 // The ctx parameter supports cancellation and timeouts.
@@ -31,6 +65,23 @@ func StorageBlobContainerExistsContext(t testing.TestingT, ctx context.Context, 
 	require.NoError(t, err)
 
 	return result
+}
+
+// StorageFileShareExists returns true if the file share name exactly matches; otherwise false.
+// This function would fail the test if there is an error.
+//
+// Deprecated: Use [StorageFileShareExistsContext] instead.
+func StorageFileShareExists(t testing.TestingT, fileShareName string, storageAccountName string, resourceGroupName string, subscriptionID string) bool {
+	t.Helper()
+
+	return StorageFileShareExistsContext(t, context.Background(), fileShareName, storageAccountName, resourceGroupName, subscriptionID)
+}
+
+// StorageFileShareExistsE returns true if the file share name exactly matches; otherwise false.
+//
+// Deprecated: Use [StorageFileShareExistsContextE] instead.
+func StorageFileShareExistsE(fileShareName string, storageAccountName string, resourceGroupName string, subscriptionID string) (bool, error) {
+	return StorageFileShareExistsContextE(context.Background(), fileShareName, storageAccountName, resourceGroupName, subscriptionID)
 }
 
 // StorageFileShareExistsContext returns true if the file share name exactly matches; otherwise false.
@@ -60,6 +111,23 @@ func StorageFileShareExistsContextE(ctx context.Context, fileShareName string, s
 	return true, nil
 }
 
+// GetStorageBlobContainerPublicAccess indicates whether a storage container has public access; otherwise false.
+// This function would fail the test if there is an error.
+//
+// Deprecated: Use [GetStorageBlobContainerPublicAccessContext] instead.
+func GetStorageBlobContainerPublicAccess(t testing.TestingT, containerName string, storageAccountName string, resourceGroupName string, subscriptionID string) bool {
+	t.Helper()
+
+	return GetStorageBlobContainerPublicAccessContext(t, context.Background(), containerName, storageAccountName, resourceGroupName, subscriptionID)
+}
+
+// GetStorageBlobContainerPublicAccessE indicates whether a storage container has public access; otherwise false.
+//
+// Deprecated: Use [GetStorageBlobContainerPublicAccessContextE] instead.
+func GetStorageBlobContainerPublicAccessE(containerName string, storageAccountName string, resourceGroupName string, subscriptionID string) (bool, error) {
+	return GetStorageBlobContainerPublicAccessContextE(context.Background(), containerName, storageAccountName, resourceGroupName, subscriptionID)
+}
+
 // GetStorageBlobContainerPublicAccessContext indicates whether a storage container has public access; otherwise false.
 // This function would fail the test if there is an error.
 // The ctx parameter supports cancellation and timeouts.
@@ -70,6 +138,23 @@ func GetStorageBlobContainerPublicAccessContext(t testing.TestingT, ctx context.
 	require.NoError(t, err)
 
 	return result
+}
+
+// GetStorageAccountKind returns one of Storage, StorageV2, BlobStorage, FileStorage, or BlockBlobStorage.
+// This function would fail the test if there is an error.
+//
+// Deprecated: Use [GetStorageAccountKindContext] instead.
+func GetStorageAccountKind(t testing.TestingT, storageAccountName string, resourceGroupName string, subscriptionID string) string {
+	t.Helper()
+
+	return GetStorageAccountKindContext(t, context.Background(), storageAccountName, resourceGroupName, subscriptionID)
+}
+
+// GetStorageAccountKindE returns one of Storage, StorageV2, BlobStorage, FileStorage, or BlockBlobStorage.
+//
+// Deprecated: Use [GetStorageAccountKindContextE] instead.
+func GetStorageAccountKindE(storageAccountName string, resourceGroupName string, subscriptionID string) (string, error) {
+	return GetStorageAccountKindContextE(context.Background(), storageAccountName, resourceGroupName, subscriptionID)
 }
 
 // GetStorageAccountKindContext returns one of Storage, StorageV2, BlobStorage, FileStorage, or BlockBlobStorage.
@@ -84,6 +169,23 @@ func GetStorageAccountKindContext(t testing.TestingT, ctx context.Context, stora
 	return result
 }
 
+// GetStorageAccountSkuTier returns the storage account sku tier as Standard or Premium.
+// This function would fail the test if there is an error.
+//
+// Deprecated: Use [GetStorageAccountSkuTierContext] instead.
+func GetStorageAccountSkuTier(t testing.TestingT, storageAccountName string, resourceGroupName string, subscriptionID string) string {
+	t.Helper()
+
+	return GetStorageAccountSkuTierContext(t, context.Background(), storageAccountName, resourceGroupName, subscriptionID)
+}
+
+// GetStorageAccountSkuTierE returns the storage account sku tier as Standard or Premium.
+//
+// Deprecated: Use [GetStorageAccountSkuTierContextE] instead.
+func GetStorageAccountSkuTierE(storageAccountName string, resourceGroupName string, subscriptionID string) (string, error) {
+	return GetStorageAccountSkuTierContextE(context.Background(), storageAccountName, resourceGroupName, subscriptionID)
+}
+
 // GetStorageAccountSkuTierContext returns the storage account sku tier as Standard or Premium.
 // This function would fail the test if there is an error.
 // The ctx parameter supports cancellation and timeouts.
@@ -96,6 +198,23 @@ func GetStorageAccountSkuTierContext(t testing.TestingT, ctx context.Context, st
 	return result
 }
 
+// GetStorageDNSString builds and returns the storage account dns string if the storage account exists.
+// This function would fail the test if there is an error.
+//
+// Deprecated: Use [GetStorageDNSStringContext] instead.
+func GetStorageDNSString(t testing.TestingT, storageAccountName string, resourceGroupName string, subscriptionID string) string {
+	t.Helper()
+
+	return GetStorageDNSStringContext(t, context.Background(), storageAccountName, resourceGroupName, subscriptionID)
+}
+
+// GetStorageDNSStringE builds and returns the storage account dns string if the storage account exists.
+//
+// Deprecated: Use [GetStorageDNSStringContextE] instead.
+func GetStorageDNSStringE(storageAccountName string, resourceGroupName string, subscriptionID string) (string, error) {
+	return GetStorageDNSStringContextE(context.Background(), storageAccountName, resourceGroupName, subscriptionID)
+}
+
 // GetStorageDNSStringContext builds and returns the storage account dns string if the storage account exists.
 // This function would fail the test if there is an error.
 // The ctx parameter supports cancellation and timeouts.
@@ -106,6 +225,13 @@ func GetStorageDNSStringContext(t testing.TestingT, ctx context.Context, storage
 	require.NoError(t, err)
 
 	return result
+}
+
+// GetStorageAccountE gets a storage account; otherwise error.
+//
+// Deprecated: Use [GetStorageAccountContextE] instead.
+func GetStorageAccountE(storageAccountName, resourceGroupName, subscriptionID string) (*armstorage.Account, error) {
+	return GetStorageAccountContextE(context.Background(), storageAccountName, resourceGroupName, subscriptionID)
 }
 
 // StorageAccountExistsContextE indicates whether the storage account name exists; otherwise false.
@@ -197,6 +323,13 @@ func GetStorageAccountSkuTierContextE(ctx context.Context, storageAccountName, r
 	return ExtractStorageAccountSkuTier(storageAccount), nil
 }
 
+// GetStorageBlobContainerE returns the Blob container client.
+//
+// Deprecated: Use [GetStorageBlobContainerContextE] instead.
+func GetStorageBlobContainerE(containerName, storageAccountName, resourceGroupName, subscriptionID string) (*armstorage.BlobContainer, error) {
+	return GetStorageBlobContainerContextE(context.Background(), containerName, storageAccountName, resourceGroupName, subscriptionID)
+}
+
 // GetStorageBlobContainerContextE returns the Blob container client.
 // The ctx parameter supports cancellation and timeouts.
 func GetStorageBlobContainerContextE(ctx context.Context, containerName, storageAccountName, resourceGroupName, subscriptionID string) (*armstorage.BlobContainer, error) {
@@ -218,6 +351,13 @@ func GetStorageBlobContainerContextE(ctx context.Context, containerName, storage
 	return FetchBlobContainer(ctx, client, resourceGroupName, storageAccountName, containerName)
 }
 
+// GetStorageAccountPropertyE returns StorageAccount properties.
+//
+// Deprecated: Use [GetStorageAccountPropertyContextE] instead.
+func GetStorageAccountPropertyE(storageAccountName, resourceGroupName, subscriptionID string) (*armstorage.Account, error) {
+	return GetStorageAccountPropertyContextE(context.Background(), storageAccountName, resourceGroupName, subscriptionID)
+}
+
 // GetStorageAccountPropertyContextE returns StorageAccount properties.
 // The ctx parameter supports cancellation and timeouts.
 func GetStorageAccountPropertyContextE(ctx context.Context, storageAccountName, resourceGroupName, subscriptionID string) (*armstorage.Account, error) {
@@ -237,6 +377,23 @@ func GetStorageAccountPropertyContextE(ctx context.Context, storageAccountName, 
 	}
 
 	return FetchStorageAccountProperties(ctx, client, resourceGroupName, storageAccountName)
+}
+
+// GetStorageFileShare returns the specified file share.
+// This function would fail the test if there is an error.
+//
+// Deprecated: Use [GetStorageFileShareContext] instead.
+func GetStorageFileShare(t testing.TestingT, fileShareName, storageAccountName, resourceGroupName, subscriptionID string) *armstorage.FileShare {
+	t.Helper()
+
+	return GetStorageFileShareContext(t, context.Background(), fileShareName, storageAccountName, resourceGroupName, subscriptionID)
+}
+
+// GetStorageFileShareE returns the specified file share.
+//
+// Deprecated: Use [GetStorageFileShareContextE] instead.
+func GetStorageFileShareE(fileShareName, storageAccountName, resourceGroupName, subscriptionID string) (*armstorage.FileShare, error) {
+	return GetStorageFileShareContextE(context.Background(), fileShareName, storageAccountName, resourceGroupName, subscriptionID)
 }
 
 // GetStorageFileShareContext returns the specified file share.
@@ -326,6 +483,13 @@ func ExtractStorageAccountSkuTier(account *armstorage.Account) string {
 	}
 
 	return string(*account.SKU.Tier)
+}
+
+// GetStorageAccountPrimaryBlobEndpointE gets the storage account blob endpoint as URI string.
+//
+// Deprecated: Use [GetStorageAccountPrimaryBlobEndpointContextE] instead.
+func GetStorageAccountPrimaryBlobEndpointE(storageAccountName, resourceGroupName, subscriptionID string) (string, error) {
+	return GetStorageAccountPrimaryBlobEndpointContextE(context.Background(), storageAccountName, resourceGroupName, subscriptionID)
 }
 
 // GetStorageAccountPrimaryBlobEndpointContextE gets the storage account blob endpoint as URI string.

--- a/modules/azure/virtualnetwork.go
+++ b/modules/azure/virtualnetwork.go
@@ -9,6 +9,23 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// VirtualNetworkExists indicates whether the specified Azure Virtual Network exists.
+// This function would fail the test if there is an error.
+//
+// Deprecated: Use [VirtualNetworkExistsContext] instead.
+func VirtualNetworkExists(t testing.TestingT, vnetName string, resGroupName string, subscriptionID string) bool {
+	t.Helper()
+
+	return VirtualNetworkExistsContext(t, context.Background(), vnetName, resGroupName, subscriptionID)
+}
+
+// VirtualNetworkExistsE indicates whether the specified Azure Virtual Network exists.
+//
+// Deprecated: Use [VirtualNetworkExistsContextE] instead.
+func VirtualNetworkExistsE(vnetName string, resGroupName string, subscriptionID string) (bool, error) {
+	return VirtualNetworkExistsContextE(context.Background(), vnetName, resGroupName, subscriptionID)
+}
+
 // VirtualNetworkExistsContext indicates whether the specified Azure Virtual Network exists.
 // This function would fail the test if there is an error.
 // The ctx parameter supports cancellation and timeouts.
@@ -34,6 +51,23 @@ func VirtualNetworkExistsContextE(ctx context.Context, vnetName string, resGroup
 	return true, nil
 }
 
+// SubnetExists indicates whether the specified Azure Virtual Network Subnet exists.
+// This function would fail the test if there is an error.
+//
+// Deprecated: Use [SubnetExistsContext] instead.
+func SubnetExists(t testing.TestingT, subnetName string, vnetName string, resGroupName string, subscriptionID string) bool {
+	t.Helper()
+
+	return SubnetExistsContext(t, context.Background(), subnetName, vnetName, resGroupName, subscriptionID)
+}
+
+// SubnetExistsE indicates whether the specified Azure Virtual Network Subnet exists.
+//
+// Deprecated: Use [SubnetExistsContextE] instead.
+func SubnetExistsE(subnetName string, vnetName string, resGroupName string, subscriptionID string) (bool, error) {
+	return SubnetExistsContextE(context.Background(), subnetName, vnetName, resGroupName, subscriptionID)
+}
+
 // SubnetExistsContext indicates whether the specified Azure Virtual Network Subnet exists.
 // This function would fail the test if there is an error.
 // The ctx parameter supports cancellation and timeouts.
@@ -57,6 +91,23 @@ func SubnetExistsContextE(ctx context.Context, subnetName string, vnetName strin
 	}
 
 	return true, nil
+}
+
+// CheckSubnetContainsIP checks if the Private IP is contained in the Subnet Address Range.
+// This function would fail the test if there is an error.
+//
+// Deprecated: Use [CheckSubnetContainsIPContext] instead.
+func CheckSubnetContainsIP(t testing.TestingT, ipAddress string, subnetName string, vnetName string, resGroupName string, subscriptionID string) bool {
+	t.Helper()
+
+	return CheckSubnetContainsIPContext(t, context.Background(), ipAddress, subnetName, vnetName, resGroupName, subscriptionID)
+}
+
+// CheckSubnetContainsIPE checks if the Private IP is contained in the Subnet Address Range.
+//
+// Deprecated: Use [CheckSubnetContainsIPContextE] instead.
+func CheckSubnetContainsIPE(ipAddress string, subnetName string, vnetName string, resGroupName string, subscriptionID string) (bool, error) {
+	return CheckSubnetContainsIPContextE(context.Background(), ipAddress, subnetName, vnetName, resGroupName, subscriptionID)
 }
 
 // CheckSubnetContainsIPContext checks if the Private IP is contained in the Subnet Address Range.
@@ -94,6 +145,23 @@ func CheckSubnetContainsIPContextE(ctx context.Context, ipAddress string, subnet
 	}
 
 	return ipNet.Contains(ip), nil
+}
+
+// GetVirtualNetworkSubnets gets all Subnet names and their respective address prefixes in the
+// specified Virtual Network. This function would fail the test if there is an error.
+//
+// Deprecated: Use [GetVirtualNetworkSubnetsContext] instead.
+func GetVirtualNetworkSubnets(t testing.TestingT, vnetName string, resGroupName string, subscriptionID string) map[string]string {
+	t.Helper()
+
+	return GetVirtualNetworkSubnetsContext(t, context.Background(), vnetName, resGroupName, subscriptionID)
+}
+
+// GetVirtualNetworkSubnetsE gets all Subnet names and their respective address prefixes in the specified Virtual Network.
+//
+// Deprecated: Use [GetVirtualNetworkSubnetsContextE] instead.
+func GetVirtualNetworkSubnetsE(vnetName string, resGroupName string, subscriptionID string) (map[string]string, error) {
+	return GetVirtualNetworkSubnetsContextE(context.Background(), vnetName, resGroupName, subscriptionID)
 }
 
 // GetVirtualNetworkSubnetsContext gets all Subnet names and their respective address prefixes in the
@@ -135,6 +203,23 @@ func GetVirtualNetworkSubnetsContextE(ctx context.Context, vnetName string, resG
 	return subNetDetails, nil
 }
 
+// GetVirtualNetworkDNSServerIPs gets a list of all Virtual Network DNS server IPs.
+// This function would fail the test if there is an error.
+//
+// Deprecated: Use [GetVirtualNetworkDNSServerIPsContext] instead.
+func GetVirtualNetworkDNSServerIPs(t testing.TestingT, vnetName string, resGroupName string, subscriptionID string) []string {
+	t.Helper()
+
+	return GetVirtualNetworkDNSServerIPsContext(t, context.Background(), vnetName, resGroupName, subscriptionID)
+}
+
+// GetVirtualNetworkDNSServerIPsE gets a list of all Virtual Network DNS server IPs.
+//
+// Deprecated: Use [GetVirtualNetworkDNSServerIPsContextE] instead.
+func GetVirtualNetworkDNSServerIPsE(vnetName string, resGroupName string, subscriptionID string) ([]string, error) {
+	return GetVirtualNetworkDNSServerIPsContextE(context.Background(), vnetName, resGroupName, subscriptionID)
+}
+
 // GetVirtualNetworkDNSServerIPsContext gets a list of all Virtual Network DNS server IPs.
 // This function would fail the test if there is an error.
 // The ctx parameter supports cancellation and timeouts.
@@ -163,6 +248,13 @@ func GetVirtualNetworkDNSServerIPsContextE(ctx context.Context, vnetName string,
 	}
 
 	return dnsServers, nil
+}
+
+// GetSubnetE gets a subnet.
+//
+// Deprecated: Use [GetSubnetContextE] instead.
+func GetSubnetE(subnetName string, vnetName string, resGroupName string, subscriptionID string) (*armnetwork.Subnet, error) {
+	return GetSubnetContextE(context.Background(), subnetName, vnetName, resGroupName, subscriptionID)
 }
 
 // GetSubnetContextE gets a subnet.
@@ -200,6 +292,13 @@ func GetSubnetClientContextE(ctx context.Context, subscriptionID string) (*armne
 // Deprecated: Use [GetSubnetClientContextE] instead.
 func GetSubnetClientE(subscriptionID string) (*armnetwork.SubnetsClient, error) {
 	return GetSubnetClientContextE(context.Background(), subscriptionID)
+}
+
+// GetVirtualNetworkE gets Virtual Network in the specified Azure Resource Group.
+//
+// Deprecated: Use [GetVirtualNetworkContextE] instead.
+func GetVirtualNetworkE(vnetName string, resGroupName string, subscriptionID string) (*armnetwork.VirtualNetwork, error) {
+	return GetVirtualNetworkContextE(context.Background(), vnetName, resGroupName, subscriptionID)
 }
 
 // GetVirtualNetworkContextE gets Virtual Network in the specified Azure Resource Group.


### PR DESCRIPTION
## Summary

Restores deprecated non-Context wrapper functions that were deleted in PRs #1740-#1742 during the Azure SDK migration. These wrappers delegate to Context variants with `context.Background()` for backward compatibility, following the pattern established in `servicebus.go`.

Note: the wrappers return new SDK types (e.g., `*armcompute.VirtualMachine`) since the Context functions they delegate to were already migrated. Consumers who only call these functions without accessing fields will compile as before. Those accessing fields will need to update to the new SDK's nested `Properties` pattern.

**Files changed (10):**
- `compute.go` — restored ~22 deprecated wrappers
- `disk.go` — restored ~4 deprecated wrappers
- `availabilityset.go` — restored ~9 deprecated wrappers
- `nsg.go` — restored ~2 deprecated wrappers
- `networkinterface.go` — restored ~6 deprecated wrappers
- `publicaddress.go` — restored ~7 deprecated wrappers
- `loadbalancer.go` — restored ~10 deprecated wrappers
- `virtualnetwork.go` — restored ~12 deprecated wrappers
- `storage.go` — restored ~18 deprecated wrappers
- `cosmosdb.go` — restored ~10 deprecated wrappers

No existing functions modified. No test changes. Purely additive.

## Validated

- [x] `go build ./...`
- [x] `go test -tags azure -c -o /dev/null ./modules/azure/...`
- [x] `go test ./modules/azure/...` — all unit tests pass
- [x] `make lint` — 0 issues