### PR TITLE
chore: marked as deprecated functions which have context variant

### DIFF
--- a/modules/aws/account.go
+++ b/modules/aws/account.go
@@ -95,6 +95,15 @@ func NewStsClientContext(t testing.TestingT, ctx context.Context, region string)
 	return client
 }
 
+// NewStsClient creates a new STS client.
+//
+// Deprecated: Use [NewStsClientContext] instead.
+func NewStsClient(t testing.TestingT, region string) *sts.Client {
+	t.Helper()
+
+	return NewStsClientContext(t, context.Background(), region)
+}
+
 // NewStsClientE creates a new STS client.
 //
 // Deprecated: Use [NewStsClientContextE] instead.

--- a/modules/aws/asg.go
+++ b/modules/aws/asg.go
@@ -144,8 +144,9 @@ func WaitForCapacityContextE(
 	maxRetries int,
 	sleepBetweenRetries time.Duration,
 ) error {
-	msg, err := retry.DoWithRetryE(
+	msg, err := retry.DoWithRetryContextE(
 		t,
+		ctx,
 		fmt.Sprintf("Waiting for ASG %s to reach desired capacity.", asgName),
 		maxRetries,
 		sleepBetweenRetries,

--- a/modules/aws/ec2-syslog.go
+++ b/modules/aws/ec2-syslog.go
@@ -36,11 +36,7 @@ func GetSyslogForInstanceContextE(t testing.TestingT, ctx context.Context, insta
 		InstanceId: aws.String(instanceID),
 	}
 
-	syslogB64, err := retry.DoWithRetryE(t, description, maxRetries, syslogRetryInterval, func() (string, error) {
-		if ctx.Err() != nil {
-			return "", ctx.Err()
-		}
-
+	syslogB64, err := retry.DoWithRetryContextE(t, ctx, description, maxRetries, syslogRetryInterval, func() (string, error) {
 		out, err := client.GetConsoleOutput(ctx, &input)
 		if err != nil {
 			return "", err

--- a/modules/aws/ec2.go
+++ b/modules/aws/ec2.go
@@ -647,6 +647,25 @@ func GetLaunchPermissionsForAmiContextE(t testing.TestingT, ctx context.Context,
 	return output.LaunchPermissions, nil
 }
 
+// GetLaunchPermissionsForAmiContext returns launchPermissions as configured in AWS.
+// This function will fail the test if there is an error.
+// The ctx parameter supports cancellation and timeouts.
+func GetLaunchPermissionsForAmiContext(t testing.TestingT, ctx context.Context, awsRegion string, amiID string) []types.LaunchPermission {
+	t.Helper()
+	output, err := GetLaunchPermissionsForAmiContextE(t, ctx, awsRegion, amiID)
+	require.NoError(t, err)
+
+	return output
+}
+
+// GetLaunchPermissionsForAmi returns launchPermissions as configured in AWS.
+//
+// Deprecated: Use [GetLaunchPermissionsForAmiContext] instead.
+func GetLaunchPermissionsForAmi(t testing.TestingT, awsRegion string, amiID string) []types.LaunchPermission {
+	t.Helper()
+	return GetLaunchPermissionsForAmiContext(t, context.Background(), awsRegion, amiID)
+}
+
 // GetLaunchPermissionsForAmiE returns launchPermissions as configured in AWS
 //
 // Deprecated: Use [GetLaunchPermissionsForAmiContextE] instead.
@@ -732,6 +751,38 @@ func GetRecommendedInstanceTypeWithClientContextE(t testing.TestingT, ctx contex
 	}
 
 	return PickRecommendedInstanceTypeE(availabilityZones, instanceTypeOfferings, instanceTypeOptions)
+}
+
+// GetRecommendedInstanceTypeWithClientContext takes in a list of EC2 instance types (e.g., "t2.micro", "t3.micro") and returns the
+// first instance type in the list that is available in all Availability Zones (AZs) in the given region. If there's no
+// instance available in all AZs, this function exits with an error. This is useful because certain instance types,
+// such as t2.micro, are not available in some of the newer AZs, while t3.micro is not available in some of the older
+// AZs. If you have code that needs to run on a "small" instance across all AZs in many different regions, you can
+// use this function to automatically figure out which instance type you should use.
+// This function expects an authenticated EC2 client from the AWS SDK Go library.
+// This function will fail the test if there is an error.
+// The ctx parameter supports cancellation and timeouts.
+func GetRecommendedInstanceTypeWithClientContext(t testing.TestingT, ctx context.Context, ec2Client *ec2.Client, instanceTypeOptions []string) string {
+	t.Helper()
+	out, err := GetRecommendedInstanceTypeWithClientContextE(t, ctx, ec2Client, instanceTypeOptions)
+	require.NoError(t, err)
+
+	return out
+}
+
+// GetRecommendedInstanceTypeWithClient takes in a list of EC2 instance types (e.g., "t2.micro", "t3.micro") and returns the
+// first instance type in the list that is available in all Availability Zones (AZs) in the given region. If there's no
+// instance available in all AZs, this function exits with an error. This is useful because certain instance types,
+// such as t2.micro, are not available in some of the newer AZs, while t3.micro is not available in some of the older
+// AZs. If you have code that needs to run on a "small" instance across all AZs in many different regions, you can
+// use this function to automatically figure out which instance type you should use.
+// This function expects an authenticated EC2 client from the AWS SDK Go library.
+// This function will fail the test if there is an error.
+//
+// Deprecated: Use [GetRecommendedInstanceTypeWithClientContext] instead.
+func GetRecommendedInstanceTypeWithClient(t testing.TestingT, ec2Client *ec2.Client, instanceTypeOptions []string) string {
+	t.Helper()
+	return GetRecommendedInstanceTypeWithClientContext(t, context.Background(), ec2Client, instanceTypeOptions)
 }
 
 // GetRecommendedInstanceTypeWithClientE takes in a list of EC2 instance types (e.g., "t2.micro", "t3.micro") and returns the

--- a/modules/aws/region.go
+++ b/modules/aws/region.go
@@ -89,6 +89,16 @@ func GetRandomStableRegion(t testing.TestingT, approvedRegions []string, forbidd
 	return GetRandomStableRegionContext(t, context.Background(), approvedRegions, forbiddenRegions)
 }
 
+// GetRandomStableRegionE gets a randomly chosen AWS region that is considered stable. Like GetRandomRegion, you can
+// further restrict the stable region list using approvedRegions and forbiddenRegions. We consider stable regions to be
+// those that have been around for at least 1 year.
+// Note that regions in the approvedRegions list that are not considered stable are ignored.
+//
+// Deprecated: Use [GetRandomStableRegionContextE] instead.
+func GetRandomStableRegionE(t testing.TestingT, approvedRegions []string, forbiddenRegions []string) (string, error) {
+	return GetRandomStableRegionContextE(t, context.Background(), approvedRegions, forbiddenRegions)
+}
+
 // GetRandomRegionContextE gets a randomly chosen AWS region. If approvedRegions is not empty, this will be a region from the approvedRegions
 // list; otherwise, this method will fetch the latest list of regions from the AWS APIs and pick one of those. If
 // forbiddenRegions is not empty, this method will make sure the returned region is not in the forbiddenRegions list.
@@ -347,4 +357,12 @@ func GetRandomRegionForService(t testing.TestingT, serviceName string) string {
 	t.Helper()
 
 	return GetRandomRegionForServiceContext(t, context.Background(), serviceName)
+}
+
+// GetRandomRegionForServiceE retrieves a list of AWS regions in which a service is available
+// Then returns one region randomly from the list and returns errors.
+//
+// Deprecated: Use [GetRandomRegionForServiceContextE] instead.
+func GetRandomRegionForServiceE(t testing.TestingT, serviceName string) (string, error) {
+	return GetRandomRegionForServiceContextE(t, context.Background(), serviceName)
 }

--- a/modules/aws/ssm.go
+++ b/modules/aws/ssm.go
@@ -272,7 +272,7 @@ func WaitForSsmInstanceWithClientContextE(t testing.TestingT, ctx context.Contex
 		},
 	}
 
-	_, err := retry.DoWithRetryE(t, description, maxRetries, timeBetweenRetries, func() (string, error) {
+	_, err := retry.DoWithRetryContextE(t, ctx, description, maxRetries, timeBetweenRetries, func() (string, error) {
 		resp, err := client.GetInventory(ctx, input)
 		if err != nil {
 			return "", err
@@ -414,7 +414,7 @@ func CheckSSMCommandWithClientWithDocumentContextE(t testing.TestingT, ctx conte
 
 	result := &CommandOutput{}
 
-	_, err = retry.DoWithRetryableErrorsE(t, description, retryableErrors, maxRetries, timeBetweenRetries, func() (string, error) {
+	_, err = retry.DoWithRetryableErrorsContextE(t, ctx, description, retryableErrors, maxRetries, timeBetweenRetries, func() (string, error) {
 		resp, err := client.GetCommandInvocation(ctx, &ssm.GetCommandInvocationInput{
 			CommandId:  resp.Command.CommandId,
 			InstanceId: &instanceID,

--- a/modules/aws/vpc.go
+++ b/modules/aws/vpc.go
@@ -311,6 +311,13 @@ func GetAzDefaultSubnetsForVpc(t testing.TestingT, vpcID string, region string) 
 	return GetAzDefaultSubnetsForVpcContext(t, context.Background(), vpcID, region)
 }
 
+// GetAzDefaultSubnetsForVpcE gets the default az subnets in the specified VPC.
+//
+// Deprecated: Use [GetAzDefaultSubnetsForVpcContextE] instead.
+func GetAzDefaultSubnetsForVpcE(t testing.TestingT, vpcID string, region string) ([]Subnet, error) {
+	return GetAzDefaultSubnetsForVpcContextE(t, context.Background(), vpcID, region)
+}
+
 // generateVpcIDFilter is a helper method to generate vpc id filter
 func generateVpcIDFilter(vpcID string) types.Filter {
 	return types.Filter{Name: aws.String(vpcIDFilterName), Values: []string{vpcID}}

--- a/modules/azure/actiongroup.go
+++ b/modules/azure/actiongroup.go
@@ -32,7 +32,7 @@ func GetActionGroupResourceContextE(ctx context.Context, ruleName string, resGro
 		return nil, err
 	}
 
-	client, err := CreateActionGroupClient(subscriptionID)
+	client, err := CreateActionGroupClientContext(ctx, subscriptionID)
 	if err != nil {
 		return nil, err
 	}

--- a/modules/azure/aks.go
+++ b/modules/azure/aks.go
@@ -8,10 +8,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// GetManagedClustersClientE is a helper function that will setup an Azure ManagedClusters client on your behalf.
-func GetManagedClustersClientE(subscriptionID string) (*containerservice.ManagedClustersClient, error) {
+// GetManagedClustersClientContextE is a helper function that will setup an Azure ManagedClusters client on your behalf.
+// The ctx parameter supports cancellation and timeouts.
+func GetManagedClustersClientContextE(ctx context.Context, subscriptionID string) (*containerservice.ManagedClustersClient, error) {
 	// Create a cluster client
-	client, err := CreateManagedClustersClientE(subscriptionID)
+	client, err := CreateManagedClustersClientContextE(ctx, subscriptionID)
 	if err != nil {
 		return nil, err
 	}
@@ -27,6 +28,13 @@ func GetManagedClustersClientE(subscriptionID string) (*containerservice.Managed
 	return &client, nil
 }
 
+// GetManagedClustersClientE is a helper function that will setup an Azure ManagedClusters client on your behalf.
+//
+// Deprecated: Use [GetManagedClustersClientContextE] instead.
+func GetManagedClustersClientE(subscriptionID string) (*containerservice.ManagedClustersClient, error) {
+	return GetManagedClustersClientContextE(context.Background(), subscriptionID)
+}
+
 // GetManagedClusterContextE returns a ManagedCluster for the specified cluster in the given resource group.
 // The ctx parameter supports cancellation and timeouts.
 func GetManagedClusterContextE(t testing.TestingT, ctx context.Context, resourceGroupName, clusterName, subscriptionID string) (*containerservice.ManagedCluster, error) {
@@ -35,7 +43,7 @@ func GetManagedClusterContextE(t testing.TestingT, ctx context.Context, resource
 		return nil, err
 	}
 
-	client, err := GetManagedClustersClientE(subscriptionID)
+	client, err := GetManagedClustersClientContextE(ctx, subscriptionID)
 	if err != nil {
 		return nil, err
 	}

--- a/modules/azure/appService.go
+++ b/modules/azure/appService.go
@@ -82,7 +82,7 @@ func GetAppServiceContextE(ctx context.Context, appName string, resGroupName str
 		return nil, err
 	}
 
-	client, err := GetAppServiceClientE(subscriptionID)
+	client, err := GetAppServiceClientContextE(ctx, subscriptionID)
 	if err != nil {
 		return nil, err
 	}
@@ -102,12 +102,20 @@ func GetAppServiceE(appName string, resGroupName string, subscriptionID string) 
 	return GetAppServiceContextE(context.Background(), appName, resGroupName, subscriptionID)
 }
 
-// GetAppServiceClientE creates and returns an App Service web apps client.
-func GetAppServiceClientE(subscriptionID string) (*armappservice.WebAppsClient, error) {
+// GetAppServiceClientContextE creates and returns an App Service web apps client.
+// The ctx parameter supports cancellation and timeouts.
+func GetAppServiceClientContextE(_ context.Context, subscriptionID string) (*armappservice.WebAppsClient, error) {
 	clientFactory, err := getArmAppServiceClientFactory(subscriptionID)
 	if err != nil {
 		return nil, err
 	}
 
 	return clientFactory.NewWebAppsClient(), nil
+}
+
+// GetAppServiceClientE creates and returns an App Service web apps client.
+//
+// Deprecated: Use [GetAppServiceClientContextE] instead.
+func GetAppServiceClientE(subscriptionID string) (*armappservice.WebAppsClient, error) {
+	return GetAppServiceClientContextE(context.Background(), subscriptionID)
 }

--- a/modules/azure/availabilityset.go
+++ b/modules/azure/availabilityset.go
@@ -51,7 +51,7 @@ func CheckAvailabilitySetContainsVMContext(t testing.TestingT, ctx context.Conte
 // CheckAvailabilitySetContainsVMContextE checks if the Virtual Machine is contained in the Availability Set VMs.
 // The ctx parameter supports cancellation and timeouts.
 func CheckAvailabilitySetContainsVMContextE(t testing.TestingT, ctx context.Context, vmName string, avsName string, resGroupName string, subscriptionID string) (bool, error) {
-	client, err := CreateAvailabilitySetClientE(subscriptionID)
+	client, err := CreateAvailabilitySetClientContextE(ctx, subscriptionID)
 	if err != nil {
 		return false, err
 	}
@@ -86,7 +86,7 @@ func GetAvailabilitySetVMNamesInCapsContext(t testing.TestingT, ctx context.Cont
 // GetAvailabilitySetVMNamesInCapsContextE gets a list of VM names in the specified Azure Availability Set.
 // The ctx parameter supports cancellation and timeouts.
 func GetAvailabilitySetVMNamesInCapsContextE(t testing.TestingT, ctx context.Context, avsName string, resGroupName string, subscriptionID string) ([]string, error) {
-	client, err := CreateAvailabilitySetClientE(subscriptionID)
+	client, err := CreateAvailabilitySetClientContextE(ctx, subscriptionID)
 	if err != nil {
 		return nil, err
 	}
@@ -139,7 +139,7 @@ func GetAvailabilitySetContextE(t testing.TestingT, ctx context.Context, avsName
 		return nil, err
 	}
 
-	client, err := CreateAvailabilitySetClientE(subscriptionID)
+	client, err := CreateAvailabilitySetClientContextE(ctx, subscriptionID)
 	if err != nil {
 		return nil, err
 	}

--- a/modules/azure/client_factory.go
+++ b/modules/azure/client_factory.go
@@ -11,6 +11,7 @@ package azure
 // snippet-tag-start::client_factory_example.imports
 
 import (
+	"context"
 	"errors"
 	"os"
 	"reflect"
@@ -196,9 +197,10 @@ func getArmServiceBusClientFactory(subscriptionID string) (*armservicebus.Client
 
 // ---- Public client creator functions ----
 
-// CreateSubscriptionsClientE returns a virtual machines client instance configured with the correct BaseURI depending on
+// CreateSubscriptionsClientContextE returns a subscriptions client instance configured with the correct BaseURI depending on
 // the Azure environment that is currently setup (or "Public", if none is setup).
-func CreateSubscriptionsClientE() (subscriptions.Client, error) {
+// The ctx parameter supports cancellation and timeouts.
+func CreateSubscriptionsClientContextE(_ context.Context) (subscriptions.Client, error) {
 	// Lookup environment URI
 	baseURI, err := getBaseURI()
 	if err != nil {
@@ -209,8 +211,17 @@ func CreateSubscriptionsClientE() (subscriptions.Client, error) {
 	return subscriptions.NewClientWithBaseURI(baseURI), nil
 }
 
-// CreateVirtualMachinesClientE returns a virtual machines client.
-func CreateVirtualMachinesClientE(subscriptionID string) (*armcompute.VirtualMachinesClient, error) {
+// CreateSubscriptionsClientE returns a subscriptions client instance configured with the correct BaseURI depending on
+// the Azure environment that is currently setup (or "Public", if none is setup).
+//
+// Deprecated: Use [CreateSubscriptionsClientContextE] instead.
+func CreateSubscriptionsClientE() (subscriptions.Client, error) {
+	return CreateSubscriptionsClientContextE(context.Background())
+}
+
+// CreateVirtualMachinesClientContextE returns a virtual machines client.
+// The ctx parameter supports cancellation and timeouts.
+func CreateVirtualMachinesClientContextE(_ context.Context, subscriptionID string) (*armcompute.VirtualMachinesClient, error) {
 	clientFactory, err := getArmComputeClientFactory(subscriptionID)
 	if err != nil {
 		return nil, err
@@ -219,9 +230,17 @@ func CreateVirtualMachinesClientE(subscriptionID string) (*armcompute.VirtualMac
 	return clientFactory.NewVirtualMachinesClient(), nil
 }
 
-// CreateManagedClustersClientE returns a virtual machines client instance configured with the correct BaseURI depending on
+// CreateVirtualMachinesClientE returns a virtual machines client.
+//
+// Deprecated: Use [CreateVirtualMachinesClientContextE] instead.
+func CreateVirtualMachinesClientE(subscriptionID string) (*armcompute.VirtualMachinesClient, error) {
+	return CreateVirtualMachinesClientContextE(context.Background(), subscriptionID)
+}
+
+// CreateManagedClustersClientContextE returns a managed clusters client instance configured with the correct BaseURI depending on
 // the Azure environment that is currently setup (or "Public", if none is setup).
-func CreateManagedClustersClientE(subscriptionID string) (containerservice.ManagedClustersClient, error) {
+// The ctx parameter supports cancellation and timeouts.
+func CreateManagedClustersClientContextE(_ context.Context, subscriptionID string) (containerservice.ManagedClustersClient, error) {
 	// Validate Azure subscription ID
 	subscriptionID, err := getTargetAzureSubscription(subscriptionID)
 	if err != nil {
@@ -238,8 +257,17 @@ func CreateManagedClustersClientE(subscriptionID string) (containerservice.Manag
 	return containerservice.NewManagedClustersClientWithBaseURI(baseURI, subscriptionID), nil
 }
 
-// CreateCosmosDBAccountClientE returns a Cosmos DB database accounts client.
-func CreateCosmosDBAccountClientE(subscriptionID string) (*armcosmos.DatabaseAccountsClient, error) {
+// CreateManagedClustersClientE returns a managed clusters client instance configured with the correct BaseURI depending on
+// the Azure environment that is currently setup (or "Public", if none is setup).
+//
+// Deprecated: Use [CreateManagedClustersClientContextE] instead.
+func CreateManagedClustersClientE(subscriptionID string) (containerservice.ManagedClustersClient, error) {
+	return CreateManagedClustersClientContextE(context.Background(), subscriptionID)
+}
+
+// CreateCosmosDBAccountClientContextE returns a Cosmos DB database accounts client.
+// The ctx parameter supports cancellation and timeouts.
+func CreateCosmosDBAccountClientContextE(_ context.Context, subscriptionID string) (*armcosmos.DatabaseAccountsClient, error) {
 	clientFactory, err := getArmCosmosClientFactory(subscriptionID)
 	if err != nil {
 		return nil, err
@@ -248,14 +276,29 @@ func CreateCosmosDBAccountClientE(subscriptionID string) (*armcosmos.DatabaseAcc
 	return clientFactory.NewDatabaseAccountsClient(), nil
 }
 
-// CreateCosmosDBSQLClientE returns a Cosmos DB SQL resources client.
-func CreateCosmosDBSQLClientE(subscriptionID string) (*armcosmos.SQLResourcesClient, error) {
+// CreateCosmosDBAccountClientE returns a Cosmos DB database accounts client.
+//
+// Deprecated: Use [CreateCosmosDBAccountClientContextE] instead.
+func CreateCosmosDBAccountClientE(subscriptionID string) (*armcosmos.DatabaseAccountsClient, error) {
+	return CreateCosmosDBAccountClientContextE(context.Background(), subscriptionID)
+}
+
+// CreateCosmosDBSQLClientContextE returns a Cosmos DB SQL resources client.
+// The ctx parameter supports cancellation and timeouts.
+func CreateCosmosDBSQLClientContextE(_ context.Context, subscriptionID string) (*armcosmos.SQLResourcesClient, error) {
 	clientFactory, err := getArmCosmosClientFactory(subscriptionID)
 	if err != nil {
 		return nil, err
 	}
 
 	return clientFactory.NewSQLResourcesClient(), nil
+}
+
+// CreateCosmosDBSQLClientE returns a Cosmos DB SQL resources client.
+//
+// Deprecated: Use [CreateCosmosDBSQLClientContextE] instead.
+func CreateCosmosDBSQLClientE(subscriptionID string) (*armcosmos.SQLResourcesClient, error) {
+	return CreateCosmosDBSQLClientContextE(context.Background(), subscriptionID)
 }
 
 // getArmKeyVaultClientFactory gets an arm keyvault client factory
@@ -314,8 +357,9 @@ func getArmPostgreSQLClientFactory(subscriptionID string) (*armpostgresql.Client
 	})
 }
 
-// CreateStorageAccountClientE creates a storage account client.
-func CreateStorageAccountClientE(subscriptionID string) (*armstorage.AccountsClient, error) {
+// CreateStorageAccountClientContextE creates a storage account client.
+// The ctx parameter supports cancellation and timeouts.
+func CreateStorageAccountClientContextE(_ context.Context, subscriptionID string) (*armstorage.AccountsClient, error) {
 	clientFactory, err := getArmStorageClientFactory(subscriptionID)
 	if err != nil {
 		return nil, err
@@ -324,8 +368,16 @@ func CreateStorageAccountClientE(subscriptionID string) (*armstorage.AccountsCli
 	return clientFactory.NewAccountsClient(), nil
 }
 
-// CreateStorageBlobContainerClientE creates a storage blob container client.
-func CreateStorageBlobContainerClientE(subscriptionID string) (*armstorage.BlobContainersClient, error) {
+// CreateStorageAccountClientE creates a storage account client.
+//
+// Deprecated: Use [CreateStorageAccountClientContextE] instead.
+func CreateStorageAccountClientE(subscriptionID string) (*armstorage.AccountsClient, error) {
+	return CreateStorageAccountClientContextE(context.Background(), subscriptionID)
+}
+
+// CreateStorageBlobContainerClientContextE creates a storage blob container client.
+// The ctx parameter supports cancellation and timeouts.
+func CreateStorageBlobContainerClientContextE(_ context.Context, subscriptionID string) (*armstorage.BlobContainersClient, error) {
 	clientFactory, err := getArmStorageClientFactory(subscriptionID)
 	if err != nil {
 		return nil, err
@@ -334,8 +386,16 @@ func CreateStorageBlobContainerClientE(subscriptionID string) (*armstorage.BlobC
 	return clientFactory.NewBlobContainersClient(), nil
 }
 
-// CreateStorageFileSharesClientE creates a storage file shares client.
-func CreateStorageFileSharesClientE(subscriptionID string) (*armstorage.FileSharesClient, error) {
+// CreateStorageBlobContainerClientE creates a storage blob container client.
+//
+// Deprecated: Use [CreateStorageBlobContainerClientContextE] instead.
+func CreateStorageBlobContainerClientE(subscriptionID string) (*armstorage.BlobContainersClient, error) {
+	return CreateStorageBlobContainerClientContextE(context.Background(), subscriptionID)
+}
+
+// CreateStorageFileSharesClientContextE creates a storage file shares client.
+// The ctx parameter supports cancellation and timeouts.
+func CreateStorageFileSharesClientContextE(_ context.Context, subscriptionID string) (*armstorage.FileSharesClient, error) {
 	clientFactory, err := getArmStorageClientFactory(subscriptionID)
 	if err != nil {
 		return nil, err
@@ -344,8 +404,16 @@ func CreateStorageFileSharesClientE(subscriptionID string) (*armstorage.FileShar
 	return clientFactory.NewFileSharesClient(), nil
 }
 
-// CreateServiceBusNamespacesClientE returns a service bus namespaces client.
-func CreateServiceBusNamespacesClientE(subscriptionID string) (*armservicebus.NamespacesClient, error) {
+// CreateStorageFileSharesClientE creates a storage file shares client.
+//
+// Deprecated: Use [CreateStorageFileSharesClientContextE] instead.
+func CreateStorageFileSharesClientE(subscriptionID string) (*armstorage.FileSharesClient, error) {
+	return CreateStorageFileSharesClientContextE(context.Background(), subscriptionID)
+}
+
+// CreateServiceBusNamespacesClientContextE returns a service bus namespaces client.
+// The ctx parameter supports cancellation and timeouts.
+func CreateServiceBusNamespacesClientContextE(_ context.Context, subscriptionID string) (*armservicebus.NamespacesClient, error) {
 	clientFactory, err := getArmServiceBusClientFactory(subscriptionID)
 	if err != nil {
 		return nil, err
@@ -354,8 +422,16 @@ func CreateServiceBusNamespacesClientE(subscriptionID string) (*armservicebus.Na
 	return clientFactory.NewNamespacesClient(), nil
 }
 
-// CreateServiceBusTopicsClientE returns a service bus topics client.
-func CreateServiceBusTopicsClientE(subscriptionID string) (*armservicebus.TopicsClient, error) {
+// CreateServiceBusNamespacesClientE returns a service bus namespaces client.
+//
+// Deprecated: Use [CreateServiceBusNamespacesClientContextE] instead.
+func CreateServiceBusNamespacesClientE(subscriptionID string) (*armservicebus.NamespacesClient, error) {
+	return CreateServiceBusNamespacesClientContextE(context.Background(), subscriptionID)
+}
+
+// CreateServiceBusTopicsClientContextE returns a service bus topics client.
+// The ctx parameter supports cancellation and timeouts.
+func CreateServiceBusTopicsClientContextE(_ context.Context, subscriptionID string) (*armservicebus.TopicsClient, error) {
 	clientFactory, err := getArmServiceBusClientFactory(subscriptionID)
 	if err != nil {
 		return nil, err
@@ -364,8 +440,16 @@ func CreateServiceBusTopicsClientE(subscriptionID string) (*armservicebus.Topics
 	return clientFactory.NewTopicsClient(), nil
 }
 
-// CreateServiceBusSubscriptionsClientE returns a service bus subscriptions client.
-func CreateServiceBusSubscriptionsClientE(subscriptionID string) (*armservicebus.SubscriptionsClient, error) {
+// CreateServiceBusTopicsClientE returns a service bus topics client.
+//
+// Deprecated: Use [CreateServiceBusTopicsClientContextE] instead.
+func CreateServiceBusTopicsClientE(subscriptionID string) (*armservicebus.TopicsClient, error) {
+	return CreateServiceBusTopicsClientContextE(context.Background(), subscriptionID)
+}
+
+// CreateServiceBusSubscriptionsClientContextE returns a service bus subscriptions client.
+// The ctx parameter supports cancellation and timeouts.
+func CreateServiceBusSubscriptionsClientContextE(_ context.Context, subscriptionID string) (*armservicebus.SubscriptionsClient, error) {
 	clientFactory, err := getArmServiceBusClientFactory(subscriptionID)
 	if err != nil {
 		return nil, err
@@ -374,8 +458,16 @@ func CreateServiceBusSubscriptionsClientE(subscriptionID string) (*armservicebus
 	return clientFactory.NewSubscriptionsClient(), nil
 }
 
-// CreateAvailabilitySetClientE creates a new Availability Set client.
-func CreateAvailabilitySetClientE(subscriptionID string) (*armcompute.AvailabilitySetsClient, error) {
+// CreateServiceBusSubscriptionsClientE returns a service bus subscriptions client.
+//
+// Deprecated: Use [CreateServiceBusSubscriptionsClientContextE] instead.
+func CreateServiceBusSubscriptionsClientE(subscriptionID string) (*armservicebus.SubscriptionsClient, error) {
+	return CreateServiceBusSubscriptionsClientContextE(context.Background(), subscriptionID)
+}
+
+// CreateAvailabilitySetClientContextE creates a new Availability Set client.
+// The ctx parameter supports cancellation and timeouts.
+func CreateAvailabilitySetClientContextE(_ context.Context, subscriptionID string) (*armcompute.AvailabilitySetsClient, error) {
 	clientFactory, err := getArmComputeClientFactory(subscriptionID)
 	if err != nil {
 		return nil, err
@@ -384,8 +476,16 @@ func CreateAvailabilitySetClientE(subscriptionID string) (*armcompute.Availabili
 	return clientFactory.NewAvailabilitySetsClient(), nil
 }
 
-// CreateResourceGroupClientE gets a resource group client in a subscription
-func CreateResourceGroupClientE(subscriptionID string) (*resources.GroupsClient, error) {
+// CreateAvailabilitySetClientE creates a new Availability Set client.
+//
+// Deprecated: Use [CreateAvailabilitySetClientContextE] instead.
+func CreateAvailabilitySetClientE(subscriptionID string) (*armcompute.AvailabilitySetsClient, error) {
+	return CreateAvailabilitySetClientContextE(context.Background(), subscriptionID)
+}
+
+// CreateResourceGroupClientContextE gets a resource group client in a subscription.
+// The ctx parameter supports cancellation and timeouts.
+func CreateResourceGroupClientContextE(_ context.Context, subscriptionID string) (*resources.GroupsClient, error) {
 	subscriptionID, err := getTargetAzureSubscription(subscriptionID)
 	if err != nil {
 		return nil, err
@@ -409,8 +509,16 @@ func CreateResourceGroupClientE(subscriptionID string) (*resources.GroupsClient,
 	return &resourceGroupClient, nil
 }
 
-// CreateSQLServerClient is a helper function that will create and setup a sql server client
-func CreateSQLServerClient(subscriptionID string) (*armsql.ServersClient, error) {
+// CreateResourceGroupClientE gets a resource group client in a subscription.
+//
+// Deprecated: Use [CreateResourceGroupClientContextE] instead.
+func CreateResourceGroupClientE(subscriptionID string) (*resources.GroupsClient, error) {
+	return CreateResourceGroupClientContextE(context.Background(), subscriptionID)
+}
+
+// CreateSQLServerClientContext is a helper function that will create and setup a sql server client.
+// The ctx parameter supports cancellation and timeouts.
+func CreateSQLServerClientContext(_ context.Context, subscriptionID string) (*armsql.ServersClient, error) {
 	clientFactory, err := getArmSQLClientFactory(subscriptionID)
 	if err != nil {
 		return nil, err
@@ -419,8 +527,16 @@ func CreateSQLServerClient(subscriptionID string) (*armsql.ServersClient, error)
 	return clientFactory.NewServersClient(), nil
 }
 
-// CreateSQLMangedInstanceClient is a helper function that will create and setup a sql managed instance client
-func CreateSQLMangedInstanceClient(subscriptionID string) (*armsql.ManagedInstancesClient, error) {
+// CreateSQLServerClient is a helper function that will create and setup a sql server client.
+//
+// Deprecated: Use [CreateSQLServerClientContext] instead.
+func CreateSQLServerClient(subscriptionID string) (*armsql.ServersClient, error) {
+	return CreateSQLServerClientContext(context.Background(), subscriptionID)
+}
+
+// CreateSQLMangedInstanceClientContext is a helper function that will create and setup a sql managed instance client.
+// The ctx parameter supports cancellation and timeouts.
+func CreateSQLMangedInstanceClientContext(_ context.Context, subscriptionID string) (*armsql.ManagedInstancesClient, error) {
 	clientFactory, err := getArmSQLClientFactory(subscriptionID)
 	if err != nil {
 		return nil, err
@@ -429,14 +545,29 @@ func CreateSQLMangedInstanceClient(subscriptionID string) (*armsql.ManagedInstan
 	return clientFactory.NewManagedInstancesClient(), nil
 }
 
-// CreateSQLMangedDatabasesClient is a helper function that will create and setup a sql managed databases client
-func CreateSQLMangedDatabasesClient(subscriptionID string) (*armsql.ManagedDatabasesClient, error) {
+// CreateSQLMangedInstanceClient is a helper function that will create and setup a sql managed instance client.
+//
+// Deprecated: Use [CreateSQLMangedInstanceClientContext] instead.
+func CreateSQLMangedInstanceClient(subscriptionID string) (*armsql.ManagedInstancesClient, error) {
+	return CreateSQLMangedInstanceClientContext(context.Background(), subscriptionID)
+}
+
+// CreateSQLMangedDatabasesClientContext is a helper function that will create and setup a sql managed databases client.
+// The ctx parameter supports cancellation and timeouts.
+func CreateSQLMangedDatabasesClientContext(_ context.Context, subscriptionID string) (*armsql.ManagedDatabasesClient, error) {
 	clientFactory, err := getArmSQLClientFactory(subscriptionID)
 	if err != nil {
 		return nil, err
 	}
 
 	return clientFactory.NewManagedDatabasesClient(), nil
+}
+
+// CreateSQLMangedDatabasesClient is a helper function that will create and setup a sql managed databases client.
+//
+// Deprecated: Use [CreateSQLMangedDatabasesClientContext] instead.
+func CreateSQLMangedDatabasesClient(subscriptionID string) (*armsql.ManagedDatabasesClient, error) {
+	return CreateSQLMangedDatabasesClientContext(context.Background(), subscriptionID)
 }
 
 // getArmSQLClientFactory gets an arm sql client factory
@@ -467,8 +598,9 @@ func getArmSQLClientFactory(subscriptionID string) (*armsql.ClientFactory, error
 	})
 }
 
-// CreateDatabaseClient is a helper function that will create and setup a SQL DB client
-func CreateDatabaseClient(subscriptionID string) (*armsql.DatabasesClient, error) {
+// CreateDatabaseClientContext is a helper function that will create and setup a SQL DB client.
+// The ctx parameter supports cancellation and timeouts.
+func CreateDatabaseClientContext(_ context.Context, subscriptionID string) (*armsql.DatabasesClient, error) {
 	clientFactory, err := getArmSQLClientFactory(subscriptionID)
 	if err != nil {
 		return nil, err
@@ -477,14 +609,29 @@ func CreateDatabaseClient(subscriptionID string) (*armsql.DatabasesClient, error
 	return clientFactory.NewDatabasesClient(), nil
 }
 
-// CreateMySQLServerClientE is a helper function that will setup a mysql server client.
-func CreateMySQLServerClientE(subscriptionID string) (*armmysql.ServersClient, error) {
+// CreateDatabaseClient is a helper function that will create and setup a SQL DB client.
+//
+// Deprecated: Use [CreateDatabaseClientContext] instead.
+func CreateDatabaseClient(subscriptionID string) (*armsql.DatabasesClient, error) {
+	return CreateDatabaseClientContext(context.Background(), subscriptionID)
+}
+
+// CreateMySQLServerClientContextE is a helper function that will setup a mysql server client.
+// The ctx parameter supports cancellation and timeouts.
+func CreateMySQLServerClientContextE(_ context.Context, subscriptionID string) (*armmysql.ServersClient, error) {
 	clientFactory, err := getArmMySQLClientFactory(subscriptionID)
 	if err != nil {
 		return nil, err
 	}
 
 	return clientFactory.NewServersClient(), nil
+}
+
+// CreateMySQLServerClientE is a helper function that will setup a mysql server client.
+//
+// Deprecated: Use [CreateMySQLServerClientContextE] instead.
+func CreateMySQLServerClientE(subscriptionID string) (*armmysql.ServersClient, error) {
+	return CreateMySQLServerClientContextE(context.Background(), subscriptionID)
 }
 
 // getArmMySQLClientFactory gets an arm mysql client factory
@@ -515,8 +662,9 @@ func getArmMySQLClientFactory(subscriptionID string) (*armmysql.ClientFactory, e
 	})
 }
 
-// CreateDisksClientE returns a disks client.
-func CreateDisksClientE(subscriptionID string) (*armcompute.DisksClient, error) {
+// CreateDisksClientContextE returns a disks client.
+// The ctx parameter supports cancellation and timeouts.
+func CreateDisksClientContextE(_ context.Context, subscriptionID string) (*armcompute.DisksClient, error) {
 	clientFactory, err := getArmComputeClientFactory(subscriptionID)
 	if err != nil {
 		return nil, err
@@ -525,8 +673,16 @@ func CreateDisksClientE(subscriptionID string) (*armcompute.DisksClient, error) 
 	return clientFactory.NewDisksClient(), nil
 }
 
-// CreateActionGroupClient creates an Action Groups client for Azure Monitor.
-func CreateActionGroupClient(subscriptionID string) (*insights.ActionGroupsClient, error) {
+// CreateDisksClientE returns a disks client.
+//
+// Deprecated: Use [CreateDisksClientContextE] instead.
+func CreateDisksClientE(subscriptionID string) (*armcompute.DisksClient, error) {
+	return CreateDisksClientContextE(context.Background(), subscriptionID)
+}
+
+// CreateActionGroupClientContext creates an Action Groups client for Azure Monitor.
+// The ctx parameter supports cancellation and timeouts.
+func CreateActionGroupClientContext(_ context.Context, subscriptionID string) (*insights.ActionGroupsClient, error) {
 	subID, err := getTargetAzureSubscription(subscriptionID)
 	if err != nil {
 		return nil, err
@@ -550,8 +706,16 @@ func CreateActionGroupClient(subscriptionID string) (*insights.ActionGroupsClien
 	return &metricAlertsClient, nil
 }
 
-// CreateVMInsightsClientE gets a VM Insights client
-func CreateVMInsightsClientE(subscriptionID string) (*insights.VMInsightsClient, error) {
+// CreateActionGroupClient creates an Action Groups client for Azure Monitor.
+//
+// Deprecated: Use [CreateActionGroupClientContext] instead.
+func CreateActionGroupClient(subscriptionID string) (*insights.ActionGroupsClient, error) {
+	return CreateActionGroupClientContext(context.Background(), subscriptionID)
+}
+
+// CreateVMInsightsClientContextE gets a VM Insights client.
+// The ctx parameter supports cancellation and timeouts.
+func CreateVMInsightsClientContextE(_ context.Context, subscriptionID string) (*insights.VMInsightsClient, error) {
 	// Validate Azure subscription ID
 	subscriptionID, err := getTargetAzureSubscription(subscriptionID)
 	if err != nil {
@@ -576,8 +740,16 @@ func CreateVMInsightsClientE(subscriptionID string) (*insights.VMInsightsClient,
 	return &client, nil
 }
 
-// CreateActivityLogAlertsClientE gets an Action Groups client in the specified Azure Subscription
-func CreateActivityLogAlertsClientE(subscriptionID string) (*insights.ActivityLogAlertsClient, error) {
+// CreateVMInsightsClientE gets a VM Insights client.
+//
+// Deprecated: Use [CreateVMInsightsClientContextE] instead.
+func CreateVMInsightsClientE(subscriptionID string) (*insights.VMInsightsClient, error) {
+	return CreateVMInsightsClientContextE(context.Background(), subscriptionID)
+}
+
+// CreateActivityLogAlertsClientContextE gets an Activity Log Alerts client in the specified Azure Subscription.
+// The ctx parameter supports cancellation and timeouts.
+func CreateActivityLogAlertsClientContextE(_ context.Context, subscriptionID string) (*insights.ActivityLogAlertsClient, error) {
 	// Validate Azure subscription ID
 	subscriptionID, err := getTargetAzureSubscription(subscriptionID)
 	if err != nil {
@@ -590,7 +762,7 @@ func CreateActivityLogAlertsClientE(subscriptionID string) (*insights.ActivityLo
 		return nil, err
 	}
 
-	// Get the Action Groups client
+	// Get the Activity Log Alerts client
 	client := insights.NewActivityLogAlertsClientWithBaseURI(baseURI, subscriptionID)
 
 	// Create an authorizer
@@ -604,8 +776,16 @@ func CreateActivityLogAlertsClientE(subscriptionID string) (*insights.ActivityLo
 	return &client, nil
 }
 
-// CreateDiagnosticsSettingsClientE returns a diagnostics settings client
-func CreateDiagnosticsSettingsClientE(subscriptionID string) (*insights.DiagnosticSettingsClient, error) {
+// CreateActivityLogAlertsClientE gets an Activity Log Alerts client in the specified Azure Subscription.
+//
+// Deprecated: Use [CreateActivityLogAlertsClientContextE] instead.
+func CreateActivityLogAlertsClientE(subscriptionID string) (*insights.ActivityLogAlertsClient, error) {
+	return CreateActivityLogAlertsClientContextE(context.Background(), subscriptionID)
+}
+
+// CreateDiagnosticsSettingsClientContextE returns a diagnostics settings client.
+// The ctx parameter supports cancellation and timeouts.
+func CreateDiagnosticsSettingsClientContextE(_ context.Context, subscriptionID string) (*insights.DiagnosticSettingsClient, error) {
 	// Validate Azure subscription ID
 	subscriptionID, err := getTargetAzureSubscription(subscriptionID)
 	if err != nil {
@@ -630,8 +810,16 @@ func CreateDiagnosticsSettingsClientE(subscriptionID string) (*insights.Diagnost
 	return &client, nil
 }
 
-// CreateNsgDefaultRulesClientE returns an NSG default (platform) rules client.
-func CreateNsgDefaultRulesClientE(subscriptionID string) (*armnetwork.DefaultSecurityRulesClient, error) {
+// CreateDiagnosticsSettingsClientE returns a diagnostics settings client.
+//
+// Deprecated: Use [CreateDiagnosticsSettingsClientContextE] instead.
+func CreateDiagnosticsSettingsClientE(subscriptionID string) (*insights.DiagnosticSettingsClient, error) {
+	return CreateDiagnosticsSettingsClientContextE(context.Background(), subscriptionID)
+}
+
+// CreateNsgDefaultRulesClientContextE returns an NSG default (platform) rules client.
+// The ctx parameter supports cancellation and timeouts.
+func CreateNsgDefaultRulesClientContextE(_ context.Context, subscriptionID string) (*armnetwork.DefaultSecurityRulesClient, error) {
 	clientFactory, err := getArmNetworkClientFactory(subscriptionID)
 	if err != nil {
 		return nil, err
@@ -640,8 +828,16 @@ func CreateNsgDefaultRulesClientE(subscriptionID string) (*armnetwork.DefaultSec
 	return clientFactory.NewDefaultSecurityRulesClient(), nil
 }
 
-// CreateNsgCustomRulesClientE returns an NSG custom (user) rules client.
-func CreateNsgCustomRulesClientE(subscriptionID string) (*armnetwork.SecurityRulesClient, error) {
+// CreateNsgDefaultRulesClientE returns an NSG default (platform) rules client.
+//
+// Deprecated: Use [CreateNsgDefaultRulesClientContextE] instead.
+func CreateNsgDefaultRulesClientE(subscriptionID string) (*armnetwork.DefaultSecurityRulesClient, error) {
+	return CreateNsgDefaultRulesClientContextE(context.Background(), subscriptionID)
+}
+
+// CreateNsgCustomRulesClientContextE returns an NSG custom (user) rules client.
+// The ctx parameter supports cancellation and timeouts.
+func CreateNsgCustomRulesClientContextE(_ context.Context, subscriptionID string) (*armnetwork.SecurityRulesClient, error) {
 	clientFactory, err := getArmNetworkClientFactory(subscriptionID)
 	if err != nil {
 		return nil, err
@@ -650,8 +846,16 @@ func CreateNsgCustomRulesClientE(subscriptionID string) (*armnetwork.SecurityRul
 	return clientFactory.NewSecurityRulesClient(), nil
 }
 
-// CreateNewNetworkInterfacesClientE returns a network interfaces client.
-func CreateNewNetworkInterfacesClientE(subscriptionID string) (*armnetwork.InterfacesClient, error) {
+// CreateNsgCustomRulesClientE returns an NSG custom (user) rules client.
+//
+// Deprecated: Use [CreateNsgCustomRulesClientContextE] instead.
+func CreateNsgCustomRulesClientE(subscriptionID string) (*armnetwork.SecurityRulesClient, error) {
+	return CreateNsgCustomRulesClientContextE(context.Background(), subscriptionID)
+}
+
+// CreateNewNetworkInterfacesClientContextE returns a network interfaces client.
+// The ctx parameter supports cancellation and timeouts.
+func CreateNewNetworkInterfacesClientContextE(_ context.Context, subscriptionID string) (*armnetwork.InterfacesClient, error) {
 	clientFactory, err := getArmNetworkClientFactory(subscriptionID)
 	if err != nil {
 		return nil, err
@@ -660,8 +864,16 @@ func CreateNewNetworkInterfacesClientE(subscriptionID string) (*armnetwork.Inter
 	return clientFactory.NewInterfacesClient(), nil
 }
 
-// CreateNewNetworkInterfaceIPConfigurationClientE returns a NIC IP configuration client.
-func CreateNewNetworkInterfaceIPConfigurationClientE(subscriptionID string) (*armnetwork.InterfaceIPConfigurationsClient, error) {
+// CreateNewNetworkInterfacesClientE returns a network interfaces client.
+//
+// Deprecated: Use [CreateNewNetworkInterfacesClientContextE] instead.
+func CreateNewNetworkInterfacesClientE(subscriptionID string) (*armnetwork.InterfacesClient, error) {
+	return CreateNewNetworkInterfacesClientContextE(context.Background(), subscriptionID)
+}
+
+// CreateNewNetworkInterfaceIPConfigurationClientContextE returns a NIC IP configuration client.
+// The ctx parameter supports cancellation and timeouts.
+func CreateNewNetworkInterfaceIPConfigurationClientContextE(_ context.Context, subscriptionID string) (*armnetwork.InterfaceIPConfigurationsClient, error) {
 	clientFactory, err := getArmNetworkClientFactory(subscriptionID)
 	if err != nil {
 		return nil, err
@@ -670,8 +882,16 @@ func CreateNewNetworkInterfaceIPConfigurationClientE(subscriptionID string) (*ar
 	return clientFactory.NewInterfaceIPConfigurationsClient(), nil
 }
 
-// CreatePublicIPAddressesClientE returns a public IP addresses client.
-func CreatePublicIPAddressesClientE(subscriptionID string) (*armnetwork.PublicIPAddressesClient, error) {
+// CreateNewNetworkInterfaceIPConfigurationClientE returns a NIC IP configuration client.
+//
+// Deprecated: Use [CreateNewNetworkInterfaceIPConfigurationClientContextE] instead.
+func CreateNewNetworkInterfaceIPConfigurationClientE(subscriptionID string) (*armnetwork.InterfaceIPConfigurationsClient, error) {
+	return CreateNewNetworkInterfaceIPConfigurationClientContextE(context.Background(), subscriptionID)
+}
+
+// CreatePublicIPAddressesClientContextE returns a public IP addresses client.
+// The ctx parameter supports cancellation and timeouts.
+func CreatePublicIPAddressesClientContextE(_ context.Context, subscriptionID string) (*armnetwork.PublicIPAddressesClient, error) {
 	clientFactory, err := getArmNetworkClientFactory(subscriptionID)
 	if err != nil {
 		return nil, err
@@ -680,8 +900,16 @@ func CreatePublicIPAddressesClientE(subscriptionID string) (*armnetwork.PublicIP
 	return clientFactory.NewPublicIPAddressesClient(), nil
 }
 
-// CreateLoadBalancerClientE returns a load balancer client.
-func CreateLoadBalancerClientE(subscriptionID string) (*armnetwork.LoadBalancersClient, error) {
+// CreatePublicIPAddressesClientE returns a public IP addresses client.
+//
+// Deprecated: Use [CreatePublicIPAddressesClientContextE] instead.
+func CreatePublicIPAddressesClientE(subscriptionID string) (*armnetwork.PublicIPAddressesClient, error) {
+	return CreatePublicIPAddressesClientContextE(context.Background(), subscriptionID)
+}
+
+// CreateLoadBalancerClientContextE returns a load balancer client.
+// The ctx parameter supports cancellation and timeouts.
+func CreateLoadBalancerClientContextE(_ context.Context, subscriptionID string) (*armnetwork.LoadBalancersClient, error) {
 	clientFactory, err := getArmNetworkClientFactory(subscriptionID)
 	if err != nil {
 		return nil, err
@@ -690,8 +918,16 @@ func CreateLoadBalancerClientE(subscriptionID string) (*armnetwork.LoadBalancers
 	return clientFactory.NewLoadBalancersClient(), nil
 }
 
-// CreateLoadBalancerFrontendIPConfigClientE returns a load balancer frontend IP configuration client.
-func CreateLoadBalancerFrontendIPConfigClientE(subscriptionID string) (*armnetwork.LoadBalancerFrontendIPConfigurationsClient, error) {
+// CreateLoadBalancerClientE returns a load balancer client.
+//
+// Deprecated: Use [CreateLoadBalancerClientContextE] instead.
+func CreateLoadBalancerClientE(subscriptionID string) (*armnetwork.LoadBalancersClient, error) {
+	return CreateLoadBalancerClientContextE(context.Background(), subscriptionID)
+}
+
+// CreateLoadBalancerFrontendIPConfigClientContextE returns a load balancer frontend IP configuration client.
+// The ctx parameter supports cancellation and timeouts.
+func CreateLoadBalancerFrontendIPConfigClientContextE(_ context.Context, subscriptionID string) (*armnetwork.LoadBalancerFrontendIPConfigurationsClient, error) {
 	clientFactory, err := getArmNetworkClientFactory(subscriptionID)
 	if err != nil {
 		return nil, err
@@ -700,8 +936,16 @@ func CreateLoadBalancerFrontendIPConfigClientE(subscriptionID string) (*armnetwo
 	return clientFactory.NewLoadBalancerFrontendIPConfigurationsClient(), nil
 }
 
-// CreateNewSubnetClientE returns a subnet client.
-func CreateNewSubnetClientE(subscriptionID string) (*armnetwork.SubnetsClient, error) {
+// CreateLoadBalancerFrontendIPConfigClientE returns a load balancer frontend IP configuration client.
+//
+// Deprecated: Use [CreateLoadBalancerFrontendIPConfigClientContextE] instead.
+func CreateLoadBalancerFrontendIPConfigClientE(subscriptionID string) (*armnetwork.LoadBalancerFrontendIPConfigurationsClient, error) {
+	return CreateLoadBalancerFrontendIPConfigClientContextE(context.Background(), subscriptionID)
+}
+
+// CreateNewSubnetClientContextE returns a subnet client.
+// The ctx parameter supports cancellation and timeouts.
+func CreateNewSubnetClientContextE(_ context.Context, subscriptionID string) (*armnetwork.SubnetsClient, error) {
 	clientFactory, err := getArmNetworkClientFactory(subscriptionID)
 	if err != nil {
 		return nil, err
@@ -710,8 +954,16 @@ func CreateNewSubnetClientE(subscriptionID string) (*armnetwork.SubnetsClient, e
 	return clientFactory.NewSubnetsClient(), nil
 }
 
-// CreateNetworkManagementClientE returns a network management client.
-func CreateNetworkManagementClientE(subscriptionID string) (*armnetwork.ManagementClient, error) {
+// CreateNewSubnetClientE returns a subnet client.
+//
+// Deprecated: Use [CreateNewSubnetClientContextE] instead.
+func CreateNewSubnetClientE(subscriptionID string) (*armnetwork.SubnetsClient, error) {
+	return CreateNewSubnetClientContextE(context.Background(), subscriptionID)
+}
+
+// CreateNetworkManagementClientContextE returns a network management client.
+// The ctx parameter supports cancellation and timeouts.
+func CreateNetworkManagementClientContextE(_ context.Context, subscriptionID string) (*armnetwork.ManagementClient, error) {
 	clientFactory, err := getArmNetworkClientFactory(subscriptionID)
 	if err != nil {
 		return nil, err
@@ -720,8 +972,16 @@ func CreateNetworkManagementClientE(subscriptionID string) (*armnetwork.Manageme
 	return clientFactory.NewManagementClient(), nil
 }
 
-// CreateNewVirtualNetworkClientE returns a virtual network client.
-func CreateNewVirtualNetworkClientE(subscriptionID string) (*armnetwork.VirtualNetworksClient, error) {
+// CreateNetworkManagementClientE returns a network management client.
+//
+// Deprecated: Use [CreateNetworkManagementClientContextE] instead.
+func CreateNetworkManagementClientE(subscriptionID string) (*armnetwork.ManagementClient, error) {
+	return CreateNetworkManagementClientContextE(context.Background(), subscriptionID)
+}
+
+// CreateNewVirtualNetworkClientContextE returns a virtual network client.
+// The ctx parameter supports cancellation and timeouts.
+func CreateNewVirtualNetworkClientContextE(_ context.Context, subscriptionID string) (*armnetwork.VirtualNetworksClient, error) {
 	clientFactory, err := getArmNetworkClientFactory(subscriptionID)
 	if err != nil {
 		return nil, err
@@ -730,15 +990,31 @@ func CreateNewVirtualNetworkClientE(subscriptionID string) (*armnetwork.VirtualN
 	return clientFactory.NewVirtualNetworksClient(), nil
 }
 
-// CreateAppServiceClientE returns an App service client instance configured with the
+// CreateNewVirtualNetworkClientE returns a virtual network client.
+//
+// Deprecated: Use [CreateNewVirtualNetworkClientContextE] instead.
+func CreateNewVirtualNetworkClientE(subscriptionID string) (*armnetwork.VirtualNetworksClient, error) {
+	return CreateNewVirtualNetworkClientContextE(context.Background(), subscriptionID)
+}
+
+// CreateAppServiceClientContextE returns an App service client instance configured with the
 // correct BaseURI depending on the Azure environment that is currently setup (or "Public", if none is setup).
-func CreateAppServiceClientE(subscriptionID string) (*armappservice.WebAppsClient, error) {
+// The ctx parameter supports cancellation and timeouts.
+func CreateAppServiceClientContextE(_ context.Context, subscriptionID string) (*armappservice.WebAppsClient, error) {
 	clientFactory, err := getArmAppServiceClientFactory(subscriptionID)
 	if err != nil {
 		return nil, err
 	}
 
 	return clientFactory.NewWebAppsClient(), nil
+}
+
+// CreateAppServiceClientE returns an App service client instance configured with the
+// correct BaseURI depending on the Azure environment that is currently setup (or "Public", if none is setup).
+//
+// Deprecated: Use [CreateAppServiceClientContextE] instead.
+func CreateAppServiceClientE(subscriptionID string) (*armappservice.WebAppsClient, error) {
+	return CreateAppServiceClientContextE(context.Background(), subscriptionID)
 }
 
 // getArmAppServiceClientFactory gets an arm app service client factory
@@ -769,9 +1045,10 @@ func getArmAppServiceClientFactory(subscriptionID string) (*armappservice.Client
 	})
 }
 
-// CreateContainerRegistryClientE returns an ACR client instance configured with the
+// CreateContainerRegistryClientContextE returns an ACR client instance configured with the
 // correct BaseURI depending on the Azure environment that is currently setup (or "Public", if none is setup).
-func CreateContainerRegistryClientE(subscriptionID string) (*containerregistry.RegistriesClient, error) {
+// The ctx parameter supports cancellation and timeouts.
+func CreateContainerRegistryClientContextE(_ context.Context, subscriptionID string) (*containerregistry.RegistriesClient, error) {
 	// Validate Azure subscription ID
 	subscriptionID, err := getTargetAzureSubscription(subscriptionID)
 	if err != nil {
@@ -790,9 +1067,18 @@ func CreateContainerRegistryClientE(subscriptionID string) (*containerregistry.R
 	return &registryClient, nil
 }
 
-// CreateContainerInstanceClientE returns an ACI client instance configured with the
+// CreateContainerRegistryClientE returns an ACR client instance configured with the
 // correct BaseURI depending on the Azure environment that is currently setup (or "Public", if none is setup).
-func CreateContainerInstanceClientE(subscriptionID string) (*containerinstance.ContainerGroupsClient, error) {
+//
+// Deprecated: Use [CreateContainerRegistryClientContextE] instead.
+func CreateContainerRegistryClientE(subscriptionID string) (*containerregistry.RegistriesClient, error) {
+	return CreateContainerRegistryClientContextE(context.Background(), subscriptionID)
+}
+
+// CreateContainerInstanceClientContextE returns an ACI client instance configured with the
+// correct BaseURI depending on the Azure environment that is currently setup (or "Public", if none is setup).
+// The ctx parameter supports cancellation and timeouts.
+func CreateContainerInstanceClientContextE(_ context.Context, subscriptionID string) (*containerinstance.ContainerGroupsClient, error) {
 	// Validate Azure subscription ID
 	subscriptionID, err := getTargetAzureSubscription(subscriptionID)
 	if err != nil {
@@ -811,9 +1097,18 @@ func CreateContainerInstanceClientE(subscriptionID string) (*containerinstance.C
 	return &instanceClient, nil
 }
 
-// CreateFrontDoorClientE returns an AFD client instance configured with the
+// CreateContainerInstanceClientE returns an ACI client instance configured with the
 // correct BaseURI depending on the Azure environment that is currently setup (or "Public", if none is setup).
-func CreateFrontDoorClientE(subscriptionID string) (*frontdoor.FrontDoorsClient, error) {
+//
+// Deprecated: Use [CreateContainerInstanceClientContextE] instead.
+func CreateContainerInstanceClientE(subscriptionID string) (*containerinstance.ContainerGroupsClient, error) {
+	return CreateContainerInstanceClientContextE(context.Background(), subscriptionID)
+}
+
+// CreateFrontDoorClientContextE returns an AFD client instance configured with the
+// correct BaseURI depending on the Azure environment that is currently setup (or "Public", if none is setup).
+// The ctx parameter supports cancellation and timeouts.
+func CreateFrontDoorClientContextE(_ context.Context, subscriptionID string) (*frontdoor.FrontDoorsClient, error) {
 	// Validate Azure subscription ID
 	subscriptionID, err := getTargetAzureSubscription(subscriptionID)
 	if err != nil {
@@ -832,9 +1127,18 @@ func CreateFrontDoorClientE(subscriptionID string) (*frontdoor.FrontDoorsClient,
 	return &client, nil
 }
 
-// CreateFrontDoorFrontendEndpointClientE returns an AFD Frontend Endpoints client instance configured with the
+// CreateFrontDoorClientE returns an AFD client instance configured with the
 // correct BaseURI depending on the Azure environment that is currently setup (or "Public", if none is setup).
-func CreateFrontDoorFrontendEndpointClientE(subscriptionID string) (*frontdoor.FrontendEndpointsClient, error) {
+//
+// Deprecated: Use [CreateFrontDoorClientContextE] instead.
+func CreateFrontDoorClientE(subscriptionID string) (*frontdoor.FrontDoorsClient, error) {
+	return CreateFrontDoorClientContextE(context.Background(), subscriptionID)
+}
+
+// CreateFrontDoorFrontendEndpointClientContextE returns an AFD Frontend Endpoints client instance configured with the
+// correct BaseURI depending on the Azure environment that is currently setup (or "Public", if none is setup).
+// The ctx parameter supports cancellation and timeouts.
+func CreateFrontDoorFrontendEndpointClientContextE(_ context.Context, subscriptionID string) (*frontdoor.FrontendEndpointsClient, error) {
 	// Validate Azure subscription ID
 	subscriptionID, err := getTargetAzureSubscription(subscriptionID)
 	if err != nil {
@@ -853,8 +1157,17 @@ func CreateFrontDoorFrontendEndpointClientE(subscriptionID string) (*frontdoor.F
 	return &client, nil
 }
 
-// CreateSynapseWorkspaceClientE is a helper function that will setup a synapse workspace client.
-func CreateSynapseWorkspaceClientE(subscriptionID string) (*armsynapse.WorkspacesClient, error) {
+// CreateFrontDoorFrontendEndpointClientE returns an AFD Frontend Endpoints client instance configured with the
+// correct BaseURI depending on the Azure environment that is currently setup (or "Public", if none is setup).
+//
+// Deprecated: Use [CreateFrontDoorFrontendEndpointClientContextE] instead.
+func CreateFrontDoorFrontendEndpointClientE(subscriptionID string) (*frontdoor.FrontendEndpointsClient, error) {
+	return CreateFrontDoorFrontendEndpointClientContextE(context.Background(), subscriptionID)
+}
+
+// CreateSynapseWorkspaceClientContextE is a helper function that will setup a synapse workspace client.
+// The ctx parameter supports cancellation and timeouts.
+func CreateSynapseWorkspaceClientContextE(_ context.Context, subscriptionID string) (*armsynapse.WorkspacesClient, error) {
 	clientFactory, err := getArmSynapseClientFactory(subscriptionID)
 	if err != nil {
 		return nil, err
@@ -863,8 +1176,16 @@ func CreateSynapseWorkspaceClientE(subscriptionID string) (*armsynapse.Workspace
 	return clientFactory.NewWorkspacesClient(), nil
 }
 
-// CreateSynapseSQLPoolClientE is a helper function that will setup a Synapse SQL pool client.
-func CreateSynapseSQLPoolClientE(subscriptionID string) (*armsynapse.SQLPoolsClient, error) {
+// CreateSynapseWorkspaceClientE is a helper function that will setup a synapse workspace client.
+//
+// Deprecated: Use [CreateSynapseWorkspaceClientContextE] instead.
+func CreateSynapseWorkspaceClientE(subscriptionID string) (*armsynapse.WorkspacesClient, error) {
+	return CreateSynapseWorkspaceClientContextE(context.Background(), subscriptionID)
+}
+
+// CreateSynapseSQLPoolClientContextE is a helper function that will setup a Synapse SQL pool client.
+// The ctx parameter supports cancellation and timeouts.
+func CreateSynapseSQLPoolClientContextE(_ context.Context, subscriptionID string) (*armsynapse.SQLPoolsClient, error) {
 	clientFactory, err := getArmSynapseClientFactory(subscriptionID)
 	if err != nil {
 		return nil, err
@@ -873,13 +1194,30 @@ func CreateSynapseSQLPoolClientE(subscriptionID string) (*armsynapse.SQLPoolsCli
 	return clientFactory.NewSQLPoolsClient(), nil
 }
 
+// CreateSynapseSQLPoolClientE is a helper function that will setup a Synapse SQL pool client.
+//
+// Deprecated: Use [CreateSynapseSQLPoolClientContextE] instead.
+func CreateSynapseSQLPoolClientE(subscriptionID string) (*armsynapse.SQLPoolsClient, error) {
+	return CreateSynapseSQLPoolClientContextE(context.Background(), subscriptionID)
+}
+
+// CreateSynapseSqlPoolClientContextE is a helper function that will setup a Synapse SQL pool client.
+// The ctx parameter supports cancellation and timeouts.
+//
+// Deprecated: Use [CreateSynapseSQLPoolClientContextE] instead.
+//
+//nolint:staticcheck,revive // preserving existing function name
+func CreateSynapseSqlPoolClientContextE(ctx context.Context, subscriptionID string) (*armsynapse.SQLPoolsClient, error) {
+	return CreateSynapseSQLPoolClientContextE(ctx, subscriptionID)
+}
+
 // CreateSynapseSqlPoolClientE is a helper function that will setup a Synapse SQL pool client.
 //
-// Deprecated: Use [CreateSynapseSQLPoolClientE] instead.
+// Deprecated: Use [CreateSynapseSQLPoolClientContextE] instead.
 //
 //nolint:staticcheck,revive // preserving existing function name
 func CreateSynapseSqlPoolClientE(subscriptionID string) (*armsynapse.SQLPoolsClient, error) {
-	return CreateSynapseSQLPoolClientE(subscriptionID)
+	return CreateSynapseSQLPoolClientContextE(context.Background(), subscriptionID)
 }
 
 // getArmSynapseClientFactory gets an arm synapse client factory
@@ -910,8 +1248,9 @@ func getArmSynapseClientFactory(subscriptionID string) (*armsynapse.ClientFactor
 	})
 }
 
-// CreateDataFactoriesClientE is a helper function that will setup a data factory client.
-func CreateDataFactoriesClientE(subscriptionID string) (*armdatafactory.FactoriesClient, error) {
+// CreateDataFactoriesClientContextE is a helper function that will setup a data factory client.
+// The ctx parameter supports cancellation and timeouts.
+func CreateDataFactoriesClientContextE(_ context.Context, subscriptionID string) (*armdatafactory.FactoriesClient, error) {
 	clientFactory, err := getArmDataFactoryClientFactory(subscriptionID)
 	if err != nil {
 		return nil, err
@@ -920,8 +1259,16 @@ func CreateDataFactoriesClientE(subscriptionID string) (*armdatafactory.Factorie
 	return clientFactory.NewFactoriesClient(), nil
 }
 
-// CreateManagedEnvironmentsClientE creates a managed environments client for Azure Container Apps.
-func CreateManagedEnvironmentsClientE(subscriptionID string) (*armappcontainers.ManagedEnvironmentsClient, error) {
+// CreateDataFactoriesClientE is a helper function that will setup a data factory client.
+//
+// Deprecated: Use [CreateDataFactoriesClientContextE] instead.
+func CreateDataFactoriesClientE(subscriptionID string) (*armdatafactory.FactoriesClient, error) {
+	return CreateDataFactoriesClientContextE(context.Background(), subscriptionID)
+}
+
+// CreateManagedEnvironmentsClientContextE creates a managed environments client for Azure Container Apps.
+// The ctx parameter supports cancellation and timeouts.
+func CreateManagedEnvironmentsClientContextE(_ context.Context, subscriptionID string) (*armappcontainers.ManagedEnvironmentsClient, error) {
 	clientFactory, err := getArmAppContainersClientFactory(subscriptionID)
 	if err != nil {
 		return nil, err
@@ -932,8 +1279,16 @@ func CreateManagedEnvironmentsClientE(subscriptionID string) (*armappcontainers.
 	return client, nil
 }
 
-// CreateResourceGroupClientV2E creates a v2 resource group client using the ARM SDK.
-func CreateResourceGroupClientV2E(subscriptionID string) (*armresources.ResourceGroupsClient, error) {
+// CreateManagedEnvironmentsClientE creates a managed environments client for Azure Container Apps.
+//
+// Deprecated: Use [CreateManagedEnvironmentsClientContextE] instead.
+func CreateManagedEnvironmentsClientE(subscriptionID string) (*armappcontainers.ManagedEnvironmentsClient, error) {
+	return CreateManagedEnvironmentsClientContextE(context.Background(), subscriptionID)
+}
+
+// CreateResourceGroupClientV2ContextE creates a v2 resource group client using the ARM SDK.
+// The ctx parameter supports cancellation and timeouts.
+func CreateResourceGroupClientV2ContextE(_ context.Context, subscriptionID string) (*armresources.ResourceGroupsClient, error) {
 	clientFactory, err := getArmResourcesClientFactory(subscriptionID)
 	if err != nil {
 		return nil, err
@@ -942,8 +1297,16 @@ func CreateResourceGroupClientV2E(subscriptionID string) (*armresources.Resource
 	return clientFactory.NewResourceGroupsClient(), nil
 }
 
-// CreateContainerAppsClientE creates a Container Apps client for Azure Container Apps.
-func CreateContainerAppsClientE(subscriptionID string) (*armappcontainers.ContainerAppsClient, error) {
+// CreateResourceGroupClientV2E creates a v2 resource group client using the ARM SDK.
+//
+// Deprecated: Use [CreateResourceGroupClientV2ContextE] instead.
+func CreateResourceGroupClientV2E(subscriptionID string) (*armresources.ResourceGroupsClient, error) {
+	return CreateResourceGroupClientV2ContextE(context.Background(), subscriptionID)
+}
+
+// CreateContainerAppsClientContextE creates a Container Apps client for Azure Container Apps.
+// The ctx parameter supports cancellation and timeouts.
+func CreateContainerAppsClientContextE(_ context.Context, subscriptionID string) (*armappcontainers.ContainerAppsClient, error) {
 	clientFactory, err := getArmAppContainersClientFactory(subscriptionID)
 	if err != nil {
 		return nil, err
@@ -954,8 +1317,16 @@ func CreateContainerAppsClientE(subscriptionID string) (*armappcontainers.Contai
 	return client, nil
 }
 
-// CreateContainerAppJobsClientE creates a Container App Jobs client for Azure Container Apps.
-func CreateContainerAppJobsClientE(subscriptionID string) (*armappcontainers.JobsClient, error) {
+// CreateContainerAppsClientE creates a Container Apps client for Azure Container Apps.
+//
+// Deprecated: Use [CreateContainerAppsClientContextE] instead.
+func CreateContainerAppsClientE(subscriptionID string) (*armappcontainers.ContainerAppsClient, error) {
+	return CreateContainerAppsClientContextE(context.Background(), subscriptionID)
+}
+
+// CreateContainerAppJobsClientContextE creates a Container App Jobs client for Azure Container Apps.
+// The ctx parameter supports cancellation and timeouts.
+func CreateContainerAppJobsClientContextE(_ context.Context, subscriptionID string) (*armappcontainers.JobsClient, error) {
 	clientFactory, err := getArmAppContainersClientFactory(subscriptionID)
 	if err != nil {
 		return nil, err
@@ -966,8 +1337,16 @@ func CreateContainerAppJobsClientE(subscriptionID string) (*armappcontainers.Job
 	return client, nil
 }
 
-// GetKeyVaultURISuffixE returns the proper KeyVault URI suffix for the configured Azure environment.
-func GetKeyVaultURISuffixE() (string, error) {
+// CreateContainerAppJobsClientE creates a Container App Jobs client for Azure Container Apps.
+//
+// Deprecated: Use [CreateContainerAppJobsClientContextE] instead.
+func CreateContainerAppJobsClientE(subscriptionID string) (*armappcontainers.JobsClient, error) {
+	return CreateContainerAppJobsClientContextE(context.Background(), subscriptionID)
+}
+
+// GetKeyVaultURISuffixContextE returns the proper KeyVault URI suffix for the configured Azure environment.
+// The ctx parameter supports cancellation and timeouts.
+func GetKeyVaultURISuffixContextE(_ context.Context) (string, error) {
 	envName := getDefaultEnvironmentName()
 
 	switch strings.ToUpper(envName) {
@@ -982,8 +1361,16 @@ func GetKeyVaultURISuffixE() (string, error) {
 	}
 }
 
-// GetStorageURISuffixE returns the proper storage URI suffix for the configured Azure environment.
-func GetStorageURISuffixE() (string, error) {
+// GetKeyVaultURISuffixE returns the proper KeyVault URI suffix for the configured Azure environment.
+//
+// Deprecated: Use [GetKeyVaultURISuffixContextE] instead.
+func GetKeyVaultURISuffixE() (string, error) {
+	return GetKeyVaultURISuffixContextE(context.Background())
+}
+
+// GetStorageURISuffixContextE returns the proper storage URI suffix for the configured Azure environment.
+// The ctx parameter supports cancellation and timeouts.
+func GetStorageURISuffixContextE(_ context.Context) (string, error) {
 	envName := getDefaultEnvironmentName()
 
 	switch strings.ToUpper(envName) {
@@ -996,6 +1383,13 @@ func GetStorageURISuffixE() (string, error) {
 	default:
 		return "", &UnknownEnvironmentError{EnvironmentName: envName}
 	}
+}
+
+// GetStorageURISuffixE returns the proper storage URI suffix for the configured Azure environment.
+//
+// Deprecated: Use [GetStorageURISuffixContextE] instead.
+func GetStorageURISuffixE() (string, error) {
+	return GetStorageURISuffixContextE(context.Background())
 }
 
 // getDefaultEnvironmentName returns either a configured Azure environment name, or the public default.

--- a/modules/azure/compute.go
+++ b/modules/azure/compute.go
@@ -10,27 +10,46 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// GetVirtualMachineClient is a helper function that will setup an Azure Virtual Machine client on your behalf.
+// GetVirtualMachineClientContext is a helper function that will setup an Azure Virtual Machine client on your behalf.
 // This function would fail the test if there is an error.
-func GetVirtualMachineClient(t testing.TestingT, subscriptionID string) *armcompute.VirtualMachinesClient {
+// The ctx parameter supports cancellation and timeouts.
+func GetVirtualMachineClientContext(t testing.TestingT, ctx context.Context, subscriptionID string) *armcompute.VirtualMachinesClient {
 	t.Helper()
 
-	vmClient, err := GetVirtualMachineClientE(subscriptionID)
+	vmClient, err := GetVirtualMachineClientContextE(ctx, subscriptionID)
 	require.NoError(t, err)
 
 	return vmClient
 }
 
-// GetVirtualMachineClientE is a helper function that will setup an Azure Virtual Machine client on your behalf.
-func GetVirtualMachineClientE(subscriptionID string) (*armcompute.VirtualMachinesClient, error) {
+// GetVirtualMachineClient is a helper function that will setup an Azure Virtual Machine client on your behalf.
+// This function would fail the test if there is an error.
+//
+// Deprecated: Use [GetVirtualMachineClientContext] instead.
+func GetVirtualMachineClient(t testing.TestingT, subscriptionID string) *armcompute.VirtualMachinesClient {
+	t.Helper()
+
+	return GetVirtualMachineClientContext(t, context.Background(), subscriptionID) //nolint:staticcheck
+}
+
+// GetVirtualMachineClientContextE is a helper function that will setup an Azure Virtual Machine client on your behalf.
+// The ctx parameter supports cancellation and timeouts.
+func GetVirtualMachineClientContextE(ctx context.Context, subscriptionID string) (*armcompute.VirtualMachinesClient, error) {
 	// snippet-tag-start::client_factory_example.helper
-	vmClient, err := CreateVirtualMachinesClientE(subscriptionID)
+	vmClient, err := CreateVirtualMachinesClientContextE(ctx, subscriptionID)
 	if err != nil {
 		return nil, err
 	}
 	// snippet-tag-end::client_factory_example.helper
 
 	return vmClient, nil
+}
+
+// GetVirtualMachineClientE is a helper function that will setup an Azure Virtual Machine client on your behalf.
+//
+// Deprecated: Use [GetVirtualMachineClientContextE] instead.
+func GetVirtualMachineClientE(subscriptionID string) (*armcompute.VirtualMachinesClient, error) {
+	return GetVirtualMachineClientContextE(context.Background(), subscriptionID)
 }
 
 // VirtualMachineExistsContext indicates whether the specified Azure Virtual Machine exists.
@@ -347,7 +366,7 @@ func ListVirtualMachinesForResourceGroupContext(t testing.TestingT, ctx context.
 // ListVirtualMachinesForResourceGroupContextE gets a list of all Virtual Machine names in the specified Resource Group.
 // The ctx parameter supports cancellation and timeouts.
 func ListVirtualMachinesForResourceGroupContextE(ctx context.Context, resourceGroupName string, subscriptionID string) ([]string, error) {
-	vmClient, err := GetVirtualMachineClientE(subscriptionID)
+	vmClient, err := GetVirtualMachineClientContextE(ctx, subscriptionID)
 	if err != nil {
 		return nil, err
 	}
@@ -391,7 +410,7 @@ func GetVirtualMachinesForResourceGroupContext(t testing.TestingT, ctx context.C
 // VM Object represents the entire set of VM compute properties accessible by using the VM name as the map key.
 // The ctx parameter supports cancellation and timeouts.
 func GetVirtualMachinesForResourceGroupContextE(ctx context.Context, resourceGroupName string, subscriptionID string) (map[string]armcompute.VirtualMachineProperties, error) {
-	vmClient, err := GetVirtualMachineClientE(subscriptionID)
+	vmClient, err := GetVirtualMachineClientContextE(ctx, subscriptionID)
 	if err != nil {
 		return nil, err
 	}
@@ -456,7 +475,7 @@ func GetVirtualMachineContextE(ctx context.Context, vmName string, resGroupName 
 		return nil, err
 	}
 
-	client, err := GetVirtualMachineClientE(subscriptionID)
+	client, err := GetVirtualMachineClientContextE(ctx, subscriptionID)
 	if err != nil {
 		return nil, err
 	}

--- a/modules/azure/container_apps.go
+++ b/modules/azure/container_apps.go
@@ -33,7 +33,7 @@ func ManagedEnvironmentExists(t testing.TestingT, environmentName string, resour
 // ManagedEnvironmentExistsContextE indicates whether the specified Managed Environment exists.
 // The ctx parameter supports cancellation and timeouts.
 func ManagedEnvironmentExistsContextE(ctx context.Context, environmentName string, resourceGroupName string, subscriptionID string) (bool, error) {
-	client, err := CreateManagedEnvironmentsClientE(subscriptionID)
+	client, err := CreateManagedEnvironmentsClientContextE(ctx, subscriptionID)
 	if err != nil {
 		return false, err
 	}
@@ -78,7 +78,7 @@ func GetManagedEnvironment(t testing.TestingT, environmentName string, resourceG
 // GetManagedEnvironmentContextE returns the Managed Environment object.
 // The ctx parameter supports cancellation and timeouts.
 func GetManagedEnvironmentContextE(ctx context.Context, environmentName string, resourceGroupName string, subscriptionID string) (*armappcontainers.ManagedEnvironment, error) {
-	client, err := CreateManagedEnvironmentsClientE(subscriptionID)
+	client, err := CreateManagedEnvironmentsClientContextE(ctx, subscriptionID)
 	if err != nil {
 		return nil, err
 	}
@@ -123,7 +123,7 @@ func ContainerAppExists(t testing.TestingT, containerAppName string, resourceGro
 // ContainerAppExistsContextE indicates whether the Container App exists for the subscription.
 // The ctx parameter supports cancellation and timeouts.
 func ContainerAppExistsContextE(ctx context.Context, containerAppName string, resourceGroupName string, subscriptionID string) (bool, error) {
-	client, err := CreateContainerAppsClientE(subscriptionID)
+	client, err := CreateContainerAppsClientContextE(ctx, subscriptionID)
 	if err != nil {
 		return false, err
 	}
@@ -168,7 +168,7 @@ func GetContainerApp(t testing.TestingT, containerAppName string, resourceGroupN
 // GetContainerAppContextE returns the Container App object.
 // The ctx parameter supports cancellation and timeouts.
 func GetContainerAppContextE(ctx context.Context, containerAppName string, resourceGroupName string, subscriptionID string) (*armappcontainers.ContainerApp, error) {
-	client, err := CreateContainerAppsClientE(subscriptionID)
+	client, err := CreateContainerAppsClientContextE(ctx, subscriptionID)
 	if err != nil {
 		return nil, err
 	}
@@ -213,7 +213,7 @@ func ContainerAppJobExists(t testing.TestingT, containerAppName string, resource
 // ContainerAppJobExistsContextE indicates whether the Container App Job exists for the subscription.
 // The ctx parameter supports cancellation and timeouts.
 func ContainerAppJobExistsContextE(ctx context.Context, containerAppName string, resourceGroupName string, subscriptionID string) (bool, error) {
-	client, err := CreateContainerAppJobsClientE(subscriptionID)
+	client, err := CreateContainerAppJobsClientContextE(ctx, subscriptionID)
 	if err != nil {
 		return false, err
 	}
@@ -258,7 +258,7 @@ func GetContainerAppJob(t testing.TestingT, containerAppName string, resourceGro
 // GetContainerAppJobContextE returns the Container App Job object.
 // The ctx parameter supports cancellation and timeouts.
 func GetContainerAppJobContextE(ctx context.Context, containerAppName string, resourceGroupName string, subscriptionID string) (*armappcontainers.Job, error) {
-	client, err := CreateContainerAppJobsClientE(subscriptionID)
+	client, err := CreateContainerAppJobsClientContextE(ctx, subscriptionID)
 	if err != nil {
 		return nil, err
 	}

--- a/modules/azure/containers.go
+++ b/modules/azure/containers.go
@@ -84,7 +84,7 @@ func GetContainerRegistryContextE(ctx context.Context, registryName string, resG
 		return nil, err
 	}
 
-	client, err := GetContainerRegistryClientE(subscriptionID)
+	client, err := GetContainerRegistryClientContextE(ctx, subscriptionID)
 	if err != nil {
 		return nil, err
 	}
@@ -104,10 +104,11 @@ func GetContainerRegistryE(registryName string, resGroupName string, subscriptio
 	return GetContainerRegistryContextE(context.Background(), registryName, resGroupName, subscriptionID)
 }
 
-// GetContainerRegistryClientE is a helper function that will setup an Azure Container Registry client on your behalf.
-func GetContainerRegistryClientE(subscriptionID string) (*containerregistry.RegistriesClient, error) {
+// GetContainerRegistryClientContextE is a helper function that will setup an Azure Container Registry client on your behalf.
+// The ctx parameter supports cancellation and timeouts.
+func GetContainerRegistryClientContextE(ctx context.Context, subscriptionID string) (*containerregistry.RegistriesClient, error) {
 	// Create an ACR client
-	registryClient, err := CreateContainerRegistryClientE(subscriptionID)
+	registryClient, err := CreateContainerRegistryClientContextE(ctx, subscriptionID)
 	if err != nil {
 		return nil, err
 	}
@@ -122,6 +123,13 @@ func GetContainerRegistryClientE(subscriptionID string) (*containerregistry.Regi
 	registryClient.Authorizer = *authorizer
 
 	return registryClient, nil
+}
+
+// GetContainerRegistryClientE is a helper function that will setup an Azure Container Registry client on your behalf.
+//
+// Deprecated: Use [GetContainerRegistryClientContextE] instead.
+func GetContainerRegistryClientE(subscriptionID string) (*containerregistry.RegistriesClient, error) {
+	return GetContainerRegistryClientContextE(context.Background(), subscriptionID)
 }
 
 // ContainerInstanceExistsContext indicates whether the specified container instance exists.
@@ -198,7 +206,7 @@ func GetContainerInstanceContextE(ctx context.Context, instanceName string, resG
 		return nil, err
 	}
 
-	client, err := GetContainerInstanceClientE(subscriptionID)
+	client, err := GetContainerInstanceClientContextE(ctx, subscriptionID)
 	if err != nil {
 		return nil, err
 	}
@@ -218,10 +226,11 @@ func GetContainerInstanceE(instanceName string, resGroupName string, subscriptio
 	return GetContainerInstanceContextE(context.Background(), instanceName, resGroupName, subscriptionID)
 }
 
-// GetContainerInstanceClientE is a helper function that will setup an Azure Container Instance client on your behalf.
-func GetContainerInstanceClientE(subscriptionID string) (*containerinstance.ContainerGroupsClient, error) {
+// GetContainerInstanceClientContextE is a helper function that will setup an Azure Container Instance client on your behalf.
+// The ctx parameter supports cancellation and timeouts.
+func GetContainerInstanceClientContextE(ctx context.Context, subscriptionID string) (*containerinstance.ContainerGroupsClient, error) {
 	// Create an ACI client
-	instanceClient, err := CreateContainerInstanceClientE(subscriptionID)
+	instanceClient, err := CreateContainerInstanceClientContextE(ctx, subscriptionID)
 	if err != nil {
 		return nil, err
 	}
@@ -236,4 +245,11 @@ func GetContainerInstanceClientE(subscriptionID string) (*containerinstance.Cont
 	instanceClient.Authorizer = *authorizer
 
 	return instanceClient, nil
+}
+
+// GetContainerInstanceClientE is a helper function that will setup an Azure Container Instance client on your behalf.
+//
+// Deprecated: Use [GetContainerInstanceClientContextE] instead.
+func GetContainerInstanceClientE(subscriptionID string) (*containerinstance.ContainerGroupsClient, error) {
+	return GetContainerInstanceClientContextE(context.Background(), subscriptionID)
 }

--- a/modules/azure/cosmosdb.go
+++ b/modules/azure/cosmosdb.go
@@ -8,18 +8,35 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// GetCosmosDBAccountClientContextE is a helper function that will setup a CosmosDB account client.
+// The ctx parameter supports cancellation and timeouts.
+func GetCosmosDBAccountClientContextE(ctx context.Context, subscriptionID string) (*armcosmos.DatabaseAccountsClient, error) {
+	return CreateCosmosDBAccountClientContextE(ctx, subscriptionID)
+}
+
 // GetCosmosDBAccountClientE is a helper function that will setup a CosmosDB account client.
+//
+// Deprecated: Use [GetCosmosDBAccountClientContextE] instead.
 func GetCosmosDBAccountClientE(subscriptionID string) (*armcosmos.DatabaseAccountsClient, error) {
-	return CreateCosmosDBAccountClientE(subscriptionID)
+	return GetCosmosDBAccountClientContextE(context.Background(), subscriptionID)
+}
+
+// GetCosmosDBAccountClientContext is a helper function that will setup a CosmosDB account client.
+// This function would fail the test if there is an error.
+// The ctx parameter supports cancellation and timeouts.
+func GetCosmosDBAccountClientContext(t testing.TestingT, ctx context.Context, subscriptionID string) *armcosmos.DatabaseAccountsClient {
+	cosmosDBAccount, err := GetCosmosDBAccountClientContextE(ctx, subscriptionID)
+	require.NoError(t, err)
+
+	return cosmosDBAccount
 }
 
 // GetCosmosDBAccountClient is a helper function that will setup a CosmosDB account client.
 // This function would fail the test if there is an error.
+//
+// Deprecated: Use [GetCosmosDBAccountClientContext] instead.
 func GetCosmosDBAccountClient(t testing.TestingT, subscriptionID string) *armcosmos.DatabaseAccountsClient {
-	cosmosDBAccount, err := GetCosmosDBAccountClientE(subscriptionID)
-	require.NoError(t, err)
-
-	return cosmosDBAccount
+	return GetCosmosDBAccountClientContext(t, context.Background(), subscriptionID) //nolint:staticcheck
 }
 
 // GetCosmosDBAccountContext is a helper function that gets the database account.
@@ -36,7 +53,7 @@ func GetCosmosDBAccountContext(t testing.TestingT, ctx context.Context, subscrip
 // The ctx parameter supports cancellation and timeouts.
 func GetCosmosDBAccountContextE(ctx context.Context, subscriptionID string, resourceGroupName string, accountName string) (*armcosmos.DatabaseAccountGetResults, error) {
 	// Create a CosmosDB client
-	cosmosClient, err := GetCosmosDBAccountClientE(subscriptionID)
+	cosmosClient, err := GetCosmosDBAccountClientContextE(ctx, subscriptionID)
 	if err != nil {
 		return nil, err
 	}
@@ -51,18 +68,35 @@ func GetCosmosDBAccountContextE(ctx context.Context, subscriptionID string, reso
 	return &resp.DatabaseAccountGetResults, nil
 }
 
+// GetCosmosDBSQLClientContextE is a helper function that will setup a CosmosDB SQL client.
+// The ctx parameter supports cancellation and timeouts.
+func GetCosmosDBSQLClientContextE(ctx context.Context, subscriptionID string) (*armcosmos.SQLResourcesClient, error) {
+	return CreateCosmosDBSQLClientContextE(ctx, subscriptionID)
+}
+
 // GetCosmosDBSQLClientE is a helper function that will setup a CosmosDB SQL client.
+//
+// Deprecated: Use [GetCosmosDBSQLClientContextE] instead.
 func GetCosmosDBSQLClientE(subscriptionID string) (*armcosmos.SQLResourcesClient, error) {
-	return CreateCosmosDBSQLClientE(subscriptionID)
+	return GetCosmosDBSQLClientContextE(context.Background(), subscriptionID)
+}
+
+// GetCosmosDBSQLClientContext is a helper function that will setup a CosmosDB SQL client.
+// This function would fail the test if there is an error.
+// The ctx parameter supports cancellation and timeouts.
+func GetCosmosDBSQLClientContext(t testing.TestingT, ctx context.Context, subscriptionID string) *armcosmos.SQLResourcesClient {
+	cosmosClient, err := GetCosmosDBSQLClientContextE(ctx, subscriptionID)
+	require.NoError(t, err)
+
+	return cosmosClient
 }
 
 // GetCosmosDBSQLClient is a helper function that will setup a CosmosDB SQL client.
 // This function would fail the test if there is an error.
+//
+// Deprecated: Use [GetCosmosDBSQLClientContext] instead.
 func GetCosmosDBSQLClient(t testing.TestingT, subscriptionID string) *armcosmos.SQLResourcesClient {
-	cosmosClient, err := GetCosmosDBSQLClientE(subscriptionID)
-	require.NoError(t, err)
-
-	return cosmosClient
+	return GetCosmosDBSQLClientContext(t, context.Background(), subscriptionID) //nolint:staticcheck
 }
 
 // GetCosmosDBSQLDatabaseContext is a helper function that gets a SQL database.
@@ -79,7 +113,7 @@ func GetCosmosDBSQLDatabaseContext(t testing.TestingT, ctx context.Context, subs
 // The ctx parameter supports cancellation and timeouts.
 func GetCosmosDBSQLDatabaseContextE(ctx context.Context, subscriptionID string, resourceGroupName string, accountName string, databaseName string) (*armcosmos.SQLDatabaseGetResults, error) {
 	// Create a CosmosDB client
-	cosmosClient, err := GetCosmosDBSQLClientE(subscriptionID)
+	cosmosClient, err := GetCosmosDBSQLClientContextE(ctx, subscriptionID)
 	if err != nil {
 		return nil, err
 	}
@@ -108,7 +142,7 @@ func GetCosmosDBSQLContainerContext(t testing.TestingT, ctx context.Context, sub
 // The ctx parameter supports cancellation and timeouts.
 func GetCosmosDBSQLContainerContextE(ctx context.Context, subscriptionID string, resourceGroupName string, accountName string, databaseName string, containerName string) (*armcosmos.SQLContainerGetResults, error) {
 	// Create a CosmosDB client
-	cosmosClient, err := GetCosmosDBSQLClientE(subscriptionID)
+	cosmosClient, err := GetCosmosDBSQLClientContextE(ctx, subscriptionID)
 	if err != nil {
 		return nil, err
 	}
@@ -137,7 +171,7 @@ func GetCosmosDBSQLDatabaseThroughputContext(t testing.TestingT, ctx context.Con
 // The ctx parameter supports cancellation and timeouts.
 func GetCosmosDBSQLDatabaseThroughputContextE(ctx context.Context, subscriptionID string, resourceGroupName string, accountName string, databaseName string) (*armcosmos.ThroughputSettingsGetResults, error) {
 	// Create a CosmosDB client
-	cosmosClient, err := GetCosmosDBSQLClientE(subscriptionID)
+	cosmosClient, err := GetCosmosDBSQLClientContextE(ctx, subscriptionID)
 	if err != nil {
 		return nil, err
 	}
@@ -166,7 +200,7 @@ func GetCosmosDBSQLContainerThroughputContext(t testing.TestingT, ctx context.Co
 // The ctx parameter supports cancellation and timeouts.
 func GetCosmosDBSQLContainerThroughputContextE(ctx context.Context, subscriptionID string, resourceGroupName string, accountName string, databaseName string, containerName string) (*armcosmos.ThroughputSettingsGetResults, error) {
 	// Create a CosmosDB client
-	cosmosClient, err := GetCosmosDBSQLClientE(subscriptionID)
+	cosmosClient, err := GetCosmosDBSQLClientContextE(ctx, subscriptionID)
 	if err != nil {
 		return nil, err
 	}

--- a/modules/azure/datafactory.go
+++ b/modules/azure/datafactory.go
@@ -78,7 +78,7 @@ func GetDataFactory(t testing.TestingT, resGroupName string, factoryName string,
 // The ctx parameter supports cancellation and timeouts.
 func GetDataFactoryContextE(ctx context.Context, subscriptionID string, resGroupName string, factoryName string) (*armdatafactory.Factory, error) {
 	// Create a datafactory client
-	datafactoryClient, err := CreateDataFactoriesClientE(subscriptionID)
+	datafactoryClient, err := CreateDataFactoriesClientContextE(ctx, subscriptionID)
 	if err != nil {
 		return nil, err
 	}

--- a/modules/azure/disk.go
+++ b/modules/azure/disk.go
@@ -55,7 +55,7 @@ func GetDiskContextE(ctx context.Context, diskName string, resGroupName string, 
 		return nil, err
 	}
 
-	client, err := CreateDisksClientE(subscriptionID)
+	client, err := CreateDisksClientContextE(ctx, subscriptionID)
 	if err != nil {
 		return nil, err
 	}

--- a/modules/azure/frontdoor.go
+++ b/modules/azure/frontdoor.go
@@ -143,7 +143,7 @@ func FrontDoorFrontendEndpointExistsE(endpointName string, frontDoorName string,
 // GetFrontDoorContextE gets the specified Front Door if it exists.
 // The ctx parameter supports cancellation and timeouts.
 func GetFrontDoorContextE(ctx context.Context, frontDoorName, resourceGroupName, subscriptionID string) (*frontdoor.FrontDoor, error) {
-	client, err := GetFrontDoorClientE(subscriptionID)
+	client, err := GetFrontDoorClientContextE(ctx, subscriptionID)
 	if err != nil {
 		return nil, err
 	}
@@ -166,7 +166,7 @@ func GetFrontDoorE(frontDoorName, resourceGroupName, subscriptionID string) (*fr
 // GetFrontDoorFrontendEndpointContextE gets the specified Frontend Endpoint for the provided Front Door if it exists.
 // The ctx parameter supports cancellation and timeouts.
 func GetFrontDoorFrontendEndpointContextE(ctx context.Context, endpointName, frontDoorName, resourceGroupName, subscriptionID string) (*frontdoor.FrontendEndpoint, error) {
-	client, err := GetFrontDoorFrontendEndpointClientE(subscriptionID)
+	client, err := GetFrontDoorFrontendEndpointClientContextE(ctx, subscriptionID)
 	if err != nil {
 		return nil, err
 	}
@@ -186,9 +186,35 @@ func GetFrontDoorFrontendEndpointE(endpointName, frontDoorName, resourceGroupNam
 	return GetFrontDoorFrontendEndpointContextE(context.Background(), endpointName, frontDoorName, resourceGroupName, subscriptionID)
 }
 
+// GetFrontDoorClientContextE returns a front door client; otherwise error.
+// The ctx parameter supports cancellation and timeouts.
+func GetFrontDoorClientContextE(ctx context.Context, subscriptionID string) (*frontdoor.FrontDoorsClient, error) {
+	client, err := CreateFrontDoorClientContextE(ctx, subscriptionID)
+	if err != nil {
+		return nil, err
+	}
+
+	authorizer, err := NewAuthorizer()
+	if err != nil {
+		return nil, err
+	}
+
+	client.Authorizer = *authorizer
+
+	return client, nil
+}
+
 // GetFrontDoorClientE returns a front door client; otherwise error.
+//
+// Deprecated: Use [GetFrontDoorClientContextE] instead.
 func GetFrontDoorClientE(subscriptionID string) (*frontdoor.FrontDoorsClient, error) {
-	client, err := CreateFrontDoorClientE(subscriptionID)
+	return GetFrontDoorClientContextE(context.Background(), subscriptionID)
+}
+
+// GetFrontDoorFrontendEndpointClientContextE returns a front door frontend endpoints client; otherwise error.
+// The ctx parameter supports cancellation and timeouts.
+func GetFrontDoorFrontendEndpointClientContextE(ctx context.Context, subscriptionID string) (*frontdoor.FrontendEndpointsClient, error) {
+	client, err := CreateFrontDoorFrontendEndpointClientContextE(ctx, subscriptionID)
 	if err != nil {
 		return nil, err
 	}
@@ -204,18 +230,8 @@ func GetFrontDoorClientE(subscriptionID string) (*frontdoor.FrontDoorsClient, er
 }
 
 // GetFrontDoorFrontendEndpointClientE returns a front door frontend endpoints client; otherwise error.
+//
+// Deprecated: Use [GetFrontDoorFrontendEndpointClientContextE] instead.
 func GetFrontDoorFrontendEndpointClientE(subscriptionID string) (*frontdoor.FrontendEndpointsClient, error) {
-	client, err := CreateFrontDoorFrontendEndpointClientE(subscriptionID)
-	if err != nil {
-		return nil, err
-	}
-
-	authorizer, err := NewAuthorizer()
-	if err != nil {
-		return nil, err
-	}
-
-	client.Authorizer = *authorizer
-
-	return client, nil
+	return GetFrontDoorFrontendEndpointClientContextE(context.Background(), subscriptionID)
 }

--- a/modules/azure/keyvault.go
+++ b/modules/azure/keyvault.go
@@ -87,7 +87,7 @@ func KeyVaultCertificateExists(t testing.TestingT, keyVaultName string, certific
 // KeyVaultCertificateExistsContextE indicates whether a certificate exists in key vault; otherwise false.
 // The ctx parameter supports cancellation and timeouts.
 func KeyVaultCertificateExistsContextE(ctx context.Context, keyVaultName, certificateName string) (bool, error) {
-	client, err := GetKeyVaultCertificatesClientE(keyVaultName)
+	client, err := GetKeyVaultCertificatesClientContextE(ctx, keyVaultName)
 	if err != nil {
 		return false, err
 	}
@@ -120,7 +120,7 @@ func KeyVaultCertificateExistsE(keyVaultName, certificateName string) (bool, err
 // KeyVaultKeyExistsContextE indicates whether a key exists in the key vault; otherwise false.
 // The ctx parameter supports cancellation and timeouts.
 func KeyVaultKeyExistsContextE(ctx context.Context, keyVaultName, keyName string) (bool, error) {
-	client, err := GetKeyVaultKeysClientE(keyVaultName)
+	client, err := GetKeyVaultKeysClientContextE(ctx, keyVaultName)
 	if err != nil {
 		return false, err
 	}
@@ -153,7 +153,7 @@ func KeyVaultKeyExistsE(keyVaultName, keyName string) (bool, error) {
 // KeyVaultSecretExistsContextE indicates whether a secret exists in the key vault; otherwise false.
 // The ctx parameter supports cancellation and timeouts.
 func KeyVaultSecretExistsContextE(ctx context.Context, keyVaultName, secretName string) (bool, error) {
-	client, err := GetKeyVaultSecretsClientE(keyVaultName)
+	client, err := GetKeyVaultSecretsClientContextE(ctx, keyVaultName)
 	if err != nil {
 		return false, err
 	}
@@ -183,9 +183,10 @@ func KeyVaultSecretExistsE(keyVaultName, secretName string) (bool, error) {
 	return KeyVaultSecretExistsContextE(context.Background(), keyVaultName, secretName)
 }
 
-// GetKeyVaultSecretsClientE creates a KeyVault secrets client.
-func GetKeyVaultSecretsClientE(keyVaultName string) (*azsecrets.Client, error) {
-	keyVaultSuffix, err := GetKeyVaultURISuffixE()
+// GetKeyVaultSecretsClientContextE creates a KeyVault secrets client.
+// The ctx parameter supports cancellation and timeouts.
+func GetKeyVaultSecretsClientContextE(_ context.Context, keyVaultName string) (*azsecrets.Client, error) {
+	keyVaultSuffix, err := GetKeyVaultURISuffixE() //nolint:contextcheck
 	if err != nil {
 		return nil, err
 	}
@@ -200,9 +201,17 @@ func GetKeyVaultSecretsClientE(keyVaultName string) (*azsecrets.Client, error) {
 	return azsecrets.NewClient(vaultURL, cred, nil)
 }
 
-// GetKeyVaultKeysClientE creates a KeyVault keys client.
-func GetKeyVaultKeysClientE(keyVaultName string) (*azkeys.Client, error) {
-	keyVaultSuffix, err := GetKeyVaultURISuffixE()
+// GetKeyVaultSecretsClientE creates a KeyVault secrets client.
+//
+// Deprecated: Use [GetKeyVaultSecretsClientContextE] instead.
+func GetKeyVaultSecretsClientE(keyVaultName string) (*azsecrets.Client, error) {
+	return GetKeyVaultSecretsClientContextE(context.Background(), keyVaultName)
+}
+
+// GetKeyVaultKeysClientContextE creates a KeyVault keys client.
+// The ctx parameter supports cancellation and timeouts.
+func GetKeyVaultKeysClientContextE(_ context.Context, keyVaultName string) (*azkeys.Client, error) {
+	keyVaultSuffix, err := GetKeyVaultURISuffixE() //nolint:contextcheck
 	if err != nil {
 		return nil, err
 	}
@@ -217,9 +226,17 @@ func GetKeyVaultKeysClientE(keyVaultName string) (*azkeys.Client, error) {
 	return azkeys.NewClient(vaultURL, cred, nil)
 }
 
-// GetKeyVaultCertificatesClientE creates a KeyVault certificates client.
-func GetKeyVaultCertificatesClientE(keyVaultName string) (*azcertificates.Client, error) {
-	keyVaultSuffix, err := GetKeyVaultURISuffixE()
+// GetKeyVaultKeysClientE creates a KeyVault keys client.
+//
+// Deprecated: Use [GetKeyVaultKeysClientContextE] instead.
+func GetKeyVaultKeysClientE(keyVaultName string) (*azkeys.Client, error) {
+	return GetKeyVaultKeysClientContextE(context.Background(), keyVaultName)
+}
+
+// GetKeyVaultCertificatesClientContextE creates a KeyVault certificates client.
+// The ctx parameter supports cancellation and timeouts.
+func GetKeyVaultCertificatesClientContextE(_ context.Context, keyVaultName string) (*azcertificates.Client, error) {
+	keyVaultSuffix, err := GetKeyVaultURISuffixE() //nolint:contextcheck
 	if err != nil {
 		return nil, err
 	}
@@ -232,6 +249,13 @@ func GetKeyVaultCertificatesClientE(keyVaultName string) (*azcertificates.Client
 	}
 
 	return azcertificates.NewClient(vaultURL, cred, nil)
+}
+
+// GetKeyVaultCertificatesClientE creates a KeyVault certificates client.
+//
+// Deprecated: Use [GetKeyVaultCertificatesClientContextE] instead.
+func GetKeyVaultCertificatesClientE(keyVaultName string) (*azcertificates.Client, error) {
+	return GetKeyVaultCertificatesClientContextE(context.Background(), keyVaultName)
 }
 
 // GetKeyVaultContext is a helper function that gets the keyvault management object.
@@ -262,7 +286,7 @@ func GetKeyVaultContextE(t testing.TestingT, ctx context.Context, resGroupName s
 	t.Helper()
 
 	// Create a key vault management client
-	vaultClient, err := GetKeyVaultManagementClientE(subscriptionID)
+	vaultClient, err := GetKeyVaultManagementClientContextE(ctx, subscriptionID)
 	if err != nil {
 		return nil, err
 	}
@@ -285,12 +309,20 @@ func GetKeyVaultE(t testing.TestingT, resGroupName string, keyVaultName string, 
 	return GetKeyVaultContextE(t, context.Background(), resGroupName, keyVaultName, subscriptionID)
 }
 
-// GetKeyVaultManagementClientE is a helper function that will setup a key vault management client.
-func GetKeyVaultManagementClientE(subscriptionID string) (*armkeyvault.VaultsClient, error) {
+// GetKeyVaultManagementClientContextE is a helper function that will setup a key vault management client.
+// The ctx parameter supports cancellation and timeouts.
+func GetKeyVaultManagementClientContextE(_ context.Context, subscriptionID string) (*armkeyvault.VaultsClient, error) {
 	clientFactory, err := getArmKeyVaultClientFactory(subscriptionID)
 	if err != nil {
 		return nil, err
 	}
 
 	return clientFactory.NewVaultsClient(), nil
+}
+
+// GetKeyVaultManagementClientE is a helper function that will setup a key vault management client.
+//
+// Deprecated: Use [GetKeyVaultManagementClientContextE] instead.
+func GetKeyVaultManagementClientE(subscriptionID string) (*armkeyvault.VaultsClient, error) {
+	return GetKeyVaultManagementClientContextE(context.Background(), subscriptionID)
 }

--- a/modules/azure/loadbalancer.go
+++ b/modules/azure/loadbalancer.go
@@ -137,7 +137,7 @@ func GetLoadBalancerFrontendIPConfigContextE(ctx context.Context, feConfigName s
 	}
 
 	// Get the client reference
-	client, err := GetLoadBalancerFrontendIPConfigClientE(subscriptionID)
+	client, err := GetLoadBalancerFrontendIPConfigClientContextE(ctx, subscriptionID)
 	if err != nil {
 		return nil, err
 	}
@@ -151,9 +151,17 @@ func GetLoadBalancerFrontendIPConfigContextE(ctx context.Context, feConfigName s
 	return &resp.FrontendIPConfiguration, nil
 }
 
+// GetLoadBalancerFrontendIPConfigClientContextE gets a new Load Balancer Frontend IP Configuration client in the specified Azure Subscription.
+// The ctx parameter supports cancellation and timeouts.
+func GetLoadBalancerFrontendIPConfigClientContextE(ctx context.Context, subscriptionID string) (*armnetwork.LoadBalancerFrontendIPConfigurationsClient, error) {
+	return CreateLoadBalancerFrontendIPConfigClientContextE(ctx, subscriptionID)
+}
+
 // GetLoadBalancerFrontendIPConfigClientE gets a new Load Balancer Frontend IP Configuration client in the specified Azure Subscription.
+//
+// Deprecated: Use [GetLoadBalancerFrontendIPConfigClientContextE] instead.
 func GetLoadBalancerFrontendIPConfigClientE(subscriptionID string) (*armnetwork.LoadBalancerFrontendIPConfigurationsClient, error) {
-	return CreateLoadBalancerFrontendIPConfigClientE(subscriptionID)
+	return GetLoadBalancerFrontendIPConfigClientContextE(context.Background(), subscriptionID)
 }
 
 // GetLoadBalancerContext gets a Load Balancer network resource in the specified Azure Resource Group.
@@ -178,7 +186,7 @@ func GetLoadBalancerContextE(ctx context.Context, loadBalancerName string, resou
 	}
 
 	// Get the client reference
-	client, err := GetLoadBalancerClientE(subscriptionID)
+	client, err := GetLoadBalancerClientContextE(ctx, subscriptionID)
 	if err != nil {
 		return nil, err
 	}
@@ -192,7 +200,15 @@ func GetLoadBalancerContextE(ctx context.Context, loadBalancerName string, resou
 	return &resp.LoadBalancer, nil
 }
 
+// GetLoadBalancerClientContextE gets a new Load Balancer client in the specified Azure Subscription.
+// The ctx parameter supports cancellation and timeouts.
+func GetLoadBalancerClientContextE(ctx context.Context, subscriptionID string) (*armnetwork.LoadBalancersClient, error) {
+	return CreateLoadBalancerClientContextE(ctx, subscriptionID)
+}
+
 // GetLoadBalancerClientE gets a new Load Balancer client in the specified Azure Subscription.
+//
+// Deprecated: Use [GetLoadBalancerClientContextE] instead.
 func GetLoadBalancerClientE(subscriptionID string) (*armnetwork.LoadBalancersClient, error) {
-	return CreateLoadBalancerClientE(subscriptionID)
+	return GetLoadBalancerClientContextE(context.Background(), subscriptionID)
 }

--- a/modules/azure/loganalytics.go
+++ b/modules/azure/loganalytics.go
@@ -56,7 +56,7 @@ func GetLogAnalyticsWorkspace(t testing.TestingT, workspaceName string, resource
 // GetLogAnalyticsWorkspaceContextE gets an operational insights workspace if it exists in a subscription.
 // The ctx parameter supports cancellation and timeouts.
 func GetLogAnalyticsWorkspaceContextE(ctx context.Context, workspaceName, resoureGroupName, subscriptionID string) (*operationalinsights.Workspace, error) {
-	client, err := GetLogAnalyticsWorkspacesClientE(subscriptionID)
+	client, err := GetLogAnalyticsWorkspacesClientContextE(ctx, subscriptionID)
 	if err != nil {
 		return nil, err
 	}
@@ -98,8 +98,9 @@ func LogAnalyticsWorkspaceExistsE(workspaceName string, resourceGroupName string
 	return LogAnalyticsWorkspaceExistsContextE(context.Background(), workspaceName, resourceGroupName, subscriptionID)
 }
 
-// GetLogAnalyticsWorkspacesClientE returns a workspaces client; otherwise error.
-func GetLogAnalyticsWorkspacesClientE(subscriptionID string) (*operationalinsights.WorkspacesClient, error) {
+// GetLogAnalyticsWorkspacesClientContextE returns a workspaces client; otherwise error.
+// The ctx parameter supports cancellation and timeouts.
+func GetLogAnalyticsWorkspacesClientContextE(_ context.Context, subscriptionID string) (*operationalinsights.WorkspacesClient, error) {
 	subscriptionID, err := getTargetAzureSubscription(subscriptionID)
 	if err != nil {
 		fmt.Println("Workspace client error getting subscription")
@@ -119,4 +120,11 @@ func GetLogAnalyticsWorkspacesClientE(subscriptionID string) (*operationalinsigh
 	client.Authorizer = *authorizer
 
 	return &client, nil
+}
+
+// GetLogAnalyticsWorkspacesClientE returns a workspaces client; otherwise error.
+//
+// Deprecated: Use [GetLogAnalyticsWorkspacesClientContextE] instead.
+func GetLogAnalyticsWorkspacesClientE(subscriptionID string) (*operationalinsights.WorkspacesClient, error) {
+	return GetLogAnalyticsWorkspacesClientContextE(context.Background(), subscriptionID)
 }

--- a/modules/azure/monitor.go
+++ b/modules/azure/monitor.go
@@ -83,7 +83,7 @@ func GetDiagnosticsSettingsResourceContextE(ctx context.Context, name string, re
 		return nil, err
 	}
 
-	client, err := CreateDiagnosticsSettingsClientE(subscriptionID)
+	client, err := CreateDiagnosticsSettingsClientContextE(ctx, subscriptionID)
 	if err != nil {
 		return nil, err
 	}
@@ -128,7 +128,7 @@ func GetVMInsightsOnboardingStatus(t testing.TestingT, resourceURI string, subsc
 // GetVMInsightsOnboardingStatusContextE gets diagnostics VM onboarding status.
 // The ctx parameter supports cancellation and timeouts.
 func GetVMInsightsOnboardingStatusContextE(t testing.TestingT, ctx context.Context, resourceURI string, subscriptionID string) (*insights.VMInsightsOnboardingStatus, error) {
-	client, err := CreateVMInsightsClientE(subscriptionID)
+	client, err := CreateVMInsightsClientContextE(ctx, subscriptionID)
 	if err != nil {
 		return nil, err
 	}
@@ -180,7 +180,7 @@ func GetActivityLogAlertResourceContextE(ctx context.Context, activityLogAlertNa
 	}
 
 	// Get the client reference
-	client, err := CreateActivityLogAlertsClientE(subscriptionID)
+	client, err := CreateActivityLogAlertsClientContextE(ctx, subscriptionID)
 	if err != nil {
 		return nil, err
 	}

--- a/modules/azure/mysql.go
+++ b/modules/azure/mysql.go
@@ -9,14 +9,22 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// GetMYSQLServerClientE is a helper function that will setup a mysql server client.
-func GetMYSQLServerClientE(subscriptionID string) (*armmysql.ServersClient, error) {
+// GetMYSQLServerClientContextE is a helper function that will setup a mysql server client.
+// The ctx parameter supports cancellation and timeouts.
+func GetMYSQLServerClientContextE(_ context.Context, subscriptionID string) (*armmysql.ServersClient, error) {
 	clientFactory, err := getArmMySQLClientFactory(subscriptionID)
 	if err != nil {
 		return nil, err
 	}
 
 	return clientFactory.NewServersClient(), nil
+}
+
+// GetMYSQLServerClientE is a helper function that will setup a mysql server client.
+//
+// Deprecated: Use [GetMYSQLServerClientContextE] instead.
+func GetMYSQLServerClientE(subscriptionID string) (*armmysql.ServersClient, error) {
+	return GetMYSQLServerClientContextE(context.Background(), subscriptionID)
 }
 
 // GetMYSQLServerContext is a helper function that gets the server.
@@ -45,7 +53,7 @@ func GetMYSQLServer(t testing.TestingT, resGroupName string, serverName string, 
 // The ctx parameter supports cancellation and timeouts.
 func GetMYSQLServerContextE(t testing.TestingT, ctx context.Context, subscriptionID string, resGroupName string, serverName string) (*armmysql.Server, error) {
 	// Create a MySQL Server client
-	mysqlClient, err := CreateMySQLServerClientE(subscriptionID)
+	mysqlClient, err := CreateMySQLServerClientContextE(ctx, subscriptionID)
 	if err != nil {
 		return nil, err
 	}
@@ -66,14 +74,22 @@ func GetMYSQLServerE(t testing.TestingT, subscriptionID string, resGroupName str
 	return GetMYSQLServerContextE(t, context.Background(), subscriptionID, resGroupName, serverName)
 }
 
-// GetMYSQLDBClientE is a helper function that will setup a mysql DB client.
-func GetMYSQLDBClientE(subscriptionID string) (*armmysql.DatabasesClient, error) {
+// GetMYSQLDBClientContextE is a helper function that will setup a mysql DB client.
+// The ctx parameter supports cancellation and timeouts.
+func GetMYSQLDBClientContextE(_ context.Context, subscriptionID string) (*armmysql.DatabasesClient, error) {
 	clientFactory, err := getArmMySQLClientFactory(subscriptionID)
 	if err != nil {
 		return nil, err
 	}
 
 	return clientFactory.NewDatabasesClient(), nil
+}
+
+// GetMYSQLDBClientE is a helper function that will setup a mysql DB client.
+//
+// Deprecated: Use [GetMYSQLDBClientContextE] instead.
+func GetMYSQLDBClientE(subscriptionID string) (*armmysql.DatabasesClient, error) {
+	return GetMYSQLDBClientContextE(context.Background(), subscriptionID)
 }
 
 // GetMYSQLDBContext is a helper function that gets the database.
@@ -102,7 +118,7 @@ func GetMYSQLDB(t testing.TestingT, resGroupName string, serverName string, dbNa
 // The ctx parameter supports cancellation and timeouts.
 func GetMYSQLDBContextE(t testing.TestingT, ctx context.Context, subscriptionID string, resGroupName string, serverName string, dbName string) (*armmysql.Database, error) {
 	// Create a MySQL db client
-	mysqldbClient, err := GetMYSQLDBClientE(subscriptionID)
+	mysqldbClient, err := GetMYSQLDBClientContextE(ctx, subscriptionID)
 	if err != nil {
 		return nil, err
 	}
@@ -149,7 +165,7 @@ func ListMySQLDB(t testing.TestingT, resGroupName string, serverName string, sub
 // The ctx parameter supports cancellation and timeouts.
 func ListMySQLDBContextE(t testing.TestingT, ctx context.Context, subscriptionID string, resGroupName string, serverName string) ([]*armmysql.Database, error) {
 	// Create a MySQL db client
-	mysqldbClient, err := GetMYSQLDBClientE(subscriptionID)
+	mysqldbClient, err := GetMYSQLDBClientContextE(ctx, subscriptionID)
 	if err != nil {
 		return nil, err
 	}

--- a/modules/azure/networkinterface.go
+++ b/modules/azure/networkinterface.go
@@ -120,7 +120,7 @@ func GetNetworkInterfaceConfigurationContextE(ctx context.Context, nicName strin
 	}
 
 	// Get the client reference
-	client, err := GetNetworkInterfaceConfigurationClientE(subscriptionID)
+	client, err := GetNetworkInterfaceConfigurationClientContextE(ctx, subscriptionID)
 	if err != nil {
 		return nil, err
 	}
@@ -134,9 +134,17 @@ func GetNetworkInterfaceConfigurationContextE(ctx context.Context, nicName strin
 	return &resp.InterfaceIPConfiguration, nil
 }
 
+// GetNetworkInterfaceConfigurationClientContextE creates a new Network Interface Configuration client in the specified Azure Subscription.
+// The ctx parameter supports cancellation and timeouts.
+func GetNetworkInterfaceConfigurationClientContextE(ctx context.Context, subscriptionID string) (*armnetwork.InterfaceIPConfigurationsClient, error) {
+	return CreateNewNetworkInterfaceIPConfigurationClientContextE(ctx, subscriptionID)
+}
+
 // GetNetworkInterfaceConfigurationClientE creates a new Network Interface Configuration client in the specified Azure Subscription.
+//
+// Deprecated: Use [GetNetworkInterfaceConfigurationClientContextE] instead.
 func GetNetworkInterfaceConfigurationClientE(subscriptionID string) (*armnetwork.InterfaceIPConfigurationsClient, error) {
-	return CreateNewNetworkInterfaceIPConfigurationClientE(subscriptionID)
+	return GetNetworkInterfaceConfigurationClientContextE(context.Background(), subscriptionID)
 }
 
 // GetNetworkInterfaceContextE gets a Network Interface in the specified Azure Resource Group.
@@ -149,7 +157,7 @@ func GetNetworkInterfaceContextE(ctx context.Context, nicName string, resGroupNa
 	}
 
 	// Get the client reference
-	client, err := GetNetworkInterfaceClientE(subscriptionID)
+	client, err := GetNetworkInterfaceClientContextE(ctx, subscriptionID)
 	if err != nil {
 		return nil, err
 	}
@@ -163,7 +171,15 @@ func GetNetworkInterfaceContextE(ctx context.Context, nicName string, resGroupNa
 	return &resp.Interface, nil
 }
 
+// GetNetworkInterfaceClientContextE creates a new Network Interface client in the specified Azure Subscription.
+// The ctx parameter supports cancellation and timeouts.
+func GetNetworkInterfaceClientContextE(ctx context.Context, subscriptionID string) (*armnetwork.InterfacesClient, error) {
+	return CreateNewNetworkInterfacesClientContextE(ctx, subscriptionID)
+}
+
 // GetNetworkInterfaceClientE creates a new Network Interface client in the specified Azure Subscription.
+//
+// Deprecated: Use [GetNetworkInterfaceClientContextE] instead.
 func GetNetworkInterfaceClientE(subscriptionID string) (*armnetwork.InterfacesClient, error) {
-	return CreateNewNetworkInterfacesClientE(subscriptionID)
+	return GetNetworkInterfaceClientContextE(context.Background(), subscriptionID)
 }

--- a/modules/azure/nsg.go
+++ b/modules/azure/nsg.go
@@ -44,44 +44,90 @@ type NsgRuleSummary struct {
 	Priority                   int32
 }
 
-// GetDefaultNsgRulesClient returns a rules client which can be used to read the list of *default* security rules
+// GetDefaultNsgRulesClientContext returns a rules client which can be used to read the list of *default* security rules
 // defined on a network security group. Note that the "default" rules are those provided implicitly
 // by the Azure platform.
 // This function would fail the test if there is an error.
-func GetDefaultNsgRulesClient(t testing.TestingT, subscriptionID string) *armnetwork.DefaultSecurityRulesClient {
+// The ctx parameter supports cancellation and timeouts.
+func GetDefaultNsgRulesClientContext(t testing.TestingT, ctx context.Context, subscriptionID string) *armnetwork.DefaultSecurityRulesClient {
 	t.Helper()
 
-	client, err := GetDefaultNsgRulesClientE(subscriptionID)
+	client, err := GetDefaultNsgRulesClientContextE(ctx, subscriptionID)
 	require.NoError(t, err)
 
 	return client
 }
 
+// GetDefaultNsgRulesClient returns a rules client which can be used to read the list of *default* security rules
+// defined on a network security group. Note that the "default" rules are those provided implicitly
+// by the Azure platform.
+// This function would fail the test if there is an error.
+//
+// Deprecated: Use [GetDefaultNsgRulesClientContext] instead.
+func GetDefaultNsgRulesClient(t testing.TestingT, subscriptionID string) *armnetwork.DefaultSecurityRulesClient {
+	t.Helper()
+
+	return GetDefaultNsgRulesClientContext(t, context.Background(), subscriptionID) //nolint:staticcheck
+}
+
+// GetDefaultNsgRulesClientContextE returns a rules client which can be used to read the list of *default* security rules
+// defined on a network security group. Note that the "default" rules are those provided implicitly
+// by the Azure platform.
+// The ctx parameter supports cancellation and timeouts.
+func GetDefaultNsgRulesClientContextE(ctx context.Context, subscriptionID string) (*armnetwork.DefaultSecurityRulesClient, error) {
+	return CreateNsgDefaultRulesClientContextE(ctx, subscriptionID)
+}
+
 // GetDefaultNsgRulesClientE returns a rules client which can be used to read the list of *default* security rules
 // defined on a network security group. Note that the "default" rules are those provided implicitly
 // by the Azure platform.
+//
+// Deprecated: Use [GetDefaultNsgRulesClientContextE] instead.
 func GetDefaultNsgRulesClientE(subscriptionID string) (*armnetwork.DefaultSecurityRulesClient, error) {
-	return CreateNsgDefaultRulesClientE(subscriptionID)
+	return GetDefaultNsgRulesClientContextE(context.Background(), subscriptionID)
+}
+
+// GetCustomNsgRulesClientContext returns a rules client which can be used to read the list of *custom* security rules
+// defined on a network security group. Note that the "custom" rules are those defined by
+// end users.
+// This function would fail the test if there is an error.
+// The ctx parameter supports cancellation and timeouts.
+func GetCustomNsgRulesClientContext(t testing.TestingT, ctx context.Context, subscriptionID string) *armnetwork.SecurityRulesClient {
+	t.Helper()
+
+	client, err := GetCustomNsgRulesClientContextE(ctx, subscriptionID)
+	require.NoError(t, err)
+
+	return client
 }
 
 // GetCustomNsgRulesClient returns a rules client which can be used to read the list of *custom* security rules
 // defined on a network security group. Note that the "custom" rules are those defined by
 // end users.
 // This function would fail the test if there is an error.
+//
+// Deprecated: Use [GetCustomNsgRulesClientContext] instead.
 func GetCustomNsgRulesClient(t testing.TestingT, subscriptionID string) *armnetwork.SecurityRulesClient {
 	t.Helper()
 
-	client, err := GetCustomNsgRulesClientE(subscriptionID)
-	require.NoError(t, err)
+	return GetCustomNsgRulesClientContext(t, context.Background(), subscriptionID) //nolint:staticcheck
+}
 
-	return client
+// GetCustomNsgRulesClientContextE returns a rules client which can be used to read the list of *custom* security rules
+// defined on a network security group. Note that the "custom" rules are those defined by
+// end users.
+// The ctx parameter supports cancellation and timeouts.
+func GetCustomNsgRulesClientContextE(ctx context.Context, subscriptionID string) (*armnetwork.SecurityRulesClient, error) {
+	return CreateNsgCustomRulesClientContextE(ctx, subscriptionID)
 }
 
 // GetCustomNsgRulesClientE returns a rules client which can be used to read the list of *custom* security rules
 // defined on a network security group. Note that the "custom" rules are those defined by
 // end users.
+//
+// Deprecated: Use [GetCustomNsgRulesClientContextE] instead.
 func GetCustomNsgRulesClientE(subscriptionID string) (*armnetwork.SecurityRulesClient, error) {
-	return CreateNsgCustomRulesClientE(subscriptionID)
+	return GetCustomNsgRulesClientContextE(context.Background(), subscriptionID)
 }
 
 // GetAllNSGRulesContext returns an NsgRuleSummaryList instance containing the combined "default" and "custom" rules
@@ -99,13 +145,13 @@ func GetAllNSGRulesContext(t testing.TestingT, ctx context.Context, resourceGrou
 // GetAllNSGRulesContextE returns an NsgRuleSummaryList instance containing the combined "default" and "custom" rules
 // from a network security group. The ctx parameter supports cancellation and timeouts.
 func GetAllNSGRulesContextE(ctx context.Context, resourceGroupName, nsgName, subscriptionID string) (NsgRuleSummaryList, error) {
-	defaultRulesClient, err := GetDefaultNsgRulesClientE(subscriptionID)
+	defaultRulesClient, err := GetDefaultNsgRulesClientContextE(ctx, subscriptionID)
 	if err != nil {
 		return NsgRuleSummaryList{}, err
 	}
 
 	// Get a client instance
-	customRulesClient, err := GetCustomNsgRulesClientE(subscriptionID)
+	customRulesClient, err := GetCustomNsgRulesClientContextE(ctx, subscriptionID)
 	if err != nil {
 		return NsgRuleSummaryList{}, err
 	}

--- a/modules/azure/postgresql.go
+++ b/modules/azure/postgresql.go
@@ -9,14 +9,22 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// GetPostgreSQLServerClientE is a helper function that will setup a postgresql server client.
-func GetPostgreSQLServerClientE(subscriptionID string) (*armpostgresql.ServersClient, error) {
+// GetPostgreSQLServerClientContextE is a helper function that will setup a postgresql server client.
+// The ctx parameter supports cancellation and timeouts.
+func GetPostgreSQLServerClientContextE(_ context.Context, subscriptionID string) (*armpostgresql.ServersClient, error) {
 	clientFactory, err := getArmPostgreSQLClientFactory(subscriptionID)
 	if err != nil {
 		return nil, err
 	}
 
 	return clientFactory.NewServersClient(), nil
+}
+
+// GetPostgreSQLServerClientE is a helper function that will setup a postgresql server client.
+//
+// Deprecated: Use [GetPostgreSQLServerClientContextE] instead.
+func GetPostgreSQLServerClientE(subscriptionID string) (*armpostgresql.ServersClient, error) {
+	return GetPostgreSQLServerClientContextE(context.Background(), subscriptionID)
 }
 
 // GetPostgreSQLServerContext is a helper function that gets the server.
@@ -45,7 +53,7 @@ func GetPostgreSQLServer(t testing.TestingT, resGroupName string, serverName str
 // The ctx parameter supports cancellation and timeouts.
 func GetPostgreSQLServerContextE(t testing.TestingT, ctx context.Context, subscriptionID string, resGroupName string, serverName string) (*armpostgresql.Server, error) {
 	// Create a postgresql Server client
-	postgresqlClient, err := GetPostgreSQLServerClientE(subscriptionID)
+	postgresqlClient, err := GetPostgreSQLServerClientContextE(ctx, subscriptionID)
 	if err != nil {
 		return nil, err
 	}
@@ -66,14 +74,22 @@ func GetPostgreSQLServerE(t testing.TestingT, subscriptionID string, resGroupNam
 	return GetPostgreSQLServerContextE(t, context.Background(), subscriptionID, resGroupName, serverName)
 }
 
-// GetPostgreSQLDBClientE is a helper function that will setup a postgresql DB client.
-func GetPostgreSQLDBClientE(subscriptionID string) (*armpostgresql.DatabasesClient, error) {
+// GetPostgreSQLDBClientContextE is a helper function that will setup a postgresql DB client.
+// The ctx parameter supports cancellation and timeouts.
+func GetPostgreSQLDBClientContextE(_ context.Context, subscriptionID string) (*armpostgresql.DatabasesClient, error) {
 	clientFactory, err := getArmPostgreSQLClientFactory(subscriptionID)
 	if err != nil {
 		return nil, err
 	}
 
 	return clientFactory.NewDatabasesClient(), nil
+}
+
+// GetPostgreSQLDBClientE is a helper function that will setup a postgresql DB client.
+//
+// Deprecated: Use [GetPostgreSQLDBClientContextE] instead.
+func GetPostgreSQLDBClientE(subscriptionID string) (*armpostgresql.DatabasesClient, error) {
+	return GetPostgreSQLDBClientContextE(context.Background(), subscriptionID)
 }
 
 // GetPostgreSQLDBContext is a helper function that gets the database.
@@ -102,7 +118,7 @@ func GetPostgreSQLDB(t testing.TestingT, resGroupName string, serverName string,
 // The ctx parameter supports cancellation and timeouts.
 func GetPostgreSQLDBContextE(t testing.TestingT, ctx context.Context, subscriptionID string, resGroupName string, serverName string, dbName string) (*armpostgresql.Database, error) {
 	// Create a postgresql db client
-	postgresqldbClient, err := GetPostgreSQLDBClientE(subscriptionID)
+	postgresqldbClient, err := GetPostgreSQLDBClientContextE(ctx, subscriptionID)
 	if err != nil {
 		return nil, err
 	}
@@ -149,7 +165,7 @@ func ListPostgreSQLDB(t testing.TestingT, subscriptionID string, resGroupName st
 // The ctx parameter supports cancellation and timeouts.
 func ListPostgreSQLDBContextE(t testing.TestingT, ctx context.Context, subscriptionID string, resGroupName string, serverName string) ([]*armpostgresql.Database, error) {
 	// Create a postgresql db client
-	postgresqldbClient, err := GetPostgreSQLDBClientE(subscriptionID)
+	postgresqldbClient, err := GetPostgreSQLDBClientContextE(ctx, subscriptionID)
 	if err != nil {
 		return nil, err
 	}

--- a/modules/azure/publicaddress.go
+++ b/modules/azure/publicaddress.go
@@ -81,7 +81,7 @@ func CheckPublicDNSNameAvailabilityContext(t testing.TestingT, ctx context.Conte
 // is available for use.
 // The ctx parameter supports cancellation and timeouts.
 func CheckPublicDNSNameAvailabilityContextE(ctx context.Context, location string, domainNameLabel string, subscriptionID string) (bool, error) {
-	client, err := CreateNetworkManagementClientE(subscriptionID)
+	client, err := CreateNetworkManagementClientContextE(ctx, subscriptionID)
 	if err != nil {
 		return false, err
 	}
@@ -102,7 +102,7 @@ func GetPublicIPAddressContextE(ctx context.Context, publicIPAddressName string,
 		return nil, err
 	}
 
-	client, err := GetPublicIPAddressClientE(subscriptionID)
+	client, err := GetPublicIPAddressClientContextE(ctx, subscriptionID)
 	if err != nil {
 		return nil, err
 	}
@@ -115,7 +115,15 @@ func GetPublicIPAddressContextE(ctx context.Context, publicIPAddressName string,
 	return &resp.PublicIPAddress, nil
 }
 
+// GetPublicIPAddressClientContextE creates a Public IP Addresses client in the specified Azure Subscription.
+// The ctx parameter supports cancellation and timeouts.
+func GetPublicIPAddressClientContextE(ctx context.Context, subscriptionID string) (*armnetwork.PublicIPAddressesClient, error) {
+	return CreatePublicIPAddressesClientContextE(ctx, subscriptionID)
+}
+
 // GetPublicIPAddressClientE creates a Public IP Addresses client in the specified Azure Subscription.
+//
+// Deprecated: Use [GetPublicIPAddressClientContextE] instead.
 func GetPublicIPAddressClientE(subscriptionID string) (*armnetwork.PublicIPAddressesClient, error) {
-	return CreatePublicIPAddressesClientE(subscriptionID)
+	return GetPublicIPAddressClientContextE(context.Background(), subscriptionID)
 }

--- a/modules/azure/region.go
+++ b/modules/azure/region.go
@@ -192,7 +192,7 @@ func GetAllAzureRegionsContextE(t testing.TestingT, ctx context.Context, subscri
 	}
 
 	// Setup Subscription client
-	subscriptionClient, err := GetSubscriptionClientE()
+	subscriptionClient, err := GetSubscriptionClientContextE(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/modules/azure/resourcegroup.go
+++ b/modules/azure/resourcegroup.go
@@ -90,7 +90,7 @@ func GetAResourceGroupContext(t testing.TestingT, ctx context.Context, resourceG
 // GetAResourceGroupContextE gets a resource group within a subscription.
 // The ctx parameter supports cancellation and timeouts.
 func GetAResourceGroupContextE(ctx context.Context, resourceGroupName, subscriptionID string) (*resources.Group, error) {
-	client, err := CreateResourceGroupClientE(subscriptionID)
+	client, err := CreateResourceGroupClientContextE(ctx, subscriptionID)
 	if err != nil {
 		return nil, err
 	}
@@ -135,7 +135,7 @@ func ListResourceGroupsByTagContext(t testing.TestingT, ctx context.Context, tag
 // ListResourceGroupsByTagContextE returns a resource group list within a subscription based on a tag key.
 // The ctx parameter supports cancellation and timeouts.
 func ListResourceGroupsByTagContextE(ctx context.Context, tag string, subscriptionID string) ([]resources.Group, error) {
-	client, err := CreateResourceGroupClientE(subscriptionID)
+	client, err := CreateResourceGroupClientContextE(ctx, subscriptionID)
 	if err != nil {
 		return nil, err
 	}

--- a/modules/azure/resourcegroupv2.go
+++ b/modules/azure/resourcegroupv2.go
@@ -86,7 +86,7 @@ func GetAResourceGroupV2Context(t testing.TestingT, ctx context.Context, resourc
 // GetAResourceGroupV2ContextE gets a resource group within a subscription.
 // The ctx parameter supports cancellation and timeouts.
 func GetAResourceGroupV2ContextE(ctx context.Context, resourceGroupName, subscriptionID string) (*armresources.ResourceGroup, error) {
-	client, err := CreateResourceGroupClientV2E(subscriptionID)
+	client, err := CreateResourceGroupClientV2ContextE(ctx, subscriptionID)
 	if err != nil {
 		return nil, err
 	}
@@ -131,7 +131,7 @@ func ListResourceGroupsByTagV2Context(t testing.TestingT, ctx context.Context, t
 // ListResourceGroupsByTagV2ContextE returns a resource group list within a subscription based on a tag key.
 // The ctx parameter supports cancellation and timeouts.
 func ListResourceGroupsByTagV2ContextE(ctx context.Context, tag string, subscriptionID string) (rg []*armresources.ResourceGroup, err error) {
-	client, err := CreateResourceGroupClientV2E(subscriptionID)
+	client, err := CreateResourceGroupClientV2ContextE(ctx, subscriptionID)
 	if err != nil {
 		return nil, err
 	}

--- a/modules/azure/servicebus.go
+++ b/modules/azure/servicebus.go
@@ -9,21 +9,21 @@ import (
 )
 
 func serviceBusNamespaceClientE(subscriptionID string) (*armservicebus.NamespacesClient, error) {
-	return CreateServiceBusNamespacesClientE(subscriptionID)
+	return CreateServiceBusNamespacesClientE(subscriptionID) //nolint:contextcheck
 }
 
 func serviceBusTopicClientE(subscriptionID string) (*armservicebus.TopicsClient, error) {
-	return CreateServiceBusTopicsClientE(subscriptionID)
+	return CreateServiceBusTopicsClientE(subscriptionID) //nolint:contextcheck
 }
 
 func serviceBusSubscriptionsClientE(subscriptionID string) (*armservicebus.SubscriptionsClient, error) {
-	return CreateServiceBusSubscriptionsClientE(subscriptionID)
+	return CreateServiceBusSubscriptionsClientE(subscriptionID) //nolint:contextcheck
 }
 
 // ListServiceBusNamespaceContextE lists all SB namespaces in all resource groups in the given subscription ID.
 // The ctx parameter supports cancellation and timeouts.
 func ListServiceBusNamespaceContextE(ctx context.Context, subscriptionID string) ([]*armservicebus.SBNamespace, error) {
-	nsClient, err := serviceBusNamespaceClientE(subscriptionID)
+	nsClient, err := serviceBusNamespaceClientE(subscriptionID) //nolint:contextcheck
 	if err != nil {
 		return nil, err
 	}
@@ -131,7 +131,7 @@ func ListServiceBusNamespaceIDsContext(t testing.TestingT, ctx context.Context, 
 // ListServiceBusNamespaceByResourceGroupContextE lists all SB namespaces in the given resource group.
 // The ctx parameter supports cancellation and timeouts.
 func ListServiceBusNamespaceByResourceGroupContextE(ctx context.Context, subscriptionID string, resourceGroup string) ([]*armservicebus.SBNamespace, error) {
-	nsClient, err := serviceBusNamespaceClientE(subscriptionID)
+	nsClient, err := serviceBusNamespaceClientE(subscriptionID) //nolint:contextcheck
 	if err != nil {
 		return nil, err
 	}
@@ -218,7 +218,7 @@ func ListServiceBusNamespaceIDsByResourceGroupContext(t testing.TestingT, ctx co
 // of authorization rules for the given namespace name, automatically crossing page boundaries as required.
 // The ctx parameter supports cancellation and timeouts.
 func ListNamespaceAuthRulesContextE(ctx context.Context, subscriptionID string, namespace string, resourceGroup string) ([]string, error) {
-	nsClient, err := serviceBusNamespaceClientE(subscriptionID)
+	nsClient, err := serviceBusNamespaceClientE(subscriptionID) //nolint:contextcheck
 	if err != nil {
 		return nil, err
 	}
@@ -258,7 +258,7 @@ func ListNamespaceAuthRulesContext(t testing.TestingT, ctx context.Context, subs
 // automatically crossing page boundaries as required.
 // The ctx parameter supports cancellation and timeouts.
 func ListNamespaceTopicsContextE(ctx context.Context, subscriptionID string, namespace string, resourceGroup string) ([]*armservicebus.SBTopic, error) {
-	tClient, err := serviceBusTopicClientE(subscriptionID)
+	tClient, err := serviceBusTopicClientE(subscriptionID) //nolint:contextcheck
 	if err != nil {
 		return nil, err
 	}
@@ -296,7 +296,7 @@ func ListNamespaceTopicsContext(t testing.TestingT, ctx context.Context, subscri
 // automatically crossing page boundaries as required.
 // The ctx parameter supports cancellation and timeouts.
 func ListTopicSubscriptionsContextE(ctx context.Context, subscriptionID string, namespace string, resourceGroup string, topicName string) ([]*armservicebus.SBSubscription, error) {
-	sClient, err := serviceBusSubscriptionsClientE(subscriptionID)
+	sClient, err := serviceBusSubscriptionsClientE(subscriptionID) //nolint:contextcheck
 	if err != nil {
 		return nil, err
 	}
@@ -334,7 +334,7 @@ func ListTopicSubscriptionsContext(t testing.TestingT, ctx context.Context, subs
 // a list of subscriptions for the given topic name, automatically crossing page boundaries as required.
 // The ctx parameter supports cancellation and timeouts.
 func ListTopicSubscriptionsNameContextE(ctx context.Context, subscriptionID string, namespace string, resourceGroup string, topicName string) ([]string, error) {
-	sClient, err := serviceBusSubscriptionsClientE(subscriptionID)
+	sClient, err := serviceBusSubscriptionsClientE(subscriptionID) //nolint:contextcheck
 	if err != nil {
 		return nil, err
 	}
@@ -374,7 +374,7 @@ func ListTopicSubscriptionsNameContext(t testing.TestingT, ctx context.Context, 
 // of authorization rules for the given topic name, automatically crossing page boundaries as required.
 // The ctx parameter supports cancellation and timeouts.
 func ListTopicAuthRulesContextE(ctx context.Context, subscriptionID string, namespace string, resourceGroup string, topicName string) ([]string, error) {
-	tClient, err := serviceBusTopicClientE(subscriptionID)
+	tClient, err := serviceBusTopicClientE(subscriptionID) //nolint:contextcheck
 	if err != nil {
 		return nil, err
 	}

--- a/modules/azure/sql.go
+++ b/modules/azure/sql.go
@@ -8,9 +8,17 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// GetSQLServerClientContext is a helper function that will setup a sql server client.
+// The ctx parameter supports cancellation and timeouts.
+func GetSQLServerClientContext(ctx context.Context, subscriptionID string) (*armsql.ServersClient, error) {
+	return CreateSQLServerClientContext(ctx, subscriptionID)
+}
+
 // GetSQLServerClient is a helper function that will setup a sql server client.
+//
+// Deprecated: Use [GetSQLServerClientContext] instead.
 func GetSQLServerClient(subscriptionID string) (*armsql.ServersClient, error) {
-	return CreateSQLServerClient(subscriptionID)
+	return GetSQLServerClientContext(context.Background(), subscriptionID)
 }
 
 // GetSQLServerContext is a helper function that gets the sql server object.
@@ -39,7 +47,7 @@ func GetSQLServer(t testing.TestingT, resGroupName string, serverName string, su
 // The ctx parameter supports cancellation and timeouts.
 func GetSQLServerContextE(t testing.TestingT, ctx context.Context, subscriptionID string, resGroupName string, serverName string) (*armsql.Server, error) {
 	// Create a SQL Server client
-	sqlClient, err := CreateSQLServerClient(subscriptionID)
+	sqlClient, err := CreateSQLServerClientContext(ctx, subscriptionID)
 	if err != nil {
 		return nil, err
 	}
@@ -60,9 +68,17 @@ func GetSQLServerE(t testing.TestingT, subscriptionID string, resGroupName strin
 	return GetSQLServerContextE(t, context.Background(), subscriptionID, resGroupName, serverName)
 }
 
+// GetDatabaseClientContext is a helper function that will setup a sql DB client.
+// The ctx parameter supports cancellation and timeouts.
+func GetDatabaseClientContext(ctx context.Context, subscriptionID string) (*armsql.DatabasesClient, error) {
+	return CreateDatabaseClientContext(ctx, subscriptionID)
+}
+
 // GetDatabaseClient is a helper function that will setup a sql DB client.
+//
+// Deprecated: Use [GetDatabaseClientContext] instead.
 func GetDatabaseClient(subscriptionID string) (*armsql.DatabasesClient, error) {
-	return CreateDatabaseClient(subscriptionID)
+	return GetDatabaseClientContext(context.Background(), subscriptionID)
 }
 
 // ListSQLServerDatabasesContext is a helper function that gets a list of databases on a sql server.
@@ -91,7 +107,7 @@ func ListSQLServerDatabases(t testing.TestingT, resGroupName string, serverName 
 // The ctx parameter supports cancellation and timeouts.
 func ListSQLServerDatabasesContextE(t testing.TestingT, ctx context.Context, resGroupName string, serverName string, subscriptionID string) ([]*armsql.Database, error) {
 	// Create a SQL db client
-	sqlClient, err := CreateDatabaseClient(subscriptionID)
+	sqlClient, err := CreateDatabaseClientContext(ctx, subscriptionID)
 	if err != nil {
 		return nil, err
 	}
@@ -146,7 +162,7 @@ func GetSQLDatabase(t testing.TestingT, resGroupName string, serverName string, 
 // The ctx parameter supports cancellation and timeouts.
 func GetSQLDatabaseContextE(t testing.TestingT, ctx context.Context, subscriptionID string, resGroupName string, serverName string, dbName string) (*armsql.Database, error) {
 	// Create a SQL db client
-	sqlClient, err := CreateDatabaseClient(subscriptionID)
+	sqlClient, err := CreateDatabaseClientContext(ctx, subscriptionID)
 	if err != nil {
 		return nil, err
 	}

--- a/modules/azure/sql_managedinstance.go
+++ b/modules/azure/sql_managedinstance.go
@@ -67,7 +67,7 @@ func GetManagedInstanceContext(t testing.TestingT, ctx context.Context, resGroup
 // GetManagedInstanceContextE retrieves the SQL managed instance object for the given subscription.
 // The ctx parameter supports cancellation and timeouts.
 func GetManagedInstanceContextE(ctx context.Context, subscriptionID string, resGroupName string, managedInstanceName string) (*armsql.ManagedInstance, error) {
-	sqlmiClient, err := CreateSQLMangedInstanceClient(subscriptionID)
+	sqlmiClient, err := CreateSQLMangedInstanceClientContext(ctx, subscriptionID)
 	if err != nil {
 		return nil, err
 	}
@@ -112,7 +112,7 @@ func GetManagedInstanceDatabaseContext(t testing.TestingT, ctx context.Context, 
 // GetManagedInstanceDatabaseContextE retrieves the SQL managed database object for the given subscription.
 // The ctx parameter supports cancellation and timeouts.
 func GetManagedInstanceDatabaseContextE(ctx context.Context, subscriptionID string, resGroupName string, managedInstanceName string, databaseName string) (*armsql.ManagedDatabase, error) {
-	sqlmiDBClient, err := CreateSQLMangedDatabasesClient(subscriptionID)
+	sqlmiDBClient, err := CreateSQLMangedDatabasesClientContext(ctx, subscriptionID)
 	if err != nil {
 		return nil, err
 	}

--- a/modules/azure/storage.go
+++ b/modules/azure/storage.go
@@ -210,7 +210,7 @@ func GetStorageBlobContainerContextE(ctx context.Context, containerName, storage
 		return nil, err2
 	}
 
-	client, err := CreateStorageBlobContainerClientE(subscriptionID)
+	client, err := CreateStorageBlobContainerClientContextE(ctx, subscriptionID)
 	if err != nil {
 		return nil, err
 	}
@@ -231,7 +231,7 @@ func GetStorageAccountPropertyContextE(ctx context.Context, storageAccountName, 
 		return nil, err2
 	}
 
-	client, err := CreateStorageAccountClientE(subscriptionID)
+	client, err := CreateStorageAccountClientContextE(ctx, subscriptionID)
 	if err != nil {
 		return nil, err
 	}
@@ -259,7 +259,7 @@ func GetStorageFileShareContextE(ctx context.Context, fileShareName, storageAcco
 		return nil, err2
 	}
 
-	client, err := CreateStorageFileSharesClientE(subscriptionID)
+	client, err := CreateStorageFileSharesClientContextE(ctx, subscriptionID)
 	if err != nil {
 		return nil, err
 	}
@@ -348,7 +348,7 @@ func GetStorageDNSStringContextE(ctx context.Context, storageAccountName, resour
 	}
 
 	if retval {
-		storageSuffix, err2 := GetStorageURISuffixE()
+		storageSuffix, err2 := GetStorageURISuffixE() //nolint:contextcheck
 		if err2 != nil {
 			return "", err2
 		}

--- a/modules/azure/subscription.go
+++ b/modules/azure/subscription.go
@@ -1,13 +1,16 @@
 package azure
 
 import (
+	"context"
+
 	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2019-06-01/subscriptions"
 )
 
-// GetSubscriptionClientE is a helper function that will setup an Azure Subscription client on your behalf
-func GetSubscriptionClientE() (*subscriptions.Client, error) {
+// GetSubscriptionClientContextE is a helper function that will setup an Azure Subscription client on your behalf.
+// The ctx parameter supports cancellation and timeouts.
+func GetSubscriptionClientContextE(ctx context.Context) (*subscriptions.Client, error) {
 	// Create a Subscription client
-	client, err := CreateSubscriptionsClientE()
+	client, err := CreateSubscriptionsClientContextE(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -22,4 +25,11 @@ func GetSubscriptionClientE() (*subscriptions.Client, error) {
 	client.Authorizer = *authorizer
 
 	return &client, nil
+}
+
+// GetSubscriptionClientE is a helper function that will setup an Azure Subscription client on your behalf.
+//
+// Deprecated: Use [GetSubscriptionClientContextE] instead.
+func GetSubscriptionClientE() (*subscriptions.Client, error) {
+	return GetSubscriptionClientContextE(context.Background())
 }

--- a/modules/azure/synapse.go
+++ b/modules/azure/synapse.go
@@ -23,7 +23,7 @@ func GetSynapseWorkspaceContext(t testing.TestingT, ctx context.Context, resGrou
 // GetSynapseWorkspaceContextE retrieves the synapse workspace for the given subscription.
 // The ctx parameter supports cancellation and timeouts.
 func GetSynapseWorkspaceContextE(ctx context.Context, subscriptionID string, resGroupName string, workspaceName string) (*armsynapse.Workspace, error) {
-	synapseClient, err := CreateSynapseWorkspaceClientE(subscriptionID)
+	synapseClient, err := CreateSynapseWorkspaceClientContextE(ctx, subscriptionID)
 	if err != nil {
 		return nil, err
 	}
@@ -68,7 +68,7 @@ func GetSynapseSQLPoolContext(t testing.TestingT, ctx context.Context, resGroupN
 // GetSynapseSQLPoolContextE retrieves the synapse SQL pool for the given subscription.
 // The ctx parameter supports cancellation and timeouts.
 func GetSynapseSQLPoolContextE(ctx context.Context, subscriptionID string, resGroupName string, workspaceName string, sqlPoolName string) (*armsynapse.SQLPool, error) {
-	synapseSQLPoolClient, err := CreateSynapseSqlPoolClientE(subscriptionID)
+	synapseSQLPoolClient, err := CreateSynapseSqlPoolClientContextE(ctx, subscriptionID)
 	if err != nil {
 		return nil, err
 	}

--- a/modules/azure/virtualnetwork.go
+++ b/modules/azure/virtualnetwork.go
@@ -112,7 +112,7 @@ func GetVirtualNetworkSubnetsContext(t testing.TestingT, ctx context.Context, vn
 func GetVirtualNetworkSubnetsContextE(ctx context.Context, vnetName string, resGroupName string, subscriptionID string) (map[string]string, error) {
 	subNetDetails := map[string]string{}
 
-	client, err := GetSubnetClientE(subscriptionID)
+	client, err := GetSubnetClientContextE(ctx, subscriptionID)
 	if err != nil {
 		return subNetDetails, err
 	}
@@ -175,7 +175,7 @@ func GetSubnetContextE(ctx context.Context, subnetName string, vnetName string, 
 	}
 
 	// Get the client reference
-	client, err := GetSubnetClientE(subscriptionID)
+	client, err := GetSubnetClientContextE(ctx, subscriptionID)
 	if err != nil {
 		return nil, err
 	}
@@ -189,9 +189,17 @@ func GetSubnetContextE(ctx context.Context, subnetName string, vnetName string, 
 	return &resp.Subnet, nil
 }
 
+// GetSubnetClientContextE creates a subnet client.
+// The ctx parameter supports cancellation and timeouts.
+func GetSubnetClientContextE(ctx context.Context, subscriptionID string) (*armnetwork.SubnetsClient, error) {
+	return CreateNewSubnetClientContextE(ctx, subscriptionID)
+}
+
 // GetSubnetClientE creates a subnet client.
+//
+// Deprecated: Use [GetSubnetClientContextE] instead.
 func GetSubnetClientE(subscriptionID string) (*armnetwork.SubnetsClient, error) {
-	return CreateNewSubnetClientE(subscriptionID)
+	return GetSubnetClientContextE(context.Background(), subscriptionID)
 }
 
 // GetVirtualNetworkContextE gets Virtual Network in the specified Azure Resource Group.
@@ -204,7 +212,7 @@ func GetVirtualNetworkContextE(ctx context.Context, vnetName string, resGroupNam
 	}
 
 	// Get the client reference
-	client, err := GetVirtualNetworksClientE(subscriptionID)
+	client, err := GetVirtualNetworksClientContextE(ctx, subscriptionID)
 	if err != nil {
 		return nil, err
 	}
@@ -218,7 +226,15 @@ func GetVirtualNetworkContextE(ctx context.Context, vnetName string, resGroupNam
 	return &resp.VirtualNetwork, nil
 }
 
+// GetVirtualNetworksClientContextE creates a virtual network client in the specified Azure Subscription.
+// The ctx parameter supports cancellation and timeouts.
+func GetVirtualNetworksClientContextE(ctx context.Context, subscriptionID string) (*armnetwork.VirtualNetworksClient, error) {
+	return CreateNewVirtualNetworkClientContextE(ctx, subscriptionID)
+}
+
 // GetVirtualNetworksClientE creates a virtual network client in the specified Azure Subscription.
+//
+// Deprecated: Use [GetVirtualNetworksClientContextE] instead.
 func GetVirtualNetworksClientE(subscriptionID string) (*armnetwork.VirtualNetworksClient, error) {
-	return CreateNewVirtualNetworkClientE(subscriptionID)
+	return GetVirtualNetworksClientContextE(context.Background(), subscriptionID)
 }

--- a/modules/dns-helper/dns_helper.go
+++ b/modules/dns-helper/dns_helper.go
@@ -242,8 +242,8 @@ func DNSLookupAuthoritativeWithRetryContext(t testing.TestingT, ctx context.Cont
 // or until max retries has been exceeded.
 // If resolvers are defined, uses them instead of the default system ones to find the authoritative nameservers.
 func DNSLookupAuthoritativeWithRetryContextE(t testing.TestingT, ctx context.Context, query DNSQuery, resolvers []string, maxRetries int, sleepBetweenRetries time.Duration) (DNSAnswers, error) {
-	res, err := retry.DoWithRetryInterfaceE(
-		t, fmt.Sprintf("DNSLookupAuthoritativeContextE %s record for %s using authoritative nameservers", query.Type, query.Name),
+	res, err := retry.DoWithRetryInterfaceContextE(
+		t, ctx, fmt.Sprintf("DNSLookupAuthoritativeContextE %s record for %s using authoritative nameservers", query.Type, query.Name),
 		maxRetries, sleepBetweenRetries,
 		func() (any, error) {
 			return DNSLookupAuthoritativeContextE(t, ctx, query, resolvers)
@@ -349,8 +349,8 @@ func DNSLookupAuthoritativeAllWithRetryContext(t testing.TestingT, ctx context.C
 // until ALL authoritative nameservers reply with the exact same non-empty answers or until max retries has been exceeded.
 // If defined, uses the given resolvers instead of the default system ones to find the authoritative nameservers.
 func DNSLookupAuthoritativeAllWithRetryContextE(t testing.TestingT, ctx context.Context, query DNSQuery, resolvers []string, maxRetries int, sleepBetweenRetries time.Duration) (DNSAnswers, error) {
-	res, err := retry.DoWithRetryInterfaceE(
-		t, fmt.Sprintf("DNSLookupAuthoritativeAllContextE %s record for %s using authoritative nameservers", query.Type, query.Name),
+	res, err := retry.DoWithRetryInterfaceContextE(
+		t, ctx, fmt.Sprintf("DNSLookupAuthoritativeAllContextE %s record for %s using authoritative nameservers", query.Type, query.Name),
 		maxRetries, sleepBetweenRetries,
 		func() (any, error) {
 			return DNSLookupAuthoritativeAllContextE(t, ctx, query, resolvers)
@@ -443,8 +443,8 @@ func DNSLookupAuthoritativeAllWithValidationRetryContext(t testing.TestingT, ctx
 // or until max retries has been exceeded.
 // If resolvers are defined, uses them instead of the default system ones to find the authoritative nameservers.
 func DNSLookupAuthoritativeAllWithValidationRetryContextE(t testing.TestingT, ctx context.Context, query DNSQuery, resolvers []string, expectedAnswers DNSAnswers, maxRetries int, sleepBetweenRetries time.Duration) error {
-	_, err := retry.DoWithRetryInterfaceE(
-		t, fmt.Sprintf("DNSLookupAuthoritativeAllWithValidationRetryContextE %s record for %s using authoritative nameservers", query.Type, query.Name),
+	_, err := retry.DoWithRetryInterfaceContextE(
+		t, ctx, fmt.Sprintf("DNSLookupAuthoritativeAllWithValidationRetryContextE %s record for %s using authoritative nameservers", query.Type, query.Name),
 		maxRetries, sleepBetweenRetries,
 		func() (any, error) {
 			return nil, DNSLookupAuthoritativeAllWithValidationContextE(t, ctx, query, resolvers, expectedAnswers)

--- a/modules/gcp/compute.go
+++ b/modules/gcp/compute.go
@@ -992,7 +992,7 @@ func NewComputeServiceContextE(t testing.TestingT, ctx context.Context) (*comput
 
 	var client *http.Client
 
-	msg, retryErr := retry.DoWithRetryE(t, description, maxRetries, defaultRetryInterval, func() (string, error) {
+	msg, retryErr := retry.DoWithRetryContextE(t, ctx, description, maxRetries, defaultRetryInterval, func() (string, error) {
 		rawClient, err := google.DefaultClient(ctx, compute.CloudPlatformScope)
 		if err != nil {
 			return "Error retrieving default GCP client", err

--- a/modules/gcp/compute_test.go
+++ b/modules/gcp/compute_test.go
@@ -41,7 +41,7 @@ func TestGetPublicIPOfInstance(t *testing.T) {
 	maxRetries := 10
 	sleepBetweenRetries := 3 * time.Second
 
-	ip := retry.DoWithRetry(t, "Read IP address of Compute Instance", maxRetries, sleepBetweenRetries, func() (string, error) {
+	ip := retry.DoWithRetryContext(t, t.Context(), "Read IP address of Compute Instance", maxRetries, sleepBetweenRetries, func() (string, error) {
 		// Consider attempting to connect to the Compute Instance at this IP in the future, but for now, we just call the
 		// the function to ensure we don't have errors
 		instance := gcp.FetchInstance(t, projectID, instanceName)
@@ -98,7 +98,7 @@ func TestGetAndSetLabels(t *testing.T) {
 	maxRetries := 30
 	sleepBetweenRetries := 3 * time.Second
 
-	retry.DoWithRetry(t, "Read newly set labels", maxRetries, sleepBetweenRetries, func() (string, error) {
+	retry.DoWithRetryContext(t, t.Context(), "Read newly set labels", maxRetries, sleepBetweenRetries, func() (string, error) {
 		instance := gcp.FetchInstance(t, projectID, instanceName)
 
 		labelsFromRead := instance.GetLabels(t)
@@ -135,7 +135,7 @@ func TestGetAndSetMetadata(t *testing.T) {
 	maxRetries := 30
 	sleepBetweenRetries := 3 * time.Second
 
-	retry.DoWithRetry(t, "Read newly set metadata", maxRetries, sleepBetweenRetries, func() (string, error) {
+	retry.DoWithRetryContext(t, t.Context(), "Read newly set metadata", maxRetries, sleepBetweenRetries, func() (string, error) {
 		instance := gcp.FetchInstance(t, projectID, instanceName)
 
 		metadataFromRead := instance.GetMetadata(t)

--- a/modules/gcp/pubsub.go
+++ b/modules/gcp/pubsub.go
@@ -10,11 +10,25 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// AssertTopicExists checks if the given Pub/Sub topic exists and fails the test if it does not.
+//
+// Deprecated: Use [AssertTopicExistsContext] instead.
+func AssertTopicExists(t testing.TestingT, projectID string, topicName string) {
+	AssertTopicExistsContext(t, context.Background(), projectID, topicName)
+}
+
 // AssertTopicExistsContext checks if the given Pub/Sub topic exists and fails the test if it does not.
 // The ctx parameter supports cancellation and timeouts.
 func AssertTopicExistsContext(t testing.TestingT, ctx context.Context, projectID string, topicName string) {
 	err := AssertTopicExistsContextE(t, ctx, projectID, topicName)
 	require.NoError(t, err)
+}
+
+// AssertTopicExistsE checks if the given Pub/Sub topic exists and returns an error if it does not.
+//
+// Deprecated: Use [AssertTopicExistsContextE] instead.
+func AssertTopicExistsE(t testing.TestingT, projectID string, topicName string) error {
+	return AssertTopicExistsContextE(t, context.Background(), projectID, topicName)
 }
 
 // AssertTopicExistsContextE checks if the given Pub/Sub topic exists and returns an error if it does not.
@@ -41,11 +55,25 @@ func AssertTopicExistsContextE(t testing.TestingT, ctx context.Context, projectI
 	return nil
 }
 
+// AssertSubscriptionExists checks if the given Pub/Sub subscription exists and fails the test if it does not.
+//
+// Deprecated: Use [AssertSubscriptionExistsContext] instead.
+func AssertSubscriptionExists(t testing.TestingT, projectID string, subscriptionName string) {
+	AssertSubscriptionExistsContext(t, context.Background(), projectID, subscriptionName)
+}
+
 // AssertSubscriptionExistsContext checks if the given Pub/Sub subscription exists and fails the test if it does not.
 // The ctx parameter supports cancellation and timeouts.
 func AssertSubscriptionExistsContext(t testing.TestingT, ctx context.Context, projectID string, subscriptionName string) {
 	err := AssertSubscriptionExistsContextE(t, ctx, projectID, subscriptionName)
 	require.NoError(t, err)
+}
+
+// AssertSubscriptionExistsE checks if the given Pub/Sub subscription exists and returns an error if it does not.
+//
+// Deprecated: Use [AssertSubscriptionExistsContextE] instead.
+func AssertSubscriptionExistsE(t testing.TestingT, projectID string, subscriptionName string) error {
+	return AssertSubscriptionExistsContextE(t, context.Background(), projectID, subscriptionName)
 }
 
 // AssertSubscriptionExistsContextE checks if the given Pub/Sub subscription exists and returns an error if it does not.
@@ -72,11 +100,25 @@ func AssertSubscriptionExistsContextE(t testing.TestingT, ctx context.Context, p
 	return nil
 }
 
+// CreateTopic creates a new Pub/Sub topic and fails the test if it cannot.
+//
+// Deprecated: Use [CreateTopicContext] instead.
+func CreateTopic(t testing.TestingT, projectID string, topicName string) {
+	CreateTopicContext(t, context.Background(), projectID, topicName)
+}
+
 // CreateTopicContext creates a new Pub/Sub topic and fails the test if it cannot.
 // The ctx parameter supports cancellation and timeouts.
 func CreateTopicContext(t testing.TestingT, ctx context.Context, projectID string, topicName string) {
 	err := CreateTopicContextE(t, ctx, projectID, topicName)
 	require.NoError(t, err)
+}
+
+// CreateTopicE creates a new Pub/Sub topic and returns an error if it fails.
+//
+// Deprecated: Use [CreateTopicContextE] instead.
+func CreateTopicE(t testing.TestingT, projectID string, topicName string) error {
+	return CreateTopicContextE(t, context.Background(), projectID, topicName)
 }
 
 // CreateTopicContextE creates a new Pub/Sub topic and returns an error if it fails.
@@ -99,11 +141,25 @@ func CreateTopicContextE(t testing.TestingT, ctx context.Context, projectID stri
 	return nil
 }
 
+// DeleteTopic deletes the given Pub/Sub topic and fails the test if it cannot.
+//
+// Deprecated: Use [DeleteTopicContext] instead.
+func DeleteTopic(t testing.TestingT, projectID string, topicName string) {
+	DeleteTopicContext(t, context.Background(), projectID, topicName)
+}
+
 // DeleteTopicContext deletes the given Pub/Sub topic and fails the test if it cannot.
 // The ctx parameter supports cancellation and timeouts.
 func DeleteTopicContext(t testing.TestingT, ctx context.Context, projectID string, topicName string) {
 	err := DeleteTopicContextE(t, ctx, projectID, topicName)
 	require.NoError(t, err)
+}
+
+// DeleteTopicE deletes the given Pub/Sub topic and returns an error if it fails.
+//
+// Deprecated: Use [DeleteTopicContextE] instead.
+func DeleteTopicE(t testing.TestingT, projectID string, topicName string) error {
+	return DeleteTopicContextE(t, context.Background(), projectID, topicName)
 }
 
 // DeleteTopicContextE deletes the given Pub/Sub topic and returns an error if it fails.
@@ -125,11 +181,25 @@ func DeleteTopicContextE(t testing.TestingT, ctx context.Context, projectID stri
 	return nil
 }
 
+// CreateSubscription creates a new Pub/Sub subscription on the given topic and fails the test if it cannot.
+//
+// Deprecated: Use [CreateSubscriptionContext] instead.
+func CreateSubscription(t testing.TestingT, projectID string, subscriptionName string, topicName string) {
+	CreateSubscriptionContext(t, context.Background(), projectID, subscriptionName, topicName)
+}
+
 // CreateSubscriptionContext creates a new Pub/Sub subscription on the given topic and fails the test if it cannot.
 // The ctx parameter supports cancellation and timeouts.
 func CreateSubscriptionContext(t testing.TestingT, ctx context.Context, projectID string, subscriptionName string, topicName string) {
 	err := CreateSubscriptionContextE(t, ctx, projectID, subscriptionName, topicName)
 	require.NoError(t, err)
+}
+
+// CreateSubscriptionE creates a new Pub/Sub subscription on the given topic and returns an error if it fails.
+//
+// Deprecated: Use [CreateSubscriptionContextE] instead.
+func CreateSubscriptionE(t testing.TestingT, projectID string, subscriptionName string, topicName string) error {
+	return CreateSubscriptionContextE(t, context.Background(), projectID, subscriptionName, topicName)
 }
 
 // CreateSubscriptionContextE creates a new Pub/Sub subscription on the given topic and returns an error if it fails.
@@ -154,11 +224,25 @@ func CreateSubscriptionContextE(t testing.TestingT, ctx context.Context, project
 	return nil
 }
 
+// DeleteSubscription deletes the given Pub/Sub subscription and fails the test if it cannot.
+//
+// Deprecated: Use [DeleteSubscriptionContext] instead.
+func DeleteSubscription(t testing.TestingT, projectID string, subscriptionName string) {
+	DeleteSubscriptionContext(t, context.Background(), projectID, subscriptionName)
+}
+
 // DeleteSubscriptionContext deletes the given Pub/Sub subscription and fails the test if it cannot.
 // The ctx parameter supports cancellation and timeouts.
 func DeleteSubscriptionContext(t testing.TestingT, ctx context.Context, projectID string, subscriptionName string) {
 	err := DeleteSubscriptionContextE(t, ctx, projectID, subscriptionName)
 	require.NoError(t, err)
+}
+
+// DeleteSubscriptionE deletes the given Pub/Sub subscription and returns an error if it fails.
+//
+// Deprecated: Use [DeleteSubscriptionContextE] instead.
+func DeleteSubscriptionE(t testing.TestingT, projectID string, subscriptionName string) error {
+	return DeleteSubscriptionContextE(t, context.Background(), projectID, subscriptionName)
 }
 
 // DeleteSubscriptionContextE deletes the given Pub/Sub subscription and returns an error if it fails.

--- a/modules/helm/format.go
+++ b/modules/helm/format.go
@@ -1,6 +1,7 @@
 package helm
 
 import (
+	"context"
 	"fmt"
 	"path/filepath"
 
@@ -30,8 +31,17 @@ func FormatSetValuesAsArgs(setValues map[string]string, flag string) []string {
 
 // FormatValuesFilesAsArgs formats the given list of values file paths as command line args for helm (e.g of the format
 // -f path). This will fail the test if one of the paths do not exist or the absolute path can not be determined.
+//
+// Deprecated: Use [FormatValuesFilesAsArgsContext] instead.
 func FormatValuesFilesAsArgs(t testing.TestingT, valuesFiles []string) []string {
-	args, err := FormatValuesFilesAsArgsE(valuesFiles)
+	return FormatValuesFilesAsArgsContext(t, context.Background(), valuesFiles)
+}
+
+// FormatValuesFilesAsArgsContext formats the given list of values file paths as command line args for helm (e.g of the
+// format -f path). The ctx parameter is accepted for API consistency with other Context-aware helpers.
+// This will fail the test if one of the paths do not exist or the absolute path can not be determined.
+func FormatValuesFilesAsArgsContext(t testing.TestingT, ctx context.Context, valuesFiles []string) []string {
+	args, err := FormatValuesFilesAsArgsContextE(ctx, valuesFiles)
 	require.NoError(t, err)
 
 	return args
@@ -39,7 +49,16 @@ func FormatValuesFilesAsArgs(t testing.TestingT, valuesFiles []string) []string 
 
 // FormatValuesFilesAsArgsE formats the given list of values file paths as command line args for helm (e.g of the format
 // -f path). This will error if the file does not exist.
+//
+// Deprecated: Use [FormatValuesFilesAsArgsContextE] instead.
 func FormatValuesFilesAsArgsE(valuesFiles []string) ([]string, error) {
+	return FormatValuesFilesAsArgsContextE(context.Background(), valuesFiles)
+}
+
+// FormatValuesFilesAsArgsContextE formats the given list of values file paths as command line args for helm (e.g of the
+// format -f path). The ctx parameter is accepted for API consistency with other Context-aware helpers.
+// This will error if the file does not exist.
+func FormatValuesFilesAsArgsContextE(ctx context.Context, valuesFiles []string) ([]string, error) {
 	args := []string{}
 
 	for _, valuesFilePath := range valuesFiles {
@@ -62,8 +81,18 @@ func FormatValuesFilesAsArgsE(valuesFiles []string) ([]string, error) {
 // FormatSetFilesAsArgs formats the given list of keys and file paths as command line args for helm to set from file
 // (e.g of the format --set-file key=path). This will fail the test if one of the paths do not exist or the absolute
 // path can not be determined.
+//
+// Deprecated: Use [FormatSetFilesAsArgsContext] instead.
 func FormatSetFilesAsArgs(t testing.TestingT, setFiles map[string]string) []string {
-	args, err := FormatSetFilesAsArgsE(setFiles)
+	return FormatSetFilesAsArgsContext(t, context.Background(), setFiles)
+}
+
+// FormatSetFilesAsArgsContext formats the given list of keys and file paths as command line args for helm to set from
+// file (e.g of the format --set-file key=path). The ctx parameter is accepted for API consistency with other
+// Context-aware helpers. This will fail the test if one of the paths do not exist or the absolute path can not be
+// determined.
+func FormatSetFilesAsArgsContext(t testing.TestingT, ctx context.Context, setFiles map[string]string) []string {
+	args, err := FormatSetFilesAsArgsContextE(ctx, setFiles)
 	require.NoError(t, err)
 
 	return args
@@ -71,7 +100,16 @@ func FormatSetFilesAsArgs(t testing.TestingT, setFiles map[string]string) []stri
 
 // FormatSetFilesAsArgsE formats the given list of keys and file paths as command line args for helm to set from file
 // (e.g of the format --set-file key=path).
+//
+// Deprecated: Use [FormatSetFilesAsArgsContextE] instead.
 func FormatSetFilesAsArgsE(setFiles map[string]string) ([]string, error) {
+	return FormatSetFilesAsArgsContextE(context.Background(), setFiles)
+}
+
+// FormatSetFilesAsArgsContextE formats the given list of keys and file paths as command line args for helm to set from
+// file (e.g of the format --set-file key=path). The ctx parameter is accepted for API consistency with other
+// Context-aware helpers.
+func FormatSetFilesAsArgsContextE(ctx context.Context, setFiles map[string]string) ([]string, error) {
 	args := []string{}
 
 	// To make it easier to test, go through the keys in sorted order

--- a/modules/helm/install.go
+++ b/modules/helm/install.go
@@ -68,7 +68,7 @@ func InstallContextE(t testing.TestingT, ctx context.Context, options *Options, 
 		args = append(args, "--version", options.Version)
 	}
 
-	args, err = getValuesArgsE(options, args...)
+	args, err = getValuesArgsE(options, args...) //nolint:contextcheck // getValuesArgsE is a local helper without context
 	if err != nil {
 		return err
 	}

--- a/modules/helm/install_test.go
+++ b/modules/helm/install_test.go
@@ -46,9 +46,9 @@ func TestRemoteChartInstall(t *testing.T) {
 	// Use default kubectl options to create a new namespace for this test, and then update the namespace for kubectl
 	kubectlOptions := k8s.NewKubectlOptions("", "", namespaceName)
 
-	defer k8s.DeleteNamespace(t, kubectlOptions, namespaceName)
+	defer k8s.DeleteNamespaceContext(t, t.Context(), kubectlOptions, namespaceName)
 
-	k8s.CreateNamespace(t, kubectlOptions, namespaceName)
+	k8s.CreateNamespaceContext(t, t.Context(), kubectlOptions, namespaceName)
 
 	// Override service type to node port and disable PDB (requires policy/v1 API
 	// which may not be available on older k8s clusters)
@@ -125,8 +125,8 @@ func TestHelmDependencyInstall(t *testing.T) {
 	// - Current context of the kubectl config file
 	kubectlOptions := k8s.NewKubectlOptions("", "", namespaceName)
 
-	k8s.CreateNamespace(t, kubectlOptions, namespaceName)
-	defer k8s.DeleteNamespace(t, kubectlOptions, namespaceName)
+	k8s.CreateNamespaceContext(t, t.Context(), kubectlOptions, namespaceName)
+	defer k8s.DeleteNamespaceContext(t, t.Context(), kubectlOptions, namespaceName)
 
 	// Helm chart deployment options.
 	options := &helm.Options{
@@ -166,10 +166,10 @@ func waitForRemoteChartPods(t *testing.T, kubectlOptions *k8s.KubectlOptions, re
 	}
 	// Use longer timeout (60 retries * 10s = 10 min) to handle slower CI environments
 	// and potential resource contention when multiple helm tests run in parallel
-	k8s.WaitUntilNumPodsCreated(t, kubectlOptions, filters, podCount, 60, 10*time.Second)
+	k8s.WaitUntilNumPodsCreatedContext(t, t.Context(), kubectlOptions, filters, podCount, 60, 10*time.Second)
 
-	pods := k8s.ListPods(t, kubectlOptions, filters)
+	pods := k8s.ListPodsContext(t, t.Context(), kubectlOptions, filters)
 	for i := range pods {
-		k8s.WaitUntilPodAvailable(t, kubectlOptions, pods[i].Name, 60, 10*time.Second)
+		k8s.WaitUntilPodAvailableContext(t, t.Context(), kubectlOptions, pods[i].Name, 60, 10*time.Second)
 	}
 }

--- a/modules/helm/template.go
+++ b/modules/helm/template.go
@@ -108,7 +108,7 @@ func getRenderArgs(t testing.TestingT, ctx context.Context, options *Options, ch
 		args = append(args, "--namespace", options.KubectlOptions.Namespace)
 	}
 
-	args, err = getValuesArgsE(options, args...)
+	args, err = getValuesArgsE(options, args...) //nolint:contextcheck // getValuesArgsE is a local helper without context
 	if err != nil {
 		return nil, err
 	}
@@ -172,7 +172,7 @@ func RenderRemoteTemplateContextE(t testing.TestingT, ctx context.Context, optio
 		args = append(args, "--namespace", options.KubectlOptions.Namespace)
 	}
 
-	args, err := getValuesArgsE(options, args...)
+	args, err := getValuesArgsE(options, args...) //nolint:contextcheck // getValuesArgsE is a local helper without context
 	if err != nil {
 		return "", err
 	}
@@ -332,8 +332,20 @@ func UnmarshalK8SYamlE(t testing.TestingT, yamlData string, destinationObj inter
 // see https://github.com/gruntwork-io/terratest/issues/1377
 // A snapshot is used to compare the current manifests of a chart with the previous manifests.
 // A global diff is run against the two snapshots and the number of differences is returned.
+//
+// Deprecated: Use [UpdateSnapshotContext] instead.
 func UpdateSnapshot(t testing.TestingT, options *Options, yamlData string, releaseName string) {
-	require.NoError(t, UpdateSnapshotE(t, options, yamlData, releaseName))
+	UpdateSnapshotContext(t, context.Background(), options, yamlData, releaseName)
+}
+
+// UpdateSnapshotContext creates or updates the k8s manifest snapshot of a chart (e.g bitnami/nginx).
+// It is one of the two functions needed to implement snapshot based testing for helm.
+// see https://github.com/gruntwork-io/terratest/issues/1377
+// A snapshot is used to compare the current manifests of a chart with the previous manifests.
+// A global diff is run against the two snapshots and the number of differences is returned.
+// The ctx parameter is accepted for API consistency with other Context-aware helpers.
+func UpdateSnapshotContext(t testing.TestingT, ctx context.Context, options *Options, yamlData string, releaseName string) {
+	require.NoError(t, UpdateSnapshotContextE(t, ctx, options, yamlData, releaseName))
 }
 
 // UpdateSnapshotE creates or updates the k8s manifest snapshot of a chart (e.g bitnami/nginx).
@@ -342,7 +354,20 @@ func UpdateSnapshot(t testing.TestingT, options *Options, yamlData string, relea
 // A snapshot is used to compare the current manifests of a chart with the previous manifests.
 // A global diff is run against the two snapshots and the number of differences is returned.
 // It will fail the test if there is an error while writing the manifests' snapshot in the file system.
+//
+// Deprecated: Use [UpdateSnapshotContextE] instead.
 func UpdateSnapshotE(t testing.TestingT, options *Options, yamlData string, releaseName string) error {
+	return UpdateSnapshotContextE(t, context.Background(), options, yamlData, releaseName)
+}
+
+// UpdateSnapshotContextE creates or updates the k8s manifest snapshot of a chart (e.g bitnami/nginx).
+// It is one of the two functions needed to implement snapshot based testing for helm.
+// see https://github.com/gruntwork-io/terratest/issues/1377
+// A snapshot is used to compare the current manifests of a chart with the previous manifests.
+// A global diff is run against the two snapshots and the number of differences is returned.
+// The ctx parameter is accepted for API consistency with other Context-aware helpers.
+// It will return an error if there is an issue while writing the manifests' snapshot in the file system.
+func UpdateSnapshotContextE(t testing.TestingT, ctx context.Context, options *Options, yamlData string, releaseName string) error {
 	snapshotDir := "__snapshot__"
 	if options.SnapshotPath != "" {
 		snapshotDir = options.SnapshotPath
@@ -381,8 +406,20 @@ func UpdateSnapshotE(t testing.TestingT, options *Options, yamlData string, rele
 // see https://github.com/gruntwork-io/terratest/issues/1377
 // It returns the number of differences between the two manifests or -1 in case of error.
 // It will fail the test if there is an error while reading or writing the two manifests in the file system.
+//
+// Deprecated: Use [DiffAgainstSnapshotContext] instead.
 func DiffAgainstSnapshot(t testing.TestingT, options *Options, yamlData string, releaseName string) int {
-	numberOfDiffs, err := DiffAgainstSnapshotE(t, options, yamlData, releaseName)
+	return DiffAgainstSnapshotContext(t, context.Background(), options, yamlData, releaseName)
+}
+
+// DiffAgainstSnapshotContext compares the current manifests of a chart (e.g bitnami/nginx)
+// with the previous manifests stored in the snapshot.
+// see https://github.com/gruntwork-io/terratest/issues/1377
+// It returns the number of differences between the two manifests or -1 in case of error.
+// The ctx parameter is accepted for API consistency with other Context-aware helpers.
+// It will fail the test if there is an error while reading or writing the two manifests in the file system.
+func DiffAgainstSnapshotContext(t testing.TestingT, ctx context.Context, options *Options, yamlData string, releaseName string) int {
+	numberOfDiffs, err := DiffAgainstSnapshotContextE(t, ctx, options, yamlData, releaseName)
 	require.NoError(t, err)
 
 	return numberOfDiffs
@@ -392,7 +429,18 @@ func DiffAgainstSnapshot(t testing.TestingT, options *Options, yamlData string, 
 // with the previous manifests stored in the snapshot.
 // see https://github.com/gruntwork-io/terratest/issues/1377
 // It returns the number of differences between the manifests or -1 in case of error.
+//
+// Deprecated: Use [DiffAgainstSnapshotContextE] instead.
 func DiffAgainstSnapshotE(t testing.TestingT, options *Options, yamlData string, releaseName string) (int, error) {
+	return DiffAgainstSnapshotContextE(t, context.Background(), options, yamlData, releaseName)
+}
+
+// DiffAgainstSnapshotContextE compares the current manifests of a chart (e.g bitnami/nginx)
+// with the previous manifests stored in the snapshot.
+// see https://github.com/gruntwork-io/terratest/issues/1377
+// The ctx parameter is accepted for API consistency with other Context-aware helpers.
+// It returns the number of differences between the manifests or -1 in case of error.
+func DiffAgainstSnapshotContextE(t testing.TestingT, ctx context.Context, options *Options, yamlData string, releaseName string) (int, error) {
 	snapshotDir := "__snapshot__"
 	if options.SnapshotPath != "" {
 		snapshotDir = options.SnapshotPath

--- a/modules/helm/upgrade.go
+++ b/modules/helm/upgrade.go
@@ -62,7 +62,7 @@ func UpgradeContextE(t testing.TestingT, ctx context.Context, options *Options, 
 		}
 	}
 
-	args, err = getValuesArgsE(options, args...)
+	args, err = getValuesArgsE(options, args...) //nolint:contextcheck // getValuesArgsE is a local helper without context
 	if err != nil {
 		return err
 	}

--- a/modules/helm/upgrade_test.go
+++ b/modules/helm/upgrade_test.go
@@ -38,9 +38,9 @@ func TestRemoteChartInstallUpgradeRollback(t *testing.T) {
 	// Use default kubectl options to create a new namespace for this test, and then update the namespace for kubectl
 	kubectlOptions := k8s.NewKubectlOptions("", "", namespaceName)
 
-	defer k8s.DeleteNamespace(t, kubectlOptions, namespaceName)
+	defer k8s.DeleteNamespaceContext(t, t.Context(), kubectlOptions, namespaceName)
 
-	k8s.CreateNamespace(t, kubectlOptions, namespaceName)
+	k8s.CreateNamespaceContext(t, t.Context(), kubectlOptions, namespaceName)
 
 	// Override service type to node port and disable PDB (requires policy/v1 API
 	// which may not be available on older k8s clusters)
@@ -125,8 +125,8 @@ func TestHelmDependencyUpgrade(t *testing.T) {
 	// - Current context of the kubectl config file
 	kubectlOptions := k8s.NewKubectlOptions("", "", namespaceName)
 
-	k8s.CreateNamespace(t, kubectlOptions, namespaceName)
-	defer k8s.DeleteNamespace(t, kubectlOptions, namespaceName)
+	k8s.CreateNamespaceContext(t, t.Context(), kubectlOptions, namespaceName)
+	defer k8s.DeleteNamespaceContext(t, t.Context(), kubectlOptions, namespaceName)
 
 	// Helm chart deployment options.
 	options := &helm.Options{

--- a/modules/http-helper/http_helper.go
+++ b/modules/http-helper/http_helper.go
@@ -625,7 +625,7 @@ func HTTPDoWithRetryWithOptionsE(
 
 	options.Body = nil
 
-	out, err := retry.DoWithRetryE(
+	out, err := retry.DoWithRetryE( //nolint:staticcheck // deprecated wrapper; use HTTPDoWithRetryContext for context support
 		t, "HTTP "+options.Method+" to URL "+options.Url, retries,
 		sleepBetweenRetries, func() (string, error) {
 			options.Body = bytes.NewReader(data)
@@ -751,7 +751,7 @@ func HTTPDoWithValidationRetryWithOptionsE(
 	t testing.TestingT, options HttpDoOptions, expectedStatus int,
 	expectedBody string, retries int, sleepBetweenRetries time.Duration,
 ) error {
-	_, err := retry.DoWithRetryE(t, "HTTP "+options.Method+" to URL "+options.Url, retries,
+	_, err := retry.DoWithRetryE(t, "HTTP "+options.Method+" to URL "+options.Url, retries, //nolint:staticcheck // deprecated wrapper; use HTTPDoWithValidationRetryContext for context support
 		sleepBetweenRetries, func() (string, error) {
 			return "", HTTPDoWithValidationWithOptionsE(t, options, expectedStatus, expectedBody)
 		})

--- a/modules/k8s/client.go
+++ b/modules/k8s/client.go
@@ -1,6 +1,8 @@
 package k8s
 
 import (
+	"context"
+
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 
@@ -9,22 +11,43 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 
 	"github.com/gruntwork-io/terratest/modules/testing"
+	"github.com/stretchr/testify/require"
 )
 
-// GetKubernetesClientE returns a Kubernetes API client that can be used to make requests.
-func GetKubernetesClientE(t testing.TestingT) (*kubernetes.Clientset, error) {
-	kubeConfigPath, err := GetKubeConfigPathE(t)
+// GetKubernetesClientContextE returns a Kubernetes API client that can be used to make requests.
+// The ctx parameter is accepted for API consistency.
+func GetKubernetesClientContextE(t testing.TestingT, ctx context.Context) (*kubernetes.Clientset, error) {
+	kubeConfigPath, err := GetKubeConfigPathContextE(t, ctx)
 	if err != nil {
 		return nil, err
 	}
 
 	options := NewKubectlOptions("", kubeConfigPath, "default")
 
-	return GetKubernetesClientFromOptionsE(t, options)
+	return GetKubernetesClientFromOptionsContextE(t, ctx, options)
 }
 
-// GetKubernetesClientFromOptionsE returns a Kubernetes API client given a configured KubectlOptions object.
-func GetKubernetesClientFromOptionsE(t testing.TestingT, options *KubectlOptions) (*kubernetes.Clientset, error) {
+// GetKubernetesClientContext returns a Kubernetes API client that can be used to make requests.
+// The ctx parameter is accepted for API consistency.
+// This will fail the test if there is an error.
+func GetKubernetesClientContext(t testing.TestingT, ctx context.Context) *kubernetes.Clientset {
+	t.Helper()
+	clientset, err := GetKubernetesClientContextE(t, ctx)
+	require.NoError(t, err)
+
+	return clientset
+}
+
+// GetKubernetesClientE returns a Kubernetes API client that can be used to make requests.
+//
+// Deprecated: Use [GetKubernetesClientContextE] instead.
+func GetKubernetesClientE(t testing.TestingT) (*kubernetes.Clientset, error) {
+	return GetKubernetesClientContextE(t, context.Background())
+}
+
+// GetKubernetesClientFromOptionsContextE returns a Kubernetes API client given a configured KubectlOptions object.
+// The ctx parameter is accepted for API consistency.
+func GetKubernetesClientFromOptionsContextE(t testing.TestingT, ctx context.Context, options *KubectlOptions) (*kubernetes.Clientset, error) { //nolint:contextcheck // GetConfigPath is a method that doesn't accept ctx
 	var (
 		err    error
 		config *rest.Config
@@ -42,7 +65,7 @@ func GetKubernetesClientFromOptionsE(t testing.TestingT, options *KubectlOptions
 		config = options.RestConfig
 		options.Logger.Logf(t, "Configuring Kubernetes client to use provided rest config object set with API server address: %s", config.Host)
 	default:
-		kubeConfigPath, err := options.GetConfigPath(t)
+		kubeConfigPath, err := options.GetConfigPath(t) //nolint:contextcheck // method doesn't accept ctx
 		if err != nil {
 			return nil, err
 		}
@@ -68,4 +91,22 @@ func GetKubernetesClientFromOptionsE(t testing.TestingT, options *KubectlOptions
 	}
 
 	return clientset, nil
+}
+
+// GetKubernetesClientFromOptionsContext returns a Kubernetes API client given a configured KubectlOptions object.
+// The ctx parameter is accepted for API consistency.
+// This will fail the test if there is an error.
+func GetKubernetesClientFromOptionsContext(t testing.TestingT, ctx context.Context, options *KubectlOptions) *kubernetes.Clientset {
+	t.Helper()
+	clientset, err := GetKubernetesClientFromOptionsContextE(t, ctx, options)
+	require.NoError(t, err)
+
+	return clientset
+}
+
+// GetKubernetesClientFromOptionsE returns a Kubernetes API client given a configured KubectlOptions object.
+//
+// Deprecated: Use [GetKubernetesClientFromOptionsContextE] instead.
+func GetKubernetesClientFromOptionsE(t testing.TestingT, options *KubectlOptions) (*kubernetes.Clientset, error) {
+	return GetKubernetesClientFromOptionsContextE(t, context.Background(), options)
 }

--- a/modules/k8s/cluster_role.go
+++ b/modules/k8s/cluster_role.go
@@ -9,20 +9,40 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// GetClusterRole returns a Kubernetes ClusterRole resource with the given name. This will fail the test if there is an error.
-func GetClusterRole(t testing.TestingT, options *KubectlOptions, roleName string) *rbacv1.ClusterRole {
-	role, err := GetClusterRoleE(t, options, roleName)
+// GetClusterRoleContextE returns a Kubernetes ClusterRole resource with the given name.
+// The ctx parameter supports cancellation and timeouts.
+func GetClusterRoleContextE(t testing.TestingT, ctx context.Context, options *KubectlOptions, roleName string) (*rbacv1.ClusterRole, error) {
+	clientset, err := GetKubernetesClientFromOptionsContextE(t, ctx, options)
+	if err != nil {
+		return nil, err
+	}
+
+	return clientset.RbacV1().ClusterRoles().Get(ctx, roleName, metav1.GetOptions{})
+}
+
+// GetClusterRoleContext returns a Kubernetes ClusterRole resource with the given name.
+// The ctx parameter supports cancellation and timeouts.
+// This will fail the test if there is an error.
+func GetClusterRoleContext(t testing.TestingT, ctx context.Context, options *KubectlOptions, roleName string) *rbacv1.ClusterRole {
+	t.Helper()
+	role, err := GetClusterRoleContextE(t, ctx, options, roleName)
 	require.NoError(t, err)
 
 	return role
 }
 
-// GetClusterRoleE returns a Kubernetes ClusterRole resource with the given name.
-func GetClusterRoleE(t testing.TestingT, options *KubectlOptions, roleName string) (*rbacv1.ClusterRole, error) {
-	clientset, err := GetKubernetesClientFromOptionsE(t, options)
-	if err != nil {
-		return nil, err
-	}
+// GetClusterRole returns a Kubernetes ClusterRole resource with the given name. This will fail the test if there is an error.
+//
+// Deprecated: Use [GetClusterRoleContext] instead.
+func GetClusterRole(t testing.TestingT, options *KubectlOptions, roleName string) *rbacv1.ClusterRole {
+	t.Helper()
 
-	return clientset.RbacV1().ClusterRoles().Get(context.Background(), roleName, metav1.GetOptions{})
+	return GetClusterRoleContext(t, context.Background(), options, roleName)
+}
+
+// GetClusterRoleE returns a Kubernetes ClusterRole resource with the given name.
+//
+// Deprecated: Use [GetClusterRoleContextE] instead.
+func GetClusterRoleE(t testing.TestingT, options *KubectlOptions, roleName string) (*rbacv1.ClusterRole, error) {
+	return GetClusterRoleContextE(t, context.Background(), options, roleName)
 }

--- a/modules/k8s/config.go
+++ b/modules/k8s/config.go
@@ -1,12 +1,14 @@
 package k8s
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"sort"
 
 	gwErrors "github.com/gruntwork-io/go-commons/errors"
 	homedir "github.com/mitchellh/go-homedir"
+	"github.com/stretchr/testify/require"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/clientcmd/api"
@@ -142,8 +144,9 @@ func RemoveOrphanedClusterAndAuthInfoConfig(config *api.Config) {
 	config.Clusters = newClusters
 }
 
-// GetKubeConfigPathE determines which file path to use as the kubectl config path
-func GetKubeConfigPathE(t testing.TestingT) (string, error) {
+// GetKubeConfigPathContextE determines which file path to use as the kubectl config path.
+// The ctx parameter is accepted for API consistency.
+func GetKubeConfigPathContextE(t testing.TestingT, ctx context.Context) (string, error) {
 	kubeConfigPath := environment.GetFirstNonEmptyEnvVarOrEmptyString(t, []string{"KUBECONFIG"})
 	if kubeConfigPath == "" {
 		configPath, err := KubeConfigPathFromHomeDirE()
@@ -155,6 +158,24 @@ func GetKubeConfigPathE(t testing.TestingT) (string, error) {
 	}
 
 	return kubeConfigPath, nil
+}
+
+// GetKubeConfigPathContext determines which file path to use as the kubectl config path.
+// The ctx parameter is accepted for API consistency.
+// This will fail the test if there is an error.
+func GetKubeConfigPathContext(t testing.TestingT, ctx context.Context) string {
+	t.Helper()
+	path, err := GetKubeConfigPathContextE(t, ctx)
+	require.NoError(t, err)
+
+	return path
+}
+
+// GetKubeConfigPathE determines which file path to use as the kubectl config path
+//
+// Deprecated: Use [GetKubeConfigPathContextE] instead.
+func GetKubeConfigPathE(t testing.TestingT) (string, error) {
+	return GetKubeConfigPathContextE(t, context.Background())
 }
 
 // KubeConfigPathFromHomeDirE returns a string to the default Kubernetes config path in the home directory. This will

--- a/modules/k8s/configmap.go
+++ b/modules/k8s/configmap.go
@@ -13,37 +13,62 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// GetConfigMap returns a Kubernetes configmap resource in the provided namespace with the given name. The namespace used
-// is the one provided in the KubectlOptions. This will fail the test if there is an error.
-func GetConfigMap(t testing.TestingT, options *KubectlOptions, configMapName string) *corev1.ConfigMap {
-	configMap, err := GetConfigMapE(t, options, configMapName)
+// GetConfigMapContextE returns a Kubernetes configmap resource in the provided namespace with the given name. The
+// namespace used is the one provided in the KubectlOptions.
+// The ctx parameter supports cancellation and timeouts.
+func GetConfigMapContextE(t testing.TestingT, ctx context.Context, options *KubectlOptions, configMapName string) (*corev1.ConfigMap, error) {
+	clientset, err := GetKubernetesClientFromOptionsContextE(t, ctx, options)
+	if err != nil {
+		return nil, err
+	}
+
+	return clientset.CoreV1().ConfigMaps(options.Namespace).Get(ctx, configMapName, metav1.GetOptions{})
+}
+
+// GetConfigMapContext returns a Kubernetes configmap resource in the provided namespace with the given name. The
+// namespace used is the one provided in the KubectlOptions.
+// The ctx parameter supports cancellation and timeouts.
+// This will fail the test if there is an error.
+func GetConfigMapContext(t testing.TestingT, ctx context.Context, options *KubectlOptions, configMapName string) *corev1.ConfigMap {
+	t.Helper()
+	configMap, err := GetConfigMapContextE(t, ctx, options, configMapName)
 	require.NoError(t, err)
 
 	return configMap
 }
 
-// GetConfigMapE returns a Kubernetes configmap resource in the provided namespace with the given name. The namespace used
-// is the one provided in the KubectlOptions.
-func GetConfigMapE(t testing.TestingT, options *KubectlOptions, configMapName string) (*corev1.ConfigMap, error) {
-	clientset, err := GetKubernetesClientFromOptionsE(t, options)
-	if err != nil {
-		return nil, err
-	}
+// GetConfigMap returns a Kubernetes configmap resource in the provided namespace with the given name. The namespace used
+// is the one provided in the KubectlOptions. This will fail the test if there is an error.
+//
+// Deprecated: Use [GetConfigMapContext] instead.
+func GetConfigMap(t testing.TestingT, options *KubectlOptions, configMapName string) *corev1.ConfigMap {
+	t.Helper()
 
-	return clientset.CoreV1().ConfigMaps(options.Namespace).Get(context.Background(), configMapName, metav1.GetOptions{})
+	return GetConfigMapContext(t, context.Background(), options, configMapName)
 }
 
-// WaitUntilConfigMapAvailable waits until the configmap is present on the cluster in cases where it is not immediately
-// available (for example, when using ClusterIssuer to request a certificate).
-func WaitUntilConfigMapAvailable(t testing.TestingT, options *KubectlOptions, configMapName string, retries int, sleepBetweenRetries time.Duration) {
+// GetConfigMapE returns a Kubernetes configmap resource in the provided namespace with the given name. The namespace used
+// is the one provided in the KubectlOptions.
+//
+// Deprecated: Use [GetConfigMapContextE] instead.
+func GetConfigMapE(t testing.TestingT, options *KubectlOptions, configMapName string) (*corev1.ConfigMap, error) {
+	return GetConfigMapContextE(t, context.Background(), options, configMapName)
+}
+
+// WaitUntilConfigMapAvailableContextE waits until the configmap is present on the cluster in cases where it is not
+// immediately available (for example, when using ClusterIssuer to request a certificate).
+// The ctx parameter supports cancellation and timeouts.
+func WaitUntilConfigMapAvailableContextE(t testing.TestingT, ctx context.Context, options *KubectlOptions, configMapName string, retries int, sleepBetweenRetries time.Duration) error {
 	statusMsg := fmt.Sprintf("Wait for configmap %s to be provisioned.", configMapName)
-	message := retry.DoWithRetry(
+
+	message, err := retry.DoWithRetryContextE(
 		t,
+		ctx,
 		statusMsg,
 		retries,
 		sleepBetweenRetries,
 		func() (string, error) {
-			_, err := GetConfigMapE(t, options, configMapName)
+			_, err := GetConfigMapContextE(t, ctx, options, configMapName)
 			if err != nil {
 				return "", err
 			}
@@ -51,5 +76,30 @@ func WaitUntilConfigMapAvailable(t testing.TestingT, options *KubectlOptions, co
 			return "configmap is now available", nil
 		},
 	)
+	if err != nil {
+		return err
+	}
+
 	options.Logger.Logf(t, "%s", message)
+
+	return nil
+}
+
+// WaitUntilConfigMapAvailableContext waits until the configmap is present on the cluster in cases where it is not
+// immediately available (for example, when using ClusterIssuer to request a certificate).
+// The ctx parameter supports cancellation and timeouts.
+// This will fail the test if there is an error.
+func WaitUntilConfigMapAvailableContext(t testing.TestingT, ctx context.Context, options *KubectlOptions, configMapName string, retries int, sleepBetweenRetries time.Duration) {
+	t.Helper()
+	err := WaitUntilConfigMapAvailableContextE(t, ctx, options, configMapName, retries, sleepBetweenRetries)
+	require.NoError(t, err)
+}
+
+// WaitUntilConfigMapAvailable waits until the configmap is present on the cluster in cases where it is not immediately
+// available (for example, when using ClusterIssuer to request a certificate).
+//
+// Deprecated: Use [WaitUntilConfigMapAvailableContext] instead.
+func WaitUntilConfigMapAvailable(t testing.TestingT, options *KubectlOptions, configMapName string, retries int, sleepBetweenRetries time.Duration) {
+	t.Helper()
+	WaitUntilConfigMapAvailableContext(t, context.Background(), options, configMapName, retries, sleepBetweenRetries)
 }

--- a/modules/k8s/cronjob.go
+++ b/modules/k8s/cronjob.go
@@ -13,26 +13,17 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// ListCronJobs list cron jobs in namespace that match provided filters. This will fail the test if there is an error.
+// ListCronJobsContextE lists cron jobs in namespace that match provided filters and returns them.
+// The ctx parameter supports cancellation and timeouts.
 //
 //nolint:gocritic // hugeParam: cannot change public function signature
-func ListCronJobs(t testing.TestingT, options *KubectlOptions, filters metav1.ListOptions) []batchv1.CronJob {
-	cronJobs, err := ListCronJobsE(t, options, filters)
-	require.NoError(t, err)
-
-	return cronJobs
-}
-
-// ListCronJobsE list cron jobs in namespace that match provided filters. This will return list or error.
-//
-//nolint:gocritic // hugeParam: cannot change public function signature
-func ListCronJobsE(t testing.TestingT, options *KubectlOptions, filters metav1.ListOptions) ([]batchv1.CronJob, error) {
-	clientset, err := GetKubernetesClientFromOptionsE(t, options)
+func ListCronJobsContextE(t testing.TestingT, ctx context.Context, options *KubectlOptions, filters metav1.ListOptions) ([]batchv1.CronJob, error) {
+	clientset, err := GetKubernetesClientFromOptionsContextE(t, ctx, options)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := clientset.BatchV1().CronJobs(options.Namespace).List(context.Background(), filters)
+	resp, err := clientset.BatchV1().CronJobs(options.Namespace).List(ctx, filters)
 	if err != nil {
 		return nil, err
 	}
@@ -40,42 +31,91 @@ func ListCronJobsE(t testing.TestingT, options *KubectlOptions, filters metav1.L
 	return resp.Items, nil
 }
 
-// GetCronJob return cron job resource from namespace by name. This will fail the test if there is an error.
-func GetCronJob(t testing.TestingT, options *KubectlOptions, cronJobName string) *batchv1.CronJob {
-	job, err := GetCronJobE(t, options, cronJobName)
+// ListCronJobsContext lists cron jobs in namespace that match provided filters and returns them.
+// The ctx parameter supports cancellation and timeouts.
+// This will fail the test if there is an error.
+//
+//nolint:gocritic // hugeParam: cannot change public function signature
+func ListCronJobsContext(t testing.TestingT, ctx context.Context, options *KubectlOptions, filters metav1.ListOptions) []batchv1.CronJob {
+	t.Helper()
+	cronJobs, err := ListCronJobsContextE(t, ctx, options, filters)
+	require.NoError(t, err)
+
+	return cronJobs
+}
+
+// ListCronJobs list cron jobs in namespace that match provided filters. This will fail the test if there is an error.
+//
+// Deprecated: Use [ListCronJobsContext] instead.
+//
+//nolint:gocritic // hugeParam: cannot change public function signature
+func ListCronJobs(t testing.TestingT, options *KubectlOptions, filters metav1.ListOptions) []batchv1.CronJob {
+	t.Helper()
+
+	return ListCronJobsContext(t, context.Background(), options, filters)
+}
+
+// ListCronJobsE list cron jobs in namespace that match provided filters. This will return list or error.
+//
+// Deprecated: Use [ListCronJobsContextE] instead.
+//
+//nolint:gocritic // hugeParam: cannot change public function signature
+func ListCronJobsE(t testing.TestingT, options *KubectlOptions, filters metav1.ListOptions) ([]batchv1.CronJob, error) {
+	return ListCronJobsContextE(t, context.Background(), options, filters)
+}
+
+// GetCronJobContextE returns a cron job resource from namespace by name.
+// The ctx parameter supports cancellation and timeouts.
+func GetCronJobContextE(t testing.TestingT, ctx context.Context, options *KubectlOptions, cronJobName string) (*batchv1.CronJob, error) {
+	clientset, err := GetKubernetesClientFromOptionsContextE(t, ctx, options)
+	if err != nil {
+		return nil, err
+	}
+
+	return clientset.BatchV1().CronJobs(options.Namespace).Get(ctx, cronJobName, metav1.GetOptions{})
+}
+
+// GetCronJobContext returns a cron job resource from namespace by name.
+// The ctx parameter supports cancellation and timeouts.
+// This will fail the test if there is an error.
+func GetCronJobContext(t testing.TestingT, ctx context.Context, options *KubectlOptions, cronJobName string) *batchv1.CronJob {
+	t.Helper()
+	job, err := GetCronJobContextE(t, ctx, options, cronJobName)
 	require.NoError(t, err)
 
 	return job
 }
 
+// GetCronJob return cron job resource from namespace by name. This will fail the test if there is an error.
+//
+// Deprecated: Use [GetCronJobContext] instead.
+func GetCronJob(t testing.TestingT, options *KubectlOptions, cronJobName string) *batchv1.CronJob {
+	t.Helper()
+
+	return GetCronJobContext(t, context.Background(), options, cronJobName)
+}
+
 // GetCronJobE return cron job resource from namespace by name. This will return cron job or error.
+//
+// Deprecated: Use [GetCronJobContextE] instead.
 func GetCronJobE(t testing.TestingT, options *KubectlOptions, cronJobName string) (*batchv1.CronJob, error) {
-	clientset, err := GetKubernetesClientFromOptionsE(t, options)
-	if err != nil {
-		return nil, err
-	}
-
-	return clientset.BatchV1().CronJobs(options.Namespace).Get(context.Background(), cronJobName, metav1.GetOptions{})
+	return GetCronJobContextE(t, context.Background(), options, cronJobName)
 }
 
-// WaitUntilCronJobSucceed waits until cron job will successfully complete a job. This will fail the test if there is an
-// error or if the check times out.
-func WaitUntilCronJobSucceed(t testing.TestingT, options *KubectlOptions, cronJobName string, retries int, sleepBetweenRetries time.Duration) {
-	require.NoError(t, WaitUntilCronJobSucceedE(t, options, cronJobName, retries, sleepBetweenRetries))
-}
-
-// WaitUntilCronJobSucceedE waits until cron job will successfully complete a job, retrying the check for the specified
-// amount of times, sleeping for the provided duration between each try.
-func WaitUntilCronJobSucceedE(t testing.TestingT, options *KubectlOptions, cronJobName string, retries int, sleepBetweenRetries time.Duration) error {
+// WaitUntilCronJobSucceedContextE waits until cron job will successfully complete a job, retrying the check for the
+// specified amount of times, sleeping for the provided duration between each try.
+// The ctx parameter supports cancellation and timeouts.
+func WaitUntilCronJobSucceedContextE(t testing.TestingT, ctx context.Context, options *KubectlOptions, cronJobName string, retries int, sleepBetweenRetries time.Duration) error { //nolint:dupl // similar retry pattern across resource types is intentional
 	statusMsg := fmt.Sprintf("Wait for CronJob %s to successfully schedule container", cronJobName)
 
-	message, err := retry.DoWithRetryE(
+	message, err := retry.DoWithRetryContextE(
 		t,
+		ctx,
 		statusMsg,
 		retries,
 		sleepBetweenRetries,
 		func() (string, error) {
-			job, err := GetCronJobE(t, options, cronJobName)
+			job, err := GetCronJobContextE(t, ctx, options, cronJobName)
 			if err != nil {
 				return "", err
 			}
@@ -95,6 +135,32 @@ func WaitUntilCronJobSucceedE(t testing.TestingT, options *KubectlOptions, cronJ
 	options.Logger.Logf(t, "%s", message)
 
 	return nil
+}
+
+// WaitUntilCronJobSucceedContext waits until cron job will successfully complete a job, retrying the check for the
+// specified amount of times, sleeping for the provided duration between each try.
+// The ctx parameter supports cancellation and timeouts.
+// This will fail the test if there is an error.
+func WaitUntilCronJobSucceedContext(t testing.TestingT, ctx context.Context, options *KubectlOptions, cronJobName string, retries int, sleepBetweenRetries time.Duration) {
+	t.Helper()
+	require.NoError(t, WaitUntilCronJobSucceedContextE(t, ctx, options, cronJobName, retries, sleepBetweenRetries))
+}
+
+// WaitUntilCronJobSucceed waits until cron job will successfully complete a job. This will fail the test if there is an
+// error or if the check times out.
+//
+// Deprecated: Use [WaitUntilCronJobSucceedContext] instead.
+func WaitUntilCronJobSucceed(t testing.TestingT, options *KubectlOptions, cronJobName string, retries int, sleepBetweenRetries time.Duration) {
+	t.Helper()
+	WaitUntilCronJobSucceedContext(t, context.Background(), options, cronJobName, retries, sleepBetweenRetries)
+}
+
+// WaitUntilCronJobSucceedE waits until cron job will successfully complete a job, retrying the check for the specified
+// amount of times, sleeping for the provided duration between each try.
+//
+// Deprecated: Use [WaitUntilCronJobSucceedContextE] instead.
+func WaitUntilCronJobSucceedE(t testing.TestingT, options *KubectlOptions, cronJobName string, retries int, sleepBetweenRetries time.Duration) error {
+	return WaitUntilCronJobSucceedContextE(t, context.Background(), options, cronJobName, retries, sleepBetweenRetries)
 }
 
 // IsCronJobSucceeded returns true if cron job successfully scheduled and completed job.

--- a/modules/k8s/daemonset.go
+++ b/modules/k8s/daemonset.go
@@ -10,27 +10,17 @@ import (
 	"github.com/gruntwork-io/terratest/modules/testing"
 )
 
-// ListDaemonSets will look for daemonsets in the given namespace that match the given filters and return them. This will
-// fail the test if there is an error.
+// ListDaemonSetsContextE looks up daemonsets in the given namespace that match the given filters and return them.
+// The ctx parameter supports cancellation and timeouts.
 //
 //nolint:gocritic // hugeParam: cannot change public function signature
-func ListDaemonSets(t testing.TestingT, options *KubectlOptions, filters metav1.ListOptions) []appsv1.DaemonSet {
-	daemonset, err := ListDaemonSetsE(t, options, filters)
-	require.NoError(t, err)
-
-	return daemonset
-}
-
-// ListDaemonSetsE will look for daemonsets in the given namespace that match the given filters and return them.
-//
-//nolint:gocritic // hugeParam: cannot change public function signature
-func ListDaemonSetsE(t testing.TestingT, options *KubectlOptions, filters metav1.ListOptions) ([]appsv1.DaemonSet, error) {
-	clientset, err := GetKubernetesClientFromOptionsE(t, options)
+func ListDaemonSetsContextE(t testing.TestingT, ctx context.Context, options *KubectlOptions, filters metav1.ListOptions) ([]appsv1.DaemonSet, error) {
+	clientset, err := GetKubernetesClientFromOptionsContextE(t, ctx, options)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := clientset.AppsV1().DaemonSets(options.Namespace).List(context.Background(), filters)
+	resp, err := clientset.AppsV1().DaemonSets(options.Namespace).List(ctx, filters)
 	if err != nil {
 		return nil, err
 	}
@@ -38,21 +28,75 @@ func ListDaemonSetsE(t testing.TestingT, options *KubectlOptions, filters metav1
 	return resp.Items, nil
 }
 
-// GetDaemonSet returns a Kubernetes daemonset resource in the provided namespace with the given name. This will
-// fail the test if there is an error.
-func GetDaemonSet(t testing.TestingT, options *KubectlOptions, daemonSetName string) *appsv1.DaemonSet {
-	daemonset, err := GetDaemonSetE(t, options, daemonSetName)
+// ListDaemonSetsContext looks up daemonsets in the given namespace that match the given filters and return them.
+// The ctx parameter supports cancellation and timeouts.
+// This will fail the test if there is an error.
+//
+//nolint:gocritic // hugeParam: cannot change public function signature
+func ListDaemonSetsContext(t testing.TestingT, ctx context.Context, options *KubectlOptions, filters metav1.ListOptions) []appsv1.DaemonSet {
+	t.Helper()
+	daemonset, err := ListDaemonSetsContextE(t, ctx, options, filters)
 	require.NoError(t, err)
 
 	return daemonset
 }
 
-// GetDaemonSetE returns a Kubernetes daemonset resource in the provided namespace with the given name.
-func GetDaemonSetE(t testing.TestingT, options *KubectlOptions, daemonSetName string) (*appsv1.DaemonSet, error) {
-	clientset, err := GetKubernetesClientFromOptionsE(t, options)
+// ListDaemonSets will look for daemonsets in the given namespace that match the given filters and return them. This will
+// fail the test if there is an error.
+//
+// Deprecated: Use [ListDaemonSetsContext] instead.
+//
+//nolint:gocritic // hugeParam: cannot change public function signature
+func ListDaemonSets(t testing.TestingT, options *KubectlOptions, filters metav1.ListOptions) []appsv1.DaemonSet {
+	t.Helper()
+
+	return ListDaemonSetsContext(t, context.Background(), options, filters)
+}
+
+// ListDaemonSetsE will look for daemonsets in the given namespace that match the given filters and return them.
+//
+// Deprecated: Use [ListDaemonSetsContextE] instead.
+//
+//nolint:gocritic // hugeParam: cannot change public function signature
+func ListDaemonSetsE(t testing.TestingT, options *KubectlOptions, filters metav1.ListOptions) ([]appsv1.DaemonSet, error) {
+	return ListDaemonSetsContextE(t, context.Background(), options, filters)
+}
+
+// GetDaemonSetContextE returns a Kubernetes daemonset resource in the provided namespace with the given name.
+// The ctx parameter supports cancellation and timeouts.
+func GetDaemonSetContextE(t testing.TestingT, ctx context.Context, options *KubectlOptions, daemonSetName string) (*appsv1.DaemonSet, error) {
+	clientset, err := GetKubernetesClientFromOptionsContextE(t, ctx, options)
 	if err != nil {
 		return nil, err
 	}
 
-	return clientset.AppsV1().DaemonSets(options.Namespace).Get(context.Background(), daemonSetName, metav1.GetOptions{})
+	return clientset.AppsV1().DaemonSets(options.Namespace).Get(ctx, daemonSetName, metav1.GetOptions{})
+}
+
+// GetDaemonSetContext returns a Kubernetes daemonset resource in the provided namespace with the given name.
+// The ctx parameter supports cancellation and timeouts.
+// This will fail the test if there is an error.
+func GetDaemonSetContext(t testing.TestingT, ctx context.Context, options *KubectlOptions, daemonSetName string) *appsv1.DaemonSet {
+	t.Helper()
+	daemonset, err := GetDaemonSetContextE(t, ctx, options, daemonSetName)
+	require.NoError(t, err)
+
+	return daemonset
+}
+
+// GetDaemonSet returns a Kubernetes daemonset resource in the provided namespace with the given name. This will
+// fail the test if there is an error.
+//
+// Deprecated: Use [GetDaemonSetContext] instead.
+func GetDaemonSet(t testing.TestingT, options *KubectlOptions, daemonSetName string) *appsv1.DaemonSet {
+	t.Helper()
+
+	return GetDaemonSetContext(t, context.Background(), options, daemonSetName)
+}
+
+// GetDaemonSetE returns a Kubernetes daemonset resource in the provided namespace with the given name.
+//
+// Deprecated: Use [GetDaemonSetContextE] instead.
+func GetDaemonSetE(t testing.TestingT, options *KubectlOptions, daemonSetName string) (*appsv1.DaemonSet, error) {
+	return GetDaemonSetContextE(t, context.Background(), options, daemonSetName)
 }

--- a/modules/k8s/deployment.go
+++ b/modules/k8s/deployment.go
@@ -14,27 +14,17 @@ import (
 	"github.com/gruntwork-io/terratest/modules/testing"
 )
 
-// ListDeployments will look for deployments in the given namespace that match the given filters and return them. This will
-// fail the test if there is an error.
+// ListDeploymentsContextE looks up deployments in the given namespace that match the given filters and return them.
+// The ctx parameter supports cancellation and timeouts.
 //
 //nolint:gocritic // hugeParam: cannot change public function signature
-func ListDeployments(t testing.TestingT, options *KubectlOptions, filters metav1.ListOptions) []appsv1.Deployment {
-	deployment, err := ListDeploymentsE(t, options, filters)
-	require.NoError(t, err)
-
-	return deployment
-}
-
-// ListDeploymentsE will look for deployments in the given namespace that match the given filters and return them.
-//
-//nolint:gocritic // hugeParam: cannot change public function signature
-func ListDeploymentsE(t testing.TestingT, options *KubectlOptions, filters metav1.ListOptions) ([]appsv1.Deployment, error) {
-	clientset, err := GetKubernetesClientFromOptionsE(t, options)
+func ListDeploymentsContextE(t testing.TestingT, ctx context.Context, options *KubectlOptions, filters metav1.ListOptions) ([]appsv1.Deployment, error) {
+	clientset, err := GetKubernetesClientFromOptionsContextE(t, ctx, options)
 	if err != nil {
 		return nil, err
 	}
 
-	deployments, err := clientset.AppsV1().Deployments(options.Namespace).List(context.Background(), filters)
+	deployments, err := clientset.AppsV1().Deployments(options.Namespace).List(ctx, filters)
 	if err != nil {
 		return nil, err
 	}
@@ -42,38 +32,85 @@ func ListDeploymentsE(t testing.TestingT, options *KubectlOptions, filters metav
 	return deployments.Items, nil
 }
 
-// GetDeployment returns a Kubernetes deployment resource in the provided namespace with the given name. This will
-// fail the test if there is an error.
-func GetDeployment(t testing.TestingT, options *KubectlOptions, deploymentName string) *appsv1.Deployment {
-	deployment, err := GetDeploymentE(t, options, deploymentName)
+// ListDeploymentsContext looks up deployments in the given namespace that match the given filters and return them.
+// The ctx parameter supports cancellation and timeouts.
+// This will fail the test if there is an error.
+//
+//nolint:gocritic // hugeParam: cannot change public function signature
+func ListDeploymentsContext(t testing.TestingT, ctx context.Context, options *KubectlOptions, filters metav1.ListOptions) []appsv1.Deployment {
+	t.Helper()
+	deployment, err := ListDeploymentsContextE(t, ctx, options, filters)
 	require.NoError(t, err)
 
 	return deployment
 }
 
-// GetDeploymentE returns a Kubernetes deployment resource in the provided namespace with the given name.
-func GetDeploymentE(t testing.TestingT, options *KubectlOptions, deploymentName string) (*appsv1.Deployment, error) {
-	clientset, err := GetKubernetesClientFromOptionsE(t, options)
+// ListDeployments will look for deployments in the given namespace that match the given filters and return them. This will
+// fail the test if there is an error.
+//
+// Deprecated: Use [ListDeploymentsContext] instead.
+//
+//nolint:gocritic // hugeParam: cannot change public function signature
+func ListDeployments(t testing.TestingT, options *KubectlOptions, filters metav1.ListOptions) []appsv1.Deployment {
+	t.Helper()
+
+	return ListDeploymentsContext(t, context.Background(), options, filters)
+}
+
+// ListDeploymentsE will look for deployments in the given namespace that match the given filters and return them.
+//
+// Deprecated: Use [ListDeploymentsContextE] instead.
+//
+//nolint:gocritic // hugeParam: cannot change public function signature
+func ListDeploymentsE(t testing.TestingT, options *KubectlOptions, filters metav1.ListOptions) ([]appsv1.Deployment, error) {
+	return ListDeploymentsContextE(t, context.Background(), options, filters)
+}
+
+// GetDeploymentContextE returns a Kubernetes deployment resource in the provided namespace with the given name.
+// The ctx parameter supports cancellation and timeouts.
+func GetDeploymentContextE(t testing.TestingT, ctx context.Context, options *KubectlOptions, deploymentName string) (*appsv1.Deployment, error) {
+	clientset, err := GetKubernetesClientFromOptionsContextE(t, ctx, options)
 	if err != nil {
 		return nil, err
 	}
 
-	return clientset.AppsV1().Deployments(options.Namespace).Get(context.Background(), deploymentName, metav1.GetOptions{})
+	return clientset.AppsV1().Deployments(options.Namespace).Get(ctx, deploymentName, metav1.GetOptions{})
 }
 
-// WaitUntilDeploymentAvailable waits until all pods within the deployment are ready and started,
-// retrying the check for the specified amount of times, sleeping
-// for the provided duration between each try.
+// GetDeploymentContext returns a Kubernetes deployment resource in the provided namespace with the given name.
+// The ctx parameter supports cancellation and timeouts.
 // This will fail the test if there is an error.
-func WaitUntilDeploymentAvailable(t testing.TestingT, options *KubectlOptions, deploymentName string, retries int, sleepBetweenRetries time.Duration) {
-	require.NoError(t, WaitUntilDeploymentAvailableE(t, options, deploymentName, retries, sleepBetweenRetries))
+func GetDeploymentContext(t testing.TestingT, ctx context.Context, options *KubectlOptions, deploymentName string) *appsv1.Deployment {
+	t.Helper()
+	deployment, err := GetDeploymentContextE(t, ctx, options, deploymentName)
+	require.NoError(t, err)
+
+	return deployment
 }
 
-// WaitUntilDeploymentAvailableE waits until all pods within the deployment are ready and started,
-// retrying the check for the specified amount of times, sleeping
-// for the provided duration between each try.
-func WaitUntilDeploymentAvailableE(
+// GetDeployment returns a Kubernetes deployment resource in the provided namespace with the given name. This will
+// fail the test if there is an error.
+//
+// Deprecated: Use [GetDeploymentContext] instead.
+func GetDeployment(t testing.TestingT, options *KubectlOptions, deploymentName string) *appsv1.Deployment {
+	t.Helper()
+
+	return GetDeploymentContext(t, context.Background(), options, deploymentName)
+}
+
+// GetDeploymentE returns a Kubernetes deployment resource in the provided namespace with the given name.
+//
+// Deprecated: Use [GetDeploymentContextE] instead.
+func GetDeploymentE(t testing.TestingT, options *KubectlOptions, deploymentName string) (*appsv1.Deployment, error) {
+	return GetDeploymentContextE(t, context.Background(), options, deploymentName)
+}
+
+// WaitUntilDeploymentAvailableContextE waits until all pods within the deployment are ready and started,
+// retrying the check for the specified amount of times, sleeping for the provided duration between each try.
+// The ctx parameter supports cancellation and timeouts.
+func WaitUntilDeploymentAvailableContextE( //nolint:dupl // similar retry pattern across resource types is intentional
 	t testing.TestingT,
+	ctx context.Context,
 	options *KubectlOptions,
 	deploymentName string,
 	retries int,
@@ -81,13 +118,14 @@ func WaitUntilDeploymentAvailableE(
 ) error {
 	statusMsg := fmt.Sprintf("Wait for deployment %s to be provisioned.", deploymentName)
 
-	message, err := retry.DoWithRetryE(
+	message, err := retry.DoWithRetryContextE(
 		t,
+		ctx,
 		statusMsg,
 		retries,
 		sleepBetweenRetries,
 		func() (string, error) {
-			deployment, err := GetDeploymentE(t, options, deploymentName)
+			deployment, err := GetDeploymentContextE(t, ctx, options, deploymentName)
 			if err != nil {
 				return "", err
 			}
@@ -107,6 +145,41 @@ func WaitUntilDeploymentAvailableE(
 	options.Logger.Logf(t, "%s", message)
 
 	return nil
+}
+
+// WaitUntilDeploymentAvailableContext waits until all pods within the deployment are ready and started,
+// retrying the check for the specified amount of times, sleeping for the provided duration between each try.
+// The ctx parameter supports cancellation and timeouts.
+// This will fail the test if there is an error.
+func WaitUntilDeploymentAvailableContext(t testing.TestingT, ctx context.Context, options *KubectlOptions, deploymentName string, retries int, sleepBetweenRetries time.Duration) {
+	t.Helper()
+	require.NoError(t, WaitUntilDeploymentAvailableContextE(t, ctx, options, deploymentName, retries, sleepBetweenRetries))
+}
+
+// WaitUntilDeploymentAvailable waits until all pods within the deployment are ready and started,
+// retrying the check for the specified amount of times, sleeping
+// for the provided duration between each try.
+// This will fail the test if there is an error.
+//
+// Deprecated: Use [WaitUntilDeploymentAvailableContext] instead.
+func WaitUntilDeploymentAvailable(t testing.TestingT, options *KubectlOptions, deploymentName string, retries int, sleepBetweenRetries time.Duration) {
+	t.Helper()
+	WaitUntilDeploymentAvailableContext(t, context.Background(), options, deploymentName, retries, sleepBetweenRetries)
+}
+
+// WaitUntilDeploymentAvailableE waits until all pods within the deployment are ready and started,
+// retrying the check for the specified amount of times, sleeping
+// for the provided duration between each try.
+//
+// Deprecated: Use [WaitUntilDeploymentAvailableContextE] instead.
+func WaitUntilDeploymentAvailableE(
+	t testing.TestingT,
+	options *KubectlOptions,
+	deploymentName string,
+	retries int,
+	sleepBetweenRetries time.Duration,
+) error {
+	return WaitUntilDeploymentAvailableContextE(t, context.Background(), options, deploymentName, retries, sleepBetweenRetries)
 }
 
 // IsDeploymentAvailable returns true if all pods within the deployment are ready and started

--- a/modules/k8s/event.go
+++ b/modules/k8s/event.go
@@ -11,30 +11,54 @@ import (
 	"github.com/gruntwork-io/terratest/modules/testing"
 )
 
-// ListEvents will retrieve the Events in the given namespace that match the given filters and return them. This will fail the
-// test if there is an error.
+// ListEventsContextE retrieves the Events in the given namespace that match the given filters and return them.
+// The ctx parameter supports cancellation and timeouts.
 //
 //nolint:gocritic // hugeParam: cannot change public function signature
-func ListEvents(t testing.TestingT, options *KubectlOptions, filters metav1.ListOptions) []corev1.Event {
-	events, err := ListEventsE(t, options, filters)
-	require.NoError(t, err)
-
-	return events
-}
-
-// ListEventsE will retrieve the Events that match the given filters and return them.
-//
-//nolint:gocritic // hugeParam: cannot change public function signature
-func ListEventsE(t testing.TestingT, options *KubectlOptions, filters metav1.ListOptions) ([]corev1.Event, error) {
-	clientset, err := GetKubernetesClientFromOptionsE(t, options)
+func ListEventsContextE(t testing.TestingT, ctx context.Context, options *KubectlOptions, filters metav1.ListOptions) ([]corev1.Event, error) {
+	clientset, err := GetKubernetesClientFromOptionsContextE(t, ctx, options)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := clientset.CoreV1().Events(options.Namespace).List(context.Background(), filters)
+	resp, err := clientset.CoreV1().Events(options.Namespace).List(ctx, filters)
 	if err != nil {
 		return nil, err
 	}
 
 	return resp.Items, nil
+}
+
+// ListEventsContext retrieves the Events in the given namespace that match the given filters and return them.
+// The ctx parameter supports cancellation and timeouts.
+// This will fail the test if there is an error.
+//
+//nolint:gocritic // hugeParam: cannot change public function signature
+func ListEventsContext(t testing.TestingT, ctx context.Context, options *KubectlOptions, filters metav1.ListOptions) []corev1.Event {
+	t.Helper()
+	events, err := ListEventsContextE(t, ctx, options, filters)
+	require.NoError(t, err)
+
+	return events
+}
+
+// ListEvents will retrieve the Events in the given namespace that match the given filters and return them. This will fail the
+// test if there is an error.
+//
+// Deprecated: Use [ListEventsContext] instead.
+//
+//nolint:gocritic // hugeParam: cannot change public function signature
+func ListEvents(t testing.TestingT, options *KubectlOptions, filters metav1.ListOptions) []corev1.Event {
+	t.Helper()
+
+	return ListEventsContext(t, context.Background(), options, filters)
+}
+
+// ListEventsE will retrieve the Events that match the given filters and return them.
+//
+// Deprecated: Use [ListEventsContextE] instead.
+//
+//nolint:gocritic // hugeParam: cannot change public function signature
+func ListEventsE(t testing.TestingT, options *KubectlOptions, filters metav1.ListOptions) ([]corev1.Event, error) {
+	return ListEventsContextE(t, context.Background(), options, filters)
 }

--- a/modules/k8s/ingress.go
+++ b/modules/k8s/ingress.go
@@ -14,27 +14,17 @@ import (
 	"github.com/gruntwork-io/terratest/modules/testing"
 )
 
-// ListIngresses will look for Ingress resources in the given namespace that match the given filters and return them.
-// This will fail the test if there is an error.
+// ListIngressesContextE will look for Ingress resources in the given namespace that match the given filters and return
+// them. The ctx parameter supports cancellation and timeouts.
 //
 //nolint:gocritic // hugeParam: cannot change public function signature
-func ListIngresses(t testing.TestingT, options *KubectlOptions, filters metav1.ListOptions) []networkingv1.Ingress {
-	ingresses, err := ListIngressesE(t, options, filters)
-	require.NoError(t, err)
-
-	return ingresses
-}
-
-// ListIngressesE will look for Ingress resources in the given namespace that match the given filters and return them.
-//
-//nolint:gocritic // hugeParam: cannot change public function signature
-func ListIngressesE(t testing.TestingT, options *KubectlOptions, filters metav1.ListOptions) ([]networkingv1.Ingress, error) {
-	clientset, err := GetKubernetesClientFromOptionsE(t, options)
+func ListIngressesContextE(t testing.TestingT, ctx context.Context, options *KubectlOptions, filters metav1.ListOptions) ([]networkingv1.Ingress, error) {
+	clientset, err := GetKubernetesClientFromOptionsContextE(t, ctx, options)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := clientset.NetworkingV1().Ingresses(options.Namespace).List(context.Background(), filters)
+	resp, err := clientset.NetworkingV1().Ingresses(options.Namespace).List(ctx, filters)
 	if err != nil {
 		return nil, err
 	}
@@ -42,23 +32,77 @@ func ListIngressesE(t testing.TestingT, options *KubectlOptions, filters metav1.
 	return resp.Items, nil
 }
 
-// GetIngress returns a Kubernetes Ingress resource in the provided namespace with the given name. This will fail the
-// test if there is an error.
-func GetIngress(t testing.TestingT, options *KubectlOptions, ingressName string) *networkingv1.Ingress {
-	ingress, err := GetIngressE(t, options, ingressName)
+// ListIngressesContext will look for Ingress resources in the given namespace that match the given filters and return
+// them. The ctx parameter supports cancellation and timeouts.
+// This will fail the test if there is an error.
+//
+//nolint:gocritic // hugeParam: cannot change public function signature
+func ListIngressesContext(t testing.TestingT, ctx context.Context, options *KubectlOptions, filters metav1.ListOptions) []networkingv1.Ingress {
+	t.Helper()
+	ingresses, err := ListIngressesContextE(t, ctx, options, filters)
+	require.NoError(t, err)
+
+	return ingresses
+}
+
+// ListIngresses will look for Ingress resources in the given namespace that match the given filters and return them.
+// This will fail the test if there is an error.
+//
+// Deprecated: Use [ListIngressesContext] instead.
+//
+//nolint:gocritic // hugeParam: cannot change public function signature
+func ListIngresses(t testing.TestingT, options *KubectlOptions, filters metav1.ListOptions) []networkingv1.Ingress {
+	t.Helper()
+
+	return ListIngressesContext(t, context.Background(), options, filters)
+}
+
+// ListIngressesE will look for Ingress resources in the given namespace that match the given filters and return them.
+//
+// Deprecated: Use [ListIngressesContextE] instead.
+//
+//nolint:gocritic // hugeParam: cannot change public function signature
+func ListIngressesE(t testing.TestingT, options *KubectlOptions, filters metav1.ListOptions) ([]networkingv1.Ingress, error) {
+	return ListIngressesContextE(t, context.Background(), options, filters)
+}
+
+// GetIngressContextE returns a Kubernetes Ingress resource in the provided namespace with the given name.
+// The ctx parameter supports cancellation and timeouts.
+func GetIngressContextE(t testing.TestingT, ctx context.Context, options *KubectlOptions, ingressName string) (*networkingv1.Ingress, error) {
+	clientset, err := GetKubernetesClientFromOptionsContextE(t, ctx, options)
+	if err != nil {
+		return nil, err
+	}
+
+	return clientset.NetworkingV1().Ingresses(options.Namespace).Get(ctx, ingressName, metav1.GetOptions{})
+}
+
+// GetIngressContext returns a Kubernetes Ingress resource in the provided namespace with the given name.
+// The ctx parameter supports cancellation and timeouts.
+// This will fail the test if there is an error.
+func GetIngressContext(t testing.TestingT, ctx context.Context, options *KubectlOptions, ingressName string) *networkingv1.Ingress {
+	t.Helper()
+	ingress, err := GetIngressContextE(t, ctx, options, ingressName)
 	require.NoError(t, err)
 
 	return ingress
 }
 
-// GetIngressE returns a Kubernetes Ingress resource in the provided namespace with the given name.
-func GetIngressE(t testing.TestingT, options *KubectlOptions, ingressName string) (*networkingv1.Ingress, error) {
-	clientset, err := GetKubernetesClientFromOptionsE(t, options)
-	if err != nil {
-		return nil, err
-	}
+// GetIngress returns a Kubernetes Ingress resource in the provided namespace with the given name. This will fail the
+// test if there is an error.
+//
+// Deprecated: Use [GetIngressContext] instead.
+func GetIngress(t testing.TestingT, options *KubectlOptions, ingressName string) *networkingv1.Ingress {
+	t.Helper()
 
-	return clientset.NetworkingV1().Ingresses(options.Namespace).Get(context.Background(), ingressName, metav1.GetOptions{})
+	return GetIngressContext(t, context.Background(), options, ingressName)
+}
+
+// GetIngressE returns a Kubernetes Ingress resource in the provided namespace with the given name.
+//
+// Deprecated: Use [GetIngressContextE] instead.
+func GetIngressE(t testing.TestingT, options *KubectlOptions, ingressName string) (*networkingv1.Ingress, error) {
+	return GetIngressContextE(t, context.Background(), options, ingressName)
 }
 
 // IsIngressAvailable returns true if the Ingress endpoint is provisioned and available.
@@ -68,16 +112,19 @@ func IsIngressAvailable(ingress *networkingv1.Ingress) bool {
 	return len(endpoints) > 0
 }
 
-// WaitUntilIngressAvailable waits until the Ingress resource has an endpoint provisioned for it.
-func WaitUntilIngressAvailable(t testing.TestingT, options *KubectlOptions, ingressName string, retries int, sleepBetweenRetries time.Duration) {
+// WaitUntilIngressAvailableContextE waits until the Ingress resource has an endpoint provisioned for it.
+// The ctx parameter supports cancellation and timeouts.
+func WaitUntilIngressAvailableContextE(t testing.TestingT, ctx context.Context, options *KubectlOptions, ingressName string, retries int, sleepBetweenRetries time.Duration) error {
 	statusMsg := fmt.Sprintf("Wait for ingress %s to be provisioned.", ingressName)
-	message := retry.DoWithRetry(
+
+	message, err := retry.DoWithRetryContextE(
 		t,
+		ctx,
 		statusMsg,
 		retries,
 		sleepBetweenRetries,
 		func() (string, error) {
-			ingress, err := GetIngressE(t, options, ingressName)
+			ingress, err := GetIngressContextE(t, ctx, options, ingressName)
 			if err != nil {
 				return "", err
 			}
@@ -89,31 +136,44 @@ func WaitUntilIngressAvailable(t testing.TestingT, options *KubectlOptions, ingr
 			return "Ingress is now available", nil
 		},
 	)
+	if err != nil {
+		return err
+	}
+
 	options.Logger.Logf(t, "%s", message)
+
+	return nil
 }
 
-// ListIngressesV1Beta1 will look for Ingress resources in the given namespace that match the given filters and return
-// them, using networking.k8s.io/v1beta1 API. This will fail the test if there is an error.
-//
-//nolint:gocritic // hugeParam: cannot change public function signature
-func ListIngressesV1Beta1(t testing.TestingT, options *KubectlOptions, filters metav1.ListOptions) []networkingv1beta1.Ingress {
-	ingresses, err := ListIngressesV1Beta1E(t, options, filters)
+// WaitUntilIngressAvailableContext waits until the Ingress resource has an endpoint provisioned for it.
+// The ctx parameter supports cancellation and timeouts.
+// This will fail the test if there is an error.
+func WaitUntilIngressAvailableContext(t testing.TestingT, ctx context.Context, options *KubectlOptions, ingressName string, retries int, sleepBetweenRetries time.Duration) {
+	t.Helper()
+	err := WaitUntilIngressAvailableContextE(t, ctx, options, ingressName, retries, sleepBetweenRetries)
 	require.NoError(t, err)
-
-	return ingresses
 }
 
-// ListIngressesV1Beta1E will look for Ingress resources in the given namespace that match the given filters and return
-// them, using networking.k8s.io/v1beta1 API.
+// WaitUntilIngressAvailable waits until the Ingress resource has an endpoint provisioned for it.
+//
+// Deprecated: Use [WaitUntilIngressAvailableContext] instead.
+func WaitUntilIngressAvailable(t testing.TestingT, options *KubectlOptions, ingressName string, retries int, sleepBetweenRetries time.Duration) {
+	t.Helper()
+	WaitUntilIngressAvailableContext(t, context.Background(), options, ingressName, retries, sleepBetweenRetries)
+}
+
+// ListIngressesV1Beta1ContextE will look for Ingress resources in the given namespace that match the given filters and
+// return them, using networking.k8s.io/v1beta1 API.
+// The ctx parameter supports cancellation and timeouts.
 //
 //nolint:gocritic // hugeParam: cannot change public function signature
-func ListIngressesV1Beta1E(t testing.TestingT, options *KubectlOptions, filters metav1.ListOptions) ([]networkingv1beta1.Ingress, error) {
-	clientset, err := GetKubernetesClientFromOptionsE(t, options)
+func ListIngressesV1Beta1ContextE(t testing.TestingT, ctx context.Context, options *KubectlOptions, filters metav1.ListOptions) ([]networkingv1beta1.Ingress, error) {
+	clientset, err := GetKubernetesClientFromOptionsContextE(t, ctx, options)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := clientset.NetworkingV1beta1().Ingresses(options.Namespace).List(context.Background(), filters)
+	resp, err := clientset.NetworkingV1beta1().Ingresses(options.Namespace).List(ctx, filters)
 	if err != nil {
 		return nil, err
 	}
@@ -121,24 +181,82 @@ func ListIngressesV1Beta1E(t testing.TestingT, options *KubectlOptions, filters 
 	return resp.Items, nil
 }
 
-// GetIngressV1Beta1 returns a Kubernetes Ingress resource in the provided namespace with the given name, using
-// networking.k8s.io/v1beta1 API. This will fail the test if there is an error.
-func GetIngressV1Beta1(t testing.TestingT, options *KubectlOptions, ingressName string) *networkingv1beta1.Ingress {
-	ingress, err := GetIngressV1Beta1E(t, options, ingressName)
+// ListIngressesV1Beta1Context will look for Ingress resources in the given namespace that match the given filters and
+// return them, using networking.k8s.io/v1beta1 API.
+// The ctx parameter supports cancellation and timeouts.
+// This will fail the test if there is an error.
+//
+//nolint:gocritic // hugeParam: cannot change public function signature
+func ListIngressesV1Beta1Context(t testing.TestingT, ctx context.Context, options *KubectlOptions, filters metav1.ListOptions) []networkingv1beta1.Ingress {
+	t.Helper()
+	ingresses, err := ListIngressesV1Beta1ContextE(t, ctx, options, filters)
+	require.NoError(t, err)
+
+	return ingresses
+}
+
+// ListIngressesV1Beta1 will look for Ingress resources in the given namespace that match the given filters and return
+// them, using networking.k8s.io/v1beta1 API. This will fail the test if there is an error.
+//
+// Deprecated: Use [ListIngressesV1Beta1Context] instead.
+//
+//nolint:gocritic // hugeParam: cannot change public function signature
+func ListIngressesV1Beta1(t testing.TestingT, options *KubectlOptions, filters metav1.ListOptions) []networkingv1beta1.Ingress {
+	t.Helper()
+
+	return ListIngressesV1Beta1Context(t, context.Background(), options, filters)
+}
+
+// ListIngressesV1Beta1E will look for Ingress resources in the given namespace that match the given filters and return
+// them, using networking.k8s.io/v1beta1 API.
+//
+// Deprecated: Use [ListIngressesV1Beta1ContextE] instead.
+//
+//nolint:gocritic // hugeParam: cannot change public function signature
+func ListIngressesV1Beta1E(t testing.TestingT, options *KubectlOptions, filters metav1.ListOptions) ([]networkingv1beta1.Ingress, error) {
+	return ListIngressesV1Beta1ContextE(t, context.Background(), options, filters)
+}
+
+// GetIngressV1Beta1ContextE returns a Kubernetes Ingress resource in the provided namespace with the given name, using
+// networking.k8s.io/v1beta1 API.
+// The ctx parameter supports cancellation and timeouts.
+func GetIngressV1Beta1ContextE(t testing.TestingT, ctx context.Context, options *KubectlOptions, ingressName string) (*networkingv1beta1.Ingress, error) {
+	clientset, err := GetKubernetesClientFromOptionsContextE(t, ctx, options)
+	if err != nil {
+		return nil, err
+	}
+
+	return clientset.NetworkingV1beta1().Ingresses(options.Namespace).Get(ctx, ingressName, metav1.GetOptions{})
+}
+
+// GetIngressV1Beta1Context returns a Kubernetes Ingress resource in the provided namespace with the given name, using
+// networking.k8s.io/v1beta1 API.
+// The ctx parameter supports cancellation and timeouts.
+// This will fail the test if there is an error.
+func GetIngressV1Beta1Context(t testing.TestingT, ctx context.Context, options *KubectlOptions, ingressName string) *networkingv1beta1.Ingress {
+	t.Helper()
+	ingress, err := GetIngressV1Beta1ContextE(t, ctx, options, ingressName)
 	require.NoError(t, err)
 
 	return ingress
 }
 
+// GetIngressV1Beta1 returns a Kubernetes Ingress resource in the provided namespace with the given name, using
+// networking.k8s.io/v1beta1 API. This will fail the test if there is an error.
+//
+// Deprecated: Use [GetIngressV1Beta1Context] instead.
+func GetIngressV1Beta1(t testing.TestingT, options *KubectlOptions, ingressName string) *networkingv1beta1.Ingress {
+	t.Helper()
+
+	return GetIngressV1Beta1Context(t, context.Background(), options, ingressName)
+}
+
 // GetIngressV1Beta1E returns a Kubernetes Ingress resource in the provided namespace with the given name, using
 // networking.k8s.io/v1beta1.
+//
+// Deprecated: Use [GetIngressV1Beta1ContextE] instead.
 func GetIngressV1Beta1E(t testing.TestingT, options *KubectlOptions, ingressName string) (*networkingv1beta1.Ingress, error) {
-	clientset, err := GetKubernetesClientFromOptionsE(t, options)
-	if err != nil {
-		return nil, err
-	}
-
-	return clientset.NetworkingV1beta1().Ingresses(options.Namespace).Get(context.Background(), ingressName, metav1.GetOptions{})
+	return GetIngressV1Beta1ContextE(t, context.Background(), options, ingressName)
 }
 
 // IsIngressAvailableV1Beta1 returns true if the Ingress endpoint is provisioned and available, using
@@ -149,17 +267,20 @@ func IsIngressAvailableV1Beta1(ingress *networkingv1beta1.Ingress) bool {
 	return len(endpoints) > 0
 }
 
-// WaitUntilIngressAvailableV1Beta1 waits until the Ingress resource has an endpoint provisioned for it, using
+// WaitUntilIngressAvailableV1Beta1ContextE waits until the Ingress resource has an endpoint provisioned for it, using
 // networking.k8s.io/v1beta1 API.
-func WaitUntilIngressAvailableV1Beta1(t testing.TestingT, options *KubectlOptions, ingressName string, retries int, sleepBetweenRetries time.Duration) {
+// The ctx parameter supports cancellation and timeouts.
+func WaitUntilIngressAvailableV1Beta1ContextE(t testing.TestingT, ctx context.Context, options *KubectlOptions, ingressName string, retries int, sleepBetweenRetries time.Duration) error {
 	statusMsg := fmt.Sprintf("Wait for ingress %s to be provisioned.", ingressName)
-	message := retry.DoWithRetry(
+
+	message, err := retry.DoWithRetryContextE(
 		t,
+		ctx,
 		statusMsg,
 		retries,
 		sleepBetweenRetries,
 		func() (string, error) {
-			ingress, err := GetIngressV1Beta1E(t, options, ingressName)
+			ingress, err := GetIngressV1Beta1ContextE(t, ctx, options, ingressName)
 			if err != nil {
 				return "", err
 			}
@@ -171,5 +292,30 @@ func WaitUntilIngressAvailableV1Beta1(t testing.TestingT, options *KubectlOption
 			return "Ingress is now available", nil
 		},
 	)
+	if err != nil {
+		return err
+	}
+
 	options.Logger.Logf(t, "%s", message)
+
+	return nil
+}
+
+// WaitUntilIngressAvailableV1Beta1Context waits until the Ingress resource has an endpoint provisioned for it, using
+// networking.k8s.io/v1beta1 API.
+// The ctx parameter supports cancellation and timeouts.
+// This will fail the test if there is an error.
+func WaitUntilIngressAvailableV1Beta1Context(t testing.TestingT, ctx context.Context, options *KubectlOptions, ingressName string, retries int, sleepBetweenRetries time.Duration) {
+	t.Helper()
+	err := WaitUntilIngressAvailableV1Beta1ContextE(t, ctx, options, ingressName, retries, sleepBetweenRetries)
+	require.NoError(t, err)
+}
+
+// WaitUntilIngressAvailableV1Beta1 waits until the Ingress resource has an endpoint provisioned for it, using
+// networking.k8s.io/v1beta1 API.
+//
+// Deprecated: Use [WaitUntilIngressAvailableV1Beta1Context] instead.
+func WaitUntilIngressAvailableV1Beta1(t testing.TestingT, options *KubectlOptions, ingressName string, retries int, sleepBetweenRetries time.Duration) {
+	t.Helper()
+	WaitUntilIngressAvailableV1Beta1Context(t, context.Background(), options, ingressName, retries, sleepBetweenRetries)
 }

--- a/modules/k8s/job.go
+++ b/modules/k8s/job.go
@@ -14,27 +14,17 @@ import (
 	"github.com/gruntwork-io/terratest/modules/testing"
 )
 
-// ListJobs will look for Jobs in the given namespace that match the given filters and return them. This will fail the
-// test if there is an error.
+// ListJobsContextE looks up Jobs in the given namespace that match the given filters and return them.
+// The ctx parameter supports cancellation and timeouts.
 //
 //nolint:gocritic // hugeParam: cannot change public function signature
-func ListJobs(t testing.TestingT, options *KubectlOptions, filters metav1.ListOptions) []batchv1.Job {
-	jobs, err := ListJobsE(t, options, filters)
-	require.NoError(t, err)
-
-	return jobs
-}
-
-// ListJobsE will look for jobs in the given namespace that match the given filters and return them.
-//
-//nolint:gocritic // hugeParam: cannot change public function signature
-func ListJobsE(t testing.TestingT, options *KubectlOptions, filters metav1.ListOptions) ([]batchv1.Job, error) {
-	clientset, err := GetKubernetesClientFromOptionsE(t, options)
+func ListJobsContextE(t testing.TestingT, ctx context.Context, options *KubectlOptions, filters metav1.ListOptions) ([]batchv1.Job, error) {
+	clientset, err := GetKubernetesClientFromOptionsContextE(t, ctx, options)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := clientset.BatchV1().Jobs(options.Namespace).List(context.Background(), filters)
+	resp, err := clientset.BatchV1().Jobs(options.Namespace).List(ctx, filters)
 	if err != nil {
 		return nil, err
 	}
@@ -42,43 +32,93 @@ func ListJobsE(t testing.TestingT, options *KubectlOptions, filters metav1.ListO
 	return resp.Items, nil
 }
 
-// GetJob returns a Kubernetes job resource in the provided namespace with the given name. This will
-// fail the test if there is an error.
-func GetJob(t testing.TestingT, options *KubectlOptions, jobName string) *batchv1.Job {
-	job, err := GetJobE(t, options, jobName)
+// ListJobsContext looks up Jobs in the given namespace that match the given filters and return them.
+// The ctx parameter supports cancellation and timeouts.
+// This will fail the test if there is an error.
+//
+//nolint:gocritic // hugeParam: cannot change public function signature
+func ListJobsContext(t testing.TestingT, ctx context.Context, options *KubectlOptions, filters metav1.ListOptions) []batchv1.Job {
+	t.Helper()
+	jobs, err := ListJobsContextE(t, ctx, options, filters)
+	require.NoError(t, err)
+
+	return jobs
+}
+
+// ListJobs will look for Jobs in the given namespace that match the given filters and return them. This will fail the
+// test if there is an error.
+//
+// Deprecated: Use [ListJobsContext] instead.
+//
+//nolint:gocritic // hugeParam: cannot change public function signature
+func ListJobs(t testing.TestingT, options *KubectlOptions, filters metav1.ListOptions) []batchv1.Job {
+	t.Helper()
+
+	return ListJobsContext(t, context.Background(), options, filters)
+}
+
+// ListJobsE will look for jobs in the given namespace that match the given filters and return them.
+//
+// Deprecated: Use [ListJobsContextE] instead.
+//
+//nolint:gocritic // hugeParam: cannot change public function signature
+func ListJobsE(t testing.TestingT, options *KubectlOptions, filters metav1.ListOptions) ([]batchv1.Job, error) {
+	return ListJobsContextE(t, context.Background(), options, filters)
+}
+
+// GetJobContextE returns a Kubernetes job resource in the provided namespace with the given name.
+// The ctx parameter supports cancellation and timeouts.
+func GetJobContextE(t testing.TestingT, ctx context.Context, options *KubectlOptions, jobName string) (*batchv1.Job, error) {
+	clientset, err := GetKubernetesClientFromOptionsContextE(t, ctx, options)
+	if err != nil {
+		return nil, err
+	}
+
+	return clientset.BatchV1().Jobs(options.Namespace).Get(ctx, jobName, metav1.GetOptions{})
+}
+
+// GetJobContext returns a Kubernetes job resource in the provided namespace with the given name.
+// The ctx parameter supports cancellation and timeouts.
+// This will fail the test if there is an error.
+func GetJobContext(t testing.TestingT, ctx context.Context, options *KubectlOptions, jobName string) *batchv1.Job {
+	t.Helper()
+	job, err := GetJobContextE(t, ctx, options, jobName)
 	require.NoError(t, err)
 
 	return job
 }
 
+// GetJob returns a Kubernetes job resource in the provided namespace with the given name. This will
+// fail the test if there is an error.
+//
+// Deprecated: Use [GetJobContext] instead.
+func GetJob(t testing.TestingT, options *KubectlOptions, jobName string) *batchv1.Job {
+	t.Helper()
+
+	return GetJobContext(t, context.Background(), options, jobName)
+}
+
 // GetJobE returns a Kubernetes job resource in the provided namespace with the given name.
+//
+// Deprecated: Use [GetJobContextE] instead.
 func GetJobE(t testing.TestingT, options *KubectlOptions, jobName string) (*batchv1.Job, error) {
-	clientset, err := GetKubernetesClientFromOptionsE(t, options)
-	if err != nil {
-		return nil, err
-	}
-
-	return clientset.BatchV1().Jobs(options.Namespace).Get(context.Background(), jobName, metav1.GetOptions{})
+	return GetJobContextE(t, context.Background(), options, jobName)
 }
 
-// WaitUntilJobSucceed waits until requested job is succeeded, retrying the check for the specified amount of times, sleeping
-// for the provided duration between each try. This will fail the test if there is an error or if the check times out.
-func WaitUntilJobSucceed(t testing.TestingT, options *KubectlOptions, jobName string, retries int, sleepBetweenRetries time.Duration) {
-	require.NoError(t, WaitUntilJobSucceedE(t, options, jobName, retries, sleepBetweenRetries))
-}
-
-// WaitUntilJobSucceedE waits until requested job is succeeded, retrying the check for the specified amount of times, sleeping
-// for the provided duration between each try.
-func WaitUntilJobSucceedE(t testing.TestingT, options *KubectlOptions, jobName string, retries int, sleepBetweenRetries time.Duration) error {
+// WaitUntilJobSucceedContextE waits until requested job is succeeded, retrying the check for the specified amount of
+// times, sleeping for the provided duration between each try.
+// The ctx parameter supports cancellation and timeouts.
+func WaitUntilJobSucceedContextE(t testing.TestingT, ctx context.Context, options *KubectlOptions, jobName string, retries int, sleepBetweenRetries time.Duration) error { //nolint:dupl // similar retry pattern across resource types is intentional
 	statusMsg := fmt.Sprintf("Wait for job %s to be provisioned.", jobName)
 
-	message, err := retry.DoWithRetryE(
+	message, err := retry.DoWithRetryContextE(
 		t,
+		ctx,
 		statusMsg,
 		retries,
 		sleepBetweenRetries,
 		func() (string, error) {
-			job, err := GetJobE(t, options, jobName)
+			job, err := GetJobContextE(t, ctx, options, jobName)
 			if err != nil {
 				return "", err
 			}
@@ -100,6 +140,32 @@ func WaitUntilJobSucceedE(t testing.TestingT, options *KubectlOptions, jobName s
 	return nil
 }
 
+// WaitUntilJobSucceedContext waits until requested job is succeeded, retrying the check for the specified amount of
+// times, sleeping for the provided duration between each try.
+// The ctx parameter supports cancellation and timeouts.
+// This will fail the test if there is an error.
+func WaitUntilJobSucceedContext(t testing.TestingT, ctx context.Context, options *KubectlOptions, jobName string, retries int, sleepBetweenRetries time.Duration) {
+	t.Helper()
+	require.NoError(t, WaitUntilJobSucceedContextE(t, ctx, options, jobName, retries, sleepBetweenRetries))
+}
+
+// WaitUntilJobSucceed waits until requested job is succeeded, retrying the check for the specified amount of times, sleeping
+// for the provided duration between each try. This will fail the test if there is an error or if the check times out.
+//
+// Deprecated: Use [WaitUntilJobSucceedContext] instead.
+func WaitUntilJobSucceed(t testing.TestingT, options *KubectlOptions, jobName string, retries int, sleepBetweenRetries time.Duration) {
+	t.Helper()
+	WaitUntilJobSucceedContext(t, context.Background(), options, jobName, retries, sleepBetweenRetries)
+}
+
+// WaitUntilJobSucceedE waits until requested job is succeeded, retrying the check for the specified amount of times, sleeping
+// for the provided duration between each try.
+//
+// Deprecated: Use [WaitUntilJobSucceedContextE] instead.
+func WaitUntilJobSucceedE(t testing.TestingT, options *KubectlOptions, jobName string, retries int, sleepBetweenRetries time.Duration) error {
+	return WaitUntilJobSucceedContextE(t, context.Background(), options, jobName, retries, sleepBetweenRetries)
+}
+
 // IsJobSucceeded returns true when the job status condition "Complete" is true. This behavior is documented in the kubernetes API reference:
 // https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/job-v1/#JobStatus
 func IsJobSucceeded(job *batchv1.Job) bool {
@@ -112,23 +178,16 @@ func IsJobSucceeded(job *batchv1.Job) bool {
 	return false
 }
 
-// CreateJobFromCronJob creates a Job from the specified CronJob in the given namespace and returns the created Job.
-func CreateJobFromCronJob(t testing.TestingT, options *KubectlOptions, cronJobName, newJobName string) *batchv1.Job {
-	job, err := CreateJobFromCronJobE(t, options, cronJobName, newJobName)
-	require.NoError(t, err)
-
-	return job
-}
-
-// CreateJobFromCronJobE creates a Job from the specified CronJob in the given namespace and returns the created Job.
+// CreateJobFromCronJobContextE creates a Job from the specified CronJob in the given namespace and returns the created Job.
+// The ctx parameter supports cancellation and timeouts.
 // This function is similar to running `kubectl create job --from=cronjob/<cron-job-name> <new-job-name>`.
-func CreateJobFromCronJobE(t testing.TestingT, options *KubectlOptions, cronJobName, newJobName string) (*batchv1.Job, error) {
-	clientset, err := GetKubernetesClientFromOptionsE(t, options)
+func CreateJobFromCronJobContextE(t testing.TestingT, ctx context.Context, options *KubectlOptions, cronJobName, newJobName string) (*batchv1.Job, error) {
+	clientset, err := GetKubernetesClientFromOptionsContextE(t, ctx, options)
 	if err != nil {
 		return nil, err
 	}
 
-	cronJob, err := GetCronJobE(t, options, cronJobName)
+	cronJob, err := GetCronJobContextE(t, ctx, options, cronJobName)
 	if err != nil {
 		return nil, err
 	}
@@ -149,7 +208,35 @@ func CreateJobFromCronJobE(t testing.TestingT, options *KubectlOptions, cronJobN
 		Spec: cronJob.Spec.JobTemplate.Spec,
 	}
 
-	createdJob, err := clientset.BatchV1().Jobs(options.Namespace).Create(context.Background(), job, metav1.CreateOptions{})
+	createdJob, err := clientset.BatchV1().Jobs(options.Namespace).Create(ctx, job, metav1.CreateOptions{})
 
 	return createdJob, err
+}
+
+// CreateJobFromCronJobContext creates a Job from the specified CronJob in the given namespace and returns the created Job.
+// The ctx parameter supports cancellation and timeouts.
+// This will fail the test if there is an error.
+func CreateJobFromCronJobContext(t testing.TestingT, ctx context.Context, options *KubectlOptions, cronJobName, newJobName string) *batchv1.Job {
+	t.Helper()
+	job, err := CreateJobFromCronJobContextE(t, ctx, options, cronJobName, newJobName)
+	require.NoError(t, err)
+
+	return job
+}
+
+// CreateJobFromCronJob creates a Job from the specified CronJob in the given namespace and returns the created Job.
+//
+// Deprecated: Use [CreateJobFromCronJobContext] instead.
+func CreateJobFromCronJob(t testing.TestingT, options *KubectlOptions, cronJobName, newJobName string) *batchv1.Job {
+	t.Helper()
+
+	return CreateJobFromCronJobContext(t, context.Background(), options, cronJobName, newJobName)
+}
+
+// CreateJobFromCronJobE creates a Job from the specified CronJob in the given namespace and returns the created Job.
+// This function is similar to running `kubectl create job --from=cronjob/<cron-job-name> <new-job-name>`.
+//
+// Deprecated: Use [CreateJobFromCronJobContextE] instead.
+func CreateJobFromCronJobE(t testing.TestingT, options *KubectlOptions, cronJobName, newJobName string) (*batchv1.Job, error) {
+	return CreateJobFromCronJobContextE(t, context.Background(), options, cronJobName, newJobName)
 }

--- a/modules/k8s/kubectl.go
+++ b/modules/k8s/kubectl.go
@@ -77,35 +77,77 @@ func RunKubectlAndGetOutputE(t testing.TestingT, options *KubectlOptions, args .
 
 // KubectlDelete will take in a file path and delete it from the cluster targeted by KubectlOptions. If there are any
 // errors, fail the test immediately.
+//
+// Deprecated: Use [KubectlDeleteContext] instead.
 func KubectlDelete(t testing.TestingT, options *KubectlOptions, configPath string) {
-	require.NoError(t, KubectlDeleteE(t, options, configPath))
+	KubectlDeleteContext(t, context.Background(), options, configPath)
 }
 
 // KubectlDeleteE will take in a file path and delete it from the cluster targeted by KubectlOptions.
+//
+// Deprecated: Use [KubectlDeleteContextE] instead.
 func KubectlDeleteE(t testing.TestingT, options *KubectlOptions, configPath string) error {
-	return RunKubectlE(t, options, "delete", "-f", configPath)
+	return KubectlDeleteContextE(t, context.Background(), options, configPath)
+}
+
+// KubectlDeleteContext deletes the resource at configPath from the cluster, using the provided context. Fails the test on error.
+func KubectlDeleteContext(t testing.TestingT, ctx context.Context, options *KubectlOptions, configPath string) {
+	require.NoError(t, KubectlDeleteContextE(t, ctx, options, configPath))
+}
+
+// KubectlDeleteContextE deletes the resource at configPath from the cluster, using the provided context.
+func KubectlDeleteContextE(t testing.TestingT, ctx context.Context, options *KubectlOptions, configPath string) error {
+	return RunKubectlContextE(t, ctx, options, "delete", "-f", configPath)
 }
 
 // KubectlDeleteFromKustomize will take in a kustomization directory path and delete it from the cluster targeted by KubectlOptions. If there are any
 // errors, fail the test immediately.
+//
+// Deprecated: Use [KubectlDeleteFromKustomizeContext] instead.
 func KubectlDeleteFromKustomize(t testing.TestingT, options *KubectlOptions, configPath string) {
-	require.NoError(t, KubectlDeleteFromKustomizeE(t, options, configPath))
+	KubectlDeleteFromKustomizeContext(t, context.Background(), options, configPath)
 }
 
 // KubectlDeleteFromKustomizeE will take in a kustomization directory path and delete it from the cluster targeted by KubectlOptions.
+//
+// Deprecated: Use [KubectlDeleteFromKustomizeContextE] instead.
 func KubectlDeleteFromKustomizeE(t testing.TestingT, options *KubectlOptions, configPath string) error {
-	return RunKubectlE(t, options, "delete", "-k", configPath)
+	return KubectlDeleteFromKustomizeContextE(t, context.Background(), options, configPath)
+}
+
+// KubectlDeleteFromKustomizeContext deletes the kustomization at configPath from the cluster, using the provided context. Fails the test on error.
+func KubectlDeleteFromKustomizeContext(t testing.TestingT, ctx context.Context, options *KubectlOptions, configPath string) {
+	require.NoError(t, KubectlDeleteFromKustomizeContextE(t, ctx, options, configPath))
+}
+
+// KubectlDeleteFromKustomizeContextE deletes the kustomization at configPath from the cluster, using the provided context.
+func KubectlDeleteFromKustomizeContextE(t testing.TestingT, ctx context.Context, options *KubectlOptions, configPath string) error {
+	return RunKubectlContextE(t, ctx, options, "delete", "-k", configPath)
 }
 
 // KubectlDeleteFromString will take in a kubernetes resource config as a string and delete it on the cluster specified
 // by the provided kubectl options.
+//
+// Deprecated: Use [KubectlDeleteFromStringContext] instead.
 func KubectlDeleteFromString(t testing.TestingT, options *KubectlOptions, configData string) {
-	require.NoError(t, KubectlDeleteFromStringE(t, options, configData))
+	KubectlDeleteFromStringContext(t, context.Background(), options, configData)
 }
 
 // KubectlDeleteFromStringE will take in a kubernetes resource config as a string and delete it on the cluster specified
 // by the provided kubectl options. If it fails, this will return the error.
+//
+// Deprecated: Use [KubectlDeleteFromStringContextE] instead.
 func KubectlDeleteFromStringE(t testing.TestingT, options *KubectlOptions, configData string) error {
+	return KubectlDeleteFromStringContextE(t, context.Background(), options, configData)
+}
+
+// KubectlDeleteFromStringContext deletes the kubernetes resource from configData on the cluster, using the provided context. Fails the test on error.
+func KubectlDeleteFromStringContext(t testing.TestingT, ctx context.Context, options *KubectlOptions, configData string) {
+	require.NoError(t, KubectlDeleteFromStringContextE(t, ctx, options, configData))
+}
+
+// KubectlDeleteFromStringContextE deletes the kubernetes resource from configData on the cluster, using the provided context.
+func KubectlDeleteFromStringContextE(t testing.TestingT, ctx context.Context, options *KubectlOptions, configData string) error {
 	tmpfile, err := StoreConfigToTempFileE(t, configData)
 	if err != nil {
 		return err
@@ -113,40 +155,82 @@ func KubectlDeleteFromStringE(t testing.TestingT, options *KubectlOptions, confi
 
 	defer func() { _ = os.Remove(tmpfile) }()
 
-	return KubectlDeleteE(t, options, tmpfile)
+	return KubectlDeleteContextE(t, ctx, options, tmpfile)
 }
 
 // KubectlApply will take in a file path and apply it to the cluster targeted by KubectlOptions. If there are any
 // errors, fail the test immediately.
+//
+// Deprecated: Use [KubectlApplyContext] instead.
 func KubectlApply(t testing.TestingT, options *KubectlOptions, configPath string) {
-	require.NoError(t, KubectlApplyE(t, options, configPath))
+	KubectlApplyContext(t, context.Background(), options, configPath)
 }
 
 // KubectlApplyE will take in a file path and apply it to the cluster targeted by KubectlOptions.
+//
+// Deprecated: Use [KubectlApplyContextE] instead.
 func KubectlApplyE(t testing.TestingT, options *KubectlOptions, configPath string) error {
-	return RunKubectlE(t, options, "apply", "-f", configPath)
+	return KubectlApplyContextE(t, context.Background(), options, configPath)
+}
+
+// KubectlApplyContext applies the resource at configPath to the cluster, using the provided context. Fails the test on error.
+func KubectlApplyContext(t testing.TestingT, ctx context.Context, options *KubectlOptions, configPath string) {
+	require.NoError(t, KubectlApplyContextE(t, ctx, options, configPath))
+}
+
+// KubectlApplyContextE applies the resource at configPath to the cluster, using the provided context.
+func KubectlApplyContextE(t testing.TestingT, ctx context.Context, options *KubectlOptions, configPath string) error {
+	return RunKubectlContextE(t, ctx, options, "apply", "-f", configPath)
 }
 
 // KubectlApplyFromKustomize will take in a kustomization directory path and apply it to the cluster targeted by KubectlOptions. If there are any
 // errors, fail the test immediately.
+//
+// Deprecated: Use [KubectlApplyFromKustomizeContext] instead.
 func KubectlApplyFromKustomize(t testing.TestingT, options *KubectlOptions, configPath string) {
-	require.NoError(t, KubectlApplyFromKustomizeE(t, options, configPath))
+	KubectlApplyFromKustomizeContext(t, context.Background(), options, configPath)
 }
 
 // KubectlApplyFromKustomizeE will take in a kustomization directory path and apply it to the cluster targeted by KubectlOptions.
+//
+// Deprecated: Use [KubectlApplyFromKustomizeContextE] instead.
 func KubectlApplyFromKustomizeE(t testing.TestingT, options *KubectlOptions, configPath string) error {
-	return RunKubectlE(t, options, "apply", "-k", configPath)
+	return KubectlApplyFromKustomizeContextE(t, context.Background(), options, configPath)
+}
+
+// KubectlApplyFromKustomizeContext applies the kustomization at configPath to the cluster, using the provided context. Fails the test on error.
+func KubectlApplyFromKustomizeContext(t testing.TestingT, ctx context.Context, options *KubectlOptions, configPath string) {
+	require.NoError(t, KubectlApplyFromKustomizeContextE(t, ctx, options, configPath))
+}
+
+// KubectlApplyFromKustomizeContextE applies the kustomization at configPath to the cluster, using the provided context.
+func KubectlApplyFromKustomizeContextE(t testing.TestingT, ctx context.Context, options *KubectlOptions, configPath string) error {
+	return RunKubectlContextE(t, ctx, options, "apply", "-k", configPath)
 }
 
 // KubectlApplyFromString will take in a kubernetes resource config as a string and apply it on the cluster specified
 // by the provided kubectl options.
+//
+// Deprecated: Use [KubectlApplyFromStringContext] instead.
 func KubectlApplyFromString(t testing.TestingT, options *KubectlOptions, configData string) {
-	require.NoError(t, KubectlApplyFromStringE(t, options, configData))
+	KubectlApplyFromStringContext(t, context.Background(), options, configData)
 }
 
 // KubectlApplyFromStringE will take in a kubernetes resource config as a string and apply it on the cluster specified
 // by the provided kubectl options. If it fails, this will return the error.
+//
+// Deprecated: Use [KubectlApplyFromStringContextE] instead.
 func KubectlApplyFromStringE(t testing.TestingT, options *KubectlOptions, configData string) error {
+	return KubectlApplyFromStringContextE(t, context.Background(), options, configData)
+}
+
+// KubectlApplyFromStringContext applies the kubernetes resource from configData to the cluster, using the provided context. Fails the test on error.
+func KubectlApplyFromStringContext(t testing.TestingT, ctx context.Context, options *KubectlOptions, configData string) {
+	require.NoError(t, KubectlApplyFromStringContextE(t, ctx, options, configData))
+}
+
+// KubectlApplyFromStringContextE applies the kubernetes resource from configData to the cluster, using the provided context.
+func KubectlApplyFromStringContextE(t testing.TestingT, ctx context.Context, options *KubectlOptions, configData string) error {
 	tmpfile, err := StoreConfigToTempFileE(t, configData)
 	if err != nil {
 		return err
@@ -154,7 +238,7 @@ func KubectlApplyFromStringE(t testing.TestingT, options *KubectlOptions, config
 
 	defer func() { _ = os.Remove(tmpfile) }()
 
-	return KubectlApplyE(t, options, tmpfile)
+	return KubectlApplyContextE(t, ctx, options, tmpfile)
 }
 
 // StoreConfigToTempFile will store the provided config data to a temporary file created on the os and return the

--- a/modules/k8s/namespace.go
+++ b/modules/k8s/namespace.go
@@ -10,27 +10,48 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// CreateNamespace will create a new Kubernetes namespace on the cluster targeted by the provided options. This will
-// fail the test if there is an error in creating the namespace.
-func CreateNamespace(t testing.TestingT, options *KubectlOptions, namespaceName string) {
-	require.NoError(t, CreateNamespaceE(t, options, namespaceName))
-}
-
-// CreateNamespaceE will create a new Kubernetes namespace on the cluster targeted by the provided options.
-func CreateNamespaceE(t testing.TestingT, options *KubectlOptions, namespaceName string) error {
+// CreateNamespaceContextE will create a new Kubernetes namespace on the cluster targeted by the provided options.
+// The ctx parameter supports cancellation and timeouts.
+func CreateNamespaceContextE(t testing.TestingT, ctx context.Context, options *KubectlOptions, namespaceName string) error {
 	namespaceObject := metav1.ObjectMeta{
 		Name: namespaceName,
 	}
 
-	return CreateNamespaceWithMetadataE(t, options, namespaceObject)
+	return CreateNamespaceWithMetadataContextE(t, ctx, options, namespaceObject)
 }
 
-// CreateNamespaceWithMetadataE will create a new Kubernetes namespace on the cluster targeted by the provided options and
-// with the provided metadata. This method expects the entire namespace ObjectMeta to be passed in, so you'll need to set the name within the ObjectMeta struct yourself.
+// CreateNamespaceContext will create a new Kubernetes namespace on the cluster targeted by the provided options.
+// The ctx parameter supports cancellation and timeouts.
+// This will fail the test if there is an error in creating the namespace.
+func CreateNamespaceContext(t testing.TestingT, ctx context.Context, options *KubectlOptions, namespaceName string) {
+	t.Helper()
+	require.NoError(t, CreateNamespaceContextE(t, ctx, options, namespaceName))
+}
+
+// CreateNamespace will create a new Kubernetes namespace on the cluster targeted by the provided options. This will
+// fail the test if there is an error in creating the namespace.
+//
+// Deprecated: Use [CreateNamespaceContext] instead.
+func CreateNamespace(t testing.TestingT, options *KubectlOptions, namespaceName string) {
+	t.Helper()
+	CreateNamespaceContext(t, context.Background(), options, namespaceName)
+}
+
+// CreateNamespaceE will create a new Kubernetes namespace on the cluster targeted by the provided options.
+//
+// Deprecated: Use [CreateNamespaceContextE] instead.
+func CreateNamespaceE(t testing.TestingT, options *KubectlOptions, namespaceName string) error {
+	return CreateNamespaceContextE(t, context.Background(), options, namespaceName)
+}
+
+// CreateNamespaceWithMetadataContextE will create a new Kubernetes namespace on the cluster targeted by the provided
+// options and with the provided metadata.
+// The ctx parameter supports cancellation and timeouts.
+// This method expects the entire namespace ObjectMeta to be passed in, so you'll need to set the name within the ObjectMeta struct yourself.
 //
 //nolint:gocritic // hugeParam: cannot change public function signature
-func CreateNamespaceWithMetadataE(t testing.TestingT, options *KubectlOptions, namespaceObjectMeta metav1.ObjectMeta) error {
-	clientset, err := GetKubernetesClientFromOptionsE(t, options)
+func CreateNamespaceWithMetadataContextE(t testing.TestingT, ctx context.Context, options *KubectlOptions, namespaceObjectMeta metav1.ObjectMeta) error {
+	clientset, err := GetKubernetesClientFromOptionsContextE(t, ctx, options)
 	if err != nil {
 		return err
 	}
@@ -38,62 +59,145 @@ func CreateNamespaceWithMetadataE(t testing.TestingT, options *KubectlOptions, n
 	namespace := corev1.Namespace{
 		ObjectMeta: namespaceObjectMeta,
 	}
-	_, err = clientset.CoreV1().Namespaces().Create(context.Background(), &namespace, metav1.CreateOptions{})
+	_, err = clientset.CoreV1().Namespaces().Create(ctx, &namespace, metav1.CreateOptions{})
 
 	return err
+}
+
+// CreateNamespaceWithMetadataContext will create a new Kubernetes namespace on the cluster targeted by the provided
+// options and with the provided metadata.
+// The ctx parameter supports cancellation and timeouts.
+// This will fail the test if there is an error while creating the namespace.
+//
+//nolint:gocritic // hugeParam: cannot change public function signature
+func CreateNamespaceWithMetadataContext(t testing.TestingT, ctx context.Context, options *KubectlOptions, namespaceObjectMeta metav1.ObjectMeta) {
+	t.Helper()
+	require.NoError(t, CreateNamespaceWithMetadataContextE(t, ctx, options, namespaceObjectMeta))
+}
+
+// CreateNamespaceWithMetadataE will create a new Kubernetes namespace on the cluster targeted by the provided options and
+// with the provided metadata. This method expects the entire namespace ObjectMeta to be passed in, so you'll need to set the name within the ObjectMeta struct yourself.
+//
+// Deprecated: Use [CreateNamespaceWithMetadataContextE] instead.
+//
+//nolint:gocritic // hugeParam: cannot change public function signature
+func CreateNamespaceWithMetadataE(t testing.TestingT, options *KubectlOptions, namespaceObjectMeta metav1.ObjectMeta) error {
+	return CreateNamespaceWithMetadataContextE(t, context.Background(), options, namespaceObjectMeta)
 }
 
 // CreateNamespaceWithMetadata will create a new Kubernetes namespace on the cluster targeted by the provided options and
 // with the provided metadata. This method expects the entire namespace ObjectMeta to be passed in, so you'll need to set the name within the ObjectMeta struct yourself.
 // This will fail the test if there is an error while creating the namespace.
 //
+// Deprecated: Use [CreateNamespaceWithMetadataContext] instead.
+//
 //nolint:gocritic // hugeParam: cannot change public function signature
 func CreateNamespaceWithMetadata(t testing.TestingT, options *KubectlOptions, namespaceObjectMeta metav1.ObjectMeta) {
-	require.NoError(t, CreateNamespaceWithMetadataE(t, options, namespaceObjectMeta))
+	t.Helper()
+	CreateNamespaceWithMetadataContext(t, context.Background(), options, namespaceObjectMeta)
 }
 
-// GetNamespace will query the Kubernetes cluster targeted by the provided options for the requested namespace. This will
-// fail the test if there is an error in getting the namespace or if the namespace doesn't exist.
-func GetNamespace(t testing.TestingT, options *KubectlOptions, namespaceName string) *corev1.Namespace {
-	namespace, err := GetNamespaceE(t, options, namespaceName)
+// GetNamespaceContextE will query the Kubernetes cluster targeted by the provided options for the requested namespace.
+// The ctx parameter supports cancellation and timeouts.
+func GetNamespaceContextE(t testing.TestingT, ctx context.Context, options *KubectlOptions, namespaceName string) (*corev1.Namespace, error) {
+	clientset, err := GetKubernetesClientFromOptionsContextE(t, ctx, options)
+	if err != nil {
+		return nil, err
+	}
+
+	return clientset.CoreV1().Namespaces().Get(ctx, namespaceName, metav1.GetOptions{})
+}
+
+// GetNamespaceContext will query the Kubernetes cluster targeted by the provided options for the requested namespace.
+// The ctx parameter supports cancellation and timeouts.
+// This will fail the test if there is an error or if the namespace doesn't exist.
+func GetNamespaceContext(t testing.TestingT, ctx context.Context, options *KubectlOptions, namespaceName string) *corev1.Namespace {
+	t.Helper()
+	namespace, err := GetNamespaceContextE(t, ctx, options, namespaceName)
 	require.NoError(t, err)
 	require.NotNil(t, namespace)
 
 	return namespace
 }
 
+// GetNamespace will query the Kubernetes cluster targeted by the provided options for the requested namespace. This will
+// fail the test if there is an error in getting the namespace or if the namespace doesn't exist.
+//
+// Deprecated: Use [GetNamespaceContext] instead.
+func GetNamespace(t testing.TestingT, options *KubectlOptions, namespaceName string) *corev1.Namespace {
+	t.Helper()
+
+	return GetNamespaceContext(t, context.Background(), options, namespaceName)
+}
+
 // GetNamespaceE will query the Kubernetes cluster targeted by the provided options for the requested namespace.
+//
+// Deprecated: Use [GetNamespaceContextE] instead.
 func GetNamespaceE(t testing.TestingT, options *KubectlOptions, namespaceName string) (*corev1.Namespace, error) {
-	clientset, err := GetKubernetesClientFromOptionsE(t, options)
-	if err != nil {
-		return nil, err
-	}
-
-	return clientset.CoreV1().Namespaces().Get(context.Background(), namespaceName, metav1.GetOptions{})
+	return GetNamespaceContextE(t, context.Background(), options, namespaceName)
 }
 
-// DeleteNamespace will delete the requested namespace from the Kubernetes cluster targeted by the provided options. This will
-// fail the test if there is an error in creating the namespace.
-func DeleteNamespace(t testing.TestingT, options *KubectlOptions, namespaceName string) {
-	require.NoError(t, DeleteNamespaceE(t, options, namespaceName))
-}
-
-// DeleteNamespaceE will delete the requested namespace from the Kubernetes cluster targeted by the provided options.
-func DeleteNamespaceE(t testing.TestingT, options *KubectlOptions, namespaceName string) error {
-	clientset, err := GetKubernetesClientFromOptionsE(t, options)
+// DeleteNamespaceContextE will delete the requested namespace from the Kubernetes cluster targeted by the provided options.
+// The ctx parameter supports cancellation and timeouts.
+func DeleteNamespaceContextE(t testing.TestingT, ctx context.Context, options *KubectlOptions, namespaceName string) error {
+	clientset, err := GetKubernetesClientFromOptionsContextE(t, ctx, options)
 	if err != nil {
 		return err
 	}
 
-	return clientset.CoreV1().Namespaces().Delete(context.Background(), namespaceName, metav1.DeleteOptions{})
+	return clientset.CoreV1().Namespaces().Delete(ctx, namespaceName, metav1.DeleteOptions{})
 }
 
-// ListNamespaces will list all namespaces in the Kubernetes cluster targeted by the provided options.
-// This will fail the test if there is an error in listing the namespaces.
+// DeleteNamespaceContext will delete the requested namespace from the Kubernetes cluster targeted by the provided options.
+// The ctx parameter supports cancellation and timeouts.
+// This will fail the test if there is an error.
+func DeleteNamespaceContext(t testing.TestingT, ctx context.Context, options *KubectlOptions, namespaceName string) {
+	t.Helper()
+	require.NoError(t, DeleteNamespaceContextE(t, ctx, options, namespaceName))
+}
+
+// DeleteNamespace will delete the requested namespace from the Kubernetes cluster targeted by the provided options. This will
+// fail the test if there is an error in creating the namespace.
+//
+// Deprecated: Use [DeleteNamespaceContext] instead.
+func DeleteNamespace(t testing.TestingT, options *KubectlOptions, namespaceName string) {
+	t.Helper()
+	DeleteNamespaceContext(t, context.Background(), options, namespaceName)
+}
+
+// DeleteNamespaceE will delete the requested namespace from the Kubernetes cluster targeted by the provided options.
+//
+// Deprecated: Use [DeleteNamespaceContextE] instead.
+func DeleteNamespaceE(t testing.TestingT, options *KubectlOptions, namespaceName string) error {
+	return DeleteNamespaceContextE(t, context.Background(), options, namespaceName)
+}
+
+// ListNamespacesContextE lists all namespaces in the Kubernetes cluster that match the given filters and returns them.
+// The ctx parameter supports cancellation and timeouts.
 //
 //nolint:gocritic // hugeParam: cannot change public function signature
-func ListNamespaces(t testing.TestingT, options *KubectlOptions, filters metav1.ListOptions) []corev1.Namespace {
-	namespaces, err := ListNamespacesE(t, options, filters)
+func ListNamespacesContextE(t testing.TestingT, ctx context.Context, options *KubectlOptions, filters metav1.ListOptions) ([]corev1.Namespace, error) {
+	clientset, err := GetKubernetesClientFromOptionsContextE(t, ctx, options)
+	if err != nil {
+		return nil, err
+	}
+
+	namespaceList, err := clientset.CoreV1().Namespaces().List(ctx, filters)
+	if err != nil {
+		return nil, err
+	}
+
+	return namespaceList.Items, nil
+}
+
+// ListNamespacesContext lists all namespaces in the Kubernetes cluster that match the given filters and returns them.
+// The ctx parameter supports cancellation and timeouts.
+// This will fail the test if there is an error.
+//
+//nolint:gocritic // hugeParam: cannot change public function signature
+func ListNamespacesContext(t testing.TestingT, ctx context.Context, options *KubectlOptions, filters metav1.ListOptions) []corev1.Namespace {
+	t.Helper()
+	namespaces, err := ListNamespacesContextE(t, ctx, options, filters)
 	require.NoError(t, err)
 
 	if len(namespaces) > 0 {
@@ -110,19 +214,23 @@ func ListNamespaces(t testing.TestingT, options *KubectlOptions, filters metav1.
 	return namespaces
 }
 
+// ListNamespaces will list all namespaces in the Kubernetes cluster targeted by the provided options.
+// This will fail the test if there is an error in listing the namespaces.
+//
+// Deprecated: Use [ListNamespacesContext] instead.
+//
+//nolint:gocritic // hugeParam: cannot change public function signature
+func ListNamespaces(t testing.TestingT, options *KubectlOptions, filters metav1.ListOptions) []corev1.Namespace {
+	t.Helper()
+
+	return ListNamespacesContext(t, context.Background(), options, filters)
+}
+
 // ListNamespacesE lists all namespaces in the Kubernetes cluster and returns them or an error.
+//
+// Deprecated: Use [ListNamespacesContextE] instead.
 //
 //nolint:gocritic // hugeParam: cannot change public function signature
 func ListNamespacesE(t testing.TestingT, options *KubectlOptions, filters metav1.ListOptions) ([]corev1.Namespace, error) {
-	clientset, err := GetKubernetesClientFromOptionsE(t, options)
-	if err != nil {
-		return nil, err
-	}
-
-	namespaceList, err := clientset.CoreV1().Namespaces().List(context.Background(), filters)
-	if err != nil {
-		return nil, err
-	}
-
-	return namespaceList.Items, nil
+	return ListNamespacesContextE(t, context.Background(), options, filters)
 }

--- a/modules/k8s/networkpolicy.go
+++ b/modules/k8s/networkpolicy.go
@@ -12,37 +12,62 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// GetNetworkPolicy returns a Kubernetes networkpolicy resource in the provided namespace with the given name. The namespace used
-// is the one provided in the KubectlOptions. This will fail the test if there is an error.
-func GetNetworkPolicy(t testing.TestingT, options *KubectlOptions, networkPolicyName string) *networkingv1.NetworkPolicy {
-	networkPolicy, err := GetNetworkPolicyE(t, options, networkPolicyName)
+// GetNetworkPolicyContextE returns a Kubernetes networkpolicy resource in the provided namespace with the given name.
+// The namespace used is the one provided in the KubectlOptions.
+// The ctx parameter supports cancellation and timeouts.
+func GetNetworkPolicyContextE(t testing.TestingT, ctx context.Context, options *KubectlOptions, networkPolicyName string) (*networkingv1.NetworkPolicy, error) {
+	clientset, err := GetKubernetesClientFromOptionsContextE(t, ctx, options)
+	if err != nil {
+		return nil, err
+	}
+
+	return clientset.NetworkingV1().NetworkPolicies(options.Namespace).Get(ctx, networkPolicyName, metav1.GetOptions{})
+}
+
+// GetNetworkPolicyContext returns a Kubernetes networkpolicy resource in the provided namespace with the given name.
+// The namespace used is the one provided in the KubectlOptions.
+// The ctx parameter supports cancellation and timeouts.
+// This will fail the test if there is an error.
+func GetNetworkPolicyContext(t testing.TestingT, ctx context.Context, options *KubectlOptions, networkPolicyName string) *networkingv1.NetworkPolicy {
+	t.Helper()
+	networkPolicy, err := GetNetworkPolicyContextE(t, ctx, options, networkPolicyName)
 	require.NoError(t, err)
 
 	return networkPolicy
 }
 
-// GetNetworkPolicyE returns a Kubernetes networkpolicy resource in the provided namespace with the given name. The namespace used
-// is the one provided in the KubectlOptions.
-func GetNetworkPolicyE(t testing.TestingT, options *KubectlOptions, networkPolicyName string) (*networkingv1.NetworkPolicy, error) {
-	clientset, err := GetKubernetesClientFromOptionsE(t, options)
-	if err != nil {
-		return nil, err
-	}
+// GetNetworkPolicy returns a Kubernetes networkpolicy resource in the provided namespace with the given name. The namespace used
+// is the one provided in the KubectlOptions. This will fail the test if there is an error.
+//
+// Deprecated: Use [GetNetworkPolicyContext] instead.
+func GetNetworkPolicy(t testing.TestingT, options *KubectlOptions, networkPolicyName string) *networkingv1.NetworkPolicy {
+	t.Helper()
 
-	return clientset.NetworkingV1().NetworkPolicies(options.Namespace).Get(context.Background(), networkPolicyName, metav1.GetOptions{})
+	return GetNetworkPolicyContext(t, context.Background(), options, networkPolicyName)
 }
 
-// WaitUntilNetworkPolicyAvailable waits until the networkpolicy is present on the cluster in cases where it is not immediately
+// GetNetworkPolicyE returns a Kubernetes networkpolicy resource in the provided namespace with the given name. The namespace used
+// is the one provided in the KubectlOptions.
+//
+// Deprecated: Use [GetNetworkPolicyContextE] instead.
+func GetNetworkPolicyE(t testing.TestingT, options *KubectlOptions, networkPolicyName string) (*networkingv1.NetworkPolicy, error) {
+	return GetNetworkPolicyContextE(t, context.Background(), options, networkPolicyName)
+}
+
+// WaitUntilNetworkPolicyAvailableContextE waits until the networkpolicy is present on the cluster in cases where it is not immediately
 // available (for example, when using ClusterIssuer to request a certificate).
-func WaitUntilNetworkPolicyAvailable(t testing.TestingT, options *KubectlOptions, networkPolicyName string, retries int, sleepBetweenRetries time.Duration) {
+// The ctx parameter supports cancellation and timeouts.
+func WaitUntilNetworkPolicyAvailableContextE(t testing.TestingT, ctx context.Context, options *KubectlOptions, networkPolicyName string, retries int, sleepBetweenRetries time.Duration) error {
 	statusMsg := fmt.Sprintf("Wait for networkpolicy %s to be provisioned.", networkPolicyName)
-	message := retry.DoWithRetry(
+
+	message, err := retry.DoWithRetryContextE(
 		t,
+		ctx,
 		statusMsg,
 		retries,
 		sleepBetweenRetries,
 		func() (string, error) {
-			_, err := GetNetworkPolicyE(t, options, networkPolicyName)
+			_, err := GetNetworkPolicyContextE(t, ctx, options, networkPolicyName)
 			if err != nil {
 				return "", err
 			}
@@ -50,5 +75,30 @@ func WaitUntilNetworkPolicyAvailable(t testing.TestingT, options *KubectlOptions
 			return "networkpolicy is now available", nil
 		},
 	)
+	if err != nil {
+		return err
+	}
+
 	options.Logger.Logf(t, "%s", message)
+
+	return nil
+}
+
+// WaitUntilNetworkPolicyAvailableContext waits until the networkpolicy is present on the cluster in cases where it is not immediately
+// available (for example, when using ClusterIssuer to request a certificate).
+// The ctx parameter supports cancellation and timeouts.
+// This will fail the test if there is an error.
+func WaitUntilNetworkPolicyAvailableContext(t testing.TestingT, ctx context.Context, options *KubectlOptions, networkPolicyName string, retries int, sleepBetweenRetries time.Duration) {
+	t.Helper()
+	err := WaitUntilNetworkPolicyAvailableContextE(t, ctx, options, networkPolicyName, retries, sleepBetweenRetries)
+	require.NoError(t, err)
+}
+
+// WaitUntilNetworkPolicyAvailable waits until the networkpolicy is present on the cluster in cases where it is not immediately
+// available (for example, when using ClusterIssuer to request a certificate).
+//
+// Deprecated: Use [WaitUntilNetworkPolicyAvailableContext] instead.
+func WaitUntilNetworkPolicyAvailable(t testing.TestingT, options *KubectlOptions, networkPolicyName string, retries int, sleepBetweenRetries time.Duration) {
+	t.Helper()
+	WaitUntilNetworkPolicyAvailableContext(t, context.Background(), options, networkPolicyName, retries, sleepBetweenRetries)
 }

--- a/modules/k8s/node.go
+++ b/modules/k8s/node.go
@@ -12,33 +12,54 @@ import (
 	"github.com/gruntwork-io/terratest/modules/testing"
 )
 
-// GetNodes queries Kubernetes for information about the worker nodes registered to the cluster. If anything goes wrong,
-// the function will automatically fail the test.
-func GetNodes(t testing.TestingT, options *KubectlOptions) []corev1.Node {
-	nodes, err := GetNodesE(t, options)
+// GetNodesContextE queries Kubernetes for information about the worker nodes registered to the cluster.
+// The ctx parameter supports cancellation and timeouts.
+func GetNodesContextE(t testing.TestingT, ctx context.Context, options *KubectlOptions) ([]corev1.Node, error) {
+	return GetNodesByFilterContextE(t, ctx, options, metav1.ListOptions{})
+}
+
+// GetNodesContext queries Kubernetes for information about the worker nodes registered to the cluster.
+// The ctx parameter supports cancellation and timeouts.
+// This will fail the test if there is an error.
+func GetNodesContext(t testing.TestingT, ctx context.Context, options *KubectlOptions) []corev1.Node {
+	t.Helper()
+	nodes, err := GetNodesContextE(t, ctx, options)
 	require.NoError(t, err)
 
 	return nodes
 }
 
-// GetNodesE queries Kubernetes for information about the worker nodes registered to the cluster.
-func GetNodesE(t testing.TestingT, options *KubectlOptions) ([]corev1.Node, error) {
-	return GetNodesByFilterE(t, options, metav1.ListOptions{})
+// GetNodes queries Kubernetes for information about the worker nodes registered to the cluster. If anything goes wrong,
+// the function will automatically fail the test.
+//
+// Deprecated: Use [GetNodesContext] instead.
+func GetNodes(t testing.TestingT, options *KubectlOptions) []corev1.Node {
+	t.Helper()
+
+	return GetNodesContext(t, context.Background(), options)
 }
 
-// GetNodesByFilterE queries Kubernetes for information about the worker nodes registered to the cluster, filtering the
-// list of nodes using the provided ListOptions.
+// GetNodesE queries Kubernetes for information about the worker nodes registered to the cluster.
+//
+// Deprecated: Use [GetNodesContextE] instead.
+func GetNodesE(t testing.TestingT, options *KubectlOptions) ([]corev1.Node, error) {
+	return GetNodesContextE(t, context.Background(), options)
+}
+
+// GetNodesByFilterContextE queries Kubernetes for information about the worker nodes registered to the cluster,
+// filtering the list of nodes using the provided ListOptions.
+// The ctx parameter supports cancellation and timeouts.
 //
 //nolint:gocritic // hugeParam: cannot change public function signature
-func GetNodesByFilterE(t testing.TestingT, options *KubectlOptions, filter metav1.ListOptions) ([]corev1.Node, error) {
+func GetNodesByFilterContextE(t testing.TestingT, ctx context.Context, options *KubectlOptions, filter metav1.ListOptions) ([]corev1.Node, error) {
 	options.Logger.Logf(t, "Getting list of nodes from Kubernetes")
 
-	clientset, err := GetKubernetesClientFromOptionsE(t, options)
+	clientset, err := GetKubernetesClientFromOptionsContextE(t, ctx, options)
 	if err != nil {
 		return nil, err
 	}
 
-	nodes, err := clientset.CoreV1().Nodes().List(context.Background(), filter)
+	nodes, err := clientset.CoreV1().Nodes().List(ctx, filter)
 	if err != nil {
 		return nil, err
 	}
@@ -46,19 +67,35 @@ func GetNodesByFilterE(t testing.TestingT, options *KubectlOptions, filter metav
 	return nodes.Items, err
 }
 
-// GetReadyNodes queries Kubernetes for information about the worker nodes registered to the cluster and only returns
-// those that are in the ready state. If anything goes wrong, the function will automatically fail the test.
-func GetReadyNodes(t testing.TestingT, options *KubectlOptions) []corev1.Node {
-	nodes, err := GetReadyNodesE(t, options)
+// GetNodesByFilterContext queries Kubernetes for information about the worker nodes registered to the cluster,
+// filtering the list of nodes using the provided ListOptions.
+// The ctx parameter supports cancellation and timeouts.
+// This will fail the test if there is an error.
+//
+//nolint:gocritic // hugeParam: cannot change public function signature
+func GetNodesByFilterContext(t testing.TestingT, ctx context.Context, options *KubectlOptions, filter metav1.ListOptions) []corev1.Node {
+	t.Helper()
+	nodes, err := GetNodesByFilterContextE(t, ctx, options, filter)
 	require.NoError(t, err)
 
 	return nodes
 }
 
-// GetReadyNodesE queries Kubernetes for information about the worker nodes registered to the cluster and only returns
-// those that are in the ready state.
-func GetReadyNodesE(t testing.TestingT, options *KubectlOptions) ([]corev1.Node, error) {
-	nodes, err := GetNodesE(t, options)
+// GetNodesByFilterE queries Kubernetes for information about the worker nodes registered to the cluster, filtering the
+// list of nodes using the provided ListOptions.
+//
+// Deprecated: Use [GetNodesByFilterContextE] instead.
+//
+//nolint:gocritic // hugeParam: cannot change public function signature
+func GetNodesByFilterE(t testing.TestingT, options *KubectlOptions, filter metav1.ListOptions) ([]corev1.Node, error) {
+	return GetNodesByFilterContextE(t, context.Background(), options, filter)
+}
+
+// GetReadyNodesContextE queries Kubernetes for information about the worker nodes registered to the cluster and only
+// returns those that are in the ready state.
+// The ctx parameter supports cancellation and timeouts.
+func GetReadyNodesContextE(t testing.TestingT, ctx context.Context, options *KubectlOptions) ([]corev1.Node, error) {
+	nodes, err := GetNodesContextE(t, ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -76,6 +113,36 @@ func GetReadyNodesE(t testing.TestingT, options *KubectlOptions) ([]corev1.Node,
 	return nodesFiltered, nil
 }
 
+// GetReadyNodesContext queries Kubernetes for information about the worker nodes registered to the cluster and only
+// returns those that are in the ready state.
+// The ctx parameter supports cancellation and timeouts.
+// This will fail the test if there is an error.
+func GetReadyNodesContext(t testing.TestingT, ctx context.Context, options *KubectlOptions) []corev1.Node {
+	t.Helper()
+	nodes, err := GetReadyNodesContextE(t, ctx, options)
+	require.NoError(t, err)
+
+	return nodes
+}
+
+// GetReadyNodes queries Kubernetes for information about the worker nodes registered to the cluster and only returns
+// those that are in the ready state. If anything goes wrong, the function will automatically fail the test.
+//
+// Deprecated: Use [GetReadyNodesContext] instead.
+func GetReadyNodes(t testing.TestingT, options *KubectlOptions) []corev1.Node {
+	t.Helper()
+
+	return GetReadyNodesContext(t, context.Background(), options)
+}
+
+// GetReadyNodesE queries Kubernetes for information about the worker nodes registered to the cluster and only returns
+// those that are in the ready state.
+//
+// Deprecated: Use [GetReadyNodesContextE] instead.
+func GetReadyNodesE(t testing.TestingT, options *KubectlOptions) ([]corev1.Node, error) {
+	return GetReadyNodesContextE(t, context.Background(), options)
+}
+
 // IsNodeReady takes a Kubernetes Node information object and checks if the Node is in the ready state.
 //
 //nolint:gocritic // hugeParam: cannot change public function signature
@@ -89,23 +156,18 @@ func IsNodeReady(node corev1.Node) bool {
 	return false
 }
 
-// WaitUntilAllNodesReady continuously polls the Kubernetes cluster until all nodes in the cluster reach the ready
-// state, or runs out of retries. Will fail the test immediately if it times out.
-func WaitUntilAllNodesReady(t testing.TestingT, options *KubectlOptions, retries int, sleepBetweenRetries time.Duration) {
-	err := WaitUntilAllNodesReadyE(t, options, retries, sleepBetweenRetries)
-	require.NoError(t, err)
-}
-
-// WaitUntilAllNodesReadyE continuously polls the Kubernetes cluster until all nodes in the cluster reach the ready
-// state, or runs out of retries.
-func WaitUntilAllNodesReadyE(t testing.TestingT, options *KubectlOptions, retries int, sleepBetweenRetries time.Duration) error {
-	message, err := retry.DoWithRetryE(
+// WaitUntilAllNodesReadyContextE continuously polls the Kubernetes cluster until all nodes in the cluster reach the
+// ready state, or runs out of retries.
+// The ctx parameter supports cancellation and timeouts.
+func WaitUntilAllNodesReadyContextE(t testing.TestingT, ctx context.Context, options *KubectlOptions, retries int, sleepBetweenRetries time.Duration) error {
+	message, err := retry.DoWithRetryContextE(
 		t,
+		ctx,
 		"Wait for all Kube Nodes to be ready",
 		retries,
 		sleepBetweenRetries,
 		func() (string, error) {
-			_, err := AreAllNodesReadyE(t, options)
+			_, err := AreAllNodesReadyContextE(t, ctx, options)
 			if err != nil {
 				return "", err
 			}
@@ -118,16 +180,38 @@ func WaitUntilAllNodesReadyE(t testing.TestingT, options *KubectlOptions, retrie
 	return err
 }
 
-// AreAllNodesReady checks if all nodes are ready in the Kubernetes cluster targeted by the current config context
-func AreAllNodesReady(t testing.TestingT, options *KubectlOptions) bool {
-	nodesReady, _ := AreAllNodesReadyE(t, options)
-	return nodesReady
+// WaitUntilAllNodesReadyContext continuously polls the Kubernetes cluster until all nodes in the cluster reach the
+// ready state, or runs out of retries.
+// The ctx parameter supports cancellation and timeouts.
+// This will fail the test if there is an error.
+func WaitUntilAllNodesReadyContext(t testing.TestingT, ctx context.Context, options *KubectlOptions, retries int, sleepBetweenRetries time.Duration) {
+	t.Helper()
+	err := WaitUntilAllNodesReadyContextE(t, ctx, options, retries, sleepBetweenRetries)
+	require.NoError(t, err)
 }
 
-// AreAllNodesReadyE checks if all nodes are ready in the Kubernetes cluster targeted by the current config context. If
-// false, returns an error indicating the reason.
-func AreAllNodesReadyE(t testing.TestingT, options *KubectlOptions) (bool, error) {
-	nodes, err := GetNodesE(t, options)
+// WaitUntilAllNodesReady continuously polls the Kubernetes cluster until all nodes in the cluster reach the ready
+// state, or runs out of retries. Will fail the test immediately if it times out.
+//
+// Deprecated: Use [WaitUntilAllNodesReadyContext] instead.
+func WaitUntilAllNodesReady(t testing.TestingT, options *KubectlOptions, retries int, sleepBetweenRetries time.Duration) {
+	t.Helper()
+	WaitUntilAllNodesReadyContext(t, context.Background(), options, retries, sleepBetweenRetries)
+}
+
+// WaitUntilAllNodesReadyE continuously polls the Kubernetes cluster until all nodes in the cluster reach the ready
+// state, or runs out of retries.
+//
+// Deprecated: Use [WaitUntilAllNodesReadyContextE] instead.
+func WaitUntilAllNodesReadyE(t testing.TestingT, options *KubectlOptions, retries int, sleepBetweenRetries time.Duration) error {
+	return WaitUntilAllNodesReadyContextE(t, context.Background(), options, retries, sleepBetweenRetries)
+}
+
+// AreAllNodesReadyContextE checks if all nodes are ready in the Kubernetes cluster targeted by the current config
+// context. The ctx parameter supports cancellation and timeouts.
+// If false, returns an error indicating the reason.
+func AreAllNodesReadyContextE(t testing.TestingT, ctx context.Context, options *KubectlOptions) (bool, error) {
+	nodes, err := GetNodesContextE(t, ctx, options)
 	if err != nil {
 		return false, err
 	}
@@ -143,4 +227,20 @@ func AreAllNodesReadyE(t testing.TestingT, options *KubectlOptions) (bool, error
 	}
 
 	return true, nil
+}
+
+// AreAllNodesReady checks if all nodes are ready in the Kubernetes cluster targeted by the current config context
+//
+// Deprecated: Use [AreAllNodesReadyContextE] instead.
+func AreAllNodesReady(t testing.TestingT, options *KubectlOptions) bool {
+	nodesReady, _ := AreAllNodesReadyE(t, options)
+	return nodesReady
+}
+
+// AreAllNodesReadyE checks if all nodes are ready in the Kubernetes cluster targeted by the current config context. If
+// false, returns an error indicating the reason.
+//
+// Deprecated: Use [AreAllNodesReadyContextE] instead.
+func AreAllNodesReadyE(t testing.TestingT, options *KubectlOptions) (bool, error) {
+	return AreAllNodesReadyContextE(t, context.Background(), options)
 }

--- a/modules/k8s/persistent_volume.go
+++ b/modules/k8s/persistent_volume.go
@@ -14,27 +14,17 @@ import (
 	"github.com/gruntwork-io/terratest/modules/testing"
 )
 
-// ListPersistentVolumes will look for PersistentVolumes in the given namespace that match the given filters and return them. This will fail the
-// test if there is an error.
+// ListPersistentVolumesContextE will look for PersistentVolumes that match the given filters and return them.
+// The ctx parameter supports cancellation and timeouts.
 //
 //nolint:gocritic // hugeParam: cannot change public function signature
-func ListPersistentVolumes(t testing.TestingT, options *KubectlOptions, filters metav1.ListOptions) []corev1.PersistentVolume {
-	pvs, err := ListPersistentVolumesE(t, options, filters)
-	require.NoError(t, err)
-
-	return pvs
-}
-
-// ListPersistentVolumesE will look for PersistentVolumes that match the given filters and return them.
-//
-//nolint:gocritic // hugeParam: cannot change public function signature
-func ListPersistentVolumesE(t testing.TestingT, options *KubectlOptions, filters metav1.ListOptions) ([]corev1.PersistentVolume, error) {
-	clientset, err := GetKubernetesClientFromOptionsE(t, options)
+func ListPersistentVolumesContextE(t testing.TestingT, ctx context.Context, options *KubectlOptions, filters metav1.ListOptions) ([]corev1.PersistentVolume, error) {
+	clientset, err := GetKubernetesClientFromOptionsContextE(t, ctx, options)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := clientset.CoreV1().PersistentVolumes().List(context.Background(), filters)
+	resp, err := clientset.CoreV1().PersistentVolumes().List(ctx, filters)
 	if err != nil {
 		return nil, err
 	}
@@ -42,39 +32,86 @@ func ListPersistentVolumesE(t testing.TestingT, options *KubectlOptions, filters
 	return resp.Items, nil
 }
 
-// GetPersistentVolume returns a Kubernetes PersistentVolume resource with the given name. This will fail the test if there is an error.
-func GetPersistentVolume(t testing.TestingT, options *KubectlOptions, name string) *corev1.PersistentVolume {
-	pv, err := GetPersistentVolumeE(t, options, name)
+// ListPersistentVolumesContext will look for PersistentVolumes that match the given filters and return them.
+// The ctx parameter supports cancellation and timeouts.
+// This will fail the test if there is an error.
+//
+//nolint:gocritic // hugeParam: cannot change public function signature
+func ListPersistentVolumesContext(t testing.TestingT, ctx context.Context, options *KubectlOptions, filters metav1.ListOptions) []corev1.PersistentVolume {
+	t.Helper()
+	pvs, err := ListPersistentVolumesContextE(t, ctx, options, filters)
+	require.NoError(t, err)
+
+	return pvs
+}
+
+// ListPersistentVolumes will look for PersistentVolumes in the given namespace that match the given filters and return them. This will fail the
+// test if there is an error.
+//
+// Deprecated: Use [ListPersistentVolumesContext] instead.
+//
+//nolint:gocritic // hugeParam: cannot change public function signature
+func ListPersistentVolumes(t testing.TestingT, options *KubectlOptions, filters metav1.ListOptions) []corev1.PersistentVolume {
+	t.Helper()
+
+	return ListPersistentVolumesContext(t, context.Background(), options, filters)
+}
+
+// ListPersistentVolumesE will look for PersistentVolumes that match the given filters and return them.
+//
+// Deprecated: Use [ListPersistentVolumesContextE] instead.
+//
+//nolint:gocritic // hugeParam: cannot change public function signature
+func ListPersistentVolumesE(t testing.TestingT, options *KubectlOptions, filters metav1.ListOptions) ([]corev1.PersistentVolume, error) {
+	return ListPersistentVolumesContextE(t, context.Background(), options, filters)
+}
+
+// GetPersistentVolumeContextE returns a Kubernetes PersistentVolume resource with the given name.
+// The ctx parameter supports cancellation and timeouts.
+func GetPersistentVolumeContextE(t testing.TestingT, ctx context.Context, options *KubectlOptions, name string) (*corev1.PersistentVolume, error) {
+	clientset, err := GetKubernetesClientFromOptionsContextE(t, ctx, options)
+	if err != nil {
+		return nil, err
+	}
+
+	return clientset.CoreV1().PersistentVolumes().Get(ctx, name, metav1.GetOptions{})
+}
+
+// GetPersistentVolumeContext returns a Kubernetes PersistentVolume resource with the given name.
+// The ctx parameter supports cancellation and timeouts.
+// This will fail the test if there is an error.
+func GetPersistentVolumeContext(t testing.TestingT, ctx context.Context, options *KubectlOptions, name string) *corev1.PersistentVolume {
+	t.Helper()
+	pv, err := GetPersistentVolumeContextE(t, ctx, options, name)
 	require.NoError(t, err)
 
 	return pv
 }
 
+// GetPersistentVolume returns a Kubernetes PersistentVolume resource with the given name. This will fail the test if there is an error.
+//
+// Deprecated: Use [GetPersistentVolumeContext] instead.
+func GetPersistentVolume(t testing.TestingT, options *KubectlOptions, name string) *corev1.PersistentVolume {
+	t.Helper()
+
+	return GetPersistentVolumeContext(t, context.Background(), options, name)
+}
+
 // GetPersistentVolumeE returns a Kubernetes PersistentVolume resource with the given name.
+//
+// Deprecated: Use [GetPersistentVolumeContextE] instead.
 func GetPersistentVolumeE(t testing.TestingT, options *KubectlOptions, name string) (*corev1.PersistentVolume, error) {
-	clientset, err := GetKubernetesClientFromOptionsE(t, options)
-	if err != nil {
-		return nil, err
-	}
-
-	return clientset.CoreV1().PersistentVolumes().Get(context.Background(), name, metav1.GetOptions{})
+	return GetPersistentVolumeContextE(t, context.Background(), options, name)
 }
 
-// WaitUntilPersistentVolumeInStatus waits until the given Persistent Volume is the given status phase,
-// retrying the check for the specified amount of times, sleeping
-// for the provided duration between each try.
-// This will fail the test if there is an error.
-func WaitUntilPersistentVolumeInStatus(t testing.TestingT, options *KubectlOptions, pvName string, pvStatusPhase *corev1.PersistentVolumePhase, retries int, sleepBetweenRetries time.Duration) {
-	require.NoError(t, WaitUntilPersistentVolumeInStatusE(t, options, pvName, pvStatusPhase, retries, sleepBetweenRetries))
-}
-
-// WaitUntilPersistentVolumeInStatusE waits until the given PersistentVolume is in the given status phase,
-// retrying the check for the specified amount of times, sleeping
-// for the provided duration between each try.
+// WaitUntilPersistentVolumeInStatusContextE waits until the given PersistentVolume is in the given status phase,
+// retrying the check for the specified amount of times, sleeping for the provided duration between each try.
+// The ctx parameter supports cancellation and timeouts.
 //
 //nolint:dupl // structural pattern for k8s resource operations
-func WaitUntilPersistentVolumeInStatusE(
+func WaitUntilPersistentVolumeInStatusContextE(
 	t testing.TestingT,
+	ctx context.Context,
 	options *KubectlOptions,
 	pvName string,
 	pvStatusPhase *corev1.PersistentVolumePhase,
@@ -83,13 +120,14 @@ func WaitUntilPersistentVolumeInStatusE(
 ) error {
 	statusMsg := fmt.Sprintf("Wait for Persistent Volume %s to be '%s'", pvName, *pvStatusPhase)
 
-	message, err := retry.DoWithRetryE(
+	message, err := retry.DoWithRetryContextE(
 		t,
+		ctx,
 		statusMsg,
 		retries,
 		sleepBetweenRetries,
 		func() (string, error) {
-			pv, err := GetPersistentVolumeE(t, options, pvName)
+			pv, err := GetPersistentVolumeContextE(t, ctx, options, pvName)
 			if err != nil {
 				return "", err
 			}
@@ -109,6 +147,44 @@ func WaitUntilPersistentVolumeInStatusE(
 	options.Logger.Logf(t, "%s", message)
 
 	return nil
+}
+
+// WaitUntilPersistentVolumeInStatusContext waits until the given PersistentVolume is in the given status phase,
+// retrying the check for the specified amount of times, sleeping for the provided duration between each try.
+// The ctx parameter supports cancellation and timeouts.
+// This will fail the test if there is an error.
+func WaitUntilPersistentVolumeInStatusContext(t testing.TestingT, ctx context.Context, options *KubectlOptions, pvName string, pvStatusPhase *corev1.PersistentVolumePhase, retries int, sleepBetweenRetries time.Duration) {
+	t.Helper()
+	require.NoError(t, WaitUntilPersistentVolumeInStatusContextE(t, ctx, options, pvName, pvStatusPhase, retries, sleepBetweenRetries))
+}
+
+// WaitUntilPersistentVolumeInStatus waits until the given Persistent Volume is the given status phase,
+// retrying the check for the specified amount of times, sleeping
+// for the provided duration between each try.
+// This will fail the test if there is an error.
+//
+// Deprecated: Use [WaitUntilPersistentVolumeInStatusContext] instead.
+func WaitUntilPersistentVolumeInStatus(t testing.TestingT, options *KubectlOptions, pvName string, pvStatusPhase *corev1.PersistentVolumePhase, retries int, sleepBetweenRetries time.Duration) {
+	t.Helper()
+	WaitUntilPersistentVolumeInStatusContext(t, context.Background(), options, pvName, pvStatusPhase, retries, sleepBetweenRetries)
+}
+
+// WaitUntilPersistentVolumeInStatusE waits until the given PersistentVolume is in the given status phase,
+// retrying the check for the specified amount of times, sleeping
+// for the provided duration between each try.
+//
+// Deprecated: Use [WaitUntilPersistentVolumeInStatusContextE] instead.
+//
+//nolint:dupl // structural pattern for k8s resource operations
+func WaitUntilPersistentVolumeInStatusE(
+	t testing.TestingT,
+	options *KubectlOptions,
+	pvName string,
+	pvStatusPhase *corev1.PersistentVolumePhase,
+	retries int,
+	sleepBetweenRetries time.Duration,
+) error {
+	return WaitUntilPersistentVolumeInStatusContextE(t, context.Background(), options, pvName, pvStatusPhase, retries, sleepBetweenRetries)
 }
 
 // IsPersistentVolumeInStatus returns true if the given PersistentVolume is in the given status phase

--- a/modules/k8s/persistent_volume_claim.go
+++ b/modules/k8s/persistent_volume_claim.go
@@ -15,27 +15,17 @@ import (
 	"github.com/gruntwork-io/terratest/modules/testing"
 )
 
-// ListPersistentVolumeClaims will look for PersistentVolumeClaims in the given namespace that match the given filters and return them. This will fail the
-// test if there is an error.
+// ListPersistentVolumeClaimsContextE will look for PersistentVolumeClaims in the given namespace that match the given
+// filters and return them. The ctx parameter supports cancellation and timeouts.
 //
 //nolint:gocritic // hugeParam: cannot change public function signature
-func ListPersistentVolumeClaims(t testing.TestingT, options *KubectlOptions, filters metav1.ListOptions) []corev1.PersistentVolumeClaim {
-	pvcs, err := ListPersistentVolumeClaimsE(t, options, filters)
-	require.NoError(t, err)
-
-	return pvcs
-}
-
-// ListPersistentVolumeClaimsE will look for PersistentVolumeClaims in the given namespace that match the given filters and return them.
-//
-//nolint:gocritic // hugeParam: cannot change public function signature
-func ListPersistentVolumeClaimsE(t testing.TestingT, options *KubectlOptions, filters metav1.ListOptions) ([]corev1.PersistentVolumeClaim, error) {
-	clientset, err := GetKubernetesClientFromOptionsE(t, options)
+func ListPersistentVolumeClaimsContextE(t testing.TestingT, ctx context.Context, options *KubectlOptions, filters metav1.ListOptions) ([]corev1.PersistentVolumeClaim, error) {
+	clientset, err := GetKubernetesClientFromOptionsContextE(t, ctx, options)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := clientset.CoreV1().PersistentVolumeClaims(options.Namespace).List(context.Background(), filters)
+	resp, err := clientset.CoreV1().PersistentVolumeClaims(options.Namespace).List(ctx, filters)
 	if err != nil {
 		return nil, err
 	}
@@ -43,49 +33,95 @@ func ListPersistentVolumeClaimsE(t testing.TestingT, options *KubectlOptions, fi
 	return resp.Items, nil
 }
 
-// GetPersistentVolumeClaim returns a Kubernetes PersistentVolumeClaim resource in the provided namespace with the given name. This will
-// fail the test if there is an error.
-func GetPersistentVolumeClaim(t testing.TestingT, options *KubectlOptions, pvcName string) *corev1.PersistentVolumeClaim {
-	pvc, err := GetPersistentVolumeClaimE(t, options, pvcName)
+// ListPersistentVolumeClaimsContext will look for PersistentVolumeClaims in the given namespace that match the given
+// filters and return them. The ctx parameter supports cancellation and timeouts.
+// This will fail the test if there is an error.
+//
+//nolint:gocritic // hugeParam: cannot change public function signature
+func ListPersistentVolumeClaimsContext(t testing.TestingT, ctx context.Context, options *KubectlOptions, filters metav1.ListOptions) []corev1.PersistentVolumeClaim {
+	t.Helper()
+	pvcs, err := ListPersistentVolumeClaimsContextE(t, ctx, options, filters)
+	require.NoError(t, err)
+
+	return pvcs
+}
+
+// ListPersistentVolumeClaims will look for PersistentVolumeClaims in the given namespace that match the given filters and return them. This will fail the
+// test if there is an error.
+//
+// Deprecated: Use [ListPersistentVolumeClaimsContext] instead.
+//
+//nolint:gocritic // hugeParam: cannot change public function signature
+func ListPersistentVolumeClaims(t testing.TestingT, options *KubectlOptions, filters metav1.ListOptions) []corev1.PersistentVolumeClaim {
+	t.Helper()
+
+	return ListPersistentVolumeClaimsContext(t, context.Background(), options, filters)
+}
+
+// ListPersistentVolumeClaimsE will look for PersistentVolumeClaims in the given namespace that match the given filters and return them.
+//
+// Deprecated: Use [ListPersistentVolumeClaimsContextE] instead.
+//
+//nolint:gocritic // hugeParam: cannot change public function signature
+func ListPersistentVolumeClaimsE(t testing.TestingT, options *KubectlOptions, filters metav1.ListOptions) ([]corev1.PersistentVolumeClaim, error) {
+	return ListPersistentVolumeClaimsContextE(t, context.Background(), options, filters)
+}
+
+// GetPersistentVolumeClaimContextE returns a Kubernetes PersistentVolumeClaim resource in the provided namespace with
+// the given name. The ctx parameter supports cancellation and timeouts.
+func GetPersistentVolumeClaimContextE(t testing.TestingT, ctx context.Context, options *KubectlOptions, pvcName string) (*corev1.PersistentVolumeClaim, error) {
+	clientset, err := GetKubernetesClientFromOptionsContextE(t, ctx, options)
+	if err != nil {
+		return nil, err
+	}
+
+	return clientset.CoreV1().PersistentVolumeClaims(options.Namespace).Get(ctx, pvcName, metav1.GetOptions{})
+}
+
+// GetPersistentVolumeClaimContext returns a Kubernetes PersistentVolumeClaim resource in the provided namespace with
+// the given name. The ctx parameter supports cancellation and timeouts.
+// This will fail the test if there is an error.
+func GetPersistentVolumeClaimContext(t testing.TestingT, ctx context.Context, options *KubectlOptions, pvcName string) *corev1.PersistentVolumeClaim {
+	t.Helper()
+	pvc, err := GetPersistentVolumeClaimContextE(t, ctx, options, pvcName)
 	require.NoError(t, err)
 
 	return pvc
 }
 
+// GetPersistentVolumeClaim returns a Kubernetes PersistentVolumeClaim resource in the provided namespace with the given name. This will
+// fail the test if there is an error.
+//
+// Deprecated: Use [GetPersistentVolumeClaimContext] instead.
+func GetPersistentVolumeClaim(t testing.TestingT, options *KubectlOptions, pvcName string) *corev1.PersistentVolumeClaim {
+	t.Helper()
+
+	return GetPersistentVolumeClaimContext(t, context.Background(), options, pvcName)
+}
+
 // GetPersistentVolumeClaimE returns a Kubernetes PersistentVolumeClaim resource in the provided namespace with the given name.
+//
+// Deprecated: Use [GetPersistentVolumeClaimContextE] instead.
 func GetPersistentVolumeClaimE(t testing.TestingT, options *KubectlOptions, pvcName string) (*corev1.PersistentVolumeClaim, error) {
-	clientset, err := GetKubernetesClientFromOptionsE(t, options)
-	if err != nil {
-		return nil, err
-	}
-
-	return clientset.CoreV1().PersistentVolumeClaims(options.Namespace).Get(context.Background(), pvcName, metav1.GetOptions{})
+	return GetPersistentVolumeClaimContextE(t, context.Background(), options, pvcName)
 }
 
-// WaitUntilPersistentVolumeClaimInStatus waits until the given PersistentVolumeClaim is the given status phase,
-// retrying the check for the specified amount of times, sleeping
-// for the provided duration between each try.
-// This will fail the test if there is an error.
-func WaitUntilPersistentVolumeClaimInStatus(t testing.TestingT, options *KubectlOptions, pvcName string, pvcStatusPhase *corev1.PersistentVolumeClaimPhase, retries int, sleepBetweenRetries time.Duration) {
-	require.NoError(t, WaitUntilPersistentVolumeClaimInStatusE(t, options, pvcName, pvcStatusPhase, retries, sleepBetweenRetries))
-}
-
-// WaitUntilPersistentVolumeClaimInStatusE waits until the given PersistentVolumeClaim is the given status phase,
-// retrying the check for the specified amount of times, sleeping
-// for the provided duration between each try.
-// This will fail the test if there is an error.
+// WaitUntilPersistentVolumeClaimInStatusContextE waits until the given PersistentVolumeClaim is the given status phase,
+// retrying the check for the specified amount of times, sleeping for the provided duration between each try.
+// The ctx parameter supports cancellation and timeouts.
 //
 //nolint:dupl // structural pattern for k8s resource operations
-func WaitUntilPersistentVolumeClaimInStatusE(t testing.TestingT, options *KubectlOptions, pvcName string, pvcStatusPhase *corev1.PersistentVolumeClaimPhase, retries int, sleepBetweenRetries time.Duration) error {
+func WaitUntilPersistentVolumeClaimInStatusContextE(t testing.TestingT, ctx context.Context, options *KubectlOptions, pvcName string, pvcStatusPhase *corev1.PersistentVolumeClaimPhase, retries int, sleepBetweenRetries time.Duration) error {
 	statusMsg := fmt.Sprintf("Wait for PersistentVolumeClaim %s to be '%s'.", pvcName, *pvcStatusPhase)
 
-	message, err := retry.DoWithRetryE(
+	message, err := retry.DoWithRetryContextE(
 		t,
+		ctx,
 		statusMsg,
 		retries,
 		sleepBetweenRetries,
 		func() (string, error) {
-			pvc, err := GetPersistentVolumeClaimE(t, options, pvcName)
+			pvc, err := GetPersistentVolumeClaimContextE(t, ctx, options, pvcName)
 			if err != nil {
 				return "", err
 			}
@@ -105,6 +141,38 @@ func WaitUntilPersistentVolumeClaimInStatusE(t testing.TestingT, options *Kubect
 	logger.Default.Logf(t, "%s", message)
 
 	return nil
+}
+
+// WaitUntilPersistentVolumeClaimInStatusContext waits until the given PersistentVolumeClaim is the given status phase,
+// retrying the check for the specified amount of times, sleeping for the provided duration between each try.
+// The ctx parameter supports cancellation and timeouts.
+// This will fail the test if there is an error.
+func WaitUntilPersistentVolumeClaimInStatusContext(t testing.TestingT, ctx context.Context, options *KubectlOptions, pvcName string, pvcStatusPhase *corev1.PersistentVolumeClaimPhase, retries int, sleepBetweenRetries time.Duration) {
+	t.Helper()
+	require.NoError(t, WaitUntilPersistentVolumeClaimInStatusContextE(t, ctx, options, pvcName, pvcStatusPhase, retries, sleepBetweenRetries))
+}
+
+// WaitUntilPersistentVolumeClaimInStatus waits until the given PersistentVolumeClaim is the given status phase,
+// retrying the check for the specified amount of times, sleeping
+// for the provided duration between each try.
+// This will fail the test if there is an error.
+//
+// Deprecated: Use [WaitUntilPersistentVolumeClaimInStatusContext] instead.
+func WaitUntilPersistentVolumeClaimInStatus(t testing.TestingT, options *KubectlOptions, pvcName string, pvcStatusPhase *corev1.PersistentVolumeClaimPhase, retries int, sleepBetweenRetries time.Duration) {
+	t.Helper()
+	WaitUntilPersistentVolumeClaimInStatusContext(t, context.Background(), options, pvcName, pvcStatusPhase, retries, sleepBetweenRetries)
+}
+
+// WaitUntilPersistentVolumeClaimInStatusE waits until the given PersistentVolumeClaim is the given status phase,
+// retrying the check for the specified amount of times, sleeping
+// for the provided duration between each try.
+// This will fail the test if there is an error.
+//
+// Deprecated: Use [WaitUntilPersistentVolumeClaimInStatusContextE] instead.
+//
+//nolint:dupl // structural pattern for k8s resource operations
+func WaitUntilPersistentVolumeClaimInStatusE(t testing.TestingT, options *KubectlOptions, pvcName string, pvcStatusPhase *corev1.PersistentVolumeClaimPhase, retries int, sleepBetweenRetries time.Duration) error {
+	return WaitUntilPersistentVolumeClaimInStatusContextE(t, context.Background(), options, pvcName, pvcStatusPhase, retries, sleepBetweenRetries)
 }
 
 // IsPersistentVolumeClaimInStatus returns true if the given PersistentVolumeClaim is in the given status phase

--- a/modules/k8s/pod.go
+++ b/modules/k8s/pod.go
@@ -13,27 +13,17 @@ import (
 	"github.com/gruntwork-io/terratest/modules/testing"
 )
 
-// ListPods will look for pods in the given namespace that match the given filters and return them. This will fail the
-// test if there is an error.
+// ListPodsContextE looks up pods in the given namespace that match the given filters and return them.
+// The ctx parameter supports cancellation and timeouts.
 //
 //nolint:gocritic // hugeParam: cannot change public function signature
-func ListPods(t testing.TestingT, options *KubectlOptions, filters metav1.ListOptions) []corev1.Pod {
-	pods, err := ListPodsE(t, options, filters)
-	require.NoError(t, err)
-
-	return pods
-}
-
-// ListPodsE will look for pods in the given namespace that match the given filters and return them.
-//
-//nolint:gocritic // hugeParam: cannot change public function signature
-func ListPodsE(t testing.TestingT, options *KubectlOptions, filters metav1.ListOptions) ([]corev1.Pod, error) {
-	clientset, err := GetKubernetesClientFromOptionsE(t, options)
+func ListPodsContextE(t testing.TestingT, ctx context.Context, options *KubectlOptions, filters metav1.ListOptions) ([]corev1.Pod, error) {
+	clientset, err := GetKubernetesClientFromOptionsContextE(t, ctx, options)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := clientset.CoreV1().Pods(options.Namespace).List(context.Background(), filters)
+	resp, err := clientset.CoreV1().Pods(options.Namespace).List(ctx, filters)
 	if err != nil {
 		return nil, err
 	}
@@ -41,47 +31,86 @@ func ListPodsE(t testing.TestingT, options *KubectlOptions, filters metav1.ListO
 	return resp.Items, nil
 }
 
-// GetPod returns a Kubernetes pod resource in the provided namespace with the given name. This will
-// fail the test if there is an error.
-func GetPod(t testing.TestingT, options *KubectlOptions, podName string) *corev1.Pod {
-	pod, err := GetPodE(t, options, podName)
+// ListPodsContext looks up pods in the given namespace that match the given filters and return them.
+// The ctx parameter supports cancellation and timeouts.
+// This will fail the test if there is an error.
+//
+//nolint:gocritic // hugeParam: cannot change public function signature
+func ListPodsContext(t testing.TestingT, ctx context.Context, options *KubectlOptions, filters metav1.ListOptions) []corev1.Pod {
+	t.Helper()
+	pods, err := ListPodsContextE(t, ctx, options, filters)
+	require.NoError(t, err)
+
+	return pods
+}
+
+// ListPods will look for pods in the given namespace that match the given filters and return them. This will fail the
+// test if there is an error.
+//
+// Deprecated: Use [ListPodsContext] instead.
+//
+//nolint:gocritic // hugeParam: cannot change public function signature
+func ListPods(t testing.TestingT, options *KubectlOptions, filters metav1.ListOptions) []corev1.Pod {
+	t.Helper()
+
+	return ListPodsContext(t, context.Background(), options, filters)
+}
+
+// ListPodsE will look for pods in the given namespace that match the given filters and return them.
+//
+// Deprecated: Use [ListPodsContextE] instead.
+//
+//nolint:gocritic // hugeParam: cannot change public function signature
+func ListPodsE(t testing.TestingT, options *KubectlOptions, filters metav1.ListOptions) ([]corev1.Pod, error) {
+	return ListPodsContextE(t, context.Background(), options, filters)
+}
+
+// GetPodContextE returns a Kubernetes pod resource in the provided namespace with the given name.
+// The ctx parameter supports cancellation and timeouts.
+func GetPodContextE(t testing.TestingT, ctx context.Context, options *KubectlOptions, podName string) (*corev1.Pod, error) {
+	clientset, err := GetKubernetesClientFromOptionsContextE(t, ctx, options)
+	if err != nil {
+		return nil, err
+	}
+
+	return clientset.CoreV1().Pods(options.Namespace).Get(ctx, podName, metav1.GetOptions{})
+}
+
+// GetPodContext returns a Kubernetes pod resource in the provided namespace with the given name.
+// The ctx parameter supports cancellation and timeouts.
+// This will fail the test if there is an error.
+func GetPodContext(t testing.TestingT, ctx context.Context, options *KubectlOptions, podName string) *corev1.Pod {
+	t.Helper()
+	pod, err := GetPodContextE(t, ctx, options, podName)
 	require.NoError(t, err)
 
 	return pod
 }
 
+// GetPod returns a Kubernetes pod resource in the provided namespace with the given name. This will
+// fail the test if there is an error.
+//
+// Deprecated: Use [GetPodContext] instead.
+func GetPod(t testing.TestingT, options *KubectlOptions, podName string) *corev1.Pod {
+	t.Helper()
+
+	return GetPodContext(t, context.Background(), options, podName)
+}
+
 // GetPodE returns a Kubernetes pod resource in the provided namespace with the given name.
+//
+// Deprecated: Use [GetPodContextE] instead.
 func GetPodE(t testing.TestingT, options *KubectlOptions, podName string) (*corev1.Pod, error) {
-	clientset, err := GetKubernetesClientFromOptionsE(t, options)
-	if err != nil {
-		return nil, err
-	}
-
-	return clientset.CoreV1().Pods(options.Namespace).Get(context.Background(), podName, metav1.GetOptions{})
+	return GetPodContextE(t, context.Background(), options, podName)
 }
 
-// WaitUntilNumPodsCreated waits until the desired number of pods are created that match the provided filter. This will
-// retry the check for the specified amount of times, sleeping for the provided duration between each try. This will
-// fail the test if the retry times out.
+// WaitUntilNumPodsCreatedContextE waits until the desired number of pods are created that match the provided filter.
+// The ctx parameter supports cancellation and timeouts.
 //
 //nolint:gocritic // hugeParam: cannot change public function signature
-func WaitUntilNumPodsCreated(
+func WaitUntilNumPodsCreatedContextE(
 	t testing.TestingT,
-	options *KubectlOptions,
-	filters metav1.ListOptions,
-	desiredCount int,
-	retries int,
-	sleepBetweenRetries time.Duration,
-) {
-	require.NoError(t, WaitUntilNumPodsCreatedE(t, options, filters, desiredCount, retries, sleepBetweenRetries))
-}
-
-// WaitUntilNumPodsCreatedE waits until the desired number of pods are created that match the provided filter. This will
-// retry the check for the specified amount of times, sleeping for the provided duration between each try.
-//
-//nolint:gocritic // hugeParam: cannot change public function signature
-func WaitUntilNumPodsCreatedE(
-	t testing.TestingT,
+	ctx context.Context,
 	options *KubectlOptions,
 	filters metav1.ListOptions,
 	desiredCount int,
@@ -90,13 +119,14 @@ func WaitUntilNumPodsCreatedE(
 ) error {
 	statusMsg := fmt.Sprintf("Wait for num pods created to match desired count %d.", desiredCount)
 
-	message, err := retry.DoWithRetryE(
+	message, err := retry.DoWithRetryContextE(
 		t,
+		ctx,
 		statusMsg,
 		retries,
 		sleepBetweenRetries,
 		func() (string, error) {
-			pods, err := ListPodsE(t, options, filters)
+			pods, err := ListPodsContextE(t, ctx, options, filters)
 			if err != nil {
 				return "", err
 			}
@@ -118,24 +148,74 @@ func WaitUntilNumPodsCreatedE(
 	return nil
 }
 
-// WaitUntilPodAvailable waits until all of the containers within the pod are ready and started, retrying the check for the specified amount of times, sleeping
-// for the provided duration between each try. This will fail the test if there is an error or if the check times out.
-func WaitUntilPodAvailable(t testing.TestingT, options *KubectlOptions, podName string, retries int, sleepBetweenRetries time.Duration) {
-	require.NoError(t, WaitUntilPodAvailableE(t, options, podName, retries, sleepBetweenRetries))
+// WaitUntilNumPodsCreatedContext waits until the desired number of pods are created that match the provided filter.
+// The ctx parameter supports cancellation and timeouts.
+// This will fail the test if there is an error.
+//
+//nolint:gocritic // hugeParam: cannot change public function signature
+func WaitUntilNumPodsCreatedContext(
+	t testing.TestingT,
+	ctx context.Context,
+	options *KubectlOptions,
+	filters metav1.ListOptions,
+	desiredCount int,
+	retries int,
+	sleepBetweenRetries time.Duration,
+) {
+	t.Helper()
+	require.NoError(t, WaitUntilNumPodsCreatedContextE(t, ctx, options, filters, desiredCount, retries, sleepBetweenRetries))
 }
 
-// WaitUntilPodAvailableE waits until all of the containers within the pod are ready and started, retrying the check for the specified amount of times, sleeping
-// for the provided duration between each try.
-func WaitUntilPodAvailableE(t testing.TestingT, options *KubectlOptions, podName string, retries int, sleepBetweenRetries time.Duration) error {
+// WaitUntilNumPodsCreated waits until the desired number of pods are created that match the provided filter. This will
+// retry the check for the specified amount of times, sleeping for the provided duration between each try. This will
+// fail the test if the retry times out.
+//
+// Deprecated: Use [WaitUntilNumPodsCreatedContext] instead.
+//
+//nolint:gocritic // hugeParam: cannot change public function signature
+func WaitUntilNumPodsCreated(
+	t testing.TestingT,
+	options *KubectlOptions,
+	filters metav1.ListOptions,
+	desiredCount int,
+	retries int,
+	sleepBetweenRetries time.Duration,
+) {
+	t.Helper()
+	WaitUntilNumPodsCreatedContext(t, context.Background(), options, filters, desiredCount, retries, sleepBetweenRetries)
+}
+
+// WaitUntilNumPodsCreatedE waits until the desired number of pods are created that match the provided filter. This will
+// retry the check for the specified amount of times, sleeping for the provided duration between each try.
+//
+// Deprecated: Use [WaitUntilNumPodsCreatedContextE] instead.
+//
+//nolint:gocritic // hugeParam: cannot change public function signature
+func WaitUntilNumPodsCreatedE(
+	t testing.TestingT,
+	options *KubectlOptions,
+	filters metav1.ListOptions,
+	desiredCount int,
+	retries int,
+	sleepBetweenRetries time.Duration,
+) error {
+	return WaitUntilNumPodsCreatedContextE(t, context.Background(), options, filters, desiredCount, retries, sleepBetweenRetries)
+}
+
+// WaitUntilPodAvailableContextE waits until all of the containers within the pod are ready and started,
+// retrying the check for the specified amount of times, sleeping for the provided duration between each try.
+// The ctx parameter supports cancellation and timeouts.
+func WaitUntilPodAvailableContextE(t testing.TestingT, ctx context.Context, options *KubectlOptions, podName string, retries int, sleepBetweenRetries time.Duration) error { //nolint:dupl // similar retry pattern across resource types is intentional
 	statusMsg := fmt.Sprintf("Wait for pod %s to be provisioned.", podName)
 
-	message, err := retry.DoWithRetryE(
+	message, err := retry.DoWithRetryContextE(
 		t,
+		ctx,
 		statusMsg,
 		retries,
 		sleepBetweenRetries,
 		func() (string, error) {
-			pod, err := GetPodE(t, options, podName)
+			pod, err := GetPodContextE(t, ctx, options, podName)
 			if err != nil {
 				return "", err
 			}
@@ -157,6 +237,32 @@ func WaitUntilPodAvailableE(t testing.TestingT, options *KubectlOptions, podName
 	return nil
 }
 
+// WaitUntilPodAvailableContext waits until all of the containers within the pod are ready and started,
+// retrying the check for the specified amount of times, sleeping for the provided duration between each try.
+// The ctx parameter supports cancellation and timeouts.
+// This will fail the test if there is an error.
+func WaitUntilPodAvailableContext(t testing.TestingT, ctx context.Context, options *KubectlOptions, podName string, retries int, sleepBetweenRetries time.Duration) {
+	t.Helper()
+	require.NoError(t, WaitUntilPodAvailableContextE(t, ctx, options, podName, retries, sleepBetweenRetries))
+}
+
+// WaitUntilPodAvailable waits until all of the containers within the pod are ready and started, retrying the check for the specified amount of times, sleeping
+// for the provided duration between each try. This will fail the test if there is an error or if the check times out.
+//
+// Deprecated: Use [WaitUntilPodAvailableContext] instead.
+func WaitUntilPodAvailable(t testing.TestingT, options *KubectlOptions, podName string, retries int, sleepBetweenRetries time.Duration) {
+	t.Helper()
+	WaitUntilPodAvailableContext(t, context.Background(), options, podName, retries, sleepBetweenRetries)
+}
+
+// WaitUntilPodAvailableE waits until all of the containers within the pod are ready and started, retrying the check for the specified amount of times, sleeping
+// for the provided duration between each try.
+//
+// Deprecated: Use [WaitUntilPodAvailableContextE] instead.
+func WaitUntilPodAvailableE(t testing.TestingT, options *KubectlOptions, podName string, retries int, sleepBetweenRetries time.Duration) error {
+	return WaitUntilPodAvailableContextE(t, context.Background(), options, podName, retries, sleepBetweenRetries)
+}
+
 // IsPodAvailable returns true if the all of the containers within the pod are ready and started
 func IsPodAvailable(pod *corev1.Pod) bool {
 	// Ensure all containers have reported their status
@@ -176,19 +282,21 @@ func IsPodAvailable(pod *corev1.Pod) bool {
 	return pod.Status.Phase == corev1.PodRunning
 }
 
-// GetPodLogsE returns the logs of a Pod at the time when the function was called. Pass container name if there are more containers in the Pod or set to "" if there is only one.
+// GetPodLogsContextE returns the logs of a Pod at the time when the function was called.
+// The ctx parameter supports cancellation and timeouts.
+// Pass container name if there are more containers in the Pod or set to "" if there is only one.
 // If the Pod is not running an Error is returned.
 // If the provided containerName is not the name of a container in the Pod an Error is returned.
-func GetPodLogsE(t testing.TestingT, options *KubectlOptions, pod *corev1.Pod, containerName string) (string, error) {
+func GetPodLogsContextE(t testing.TestingT, ctx context.Context, options *KubectlOptions, pod *corev1.Pod, containerName string) (string, error) {
 	var (
 		output string
 		err    error
 	)
 
 	if containerName == "" {
-		output, err = RunKubectlAndGetOutputE(t, options, "logs", pod.Name)
+		output, err = RunKubectlAndGetOutputContextE(t, ctx, options, "logs", pod.Name)
 	} else {
-		output, err = RunKubectlAndGetOutputE(t, options, "logs", pod.Name, "-c"+containerName)
+		output, err = RunKubectlAndGetOutputContextE(t, ctx, options, "logs", pod.Name, "-c"+containerName)
 	}
 
 	if err != nil {
@@ -198,26 +306,40 @@ func GetPodLogsE(t testing.TestingT, options *KubectlOptions, pod *corev1.Pod, c
 	return output, nil
 }
 
-// GetPodLogs returns the logs of a Pod at the time when the function was called.  Pass container name if there are more containers in the Pod or set to "" if there is only one.
-func GetPodLogs(t testing.TestingT, options *KubectlOptions, pod *corev1.Pod, containerName string) string {
-	logs, err := GetPodLogsE(t, options, pod, containerName)
+// GetPodLogsContext returns the logs of a Pod at the time when the function was called.
+// The ctx parameter supports cancellation and timeouts.
+// Pass container name if there are more containers in the Pod or set to "" if there is only one.
+// This will fail the test if there is an error.
+func GetPodLogsContext(t testing.TestingT, ctx context.Context, options *KubectlOptions, pod *corev1.Pod, containerName string) string {
+	t.Helper()
+	logs, err := GetPodLogsContextE(t, ctx, options, pod, containerName)
 	require.NoError(t, err)
 
 	return logs
 }
 
-// ExecPod executes a command in a container within a Kubernetes pod and returns the output. This will fail the test if
-// there is an error. Set containerName to "" if there is only one container in the pod.
-func ExecPod(t testing.TestingT, options *KubectlOptions, podName string, containerName string, command ...string) string {
-	o, err := ExecPodE(t, options, podName, containerName, command...)
-	require.NoError(t, err)
+// GetPodLogs returns the logs of a Pod at the time when the function was called.  Pass container name if there are more containers in the Pod or set to "" if there is only one.
+//
+// Deprecated: Use [GetPodLogsContext] instead.
+func GetPodLogs(t testing.TestingT, options *KubectlOptions, pod *corev1.Pod, containerName string) string {
+	t.Helper()
 
-	return o
+	return GetPodLogsContext(t, context.Background(), options, pod, containerName)
 }
 
-// ExecPodE executes a command in a container within a Kubernetes pod and returns the output. Set containerName to "" if
-// there is only one container in the pod.
-func ExecPodE(t testing.TestingT, options *KubectlOptions, podName string, containerName string, command ...string) (string, error) {
+// GetPodLogsE returns the logs of a Pod at the time when the function was called. Pass container name if there are more containers in the Pod or set to "" if there is only one.
+// If the Pod is not running an Error is returned.
+// If the provided containerName is not the name of a container in the Pod an Error is returned.
+//
+// Deprecated: Use [GetPodLogsContextE] instead.
+func GetPodLogsE(t testing.TestingT, options *KubectlOptions, pod *corev1.Pod, containerName string) (string, error) {
+	return GetPodLogsContextE(t, context.Background(), options, pod, containerName)
+}
+
+// ExecPodContextE executes a command in a container within a Kubernetes pod and returns the output.
+// The ctx parameter supports cancellation and timeouts.
+// Set containerName to "" if there is only one container in the pod.
+func ExecPodContextE(t testing.TestingT, ctx context.Context, options *KubectlOptions, podName string, containerName string, command ...string) (string, error) {
 	var args []string
 	if containerName == "" {
 		args = append([]string{"exec", podName, "--"}, command...)
@@ -225,5 +347,34 @@ func ExecPodE(t testing.TestingT, options *KubectlOptions, podName string, conta
 		args = append([]string{"exec", podName, "-c" + containerName, "--"}, command...)
 	}
 
-	return RunKubectlAndGetOutputE(t, options, args...)
+	return RunKubectlAndGetOutputContextE(t, ctx, options, args...)
+}
+
+// ExecPodContext executes a command in a container within a Kubernetes pod and returns the output.
+// The ctx parameter supports cancellation and timeouts.
+// This will fail the test if there is an error. Set containerName to "" if there is only one container in the pod.
+func ExecPodContext(t testing.TestingT, ctx context.Context, options *KubectlOptions, podName string, containerName string, command ...string) string {
+	t.Helper()
+	o, err := ExecPodContextE(t, ctx, options, podName, containerName, command...)
+	require.NoError(t, err)
+
+	return o
+}
+
+// ExecPod executes a command in a container within a Kubernetes pod and returns the output. This will fail the test if
+// there is an error. Set containerName to "" if there is only one container in the pod.
+//
+// Deprecated: Use [ExecPodContext] instead.
+func ExecPod(t testing.TestingT, options *KubectlOptions, podName string, containerName string, command ...string) string {
+	t.Helper()
+
+	return ExecPodContext(t, context.Background(), options, podName, containerName, command...)
+}
+
+// ExecPodE executes a command in a container within a Kubernetes pod and returns the output. Set containerName to "" if
+// there is only one container in the pod.
+//
+// Deprecated: Use [ExecPodContextE] instead.
+func ExecPodE(t testing.TestingT, options *KubectlOptions, podName string, containerName string, command ...string) (string, error) {
+	return ExecPodContextE(t, context.Background(), options, podName, containerName, command...)
 }

--- a/modules/k8s/replicaset.go
+++ b/modules/k8s/replicaset.go
@@ -10,27 +10,17 @@ import (
 	"github.com/gruntwork-io/terratest/modules/testing"
 )
 
-// ListReplicaSets will look for replicasets in the given namespace that match the given filters and return them. This will
-// fail the test if there is an error.
+// ListReplicaSetsContextE looks up replicasets in the given namespace that match the given filters and return them.
+// The ctx parameter supports cancellation and timeouts.
 //
 //nolint:gocritic // hugeParam: cannot change public function signature
-func ListReplicaSets(t testing.TestingT, options *KubectlOptions, filters metav1.ListOptions) []appsv1.ReplicaSet {
-	replicaset, err := ListReplicaSetsE(t, options, filters)
-	require.NoError(t, err)
-
-	return replicaset
-}
-
-// ListReplicaSetsE will look for replicasets in the given namespace that match the given filters and return them.
-//
-//nolint:gocritic // hugeParam: cannot change public function signature
-func ListReplicaSetsE(t testing.TestingT, options *KubectlOptions, filters metav1.ListOptions) ([]appsv1.ReplicaSet, error) {
-	clientset, err := GetKubernetesClientFromOptionsE(t, options)
+func ListReplicaSetsContextE(t testing.TestingT, ctx context.Context, options *KubectlOptions, filters metav1.ListOptions) ([]appsv1.ReplicaSet, error) {
+	clientset, err := GetKubernetesClientFromOptionsContextE(t, ctx, options)
 	if err != nil {
 		return nil, err
 	}
 
-	replicasets, err := clientset.AppsV1().ReplicaSets(options.Namespace).List(context.Background(), filters)
+	replicasets, err := clientset.AppsV1().ReplicaSets(options.Namespace).List(ctx, filters)
 	if err != nil {
 		return nil, err
 	}
@@ -38,21 +28,75 @@ func ListReplicaSetsE(t testing.TestingT, options *KubectlOptions, filters metav
 	return replicasets.Items, nil
 }
 
-// GetReplicaSet returns a Kubernetes replicaset resource in the provided namespace with the given name. This will
-// fail the test if there is an error.
-func GetReplicaSet(t testing.TestingT, options *KubectlOptions, replicaSetName string) *appsv1.ReplicaSet {
-	replicaset, err := GetReplicaSetE(t, options, replicaSetName)
+// ListReplicaSetsContext looks up replicasets in the given namespace that match the given filters and return them.
+// The ctx parameter supports cancellation and timeouts.
+// This will fail the test if there is an error.
+//
+//nolint:gocritic // hugeParam: cannot change public function signature
+func ListReplicaSetsContext(t testing.TestingT, ctx context.Context, options *KubectlOptions, filters metav1.ListOptions) []appsv1.ReplicaSet {
+	t.Helper()
+	replicaset, err := ListReplicaSetsContextE(t, ctx, options, filters)
 	require.NoError(t, err)
 
 	return replicaset
 }
 
-// GetReplicaSetE returns a Kubernetes replicaset resource in the provided namespace with the given name.
-func GetReplicaSetE(t testing.TestingT, options *KubectlOptions, replicaSetName string) (*appsv1.ReplicaSet, error) {
-	clientset, err := GetKubernetesClientFromOptionsE(t, options)
+// ListReplicaSets will look for replicasets in the given namespace that match the given filters and return them. This will
+// fail the test if there is an error.
+//
+// Deprecated: Use [ListReplicaSetsContext] instead.
+//
+//nolint:gocritic // hugeParam: cannot change public function signature
+func ListReplicaSets(t testing.TestingT, options *KubectlOptions, filters metav1.ListOptions) []appsv1.ReplicaSet {
+	t.Helper()
+
+	return ListReplicaSetsContext(t, context.Background(), options, filters)
+}
+
+// ListReplicaSetsE will look for replicasets in the given namespace that match the given filters and return them.
+//
+// Deprecated: Use [ListReplicaSetsContextE] instead.
+//
+//nolint:gocritic // hugeParam: cannot change public function signature
+func ListReplicaSetsE(t testing.TestingT, options *KubectlOptions, filters metav1.ListOptions) ([]appsv1.ReplicaSet, error) {
+	return ListReplicaSetsContextE(t, context.Background(), options, filters)
+}
+
+// GetReplicaSetContextE returns a Kubernetes replicaset resource in the provided namespace with the given name.
+// The ctx parameter supports cancellation and timeouts.
+func GetReplicaSetContextE(t testing.TestingT, ctx context.Context, options *KubectlOptions, replicaSetName string) (*appsv1.ReplicaSet, error) {
+	clientset, err := GetKubernetesClientFromOptionsContextE(t, ctx, options)
 	if err != nil {
 		return nil, err
 	}
 
-	return clientset.AppsV1().ReplicaSets(options.Namespace).Get(context.Background(), replicaSetName, metav1.GetOptions{})
+	return clientset.AppsV1().ReplicaSets(options.Namespace).Get(ctx, replicaSetName, metav1.GetOptions{})
+}
+
+// GetReplicaSetContext returns a Kubernetes replicaset resource in the provided namespace with the given name.
+// The ctx parameter supports cancellation and timeouts.
+// This will fail the test if there is an error.
+func GetReplicaSetContext(t testing.TestingT, ctx context.Context, options *KubectlOptions, replicaSetName string) *appsv1.ReplicaSet {
+	t.Helper()
+	replicaset, err := GetReplicaSetContextE(t, ctx, options, replicaSetName)
+	require.NoError(t, err)
+
+	return replicaset
+}
+
+// GetReplicaSet returns a Kubernetes replicaset resource in the provided namespace with the given name. This will
+// fail the test if there is an error.
+//
+// Deprecated: Use [GetReplicaSetContext] instead.
+func GetReplicaSet(t testing.TestingT, options *KubectlOptions, replicaSetName string) *appsv1.ReplicaSet {
+	t.Helper()
+
+	return GetReplicaSetContext(t, context.Background(), options, replicaSetName)
+}
+
+// GetReplicaSetE returns a Kubernetes replicaset resource in the provided namespace with the given name.
+//
+// Deprecated: Use [GetReplicaSetContextE] instead.
+func GetReplicaSetE(t testing.TestingT, options *KubectlOptions, replicaSetName string) (*appsv1.ReplicaSet, error) {
+	return GetReplicaSetContextE(t, context.Background(), options, replicaSetName)
 }

--- a/modules/k8s/role.go
+++ b/modules/k8s/role.go
@@ -9,22 +9,44 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// GetRole returns a Kubernetes role resource in the provided namespace with the given name. The namespace used
-// is the one provided in the KubectlOptions. This will fail the test if there is an error.
-func GetRole(t testing.TestingT, options *KubectlOptions, roleName string) *rbacv1.Role {
-	role, err := GetRoleE(t, options, roleName)
+// GetRoleContextE returns a Kubernetes role resource in the provided namespace with the given name.
+// The namespace used is the one provided in the KubectlOptions.
+// The ctx parameter supports cancellation and timeouts.
+func GetRoleContextE(t testing.TestingT, ctx context.Context, options *KubectlOptions, roleName string) (*rbacv1.Role, error) {
+	clientset, err := GetKubernetesClientFromOptionsContextE(t, ctx, options)
+	if err != nil {
+		return nil, err
+	}
+
+	return clientset.RbacV1().Roles(options.Namespace).Get(ctx, roleName, metav1.GetOptions{})
+}
+
+// GetRoleContext returns a Kubernetes role resource in the provided namespace with the given name.
+// The namespace used is the one provided in the KubectlOptions.
+// The ctx parameter supports cancellation and timeouts.
+// This will fail the test if there is an error.
+func GetRoleContext(t testing.TestingT, ctx context.Context, options *KubectlOptions, roleName string) *rbacv1.Role {
+	t.Helper()
+	role, err := GetRoleContextE(t, ctx, options, roleName)
 	require.NoError(t, err)
 
 	return role
 }
 
+// GetRole returns a Kubernetes role resource in the provided namespace with the given name. The namespace used
+// is the one provided in the KubectlOptions. This will fail the test if there is an error.
+//
+// Deprecated: Use [GetRoleContext] instead.
+func GetRole(t testing.TestingT, options *KubectlOptions, roleName string) *rbacv1.Role {
+	t.Helper()
+
+	return GetRoleContext(t, context.Background(), options, roleName)
+}
+
 // GetRoleE returns a Kubernetes role resource in the provided namespace with the given name. The namespace used
 // is the one provided in the KubectlOptions.
+//
+// Deprecated: Use [GetRoleContextE] instead.
 func GetRoleE(t testing.TestingT, options *KubectlOptions, roleName string) (*rbacv1.Role, error) {
-	clientset, err := GetKubernetesClientFromOptionsE(t, options)
-	if err != nil {
-		return nil, err
-	}
-
-	return clientset.RbacV1().Roles(options.Namespace).Get(context.Background(), roleName, metav1.GetOptions{})
+	return GetRoleContextE(t, context.Background(), options, roleName)
 }

--- a/modules/k8s/secret.go
+++ b/modules/k8s/secret.go
@@ -12,37 +12,62 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// GetSecret returns a Kubernetes secret resource in the provided namespace with the given name. The namespace used
-// is the one provided in the KubectlOptions. This will fail the test if there is an error.
-func GetSecret(t testing.TestingT, options *KubectlOptions, secretName string) *corev1.Secret {
-	secret, err := GetSecretE(t, options, secretName)
+// GetSecretContextE returns a Kubernetes secret resource in the provided namespace with the given name. The namespace
+// used is the one provided in the KubectlOptions.
+// The ctx parameter supports cancellation and timeouts.
+func GetSecretContextE(t testing.TestingT, ctx context.Context, options *KubectlOptions, secretName string) (*corev1.Secret, error) {
+	clientset, err := GetKubernetesClientFromOptionsContextE(t, ctx, options)
+	if err != nil {
+		return nil, err
+	}
+
+	return clientset.CoreV1().Secrets(options.Namespace).Get(ctx, secretName, metav1.GetOptions{})
+}
+
+// GetSecretContext returns a Kubernetes secret resource in the provided namespace with the given name. The namespace
+// used is the one provided in the KubectlOptions.
+// The ctx parameter supports cancellation and timeouts.
+// This will fail the test if there is an error.
+func GetSecretContext(t testing.TestingT, ctx context.Context, options *KubectlOptions, secretName string) *corev1.Secret {
+	t.Helper()
+	secret, err := GetSecretContextE(t, ctx, options, secretName)
 	require.NoError(t, err)
 
 	return secret
 }
 
-// GetSecretE returns a Kubernetes secret resource in the provided namespace with the given name. The namespace used
-// is the one provided in the KubectlOptions.
-func GetSecretE(t testing.TestingT, options *KubectlOptions, secretName string) (*corev1.Secret, error) {
-	clientset, err := GetKubernetesClientFromOptionsE(t, options)
-	if err != nil {
-		return nil, err
-	}
+// GetSecret returns a Kubernetes secret resource in the provided namespace with the given name. The namespace used
+// is the one provided in the KubectlOptions. This will fail the test if there is an error.
+//
+// Deprecated: Use [GetSecretContext] instead.
+func GetSecret(t testing.TestingT, options *KubectlOptions, secretName string) *corev1.Secret {
+	t.Helper()
 
-	return clientset.CoreV1().Secrets(options.Namespace).Get(context.Background(), secretName, metav1.GetOptions{})
+	return GetSecretContext(t, context.Background(), options, secretName)
 }
 
-// WaitUntilSecretAvailable waits until the secret is present on the cluster in cases where it is not immediately
-// available (for example, when using ClusterIssuer to request a certificate).
-func WaitUntilSecretAvailable(t testing.TestingT, options *KubectlOptions, secretName string, retries int, sleepBetweenRetries time.Duration) {
+// GetSecretE returns a Kubernetes secret resource in the provided namespace with the given name. The namespace used
+// is the one provided in the KubectlOptions.
+//
+// Deprecated: Use [GetSecretContextE] instead.
+func GetSecretE(t testing.TestingT, options *KubectlOptions, secretName string) (*corev1.Secret, error) {
+	return GetSecretContextE(t, context.Background(), options, secretName)
+}
+
+// WaitUntilSecretAvailableContextE waits until the secret is present on the cluster in cases where it is not
+// immediately available (for example, when using ClusterIssuer to request a certificate).
+// The ctx parameter supports cancellation and timeouts.
+func WaitUntilSecretAvailableContextE(t testing.TestingT, ctx context.Context, options *KubectlOptions, secretName string, retries int, sleepBetweenRetries time.Duration) error {
 	statusMsg := fmt.Sprintf("Wait for secret %s to be provisioned.", secretName)
-	message := retry.DoWithRetry(
+
+	message, err := retry.DoWithRetryContextE(
 		t,
+		ctx,
 		statusMsg,
 		retries,
 		sleepBetweenRetries,
 		func() (string, error) {
-			_, err := GetSecretE(t, options, secretName)
+			_, err := GetSecretContextE(t, ctx, options, secretName)
 			if err != nil {
 				return "", err
 			}
@@ -50,5 +75,30 @@ func WaitUntilSecretAvailable(t testing.TestingT, options *KubectlOptions, secre
 			return "Secret is now available", nil
 		},
 	)
+	if err != nil {
+		return err
+	}
+
 	options.Logger.Logf(t, "%s", message)
+
+	return nil
+}
+
+// WaitUntilSecretAvailableContext waits until the secret is present on the cluster in cases where it is not
+// immediately available (for example, when using ClusterIssuer to request a certificate).
+// The ctx parameter supports cancellation and timeouts.
+// This will fail the test if there is an error.
+func WaitUntilSecretAvailableContext(t testing.TestingT, ctx context.Context, options *KubectlOptions, secretName string, retries int, sleepBetweenRetries time.Duration) {
+	t.Helper()
+	err := WaitUntilSecretAvailableContextE(t, ctx, options, secretName, retries, sleepBetweenRetries)
+	require.NoError(t, err)
+}
+
+// WaitUntilSecretAvailable waits until the secret is present on the cluster in cases where it is not immediately
+// available (for example, when using ClusterIssuer to request a certificate).
+//
+// Deprecated: Use [WaitUntilSecretAvailableContext] instead.
+func WaitUntilSecretAvailable(t testing.TestingT, options *KubectlOptions, secretName string, retries int, sleepBetweenRetries time.Duration) {
+	t.Helper()
+	WaitUntilSecretAvailableContext(t, context.Background(), options, secretName, retries, sleepBetweenRetries)
 }

--- a/modules/k8s/self_subject_access_review.go
+++ b/modules/k8s/self_subject_access_review.go
@@ -11,23 +11,13 @@ import (
 	"github.com/gruntwork-io/terratest/modules/testing"
 )
 
-// CanIDo returns whether or not the provided action is allowed by the client configured by the provided kubectl option.
-// This will fail if there are any errors accessing the kubernetes API (but not if the action is denied).
+// CanIDoContextE returns whether or not the provided action is allowed by the client configured by the provided kubectl option.
+// This will return an error if there are problems accessing the kubernetes API (but not if the action is simply denied).
+// The ctx parameter supports cancellation and timeouts.
 //
 //nolint:gocritic // hugeParam: cannot change public function signature
-func CanIDo(t testing.TestingT, options *KubectlOptions, action authv1.ResourceAttributes) bool {
-	allowed, err := CanIDoE(t, options, action)
-	require.NoError(t, err)
-
-	return allowed
-}
-
-// CanIDoE returns whether or not the provided action is allowed by the client configured by the provided kubectl option.
-// This will an error if there are problems accessing the kubernetes API (but not if the action is simply denied).
-//
-//nolint:gocritic // hugeParam: cannot change public function signature
-func CanIDoE(t testing.TestingT, options *KubectlOptions, action authv1.ResourceAttributes) (bool, error) {
-	clientset, err := GetKubernetesClientFromOptionsE(t, options)
+func CanIDoContextE(t testing.TestingT, ctx context.Context, options *KubectlOptions, action authv1.ResourceAttributes) (bool, error) {
+	clientset, err := GetKubernetesClientFromOptionsContextE(t, ctx, options)
 	if err != nil {
 		return false, err
 	}
@@ -36,7 +26,7 @@ func CanIDoE(t testing.TestingT, options *KubectlOptions, action authv1.Resource
 		Spec: authv1.SelfSubjectAccessReviewSpec{ResourceAttributes: &action},
 	}
 
-	resp, err := clientset.AuthorizationV1().SelfSubjectAccessReviews().Create(context.Background(), &check, metav1.CreateOptions{})
+	resp, err := clientset.AuthorizationV1().SelfSubjectAccessReviews().Create(ctx, &check, metav1.CreateOptions{})
 	if err != nil {
 		return false, errors.WithStackTrace(err)
 	}
@@ -46,4 +36,39 @@ func CanIDoE(t testing.TestingT, options *KubectlOptions, action authv1.Resource
 	}
 
 	return resp.Status.Allowed, nil
+}
+
+// CanIDoContext returns whether or not the provided action is allowed by the client configured by the provided kubectl option.
+// The ctx parameter supports cancellation and timeouts.
+// This will fail if there are any errors accessing the kubernetes API (but not if the action is denied).
+//
+//nolint:gocritic // hugeParam: cannot change public function signature
+func CanIDoContext(t testing.TestingT, ctx context.Context, options *KubectlOptions, action authv1.ResourceAttributes) bool {
+	t.Helper()
+	allowed, err := CanIDoContextE(t, ctx, options, action)
+	require.NoError(t, err)
+
+	return allowed
+}
+
+// CanIDo returns whether or not the provided action is allowed by the client configured by the provided kubectl option.
+// This will fail if there are any errors accessing the kubernetes API (but not if the action is denied).
+//
+// Deprecated: Use [CanIDoContext] instead.
+//
+//nolint:gocritic // hugeParam: cannot change public function signature
+func CanIDo(t testing.TestingT, options *KubectlOptions, action authv1.ResourceAttributes) bool {
+	t.Helper()
+
+	return CanIDoContext(t, context.Background(), options, action)
+}
+
+// CanIDoE returns whether or not the provided action is allowed by the client configured by the provided kubectl option.
+// This will an error if there are problems accessing the kubernetes API (but not if the action is simply denied).
+//
+// Deprecated: Use [CanIDoContextE] instead.
+//
+//nolint:gocritic // hugeParam: cannot change public function signature
+func CanIDoE(t testing.TestingT, options *KubectlOptions, action authv1.ResourceAttributes) (bool, error) {
+	return CanIDoContextE(t, context.Background(), options, action)
 }

--- a/modules/k8s/service.go
+++ b/modules/k8s/service.go
@@ -22,7 +22,7 @@ import (
 //
 //nolint:gocritic // hugeParam: cannot change public function signature
 func ListServicesContextE(t testing.TestingT, ctx context.Context, options *KubectlOptions, filters metav1.ListOptions) ([]corev1.Service, error) {
-	clientset, err := GetKubernetesClientFromOptionsE(t, options)
+	clientset, err := GetKubernetesClientFromOptionsContextE(t, ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -72,7 +72,7 @@ func ListServicesE(t testing.TestingT, options *KubectlOptions, filters metav1.L
 // GetServiceContextE returns a Kubernetes service resource in the provided namespace with the given name.
 // The ctx parameter supports cancellation and timeouts.
 func GetServiceContextE(t testing.TestingT, ctx context.Context, options *KubectlOptions, serviceName string) (*corev1.Service, error) {
-	clientset, err := GetKubernetesClientFromOptionsE(t, options)
+	clientset, err := GetKubernetesClientFromOptionsContextE(t, ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -113,16 +113,13 @@ func GetServiceE(t testing.TestingT, options *KubectlOptions, serviceName string
 func WaitUntilServiceAvailableContextE(t testing.TestingT, ctx context.Context, options *KubectlOptions, serviceName string, retries int, sleepBetweenRetries time.Duration) error {
 	statusMsg := fmt.Sprintf("Wait for service %s to be provisioned.", serviceName)
 
-	message, err := retry.DoWithRetryE(
+	message, err := retry.DoWithRetryContextE(
 		t,
+		ctx,
 		statusMsg,
 		retries,
 		sleepBetweenRetries,
 		func() (string, error) {
-			if err := ctx.Err(); err != nil {
-				return "", err
-			}
-
 			service, err := GetServiceContextE(t, ctx, options, serviceName)
 			if err != nil {
 				return "", err
@@ -269,7 +266,7 @@ func findEndpointForNodePortServiceContext(
 	service *corev1.Service,
 	servicePort int32,
 ) (string, error) {
-	nodePort, err := FindNodePortE(service, servicePort)
+	nodePort, err := FindNodePortContextE(ctx, service, servicePort)
 	if err != nil {
 		return "", err
 	}
@@ -287,8 +284,9 @@ func findEndpointForNodePortServiceContext(
 	return fmt.Sprintf("%s:%d", nodeHostname, nodePort), nil
 }
 
-// FindNodePortE returns the allocated NodePort for the given servicePort from the service definition.
-func FindNodePortE(service *corev1.Service, servicePort int32) (int32, error) {
+// FindNodePortContextE returns the allocated NodePort for the given servicePort from the service definition.
+// The ctx parameter is accepted for API consistency but is not used since this is a local struct lookup.
+func FindNodePortContextE(_ context.Context, service *corev1.Service, servicePort int32) (int32, error) {
 	for _, port := range service.Spec.Ports {
 		if port.Port == servicePort {
 			return port.NodePort, nil
@@ -296,6 +294,25 @@ func FindNodePortE(service *corev1.Service, servicePort int32) (int32, error) {
 	}
 
 	return -1, NewUnknownServicePortError(service, servicePort)
+}
+
+// FindNodePortContext returns the allocated NodePort for the given servicePort from the service definition.
+// The ctx parameter is accepted for API consistency but is not used since this is a local struct lookup.
+// This will fail the test if there is an error.
+func FindNodePortContext(t testing.TestingT, ctx context.Context, service *corev1.Service, servicePort int32) int32 {
+	t.Helper()
+
+	nodePort, err := FindNodePortContextE(ctx, service, servicePort)
+	require.NoError(t, err)
+
+	return nodePort
+}
+
+// FindNodePortE returns the allocated NodePort for the given servicePort from the service definition.
+//
+// Deprecated: Use [FindNodePortContextE] instead.
+func FindNodePortE(service *corev1.Service, servicePort int32) (int32, error) {
+	return FindNodePortContextE(context.Background(), service, servicePort)
 }
 
 // pickRandomNode will pick a random node in the kubernetes cluster

--- a/modules/k8s/service_account.go
+++ b/modules/k8s/service_account.go
@@ -26,36 +26,53 @@ const (
 	tokenSecretSleepSeconds = 10
 )
 
-// GetServiceAccount returns a Kubernetes service account resource in the provided namespace with the given name. The
-// namespace used is the one provided in the KubectlOptions. This will fail the test if there is an error.
-func GetServiceAccount(t testing.TestingT, options *KubectlOptions, serviceAccountName string) *corev1.ServiceAccount {
-	serviceAccount, err := GetServiceAccountE(t, options, serviceAccountName)
+// GetServiceAccountContextE returns a Kubernetes service account resource in the provided namespace with the given name.
+// The namespace used is the one provided in the KubectlOptions.
+// The ctx parameter supports cancellation and timeouts.
+func GetServiceAccountContextE(t testing.TestingT, ctx context.Context, options *KubectlOptions, serviceAccountName string) (*corev1.ServiceAccount, error) {
+	clientset, err := GetKubernetesClientFromOptionsContextE(t, ctx, options)
+	if err != nil {
+		return nil, err
+	}
+
+	return clientset.CoreV1().ServiceAccounts(options.Namespace).Get(ctx, serviceAccountName, metav1.GetOptions{})
+}
+
+// GetServiceAccountContext returns a Kubernetes service account resource in the provided namespace with the given name.
+// The namespace used is the one provided in the KubectlOptions.
+// The ctx parameter supports cancellation and timeouts.
+// This will fail the test if there is an error.
+func GetServiceAccountContext(t testing.TestingT, ctx context.Context, options *KubectlOptions, serviceAccountName string) *corev1.ServiceAccount {
+	t.Helper()
+	serviceAccount, err := GetServiceAccountContextE(t, ctx, options, serviceAccountName)
 	require.NoError(t, err)
 
 	return serviceAccount
 }
 
+// GetServiceAccount returns a Kubernetes service account resource in the provided namespace with the given name. The
+// namespace used is the one provided in the KubectlOptions. This will fail the test if there is an error.
+//
+// Deprecated: Use [GetServiceAccountContext] instead.
+func GetServiceAccount(t testing.TestingT, options *KubectlOptions, serviceAccountName string) *corev1.ServiceAccount {
+	t.Helper()
+
+	return GetServiceAccountContext(t, context.Background(), options, serviceAccountName)
+}
+
 // GetServiceAccountE returns a Kubernetes service account resource in the provided namespace with the given name. The
 // namespace used is the one provided in the KubectlOptions.
+//
+// Deprecated: Use [GetServiceAccountContextE] instead.
 func GetServiceAccountE(t testing.TestingT, options *KubectlOptions, serviceAccountName string) (*corev1.ServiceAccount, error) {
-	clientset, err := GetKubernetesClientFromOptionsE(t, options)
-	if err != nil {
-		return nil, err
-	}
-
-	return clientset.CoreV1().ServiceAccounts(options.Namespace).Get(context.Background(), serviceAccountName, metav1.GetOptions{})
+	return GetServiceAccountContextE(t, context.Background(), options, serviceAccountName)
 }
 
-// CreateServiceAccount will create a new service account resource in the provided namespace with the given name. The
-// namespace used is the one provided in the KubectlOptions. This will fail the test if there is an error.
-func CreateServiceAccount(t testing.TestingT, options *KubectlOptions, serviceAccountName string) {
-	require.NoError(t, CreateServiceAccountE(t, options, serviceAccountName))
-}
-
-// CreateServiceAccountE will create a new service account resource in the provided namespace with the given name. The
-// namespace used is the one provided in the KubectlOptions.
-func CreateServiceAccountE(t testing.TestingT, options *KubectlOptions, serviceAccountName string) error {
-	clientset, err := GetKubernetesClientFromOptionsE(t, options)
+// CreateServiceAccountContextE will create a new service account resource in the provided namespace with the given name.
+// The namespace used is the one provided in the KubectlOptions.
+// The ctx parameter supports cancellation and timeouts.
+func CreateServiceAccountContextE(t testing.TestingT, ctx context.Context, options *KubectlOptions, serviceAccountName string) error {
+	clientset, err := GetKubernetesClientFromOptionsContextE(t, ctx, options)
 	if err != nil {
 		return err
 	}
@@ -66,25 +83,43 @@ func CreateServiceAccountE(t testing.TestingT, options *KubectlOptions, serviceA
 			Namespace: options.Namespace,
 		},
 	}
-	_, err = clientset.CoreV1().ServiceAccounts(options.Namespace).Create(context.Background(), &serviceAccount, metav1.CreateOptions{})
+	_, err = clientset.CoreV1().ServiceAccounts(options.Namespace).Create(ctx, &serviceAccount, metav1.CreateOptions{})
 
 	return err
 }
 
-// GetServiceAccountAuthToken will retrieve the ServiceAccount token from the cluster so it can be used to
-// authenticate requests as that ServiceAccount. This will fail the test if there is an error.
-func GetServiceAccountAuthToken(t testing.TestingT, kubectlOptions *KubectlOptions, serviceAccountName string) string {
-	token, err := GetServiceAccountAuthTokenE(t, kubectlOptions, serviceAccountName)
-	require.NoError(t, err)
-
-	return token
+// CreateServiceAccountContext will create a new service account resource in the provided namespace with the given name.
+// The namespace used is the one provided in the KubectlOptions.
+// The ctx parameter supports cancellation and timeouts.
+// This will fail the test if there is an error.
+func CreateServiceAccountContext(t testing.TestingT, ctx context.Context, options *KubectlOptions, serviceAccountName string) {
+	t.Helper()
+	require.NoError(t, CreateServiceAccountContextE(t, ctx, options, serviceAccountName))
 }
 
-// GetServiceAccountAuthTokenE will retrieve the ServiceAccount token from the cluster so it can be used to
+// CreateServiceAccount will create a new service account resource in the provided namespace with the given name. The
+// namespace used is the one provided in the KubectlOptions. This will fail the test if there is an error.
+//
+// Deprecated: Use [CreateServiceAccountContext] instead.
+func CreateServiceAccount(t testing.TestingT, options *KubectlOptions, serviceAccountName string) {
+	t.Helper()
+	CreateServiceAccountContext(t, context.Background(), options, serviceAccountName)
+}
+
+// CreateServiceAccountE will create a new service account resource in the provided namespace with the given name. The
+// namespace used is the one provided in the KubectlOptions.
+//
+// Deprecated: Use [CreateServiceAccountContextE] instead.
+func CreateServiceAccountE(t testing.TestingT, options *KubectlOptions, serviceAccountName string) error {
+	return CreateServiceAccountContextE(t, context.Background(), options, serviceAccountName)
+}
+
+// GetServiceAccountAuthTokenContextE will retrieve the ServiceAccount token from the cluster so it can be used to
 // authenticate requests as that ServiceAccount.
 // On K8s 1.24+, service account tokens are no longer auto-created as secrets, so this uses the TokenRequest API.
-func GetServiceAccountAuthTokenE(t testing.TestingT, kubectlOptions *KubectlOptions, serviceAccountName string) (string, error) {
-	clientset, err := GetKubernetesClientFromOptionsE(t, kubectlOptions)
+// The ctx parameter supports cancellation and timeouts.
+func GetServiceAccountAuthTokenContextE(t testing.TestingT, ctx context.Context, kubectlOptions *KubectlOptions, serviceAccountName string) (string, error) {
+	clientset, err := GetKubernetesClientFromOptionsContextE(t, ctx, kubectlOptions)
 	if err != nil {
 		return "", err
 	}
@@ -98,7 +133,7 @@ func GetServiceAccountAuthTokenE(t testing.TestingT, kubectlOptions *KubectlOpti
 	}
 
 	tokenResponse, err := clientset.CoreV1().ServiceAccounts(kubectlOptions.Namespace).CreateToken(
-		context.Background(),
+		ctx,
 		serviceAccountName,
 		tokenRequest,
 		metav1.CreateOptions{},
@@ -110,15 +145,20 @@ func GetServiceAccountAuthTokenE(t testing.TestingT, kubectlOptions *KubectlOpti
 	// Fall back to legacy secret-based tokens for older K8s versions
 	kubectlOptions.Logger.Logf(t, "TokenRequest API failed (%s), falling back to secret-based tokens", err)
 
-	msg, retryErr := retry.DoWithRetryE(
+	msg, retryErr := retry.DoWithRetryContextE(
 		t,
+		ctx,
 		"Waiting for ServiceAccount Token to be provisioned",
 		tokenSecretRetryCount,
 		tokenSecretSleepSeconds*time.Second,
 		func() (string, error) {
 			kubectlOptions.Logger.Logf(t, "Checking if service account has secret")
 
-			serviceAccount := GetServiceAccount(t, kubectlOptions, serviceAccountName)
+			serviceAccount, err := GetServiceAccountContextE(t, ctx, kubectlOptions, serviceAccountName)
+			if err != nil {
+				return "", err
+			}
+
 			if len(serviceAccount.Secrets) == 0 {
 				msg := "no secrets on the service account yet"
 				kubectlOptions.Logger.Logf(t, "%s", msg)
@@ -135,7 +175,7 @@ func GetServiceAccountAuthTokenE(t testing.TestingT, kubectlOptions *KubectlOpti
 
 	kubectlOptions.Logger.Logf(t, "%s", msg)
 
-	serviceAccount, err := GetServiceAccountE(t, kubectlOptions, serviceAccountName)
+	serviceAccount, err := GetServiceAccountContextE(t, ctx, kubectlOptions, serviceAccountName)
 	if err != nil {
 		return "", err
 	}
@@ -144,9 +184,43 @@ func GetServiceAccountAuthTokenE(t testing.TestingT, kubectlOptions *KubectlOpti
 		return "", errors.WithStackTrace(ServiceAccountTokenNotAvailable{serviceAccountName})
 	}
 
-	secret := GetSecret(t, kubectlOptions, serviceAccount.Secrets[0].Name)
+	secret, err := GetSecretContextE(t, ctx, kubectlOptions, serviceAccount.Secrets[0].Name)
+	if err != nil {
+		return "", err
+	}
 
 	return string(secret.Data["token"]), nil
+}
+
+// GetServiceAccountAuthTokenContext will retrieve the ServiceAccount token from the cluster so it can be used to
+// authenticate requests as that ServiceAccount.
+// The ctx parameter supports cancellation and timeouts.
+// This will fail the test if there is an error.
+func GetServiceAccountAuthTokenContext(t testing.TestingT, ctx context.Context, kubectlOptions *KubectlOptions, serviceAccountName string) string {
+	t.Helper()
+	token, err := GetServiceAccountAuthTokenContextE(t, ctx, kubectlOptions, serviceAccountName)
+	require.NoError(t, err)
+
+	return token
+}
+
+// GetServiceAccountAuthToken will retrieve the ServiceAccount token from the cluster so it can be used to
+// authenticate requests as that ServiceAccount. This will fail the test if there is an error.
+//
+// Deprecated: Use [GetServiceAccountAuthTokenContext] instead.
+func GetServiceAccountAuthToken(t testing.TestingT, kubectlOptions *KubectlOptions, serviceAccountName string) string {
+	t.Helper()
+
+	return GetServiceAccountAuthTokenContext(t, context.Background(), kubectlOptions, serviceAccountName)
+}
+
+// GetServiceAccountAuthTokenE will retrieve the ServiceAccount token from the cluster so it can be used to
+// authenticate requests as that ServiceAccount.
+// On K8s 1.24+, service account tokens are no longer auto-created as secrets, so this uses the TokenRequest API.
+//
+// Deprecated: Use [GetServiceAccountAuthTokenContextE] instead.
+func GetServiceAccountAuthTokenE(t testing.TestingT, kubectlOptions *KubectlOptions, serviceAccountName string) (string, error) {
+	return GetServiceAccountAuthTokenContextE(t, context.Background(), kubectlOptions, serviceAccountName)
 }
 
 // AddConfigContextForServiceAccountE will add a new config context that binds the ServiceAccount auth token to the

--- a/modules/k8s/version.go
+++ b/modules/k8s/version.go
@@ -1,22 +1,47 @@
 package k8s
 
-import "github.com/gruntwork-io/terratest/modules/testing"
+import (
+	"context"
 
-// GetKubernetesClusterVersionE returns the Kubernetes cluster version.
-func GetKubernetesClusterVersionE(t testing.TestingT) (string, error) {
-	kubeConfigPath, err := GetKubeConfigPathE(t)
+	"github.com/gruntwork-io/terratest/modules/testing"
+	"github.com/stretchr/testify/require"
+)
+
+// GetKubernetesClusterVersionContextE returns the Kubernetes cluster version.
+// The ctx parameter is accepted for API consistency.
+func GetKubernetesClusterVersionContextE(t testing.TestingT, ctx context.Context) (string, error) {
+	kubeConfigPath, err := GetKubeConfigPathContextE(t, ctx)
 	if err != nil {
 		return "", err
 	}
 
 	options := NewKubectlOptions("", kubeConfigPath, "default")
 
-	return GetKubernetesClusterVersionWithOptionsE(t, options)
+	return GetKubernetesClusterVersionWithOptionsContextE(t, ctx, options)
 }
 
-// GetKubernetesClusterVersionWithOptionsE returns the Kubernetes cluster version given a configured KubectlOptions object.
-func GetKubernetesClusterVersionWithOptionsE(t testing.TestingT, kubectlOptions *KubectlOptions) (string, error) {
-	clientset, err := GetKubernetesClientFromOptionsE(t, kubectlOptions)
+// GetKubernetesClusterVersionContext returns the Kubernetes cluster version.
+// The ctx parameter is accepted for API consistency.
+// This will fail the test if there is an error.
+func GetKubernetesClusterVersionContext(t testing.TestingT, ctx context.Context) string {
+	t.Helper()
+	version, err := GetKubernetesClusterVersionContextE(t, ctx)
+	require.NoError(t, err)
+
+	return version
+}
+
+// GetKubernetesClusterVersionE returns the Kubernetes cluster version.
+//
+// Deprecated: Use [GetKubernetesClusterVersionContextE] instead.
+func GetKubernetesClusterVersionE(t testing.TestingT) (string, error) {
+	return GetKubernetesClusterVersionContextE(t, context.Background())
+}
+
+// GetKubernetesClusterVersionWithOptionsContextE returns the Kubernetes cluster version given a configured KubectlOptions object.
+// The ctx parameter is accepted for API consistency.
+func GetKubernetesClusterVersionWithOptionsContextE(t testing.TestingT, ctx context.Context, kubectlOptions *KubectlOptions) (string, error) {
+	clientset, err := GetKubernetesClientFromOptionsContextE(t, ctx, kubectlOptions)
 	if err != nil {
 		return "", err
 	}
@@ -27,4 +52,22 @@ func GetKubernetesClusterVersionWithOptionsE(t testing.TestingT, kubectlOptions 
 	}
 
 	return versionInfo.String(), nil
+}
+
+// GetKubernetesClusterVersionWithOptionsContext returns the Kubernetes cluster version given a configured KubectlOptions object.
+// The ctx parameter is accepted for API consistency.
+// This will fail the test if there is an error.
+func GetKubernetesClusterVersionWithOptionsContext(t testing.TestingT, ctx context.Context, kubectlOptions *KubectlOptions) string {
+	t.Helper()
+	version, err := GetKubernetesClusterVersionWithOptionsContextE(t, ctx, kubectlOptions)
+	require.NoError(t, err)
+
+	return version
+}
+
+// GetKubernetesClusterVersionWithOptionsE returns the Kubernetes cluster version given a configured KubectlOptions object.
+//
+// Deprecated: Use [GetKubernetesClusterVersionWithOptionsContextE] instead.
+func GetKubernetesClusterVersionWithOptionsE(t testing.TestingT, kubectlOptions *KubectlOptions) (string, error) {
+	return GetKubernetesClusterVersionWithOptionsContextE(t, context.Background(), kubectlOptions)
 }

--- a/modules/packer/packer.go
+++ b/modules/packer/packer.go
@@ -169,7 +169,7 @@ func BuildArtifactContextE(t testing.TestingT, ctx context.Context, options *Opt
 
 	description := fmt.Sprintf("%s %v", cmd.Command, cmd.Args)
 
-	output, err := retry.DoWithRetryableErrorsE(t, description, options.RetryableErrors, options.MaxRetries, options.TimeBetweenRetries, func() (string, error) {
+	output, err := retry.DoWithRetryableErrorsContextE(t, ctx, description, options.RetryableErrors, options.MaxRetries, options.TimeBetweenRetries, func() (string, error) {
 		return shell.RunCommandContextAndGetOutputE(t, ctx, &cmd)
 	})
 	if err != nil {
@@ -312,7 +312,7 @@ func packerInit(t testing.TestingT, ctx context.Context, options *Options) error
 
 	description := "Running Packer init"
 
-	_, err = retry.DoWithRetryableErrorsE(t, description, options.RetryableErrors, options.MaxRetries, options.TimeBetweenRetries, func() (string, error) {
+	_, err = retry.DoWithRetryableErrorsContextE(t, ctx, description, options.RetryableErrors, options.MaxRetries, options.TimeBetweenRetries, func() (string, error) {
 		return shell.RunCommandContextAndGetOutputE(t, ctx, &cmd)
 	})
 

--- a/modules/retry/retry.go
+++ b/modules/retry/retry.go
@@ -22,8 +22,17 @@ type Either struct {
 
 // DoWithTimeout runs the specified action and waits up to the specified timeout for it to complete. Return the output of the action if
 // it completes on time or fail the test otherwise.
+//
+// Deprecated: Use [DoWithTimeoutContext] instead.
 func DoWithTimeout(t testing.TestingT, actionDescription string, timeout time.Duration, action func() (string, error)) string {
-	out, err := DoWithTimeoutE(t, actionDescription, timeout, action)
+	return DoWithTimeoutContext(t, context.Background(), actionDescription, timeout, action)
+}
+
+// DoWithTimeoutContext runs the specified action and waits up to the specified timeout for it to complete. Return the
+// output of the action if it completes on time or fail the test otherwise. The ctx parameter supports cancellation
+// and timeouts.
+func DoWithTimeoutContext(t testing.TestingT, ctx context.Context, actionDescription string, timeout time.Duration, action func() (string, error)) string {
+	out, err := DoWithTimeoutContextE(t, ctx, actionDescription, timeout, action)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -33,8 +42,17 @@ func DoWithTimeout(t testing.TestingT, actionDescription string, timeout time.Du
 
 // DoWithTimeoutE runs the specified action and waits up to the specified timeout for it to complete. Return the output of the action if
 // it completes on time or an error otherwise.
+//
+// Deprecated: Use [DoWithTimeoutContextE] instead.
 func DoWithTimeoutE(t testing.TestingT, actionDescription string, timeout time.Duration, action func() (string, error)) (string, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	return DoWithTimeoutContextE(t, context.Background(), actionDescription, timeout, action)
+}
+
+// DoWithTimeoutContextE runs the specified action and waits up to the specified timeout for it to complete. Return the
+// output of the action if it completes on time or an error otherwise. The ctx parameter supports cancellation and
+// timeouts.
+func DoWithTimeoutContextE(t testing.TestingT, ctx context.Context, actionDescription string, timeout time.Duration, action func() (string, error)) (string, error) {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
 	resultChannel := make(chan Either, 1)
@@ -55,8 +73,18 @@ func DoWithTimeoutE(t testing.TestingT, actionDescription string, timeout time.D
 // DoWithRetry runs the specified action. If it returns a string, return that string. If it returns a FatalError, return that error
 // immediately. If it returns any other type of error, sleep for sleepBetweenRetries and try again, up to a maximum of
 // maxRetries retries. If maxRetries is exceeded, fail the test.
+//
+// Deprecated: Use [DoWithRetryContext] instead.
 func DoWithRetry(t testing.TestingT, actionDescription string, maxRetries int, sleepBetweenRetries time.Duration, action func() (string, error)) string {
-	out, err := DoWithRetryE(t, actionDescription, maxRetries, sleepBetweenRetries, action)
+	return DoWithRetryContext(t, context.Background(), actionDescription, maxRetries, sleepBetweenRetries, action)
+}
+
+// DoWithRetryContext runs the specified action. If it returns a string, return that string. If it returns a FatalError,
+// return that error immediately. If it returns any other type of error, sleep for sleepBetweenRetries and try again, up
+// to a maximum of maxRetries retries. If maxRetries is exceeded, fail the test. The ctx parameter supports cancellation
+// and timeouts.
+func DoWithRetryContext(t testing.TestingT, ctx context.Context, actionDescription string, maxRetries int, sleepBetweenRetries time.Duration, action func() (string, error)) string {
+	out, err := DoWithRetryContextE(t, ctx, actionDescription, maxRetries, sleepBetweenRetries, action)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -67,8 +95,18 @@ func DoWithRetry(t testing.TestingT, actionDescription string, maxRetries int, s
 // DoWithRetryE runs the specified action. If it returns a string, return that string. If it returns a FatalError, return that error
 // immediately. If it returns any other type of error, sleep for sleepBetweenRetries and try again, up to a maximum of
 // maxRetries retries. If maxRetries is exceeded, return a MaxRetriesExceeded error.
+//
+// Deprecated: Use [DoWithRetryContextE] instead.
 func DoWithRetryE(t testing.TestingT, actionDescription string, maxRetries int, sleepBetweenRetries time.Duration, action func() (string, error)) (string, error) {
-	out, err := DoWithRetryInterfaceE(t, actionDescription, maxRetries, sleepBetweenRetries, func() (any, error) { return action() })
+	return DoWithRetryContextE(t, context.Background(), actionDescription, maxRetries, sleepBetweenRetries, action)
+}
+
+// DoWithRetryContextE runs the specified action. If it returns a string, return that string. If it returns a FatalError,
+// return that error immediately. If it returns any other type of error, sleep for sleepBetweenRetries and try again, up
+// to a maximum of maxRetries retries. If maxRetries is exceeded, return a MaxRetriesExceeded error. The ctx parameter
+// supports cancellation and timeouts.
+func DoWithRetryContextE(t testing.TestingT, ctx context.Context, actionDescription string, maxRetries int, sleepBetweenRetries time.Duration, action func() (string, error)) (string, error) {
+	out, err := DoWithRetryInterfaceContextE(t, ctx, actionDescription, maxRetries, sleepBetweenRetries, func() (any, error) { return action() })
 
 	return out.(string), err
 }
@@ -76,8 +114,18 @@ func DoWithRetryE(t testing.TestingT, actionDescription string, maxRetries int, 
 // DoWithRetryInterface runs the specified action. If it returns a value, return that value. If it returns a FatalError, return that error
 // immediately. If it returns any other type of error, sleep for sleepBetweenRetries and try again, up to a maximum of
 // maxRetries retries. If maxRetries is exceeded, fail the test.
+//
+// Deprecated: Use [DoWithRetryInterfaceContext] instead.
 func DoWithRetryInterface(t testing.TestingT, actionDescription string, maxRetries int, sleepBetweenRetries time.Duration, action func() (any, error)) any {
-	out, err := DoWithRetryInterfaceE(t, actionDescription, maxRetries, sleepBetweenRetries, action)
+	return DoWithRetryInterfaceContext(t, context.Background(), actionDescription, maxRetries, sleepBetweenRetries, action)
+}
+
+// DoWithRetryInterfaceContext runs the specified action. If it returns a value, return that value. If it returns a
+// FatalError, return that error immediately. If it returns any other type of error, sleep for sleepBetweenRetries and
+// try again, up to a maximum of maxRetries retries. If maxRetries is exceeded, fail the test. The ctx parameter
+// supports cancellation and timeouts.
+func DoWithRetryInterfaceContext(t testing.TestingT, ctx context.Context, actionDescription string, maxRetries int, sleepBetweenRetries time.Duration, action func() (any, error)) any {
+	out, err := DoWithRetryInterfaceContextE(t, ctx, actionDescription, maxRetries, sleepBetweenRetries, action)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -88,12 +136,26 @@ func DoWithRetryInterface(t testing.TestingT, actionDescription string, maxRetri
 // DoWithRetryInterfaceE runs the specified action. If it returns a value, return that value. If it returns a FatalError, return that error
 // immediately. If it returns any other type of error, sleep for sleepBetweenRetries and try again, up to a maximum of
 // maxRetries retries. If maxRetries is exceeded, return a MaxRetriesExceeded error.
+//
+// Deprecated: Use [DoWithRetryInterfaceContextE] instead.
 func DoWithRetryInterfaceE(t testing.TestingT, actionDescription string, maxRetries int, sleepBetweenRetries time.Duration, action func() (any, error)) (any, error) {
+	return DoWithRetryInterfaceContextE(t, context.Background(), actionDescription, maxRetries, sleepBetweenRetries, action)
+}
+
+// DoWithRetryInterfaceContextE runs the specified action. If it returns a value, return that value. If it returns a
+// FatalError, return that error immediately. If it returns any other type of error, sleep for sleepBetweenRetries and
+// try again, up to a maximum of maxRetries retries. If maxRetries is exceeded, return a MaxRetriesExceeded error. The
+// ctx parameter supports cancellation and timeouts.
+func DoWithRetryInterfaceContextE(t testing.TestingT, ctx context.Context, actionDescription string, maxRetries int, sleepBetweenRetries time.Duration, action func() (any, error)) (any, error) {
 	var output any
 
 	var err error
 
 	for i := 0; i <= maxRetries; i++ {
+		if err := ctx.Err(); err != nil {
+			return output, err
+		}
+
 		logger.Default.Logf(t, "%s", actionDescription)
 
 		output, err = action()
@@ -109,7 +171,13 @@ func DoWithRetryInterfaceE(t testing.TestingT, actionDescription string, maxRetr
 		}
 
 		logger.Default.Logf(t, "%s returned an error: %s. Sleeping for %s and will try again.", actionDescription, err.Error(), sleepBetweenRetries)
-		time.Sleep(sleepBetweenRetries)
+
+		select {
+		case <-time.After(sleepBetweenRetries):
+			// Continue to next retry
+		case <-ctx.Done():
+			return output, ctx.Err()
+		}
 	}
 
 	return output, MaxRetriesExceeded{Description: actionDescription, MaxRetries: maxRetries}
@@ -120,8 +188,20 @@ func DoWithRetryInterfaceE(t testing.TestingT, actionDescription string, maxRetr
 // matches any of the regular expressions in the specified retryableErrors map. If there is a match, sleep for
 // sleepBetweenRetries, and retry the specified action, up to a maximum of maxRetries retries. If there is no match,
 // return that error immediately, wrapped in a FatalError. If maxRetries is exceeded, return a MaxRetriesExceeded error.
+//
+// Deprecated: Use [DoWithRetryableErrorsContext] instead.
 func DoWithRetryableErrors(t testing.TestingT, actionDescription string, retryableErrors map[string]string, maxRetries int, sleepBetweenRetries time.Duration, action func() (string, error)) string {
-	out, err := DoWithRetryableErrorsE(t, actionDescription, retryableErrors, maxRetries, sleepBetweenRetries, action)
+	return DoWithRetryableErrorsContext(t, context.Background(), actionDescription, retryableErrors, maxRetries, sleepBetweenRetries, action)
+}
+
+// DoWithRetryableErrorsContext runs the specified action. If it returns a value, return that value. If it returns an
+// error, check if error message or the string output from the action (which is often stdout/stderr from running some
+// command) matches any of the regular expressions in the specified retryableErrors map. If there is a match, sleep for
+// sleepBetweenRetries, and retry the specified action, up to a maximum of maxRetries retries. If there is no match,
+// return that error immediately, wrapped in a FatalError. If maxRetries is exceeded, return a MaxRetriesExceeded error.
+// The ctx parameter supports cancellation and timeouts.
+func DoWithRetryableErrorsContext(t testing.TestingT, ctx context.Context, actionDescription string, retryableErrors map[string]string, maxRetries int, sleepBetweenRetries time.Duration, action func() (string, error)) string {
+	out, err := DoWithRetryableErrorsContextE(t, ctx, actionDescription, retryableErrors, maxRetries, sleepBetweenRetries, action)
 	require.NoError(t, err)
 
 	return out
@@ -132,7 +212,19 @@ func DoWithRetryableErrors(t testing.TestingT, actionDescription string, retryab
 // matches any of the regular expressions in the specified retryableErrors map. If there is a match, sleep for
 // sleepBetweenRetries, and retry the specified action, up to a maximum of maxRetries retries. If there is no match,
 // return that error immediately, wrapped in a FatalError. If maxRetries is exceeded, return a MaxRetriesExceeded error.
+//
+// Deprecated: Use [DoWithRetryableErrorsContextE] instead.
 func DoWithRetryableErrorsE(t testing.TestingT, actionDescription string, retryableErrors map[string]string, maxRetries int, sleepBetweenRetries time.Duration, action func() (string, error)) (string, error) {
+	return DoWithRetryableErrorsContextE(t, context.Background(), actionDescription, retryableErrors, maxRetries, sleepBetweenRetries, action)
+}
+
+// DoWithRetryableErrorsContextE runs the specified action. If it returns a value, return that value. If it returns an
+// error, check if error message or the string output from the action (which is often stdout/stderr from running some
+// command) matches any of the regular expressions in the specified retryableErrors map. If there is a match, sleep for
+// sleepBetweenRetries, and retry the specified action, up to a maximum of maxRetries retries. If there is no match,
+// return that error immediately, wrapped in a FatalError. If maxRetries is exceeded, return a MaxRetriesExceeded error.
+// The ctx parameter supports cancellation and timeouts.
+func DoWithRetryableErrorsContextE(t testing.TestingT, ctx context.Context, actionDescription string, retryableErrors map[string]string, maxRetries int, sleepBetweenRetries time.Duration, action func() (string, error)) (string, error) {
 	retryableErrorsRegexp := map[*regexp.Regexp]string{}
 
 	for errorStr, errorMessage := range retryableErrors {
@@ -144,7 +236,7 @@ func DoWithRetryableErrorsE(t testing.TestingT, actionDescription string, retrya
 		retryableErrorsRegexp[errorRegex] = errorMessage
 	}
 
-	return DoWithRetryE(t, actionDescription, maxRetries, sleepBetweenRetries, func() (string, error) {
+	return DoWithRetryContextE(t, ctx, actionDescription, maxRetries, sleepBetweenRetries, func() (string, error) {
 		output, err := action()
 		if err == nil {
 			return output, nil
@@ -173,11 +265,28 @@ func (done Done) Done() {
 
 // DoInBackgroundUntilStopped runs the specified action in the background (in a goroutine) repeatedly, waiting the specified amount of time between
 // repetitions. To stop this action, call the Done() function on the returned value.
+//
+// Deprecated: Use [DoInBackgroundUntilStoppedContext] instead.
 func DoInBackgroundUntilStopped(t testing.TestingT, actionDescription string, sleepBetweenRepeats time.Duration, action func()) Done {
+	return DoInBackgroundUntilStoppedContext(t, context.Background(), actionDescription, sleepBetweenRepeats, action)
+}
+
+// DoInBackgroundUntilStoppedContext runs the specified action in the background (in a goroutine) repeatedly, waiting
+// the specified amount of time between repetitions. To stop this action, cancel the ctx or call the Done() function on
+// the returned value. The ctx parameter supports cancellation and timeouts.
+func DoInBackgroundUntilStoppedContext(t testing.TestingT, ctx context.Context, actionDescription string, sleepBetweenRepeats time.Duration, action func()) Done {
 	stop := make(chan bool)
 
 	go func() {
 		for {
+			select {
+			case <-ctx.Done():
+				logger.Default.Logf(t, "Context cancelled for action '%s'.", actionDescription)
+				return
+			default:
+				// Continue
+			}
+
 			logger.Default.Logf(t, "Executing action '%s'", actionDescription)
 
 			action()
@@ -189,6 +298,9 @@ func DoInBackgroundUntilStopped(t testing.TestingT, actionDescription string, sl
 				// Nothing to do, just allow the loop to continue
 			case <-stop:
 				logger.Default.Logf(t, "Received stop signal for action '%s'.", actionDescription)
+				return
+			case <-ctx.Done():
+				logger.Default.Logf(t, "Context cancelled for action '%s'.", actionDescription)
 				return
 			}
 		}

--- a/modules/slack/validate_test.go
+++ b/modules/slack/validate_test.go
@@ -39,8 +39,9 @@ func TestValidateSlackMessage(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	retry.DoWithRetry(
+	retry.DoWithRetryContext(
 		t,
+		t.Context(),
 		"wait for slack message",
 		10, 10*time.Second,
 		func() (string, error) {

--- a/modules/ssh/ssh.go
+++ b/modules/ssh/ssh.go
@@ -367,7 +367,7 @@ func CheckSSHConnectionWithRetryContextE(t testing.TestingT, ctx context.Context
 		handler = f[0]
 	}
 
-	_, err := retry.DoWithRetryE(t, "Checking SSH connection to "+host.Hostname, retries, sleepBetweenRetries, func() (string, error) {
+	_, err := retry.DoWithRetryContextE(t, ctx, "Checking SSH connection to "+host.Hostname, retries, sleepBetweenRetries, func() (string, error) {
 		return "", handler(t, ctx, host)
 	})
 
@@ -489,7 +489,7 @@ func CheckSSHCommandWithRetryContextE(t testing.TestingT, ctx context.Context, h
 		handler = f[0]
 	}
 
-	return retry.DoWithRetryE(t, "Checking SSH connection to "+host.Hostname, retries, sleepBetweenRetries, func() (string, error) {
+	return retry.DoWithRetryContextE(t, ctx, "Checking SSH connection to "+host.Hostname, retries, sleepBetweenRetries, func() (string, error) {
 		return handler(t, ctx, host, command)
 	})
 }

--- a/modules/terraform/cmd.go
+++ b/modules/terraform/cmd.go
@@ -85,7 +85,7 @@ func RunTerraformCommandContextE(t testing.TestingT, ctx context.Context, additi
 	cmd := generateCommand(options, args...)
 	description := fmt.Sprintf("%s %v", options.TerraformBinary, args)
 
-	return retry.DoWithRetryableErrorsE(t, description, options.RetryableTerraformErrors, options.MaxRetries, options.TimeBetweenRetries, func() (string, error) {
+	return retry.DoWithRetryableErrorsContextE(t, ctx, description, options.RetryableTerraformErrors, options.MaxRetries, options.TimeBetweenRetries, func() (string, error) {
 		s, err := shell.RunCommandContextAndGetOutputE(t, ctx, &cmd)
 		if err != nil {
 			return s, err
@@ -165,7 +165,7 @@ func RunTerraformCommandAndGetStdOutErrCodeContextE(t testing.TestingT, ctx cont
 
 	exit = DefaultErrorExitCode
 
-	_, err = retry.DoWithRetryableErrorsE(t, description, options.RetryableTerraformErrors, options.MaxRetries, options.TimeBetweenRetries, func() (string, error) {
+	_, err = retry.DoWithRetryableErrorsContextE(t, ctx, description, options.RetryableTerraformErrors, options.MaxRetries, options.TimeBetweenRetries, func() (string, error) {
 		stdout, stderr, err = shell.RunCommandContextAndGetStdOutErrE(t, ctx, &cmd)
 		if err != nil {
 			exitCode, getExitCodeErr := shell.GetExitCodeForRunCommandError(err)

--- a/modules/terragrunt/cmd.go
+++ b/modules/terragrunt/cmd.go
@@ -59,8 +59,9 @@ func executeTerragruntCommand(t testing.TestingT, ctx context.Context, opts *Opt
 	commandDescription := fmt.Sprintf("%s %v", opts.TerragruntBinary, finalArgs)
 
 	// Execute the command with retry logic and error handling
-	return retry.DoWithRetryableErrorsE(
+	return retry.DoWithRetryableErrorsContextE(
 		t,
+		ctx,
 		commandDescription,
 		opts.RetryableTerraformErrors,
 		opts.MaxRetries,

--- a/modules/version-checker/version_checker.go
+++ b/modules/version-checker/version_checker.go
@@ -77,7 +77,7 @@ func CheckVersionContextE(
 func CheckVersion(
 	t testing.TestingT,
 	params CheckVersionParams) {
-	require.NoError(t, CheckVersionE(t, params))
+	CheckVersionContext(t, context.Background(), params)
 }
 
 // CheckVersionContext is like CheckVersion but includes a context.

--- a/test/azure/terraform_azure_aks_example_test.go
+++ b/test/azure/terraform_azure_aks_example_test.go
@@ -67,15 +67,15 @@ func TestTerraformAzureAKSExample(t *testing.T) {
 	// - Current context of the kubectl config file
 	options := k8s.NewKubectlOptions("", "../../examples/azure/terraform-azure-aks-example/kubeconfig", namespaceName)
 
-	k8s.CreateNamespace(t, options, namespaceName)
+	k8s.CreateNamespaceContext(t, t.Context(), options, namespaceName)
 	// ... and make sure to delete the namespace at the end of the test
-	defer k8s.DeleteNamespace(t, options, namespaceName)
+	defer k8s.DeleteNamespaceContext(t, t.Context(), options, namespaceName)
 
 	// At the end of the test, run `kubectl delete -f RESOURCE_CONFIG` to clean up any resources that were created.
-	defer k8s.KubectlDelete(t, options, kubeResourcePath)
+	defer k8s.KubectlDeleteContext(t, t.Context(), options, kubeResourcePath)
 
 	// This will run `kubectl apply -f RESOURCE_CONFIG` and fail the test if there are any errors
-	k8s.KubectlApply(t, options, kubeResourcePath)
+	k8s.KubectlApplyContext(t, t.Context(), options, kubeResourcePath)
 
 	// This will wait up to 10 seconds for the service to become available, to ensure that we can access it.
 	k8s.WaitUntilServiceAvailableContext(t, t.Context(), options, "nginx-service", 10, 20*time.Second)

--- a/test/azure/terraform_azure_storage_example_test.go
+++ b/test/azure/terraform_azure_storage_example_test.go
@@ -65,7 +65,7 @@ func TestTerraformAzureStorageExample(t *testing.T) {
 	assert.Equal(t, storageAccountTier, skuTier, "sku tier mismatch")
 
 	actualDNSString := azure.GetStorageDNSStringContext(t, t.Context(), storageAccountName, resourceGroupName, subscriptionID)
-	storageSuffix, _ := azure.GetStorageURISuffixE()
+	storageSuffix, _ := azure.GetStorageURISuffixContextE(t.Context())
 	expectedDNS := fmt.Sprintf("https://%s.blob.%s/", storageAccountName, storageSuffix)
 	assert.Equal(t, expectedDNS, actualDNSString, "Storage DNS string mismatch")
 }

--- a/test/gcp/terraform_gcp_example_test.go
+++ b/test/gcp/terraform_gcp_example_test.go
@@ -82,7 +82,7 @@ func TestTerraformGcpExample(t *testing.T) {
 	expectedText := "testing-tag-value2"
 
 	// website::tag::4::Check if the GCP instance contains a given tag.
-	retry.DoWithRetry(t, fmt.Sprintf("Checking Instance %s for labels", instanceName), maxRetries, timeBetweenRetries, func() (string, error) {
+	retry.DoWithRetryContext(t, t.Context(), fmt.Sprintf("Checking Instance %s for labels", instanceName), maxRetries, timeBetweenRetries, func() (string, error) {
 		// Look up the tags for the given Instance ID
 		instance := gcp.FetchInstanceContext(t, t.Context(), projectID, instanceName)
 		instanceLabels := instance.GetLabelsContext(t, t.Context())
@@ -153,7 +153,7 @@ func TestSshAccessToComputeInstance(t *testing.T) {
 	maxRetries := 20
 	sleepBetweenRetries := 3 * time.Second
 
-	retry.DoWithRetry(t, "Attempting to SSH", maxRetries, sleepBetweenRetries, func() (string, error) {
+	retry.DoWithRetryContext(t, t.Context(), "Attempting to SSH", maxRetries, sleepBetweenRetries, func() (string, error) {
 		output, err := ssh.CheckSSHCommandContextE(t, t.Context(), &host, fmt.Sprintf("echo '%s'", sampleText))
 		if err != nil {
 			return "", err

--- a/test/gcp/terraform_gcp_ig_example_test.go
+++ b/test/gcp/terraform_gcp_ig_example_test.go
@@ -56,7 +56,7 @@ func TestTerraformGcpInstanceGroupExample(t *testing.T) {
 	maxRetries := 100
 	sleepBetweenRetries := 3 * time.Second
 
-	retry.DoWithRetry(t, "Attempting to fetch Instances from Instance Group", maxRetries, sleepBetweenRetries, func() (string, error) {
+	retry.DoWithRetryContext(t, t.Context(), "Attempting to fetch Instances from Instance Group", maxRetries, sleepBetweenRetries, func() (string, error) {
 		instances, err := instanceGroup.GetInstancesContextE(t, t.Context(), projectID)
 		if err != nil {
 			return "", fmt.Errorf("Failed to get Instances: %w", err)
@@ -70,7 +70,7 @@ func TestTerraformGcpInstanceGroupExample(t *testing.T) {
 	})
 
 	// Validate that we get the right number of IP addresses
-	retry.DoWithRetry(t, "Attempting to fetch Public IP addresses from Instance Group", maxRetries, sleepBetweenRetries, func() (string, error) {
+	retry.DoWithRetryContext(t, t.Context(), "Attempting to fetch Public IP addresses from Instance Group", maxRetries, sleepBetweenRetries, func() (string, error) {
 		ips, err := instanceGroup.GetPublicIPsContextE(t, t.Context(), projectID)
 		if err != nil {
 			return "", errors.New("Failed to get public IPs from Instance Group")

--- a/test/helm_basic_example_integration_test.go
+++ b/test/helm_basic_example_integration_test.go
@@ -43,9 +43,9 @@ func TestHelmBasicExampleDeployment(t *testing.T) {
 	// - Current context of the kubectl config file
 	kubectlOptions := k8s.NewKubectlOptions("", "", namespaceName)
 
-	k8s.CreateNamespace(t, kubectlOptions, namespaceName)
+	k8s.CreateNamespaceContext(t, t.Context(), kubectlOptions, namespaceName)
 	// ... and make sure to delete the namespace at the end of the test
-	defer k8s.DeleteNamespace(t, kubectlOptions, namespaceName)
+	defer k8s.DeleteNamespaceContext(t, t.Context(), kubectlOptions, namespaceName)
 
 	// Setup the args. For this test, we will set the following input values:
 	// - containerImageRepo=nginx

--- a/test/helm_keda_remote_example_template_snapshot_test.go
+++ b/test/helm_keda_remote_example_template_snapshot_test.go
@@ -70,7 +70,7 @@ func TestHelmKedaRemoteExampleTemplateRenderedDeploymentDump(t *testing.T) { //n
 	require.Equal(t, expectedMetricsServerReplica, deploymentMetricsServerReplica)
 
 	// write chart manifest to a local filesystem directory
-	helm.UpdateSnapshot(t, options, output, releaseName)
+	helm.UpdateSnapshotContext(t, t.Context(), options, output, releaseName)
 }
 
 // An example of how to verify the rendered template object of a Helm Chart given various inputs.
@@ -113,7 +113,7 @@ func TestHelmKedaRemoteExampleTemplateRenderedDeploymentDiff(t *testing.T) { //n
 	require.Equal(t, expectedMetricsServerReplica, deploymentMetricsServerReplica)
 
 	// run the diff and assert the number of diffs
-	require.Equal(t, 4, helm.DiffAgainstSnapshot(t, options, output, releaseName))
+	require.Equal(t, 4, helm.DiffAgainstSnapshotContext(t, t.Context(), options, output, releaseName))
 }
 
 // An example of how to store a snapshot of the current manaifest for future comparison
@@ -142,7 +142,7 @@ func TestHelmKedaRemoteExampleTemplateRenderedPackageDump(t *testing.T) { //noli
 	output := helm.RenderRemoteTemplateContext(t, t.Context(), options, "https://kedacore.github.io/charts", releaseName, []string{})
 
 	// write chart manifest to a local filesystem directory
-	helm.UpdateSnapshot(t, options, output, releaseName)
+	helm.UpdateSnapshotContext(t, t.Context(), options, output, releaseName)
 }
 
 // An example of how to verify the current helm k8s manifest against a previous snapshot
@@ -172,5 +172,5 @@ func TestHelmKedaRemoteExampleTemplateRenderedPackageDiff(t *testing.T) { //noli
 
 	// run the diff and assert the number of diffs matches the number of diffs in the snapshot
 	// (namespace diffs + intentional value changes for replicas/memory)
-	require.Equal(t, 27, helm.DiffAgainstSnapshot(t, options, output, releaseName))
+	require.Equal(t, 27, helm.DiffAgainstSnapshotContext(t, t.Context(), options, output, releaseName))
 }

--- a/test/helm_log_redirect_integration_test.go
+++ b/test/helm_log_redirect_integration_test.go
@@ -41,8 +41,8 @@ func TestHelmLogsRedirect(t *testing.T) {
 	// - Current context of the kubectl config file
 	kubectlOptions := k8s.NewKubectlOptions("", "", namespaceName)
 
-	k8s.CreateNamespace(t, kubectlOptions, namespaceName)
-	defer k8s.DeleteNamespace(t, kubectlOptions, namespaceName)
+	k8s.CreateNamespaceContext(t, t.Context(), kubectlOptions, namespaceName)
+	defer k8s.DeleteNamespaceContext(t, t.Context(), kubectlOptions, namespaceName)
 
 	customLogger := helmLogger{}
 

--- a/test/kubernetes_basic_example_logs_test.go
+++ b/test/kubernetes_basic_example_logs_test.go
@@ -41,22 +41,22 @@ func setupLogsTest(t *testing.T) (*k8s.KubectlOptions, v1.Pod) {
 	// - Current context of the kubectl config file
 	options := k8s.NewKubectlOptions("", "", namespaceName)
 
-	k8s.CreateNamespace(t, options, namespaceName)
+	k8s.CreateNamespaceContext(t, t.Context(), options, namespaceName)
 	// ... and make sure to delete the namespace at the end of the test
-	defer k8s.DeleteNamespace(t, options, namespaceName)
+	defer k8s.DeleteNamespaceContext(t, t.Context(), options, namespaceName)
 
 	// At the end of the test, run `kubectl delete -f RESOURCE_CONFIG` to clean up any resources that were created.
-	defer k8s.KubectlDelete(t, options, kubeResourcePath)
+	defer k8s.KubectlDeleteContext(t, t.Context(), options, kubeResourcePath)
 
 	// This will run `kubectl apply -f RESOURCE_CONFIG` and fail the test if there are any errors
-	k8s.KubectlApply(t, options, kubeResourcePath)
+	k8s.KubectlApplyContext(t, t.Context(), options, kubeResourcePath)
 
 	// Wait for at least 1 Pod to be ready from the DaemonSet
 	retries := 10
 	sleep := time.Second * 1
 
 	for i := 1; i < retries; i++ {
-		podsReady := k8s.GetDaemonSet(t, options, "podinfo-deamonset").Status.NumberReady
+		podsReady := k8s.GetDaemonSetContext(t, t.Context(), options, "podinfo-deamonset").Status.NumberReady
 		if podsReady > 0 {
 			break
 		}
@@ -69,7 +69,7 @@ func setupLogsTest(t *testing.T) (*k8s.KubectlOptions, v1.Pod) {
 	listOptions.LabelSelector = "app=podinfo"
 
 	// Get a list of Pods. The pods are not guaranteed to be in running state.
-	pods := k8s.ListPods(t, options, *listOptions)
+	pods := k8s.ListPodsContext(t, t.Context(), options, *listOptions)
 
 	// Check that we did not timeout waiting for the Pod of the DaemonSet to be ready
 	require.NotEmpty(t, pods)
@@ -77,21 +77,21 @@ func setupLogsTest(t *testing.T) (*k8s.KubectlOptions, v1.Pod) {
 	pod := pods[0]
 
 	// Wait fot the pod to be started and ready
-	k8s.WaitUntilPodAvailable(t, options, pod.Name, 5, 10*time.Second)
+	k8s.WaitUntilPodAvailableContext(t, t.Context(), options, pod.Name, 5, 10*time.Second)
 
 	return options, pod
 }
 
 func TestKubernetesBasicExampleLogsCheckWithContainerName(t *testing.T) { //nolint:paralleltest // t.Parallel called in setupLogsTest
 	options, pod := setupLogsTest(t)
-	logs := k8s.GetPodLogs(t, options, &pod, "podinfo")
+	logs := k8s.GetPodLogsContext(t, t.Context(), options, &pod, "podinfo")
 
 	require.Contains(t, logs, "Starting podinfo")
 }
 
 func TestKubernetesBasicExampleLogsCheckWithNoContainerName(t *testing.T) { //nolint:paralleltest // t.Parallel called in setupLogsTest
 	options, pod := setupLogsTest(t)
-	logs := k8s.GetPodLogs(t, options, &pod, "")
+	logs := k8s.GetPodLogsContext(t, t.Context(), options, &pod, "")
 
 	require.Contains(t, logs, "Starting podinfo")
 }

--- a/test/kubernetes_basic_example_service_check_test.go
+++ b/test/kubernetes_basic_example_service_check_test.go
@@ -41,15 +41,15 @@ func TestKubernetesBasicExampleServiceCheck(t *testing.T) {
 	// - Current context of the kubectl config file
 	options := k8s.NewKubectlOptions("", "", namespaceName)
 
-	k8s.CreateNamespace(t, options, namespaceName)
+	k8s.CreateNamespaceContext(t, t.Context(), options, namespaceName)
 	// ... and make sure to delete the namespace at the end of the test
-	defer k8s.DeleteNamespace(t, options, namespaceName)
+	defer k8s.DeleteNamespaceContext(t, t.Context(), options, namespaceName)
 
 	// At the end of the test, run `kubectl delete -f RESOURCE_CONFIG` to clean up any resources that were created.
-	defer k8s.KubectlDelete(t, options, kubeResourcePath)
+	defer k8s.KubectlDeleteContext(t, t.Context(), options, kubeResourcePath)
 
 	// This will run `kubectl apply -f RESOURCE_CONFIG` and fail the test if there are any errors
-	k8s.KubectlApply(t, options, kubeResourcePath)
+	k8s.KubectlApplyContext(t, t.Context(), options, kubeResourcePath)
 
 	// This will wait up to 10 seconds for the service to become available, to ensure that we can access it.
 	k8s.WaitUntilServiceAvailableContext(t, t.Context(), options, "nginx-service", 10, 1*time.Second)

--- a/test/kubernetes_basic_example_test.go
+++ b/test/kubernetes_basic_example_test.go
@@ -40,16 +40,16 @@ func TestKubernetesBasicExample(t *testing.T) {
 	// - Random namespace
 	options := k8s.NewKubectlOptions("", "", namespaceName)
 
-	k8s.CreateNamespace(t, options, namespaceName)
+	k8s.CreateNamespaceContext(t, t.Context(), options, namespaceName)
 	// website::tag::5::Make sure to delete the namespace at the end of the test
-	defer k8s.DeleteNamespace(t, options, namespaceName)
+	defer k8s.DeleteNamespaceContext(t, t.Context(), options, namespaceName)
 
 	// website::tag::6::At the end of the test, run `kubectl delete -f RESOURCE_CONFIG` to clean up any resources that were created.
-	defer k8s.KubectlDelete(t, options, kubeResourcePath)
+	defer k8s.KubectlDeleteContext(t, t.Context(), options, kubeResourcePath)
 
 	// website::tag::3::Apply kubectl with 'kubectl apply -f RESOURCE_CONFIG' command.
 	// This will run `kubectl apply -f RESOURCE_CONFIG` and fail the test if there are any errors
-	k8s.KubectlApply(t, options, kubeResourcePath)
+	k8s.KubectlApplyContext(t, t.Context(), options, kubeResourcePath)
 
 	// website::tag::4::Check if NGINX service was deployed successfully.
 	// This will get the service resource and verify that it exists and was retrieved successfully. This function will

--- a/test/kubernetes_hello_world_example_test.go
+++ b/test/kubernetes_hello_world_example_test.go
@@ -23,10 +23,10 @@ func TestKubernetesHelloWorldExample(t *testing.T) {
 	options := k8s.NewKubectlOptions("", "", "default")
 
 	// website::tag::6:: At the end of the test, run "kubectl delete" to clean up any resources that were created.
-	defer k8s.KubectlDelete(t, options, kubeResourcePath)
+	defer k8s.KubectlDeleteContext(t, t.Context(), options, kubeResourcePath)
 
 	// website::tag::3:: Run `kubectl apply` to deploy. Fail the test if there are any errors.
-	k8s.KubectlApply(t, options, kubeResourcePath)
+	k8s.KubectlApplyContext(t, t.Context(), options, kubeResourcePath)
 
 	// website::tag::4:: Verify the service is available and get the URL for it.
 	k8s.WaitUntilServiceAvailableContext(t, t.Context(), options, "hello-world-service", 10, 1*time.Second)

--- a/test/kubernetes_kustomize_example_test.go
+++ b/test/kubernetes_kustomize_example_test.go
@@ -40,16 +40,16 @@ func TestKubernetesKustomizeExample(t *testing.T) {
 	// - Random namespace
 	options := k8s.NewKubectlOptions("", "", namespaceName)
 
-	k8s.CreateNamespace(t, options, namespaceName)
+	k8s.CreateNamespaceContext(t, t.Context(), options, namespaceName)
 	// website::tag::5::Make sure to delete the namespace at the end of the test
-	defer k8s.DeleteNamespace(t, options, namespaceName)
+	defer k8s.DeleteNamespaceContext(t, t.Context(), options, namespaceName)
 
 	// website::tag::6::At the end of the test, run `kubectl delete -f RESOURCE_CONFIG` to clean up any resources that were created.
-	defer k8s.KubectlDeleteFromKustomize(t, options, kubeResourcePath)
+	defer k8s.KubectlDeleteFromKustomizeContext(t, t.Context(), options, kubeResourcePath)
 
 	// website::tag::3::Apply kubectl with 'kubectl apply -f RESOURCE_CONFIG' command.
 	// This will run `kubectl apply -f RESOURCE_CONFIG` and fail the test if there are any errors
-	k8s.KubectlApplyFromKustomize(t, options, kubeResourcePath)
+	k8s.KubectlApplyFromKustomizeContext(t, t.Context(), options, kubeResourcePath)
 
 	// website::tag::4::Check if NGINX service was deployed successfully.
 	// This will get the service resource and verify that it exists and was retrieved successfully. This function will

--- a/test/kubernetes_rbac_example_test.go
+++ b/test/kubernetes_rbac_example_test.go
@@ -43,13 +43,13 @@ func TestKubernetesRBACExample(t *testing.T) {
 	options := k8s.NewKubectlOptions("", tmpConfigPath, namespaceName)
 
 	// At the end of the test, run `kubectl delete -f RESOURCE_CONFIG` to clean up any resources that were created.
-	defer k8s.KubectlDelete(t, options, kubeResourcePath)
+	defer k8s.KubectlDeleteContext(t, t.Context(), options, kubeResourcePath)
 
 	// This will run `kubectl apply -f RESOURCE_CONFIG` and fail the test if there are any errors
-	k8s.KubectlApply(t, options, kubeResourcePath)
+	k8s.KubectlApplyContext(t, t.Context(), options, kubeResourcePath)
 
 	// Retrieve authentication token for the newly created ServiceAccount
-	token := k8s.GetServiceAccountAuthToken(t, options, serviceAccountName)
+	token := k8s.GetServiceAccountAuthTokenContext(t, t.Context(), options, serviceAccountName)
 
 	// Now update the configuration to add a new context that can be used to make requests as that service account
 	require.NoError(t, k8s.AddConfigContextForServiceAccountE(
@@ -69,12 +69,12 @@ func TestKubernetesRBACExample(t *testing.T) {
 		Verb:      "list",
 		Resource:  "pod",
 	}
-	require.False(t, k8s.CanIDo(t, serviceAccountKubectlOptions, adminListPodAction))
+	require.False(t, k8s.CanIDoContext(t, t.Context(), serviceAccountKubectlOptions, adminListPodAction))
 	// - we can access the namespace the service account is in
 	namespaceListPodAction := authv1.ResourceAttributes{
 		Namespace: namespaceName,
 		Verb:      "list",
 		Resource:  "pod",
 	}
-	require.True(t, k8s.CanIDo(t, serviceAccountKubectlOptions, namespaceListPodAction))
+	require.True(t, k8s.CanIDoContext(t, t.Context(), serviceAccountKubectlOptions, namespaceListPodAction))
 }

--- a/test/kubernetes_rest_config_example_test.go
+++ b/test/kubernetes_rest_config_example_test.go
@@ -51,16 +51,16 @@ func TestKubernetesRestConfigBasicExampleConfig(t *testing.T) {
 	// website::tag::2:: Setup the kubectl config and context.
 	options := k8s.NewKubectlOptionsWithRestConfig(config, namespaceName)
 
-	k8s.CreateNamespace(t, options, namespaceName)
+	k8s.CreateNamespaceContext(t, t.Context(), options, namespaceName)
 	// website::tag::5::Make sure to delete the namespace at the end of the test
-	defer k8s.DeleteNamespace(t, options, namespaceName)
+	defer k8s.DeleteNamespaceContext(t, t.Context(), options, namespaceName)
 
 	// website::tag::6::At the end of the test, run `kubectl delete -f RESOURCE_CONFIG` to clean up any resources that were created.
-	defer k8s.KubectlDelete(t, options, kubeResourcePath)
+	defer k8s.KubectlDeleteContext(t, t.Context(), options, kubeResourcePath)
 
 	// website::tag::3::Apply kubectl with 'kubectl apply -f RESOURCE_CONFIG' command.
 	// This will run `kubectl apply -f RESOURCE_CONFIG` and fail the test if there are any errors
-	k8s.KubectlApply(t, options, kubeResourcePath)
+	k8s.KubectlApplyContext(t, t.Context(), options, kubeResourcePath)
 
 	// website::tag::4::Check if NGINX service was deployed successfully.
 	// This will get the service resource and verify that it exists and was retrieved successfully. This function will

--- a/test/terraform_database_example_test.go
+++ b/test/terraform_database_example_test.go
@@ -43,7 +43,7 @@ func TestTerraformDatabaseExample(t *testing.T) {
 	description := "Executing commands on database " + dbConfig.Host
 
 	// Verify that we can connect to the database and run SQL commands
-	retry.DoWithRetry(t, description, maxRetries, timeBetweenRetries, func() (string, error) {
+	retry.DoWithRetryContext(t, t.Context(), description, maxRetries, timeBetweenRetries, func() (string, error) {
 		// Connect to specific database, i.e. postgres
 		db, err := database.DBConnectionWithContextE(t, t.Context(), "postgres", &dbConfig)
 		if err != nil {

--- a/test/terraform_redeploy_example_test.go
+++ b/test/terraform_redeploy_example_test.go
@@ -172,7 +172,7 @@ func validateAsgRedeploy(t *testing.T, workingDir string) {
 	tlsConfig := tls.Config{}
 
 	// Check once per second that the ELB returns a proper response to make sure there is no downtime during deployment
-	elbChecks := retry.DoInBackgroundUntilStopped(t, "Check URL "+url, 1*time.Second, func() {
+	elbChecks := retry.DoInBackgroundUntilStoppedContext(t, t.Context(), "Check URL "+url, 1*time.Second, func() {
 		http_helper.HTTPGetWithCustomValidationContext(t, t.Context(), url, &tlsConfig, func(statusCode int, body string) bool {
 			return statusCode == 200 && (body == originalText || body == newText)
 		})

--- a/test/terraform_scp_example_test.go
+++ b/test/terraform_scp_example_test.go
@@ -302,7 +302,7 @@ func writeSampleDataToInstance(t *testing.T, publicInstanceIP string, sshUserNam
 	randomData := random.UniqueID()
 
 	// Verify that we can SSH to the Instance and run commands
-	retry.DoWithRetry(t, description, maxRetries, timeBetweenRetries, func() (string, error) {
+	retry.DoWithRetryContext(t, t.Context(), description, maxRetries, timeBetweenRetries, func() (string, error) {
 		_, err := ssh.CheckSSHCommandContextE(t, t.Context(), &publicHost, fmt.Sprintf("mkdir -p %s && touch %s && touch %s && echo \"%s\" >> %s", remoteTempFolder, remoteTempFilePath, remoteTempFilePath2, randomData, remoteTempFilePath))
 		if err != nil {
 			return "", err
@@ -328,7 +328,7 @@ func cleanup(t *testing.T, publicInstanceIP string, sshUserName string, keyPair 
 	description := "SSH to public host " + publicInstanceIP
 
 	// clean up the remote folder as we want may want to run another test case
-	defer retry.DoWithRetry(t, description, maxRetries, timeBetweenRetries, func() (string, error) {
+	defer retry.DoWithRetryContext(t, t.Context(), description, maxRetries, timeBetweenRetries, func() (string, error) {
 		_, err := ssh.CheckSSHCommandContextE(t, t.Context(), &publicHost, "rm -rf "+folderToClean)
 		if err != nil {
 			return "", err

--- a/test/terraform_ssh_certificate_example_test.go
+++ b/test/terraform_ssh_certificate_example_test.go
@@ -145,7 +145,7 @@ func testSSHCertificateToPublicHost(t *testing.T, terraformOptions *terraform.Op
 	command := fmt.Sprintf("echo -n '%s'", expectedTextSSHCert)
 
 	// Verify that we can SSH to the instance and run commands.
-	retry.DoWithRetry(t, description, maxRetries, timeBetweenRetries, func() (string, error) {
+	retry.DoWithRetryContext(t, t.Context(), description, maxRetries, timeBetweenRetries, func() (string, error) {
 		actualText, err := ssh.CheckSSHCommandContextE(t, t.Context(), &publicHost, command)
 		if err != nil {
 			return "", err
@@ -163,7 +163,7 @@ func testSSHCertificateToPublicHost(t *testing.T, terraformOptions *terraform.Op
 	description = "SSH to public host " + publicInstanceIP + " with error command"
 
 	// Verify that we can SSH to the instance, run the command which forces an error, and see the output.
-	retry.DoWithRetry(t, description, maxRetries, timeBetweenRetries, func() (string, error) {
+	retry.DoWithRetryContext(t, t.Context(), description, maxRetries, timeBetweenRetries, func() (string, error) {
 		actualText, err := ssh.CheckSSHCommandContextE(t, t.Context(), &publicHost, command)
 		if err == nil {
 			return "", errors.New("Expected SSH command to return an error but got none")

--- a/test/terraform_ssh_example_test.go
+++ b/test/terraform_ssh_example_test.go
@@ -124,7 +124,7 @@ func testSSHToPublicHost(t *testing.T, terraformOptions *terraform.Options, keyP
 	command := fmt.Sprintf("echo -n '%s'", expectedTextSSH)
 
 	// Verify that we can SSH to the Instance and run commands
-	retry.DoWithRetry(t, description, maxRetries, timeBetweenRetries, func() (string, error) {
+	retry.DoWithRetryContext(t, t.Context(), description, maxRetries, timeBetweenRetries, func() (string, error) {
 		actualText, err := ssh.CheckSSHCommandContextE(t, t.Context(), &publicHost, command)
 		if err != nil {
 			return "", err
@@ -142,7 +142,7 @@ func testSSHToPublicHost(t *testing.T, terraformOptions *terraform.Options, keyP
 	description = "SSH to public host " + publicInstanceIP + " with error command"
 
 	// Verify that we can SSH to the Instance, run the command and see the output
-	retry.DoWithRetry(t, description, maxRetries, timeBetweenRetries, func() (string, error) {
+	retry.DoWithRetryContext(t, t.Context(), description, maxRetries, timeBetweenRetries, func() (string, error) {
 		actualText, err := ssh.CheckSSHCommandContextE(t, t.Context(), &publicHost, command)
 		if err == nil {
 			return "", errors.New("Expected SSH command to return an error but got none")
@@ -196,7 +196,7 @@ func sshToPrivateHost(t *testing.T, publicInstanceIP string, privateInstanceIP s
 	command := fmt.Sprintf("echo -n '%s'", expectedTextSSH)
 
 	// Verify that we can SSH to the Instance and run commands
-	retry.DoWithRetry(t, description, maxRetries, timeBetweenRetries, func() (string, error) {
+	retry.DoWithRetryContext(t, t.Context(), description, maxRetries, timeBetweenRetries, func() (string, error) {
 		actualText, err := ssh.CheckPrivateSSHConnectionContextE(t, t.Context(), &publicHost, &privateHost, command)
 		if err != nil {
 			return "", err
@@ -230,7 +230,7 @@ func testSCPToPublicHost(t *testing.T, terraformOptions *terraform.Options, keyP
 	description := "SCP file to public host " + publicInstanceIP
 
 	// Verify that we can SSH to the Instance and run commands
-	retry.DoWithRetry(t, description, maxRetries, timeBetweenRetries, func() (string, error) {
+	retry.DoWithRetryContext(t, t.Context(), description, maxRetries, timeBetweenRetries, func() (string, error) {
 		err := ssh.SCPFileToContextE(t, t.Context(), &publicHost, os.FileMode(0644), "/tmp/test.txt", expectedTextSSH)
 		if err != nil {
 			return "", err
@@ -278,7 +278,7 @@ func testSSHAgentToPublicHost(t *testing.T, terraformOptions *terraform.Options,
 	command := fmt.Sprintf("echo -n '%s'", expectedTextSSH)
 
 	// Verify that we can SSH to the Instance and run commands
-	retry.DoWithRetry(t, description, maxRetries, timeBetweenRetries, func() (string, error) {
+	retry.DoWithRetryContext(t, t.Context(), description, maxRetries, timeBetweenRetries, func() (string, error) {
 		actualText, err := ssh.CheckSSHCommandContextE(t, t.Context(), &publicHost, command)
 		if err != nil {
 			return "", err
@@ -327,7 +327,7 @@ func testSSHAgentToPrivateHost(t *testing.T, terraformOptions *terraform.Options
 	command := fmt.Sprintf("echo -n '%s'", expectedTextSSH)
 
 	// Verify that we can SSH to the Instance and run commands
-	retry.DoWithRetry(t, description, maxRetries, timeBetweenRetries, func() (string, error) {
+	retry.DoWithRetryContext(t, t.Context(), description, maxRetries, timeBetweenRetries, func() (string, error) {
 		actualText, err := ssh.CheckPrivateSSHConnectionContextE(t, t.Context(), &publicHost, &privateHost, command)
 		if err != nil {
 			return "", err

--- a/test/terraform_ssh_password_example_test.go
+++ b/test/terraform_ssh_password_example_test.go
@@ -112,7 +112,7 @@ func testSSHPasswordToPublicHost(t *testing.T, terraformOptions *terraform.Optio
 	command := fmt.Sprintf("echo -n '%s'", expectedTextSSHPassword)
 
 	// Verify that we can SSH to the instance and run commands.
-	retry.DoWithRetry(t, description, maxRetries, timeBetweenRetries, func() (string, error) {
+	retry.DoWithRetryContext(t, t.Context(), description, maxRetries, timeBetweenRetries, func() (string, error) {
 		actualText, err := ssh.CheckSSHCommandContextE(t, t.Context(), &publicHost, command)
 		if err != nil {
 			return "", err
@@ -130,7 +130,7 @@ func testSSHPasswordToPublicHost(t *testing.T, terraformOptions *terraform.Optio
 	description = "SSH to public host " + publicInstanceIP + " with error command"
 
 	// Verify that we can SSH to the instance, run the command which forces an error, and see the output.
-	retry.DoWithRetry(t, description, maxRetries, timeBetweenRetries, func() (string, error) {
+	retry.DoWithRetryContext(t, t.Context(), description, maxRetries, timeBetweenRetries, func() (string, error) {
 		actualText, err := ssh.CheckSSHCommandContextE(t, t.Context(), &publicHost, command)
 		if err == nil {
 			return "", errors.New("Expected SSH command to return an error but got none")


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Marked all non-Context functions as deprecated, updated tests to use Context variants with t.Context()

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.
- [x] Make a plan for release of the functionality in this PR. If it delivers value to an end user, you are responsible for ensuring it is released promptly, and correctly. If you are not a maintainer, you are responsible for finding a maintainer to do this for you.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->
