### PR TITLE
fix(azure)!: v1.0.0 readiness — clean up API surface before stable release

### DIFF
--- a/modules/azure/client_factory.go
+++ b/modules/azure/client_factory.go
@@ -1,8 +1,6 @@
 // Package azure allows users to interact with resources on the Microsoft Azure platform.
 package azure
 
-// snippet-tag-start::client_factory_example.imports
-
 import (
 	"context"
 	"errors"
@@ -34,8 +32,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/synapse/armsynapse"
 )
-
-// snippet-tag-end::client_factory_example.imports
 
 const (
 	// AzureEnvironmentEnvName is the name of the Azure environment to use. Set to one of the following:
@@ -791,9 +787,9 @@ func CreateNsgCustomRulesClientE(subscriptionID string) (*armnetwork.SecurityRul
 	return CreateNsgCustomRulesClientContextE(context.Background(), subscriptionID)
 }
 
-// CreateNewNetworkInterfacesClientContextE returns a network interfaces client.
+// CreateNetworkInterfacesClientContextE returns a network interfaces client.
 // The ctx parameter supports cancellation and timeouts.
-func CreateNewNetworkInterfacesClientContextE(_ context.Context, subscriptionID string) (*armnetwork.InterfacesClient, error) {
+func CreateNetworkInterfacesClientContextE(_ context.Context, subscriptionID string) (*armnetwork.InterfacesClient, error) {
 	clientFactory, err := getArmNetworkClientFactory(subscriptionID)
 	if err != nil {
 		return nil, err
@@ -802,16 +798,30 @@ func CreateNewNetworkInterfacesClientContextE(_ context.Context, subscriptionID 
 	return clientFactory.NewInterfacesClient(), nil
 }
 
-// CreateNewNetworkInterfacesClientE returns a network interfaces client.
+// CreateNetworkInterfacesClientE returns a network interfaces client.
 //
-// Deprecated: Use [CreateNewNetworkInterfacesClientContextE] instead.
-func CreateNewNetworkInterfacesClientE(subscriptionID string) (*armnetwork.InterfacesClient, error) {
-	return CreateNewNetworkInterfacesClientContextE(context.Background(), subscriptionID)
+// Deprecated: Use [CreateNetworkInterfacesClientContextE] instead.
+func CreateNetworkInterfacesClientE(subscriptionID string) (*armnetwork.InterfacesClient, error) {
+	return CreateNetworkInterfacesClientContextE(context.Background(), subscriptionID)
 }
 
-// CreateNewNetworkInterfaceIPConfigurationClientContextE returns a NIC IP configuration client.
+// CreateNewNetworkInterfacesClientContextE is an alias for backward compatibility.
+//
+// Deprecated: Use [CreateNetworkInterfacesClientContextE] instead.
+func CreateNewNetworkInterfacesClientContextE(ctx context.Context, subscriptionID string) (*armnetwork.InterfacesClient, error) {
+	return CreateNetworkInterfacesClientContextE(ctx, subscriptionID)
+}
+
+// CreateNewNetworkInterfacesClientE is an alias for backward compatibility.
+//
+// Deprecated: Use [CreateNetworkInterfacesClientContextE] instead.
+func CreateNewNetworkInterfacesClientE(subscriptionID string) (*armnetwork.InterfacesClient, error) {
+	return CreateNetworkInterfacesClientContextE(context.Background(), subscriptionID)
+}
+
+// CreateNetworkInterfaceIPConfigurationClientContextE returns a NIC IP configuration client.
 // The ctx parameter supports cancellation and timeouts.
-func CreateNewNetworkInterfaceIPConfigurationClientContextE(_ context.Context, subscriptionID string) (*armnetwork.InterfaceIPConfigurationsClient, error) {
+func CreateNetworkInterfaceIPConfigurationClientContextE(_ context.Context, subscriptionID string) (*armnetwork.InterfaceIPConfigurationsClient, error) {
 	clientFactory, err := getArmNetworkClientFactory(subscriptionID)
 	if err != nil {
 		return nil, err
@@ -820,11 +830,25 @@ func CreateNewNetworkInterfaceIPConfigurationClientContextE(_ context.Context, s
 	return clientFactory.NewInterfaceIPConfigurationsClient(), nil
 }
 
-// CreateNewNetworkInterfaceIPConfigurationClientE returns a NIC IP configuration client.
+// CreateNetworkInterfaceIPConfigurationClientE returns a NIC IP configuration client.
 //
-// Deprecated: Use [CreateNewNetworkInterfaceIPConfigurationClientContextE] instead.
+// Deprecated: Use [CreateNetworkInterfaceIPConfigurationClientContextE] instead.
+func CreateNetworkInterfaceIPConfigurationClientE(subscriptionID string) (*armnetwork.InterfaceIPConfigurationsClient, error) {
+	return CreateNetworkInterfaceIPConfigurationClientContextE(context.Background(), subscriptionID)
+}
+
+// CreateNewNetworkInterfaceIPConfigurationClientContextE is an alias for backward compatibility.
+//
+// Deprecated: Use [CreateNetworkInterfaceIPConfigurationClientContextE] instead.
+func CreateNewNetworkInterfaceIPConfigurationClientContextE(ctx context.Context, subscriptionID string) (*armnetwork.InterfaceIPConfigurationsClient, error) {
+	return CreateNetworkInterfaceIPConfigurationClientContextE(ctx, subscriptionID)
+}
+
+// CreateNewNetworkInterfaceIPConfigurationClientE is an alias for backward compatibility.
+//
+// Deprecated: Use [CreateNetworkInterfaceIPConfigurationClientContextE] instead.
 func CreateNewNetworkInterfaceIPConfigurationClientE(subscriptionID string) (*armnetwork.InterfaceIPConfigurationsClient, error) {
-	return CreateNewNetworkInterfaceIPConfigurationClientContextE(context.Background(), subscriptionID)
+	return CreateNetworkInterfaceIPConfigurationClientContextE(context.Background(), subscriptionID)
 }
 
 // CreatePublicIPAddressesClientContextE returns a public IP addresses client.
@@ -881,9 +905,9 @@ func CreateLoadBalancerFrontendIPConfigClientE(subscriptionID string) (*armnetwo
 	return CreateLoadBalancerFrontendIPConfigClientContextE(context.Background(), subscriptionID)
 }
 
-// CreateNewSubnetClientContextE returns a subnet client.
+// CreateSubnetClientContextE returns a subnet client.
 // The ctx parameter supports cancellation and timeouts.
-func CreateNewSubnetClientContextE(_ context.Context, subscriptionID string) (*armnetwork.SubnetsClient, error) {
+func CreateSubnetClientContextE(_ context.Context, subscriptionID string) (*armnetwork.SubnetsClient, error) {
 	clientFactory, err := getArmNetworkClientFactory(subscriptionID)
 	if err != nil {
 		return nil, err
@@ -892,11 +916,25 @@ func CreateNewSubnetClientContextE(_ context.Context, subscriptionID string) (*a
 	return clientFactory.NewSubnetsClient(), nil
 }
 
-// CreateNewSubnetClientE returns a subnet client.
+// CreateSubnetClientE returns a subnet client.
 //
-// Deprecated: Use [CreateNewSubnetClientContextE] instead.
+// Deprecated: Use [CreateSubnetClientContextE] instead.
+func CreateSubnetClientE(subscriptionID string) (*armnetwork.SubnetsClient, error) {
+	return CreateSubnetClientContextE(context.Background(), subscriptionID)
+}
+
+// CreateNewSubnetClientContextE is an alias for backward compatibility.
+//
+// Deprecated: Use [CreateSubnetClientContextE] instead.
+func CreateNewSubnetClientContextE(ctx context.Context, subscriptionID string) (*armnetwork.SubnetsClient, error) {
+	return CreateSubnetClientContextE(ctx, subscriptionID)
+}
+
+// CreateNewSubnetClientE is an alias for backward compatibility.
+//
+// Deprecated: Use [CreateSubnetClientContextE] instead.
 func CreateNewSubnetClientE(subscriptionID string) (*armnetwork.SubnetsClient, error) {
-	return CreateNewSubnetClientContextE(context.Background(), subscriptionID)
+	return CreateSubnetClientContextE(context.Background(), subscriptionID)
 }
 
 // CreateNetworkManagementClientContextE returns a network management client.
@@ -917,9 +955,9 @@ func CreateNetworkManagementClientE(subscriptionID string) (*armnetwork.Manageme
 	return CreateNetworkManagementClientContextE(context.Background(), subscriptionID)
 }
 
-// CreateNewVirtualNetworkClientContextE returns a virtual network client.
+// CreateVirtualNetworkClientContextE returns a virtual network client.
 // The ctx parameter supports cancellation and timeouts.
-func CreateNewVirtualNetworkClientContextE(_ context.Context, subscriptionID string) (*armnetwork.VirtualNetworksClient, error) {
+func CreateVirtualNetworkClientContextE(_ context.Context, subscriptionID string) (*armnetwork.VirtualNetworksClient, error) {
 	clientFactory, err := getArmNetworkClientFactory(subscriptionID)
 	if err != nil {
 		return nil, err
@@ -928,15 +966,28 @@ func CreateNewVirtualNetworkClientContextE(_ context.Context, subscriptionID str
 	return clientFactory.NewVirtualNetworksClient(), nil
 }
 
-// CreateNewVirtualNetworkClientE returns a virtual network client.
+// CreateVirtualNetworkClientE returns a virtual network client.
 //
-// Deprecated: Use [CreateNewVirtualNetworkClientContextE] instead.
-func CreateNewVirtualNetworkClientE(subscriptionID string) (*armnetwork.VirtualNetworksClient, error) {
-	return CreateNewVirtualNetworkClientContextE(context.Background(), subscriptionID)
+// Deprecated: Use [CreateVirtualNetworkClientContextE] instead.
+func CreateVirtualNetworkClientE(subscriptionID string) (*armnetwork.VirtualNetworksClient, error) {
+	return CreateVirtualNetworkClientContextE(context.Background(), subscriptionID)
 }
 
-// CreateAppServiceClientContextE returns an App service client instance configured with the
-// correct BaseURI depending on the Azure environment that is currently setup (or "Public", if none is setup).
+// CreateNewVirtualNetworkClientContextE is an alias for backward compatibility.
+//
+// Deprecated: Use [CreateVirtualNetworkClientContextE] instead.
+func CreateNewVirtualNetworkClientContextE(ctx context.Context, subscriptionID string) (*armnetwork.VirtualNetworksClient, error) {
+	return CreateVirtualNetworkClientContextE(ctx, subscriptionID)
+}
+
+// CreateNewVirtualNetworkClientE is an alias for backward compatibility.
+//
+// Deprecated: Use [CreateVirtualNetworkClientContextE] instead.
+func CreateNewVirtualNetworkClientE(subscriptionID string) (*armnetwork.VirtualNetworksClient, error) {
+	return CreateVirtualNetworkClientContextE(context.Background(), subscriptionID)
+}
+
+// CreateAppServiceClientContextE returns an App Service client.
 // The ctx parameter supports cancellation and timeouts.
 func CreateAppServiceClientContextE(_ context.Context, subscriptionID string) (*armappservice.WebAppsClient, error) {
 	clientFactory, err := getArmAppServiceClientFactory(subscriptionID)
@@ -947,8 +998,7 @@ func CreateAppServiceClientContextE(_ context.Context, subscriptionID string) (*
 	return clientFactory.NewWebAppsClient(), nil
 }
 
-// CreateAppServiceClientE returns an App service client instance configured with the
-// correct BaseURI depending on the Azure environment that is currently setup (or "Public", if none is setup).
+// CreateAppServiceClientE returns an App Service client.
 //
 // Deprecated: Use [CreateAppServiceClientContextE] instead.
 func CreateAppServiceClientE(subscriptionID string) (*armappservice.WebAppsClient, error) {

--- a/modules/azure/compute.go
+++ b/modules/azure/compute.go
@@ -35,12 +35,10 @@ func GetVirtualMachineClient(t testing.TestingT, subscriptionID string) *armcomp
 // GetVirtualMachineClientContextE is a helper function that will setup an Azure Virtual Machine client on your behalf.
 // The ctx parameter supports cancellation and timeouts.
 func GetVirtualMachineClientContextE(ctx context.Context, subscriptionID string) (*armcompute.VirtualMachinesClient, error) {
-	// snippet-tag-start::client_factory_example.helper
 	vmClient, err := CreateVirtualMachinesClientContextE(ctx, subscriptionID)
 	if err != nil {
 		return nil, err
 	}
-	// snippet-tag-end::client_factory_example.helper
 
 	return vmClient, nil
 }
@@ -321,7 +319,7 @@ type VMImage struct {
 // This function would fail the test if there is an error.
 //
 // Deprecated: Use [GetVirtualMachineImageContext] instead.
-func GetVirtualMachineImage(t testing.TestingT, vmName string, resGroupName string, subscriptionID string) VMImage {
+func GetVirtualMachineImage(t testing.TestingT, vmName string, resGroupName string, subscriptionID string) *VMImage {
 	t.Helper()
 
 	return GetVirtualMachineImageContext(t, context.Background(), vmName, resGroupName, subscriptionID)
@@ -330,14 +328,14 @@ func GetVirtualMachineImage(t testing.TestingT, vmName string, resGroupName stri
 // GetVirtualMachineImageE gets the Image of the specified Azure Virtual Machine.
 //
 // Deprecated: Use [GetVirtualMachineImageContextE] instead.
-func GetVirtualMachineImageE(vmName string, resGroupName string, subscriptionID string) (VMImage, error) {
+func GetVirtualMachineImageE(vmName string, resGroupName string, subscriptionID string) (*VMImage, error) {
 	return GetVirtualMachineImageContextE(context.Background(), vmName, resGroupName, subscriptionID)
 }
 
 // GetVirtualMachineImageContext gets the Image of the specified Azure Virtual Machine.
 // This function would fail the test if there is an error.
 // The ctx parameter supports cancellation and timeouts.
-func GetVirtualMachineImageContext(t testing.TestingT, ctx context.Context, vmName string, resGroupName string, subscriptionID string) VMImage {
+func GetVirtualMachineImageContext(t testing.TestingT, ctx context.Context, vmName string, resGroupName string, subscriptionID string) *VMImage {
 	t.Helper()
 
 	vmImage, err := GetVirtualMachineImageContextE(ctx, vmName, resGroupName, subscriptionID)
@@ -348,10 +346,10 @@ func GetVirtualMachineImageContext(t testing.TestingT, ctx context.Context, vmNa
 
 // GetVirtualMachineImageContextE gets the Image of the specified Azure Virtual Machine.
 // The ctx parameter supports cancellation and timeouts.
-func GetVirtualMachineImageContextE(ctx context.Context, vmName string, resGroupName string, subscriptionID string) (VMImage, error) {
+func GetVirtualMachineImageContextE(ctx context.Context, vmName string, resGroupName string, subscriptionID string) (*VMImage, error) {
 	vm, err := GetVirtualMachineContextE(ctx, vmName, resGroupName, subscriptionID)
 	if err != nil {
-		return VMImage{}, err
+		return nil, err
 	}
 
 	return extractVMImage(vm), nil
@@ -359,10 +357,10 @@ func GetVirtualMachineImageContextE(ctx context.Context, vmName string, resGroup
 
 // extractVMImage extracts the Image reference from a Virtual Machine object.
 // For custom images where Publisher/Offer/SKU/Version may be nil, empty strings are returned.
-func extractVMImage(vm *armcompute.VirtualMachine) VMImage {
+func extractVMImage(vm *armcompute.VirtualMachine) *VMImage {
 	ref := vm.Properties.StorageProfile.ImageReference
 
-	var img VMImage
+	img := &VMImage{}
 
 	if ref.Publisher != nil {
 		img.Publisher = *ref.Publisher

--- a/modules/azure/compute_test.go
+++ b/modules/azure/compute_test.go
@@ -105,7 +105,7 @@ func TestFetchVirtualMachine(t *testing.T) {
 func TestExtractVMNics(t *testing.T) {
 	t.Parallel()
 
-	tests := []struct {
+	tests := []struct { //nolint:govet // fieldalignment not worth optimizing in test structs
 		name    string
 		vm      *armcompute.VirtualMachine
 		want    []string
@@ -278,10 +278,10 @@ func TestExtractVMAvailabilitySetID(t *testing.T) {
 func TestExtractVMImage(t *testing.T) {
 	t.Parallel()
 
-	tests := []struct {
+	tests := []struct { //nolint:govet // fieldalignment not worth optimizing in test structs
 		name string
 		vm   *armcompute.VirtualMachine
-		want VMImage
+		want *VMImage
 	}{
 		{
 			name: "MarketplaceImage",
@@ -297,7 +297,7 @@ func TestExtractVMImage(t *testing.T) {
 					},
 				},
 			},
-			want: VMImage{
+			want: &VMImage{
 				Publisher: "Canonical",
 				Offer:     "UbuntuServer",
 				SKU:       "18.04-LTS",
@@ -315,7 +315,7 @@ func TestExtractVMImage(t *testing.T) {
 					},
 				},
 			},
-			want: VMImage{},
+			want: &VMImage{},
 		},
 	}
 

--- a/modules/azure/networkinterface.go
+++ b/modules/azure/networkinterface.go
@@ -187,7 +187,7 @@ func GetNetworkInterfaceConfigurationContextE(ctx context.Context, nicName strin
 // GetNetworkInterfaceConfigurationClientContextE creates a new Network Interface Configuration client in the specified Azure Subscription.
 // The ctx parameter supports cancellation and timeouts.
 func GetNetworkInterfaceConfigurationClientContextE(ctx context.Context, subscriptionID string) (*armnetwork.InterfaceIPConfigurationsClient, error) {
-	return CreateNewNetworkInterfaceIPConfigurationClientContextE(ctx, subscriptionID)
+	return CreateNetworkInterfaceIPConfigurationClientContextE(ctx, subscriptionID)
 }
 
 // GetNetworkInterfaceConfigurationClientE creates a new Network Interface Configuration client in the specified Azure Subscription.
@@ -252,7 +252,7 @@ func ExtractNetworkInterfacePrivateIPs(nic *armnetwork.Interface) []string {
 // GetNetworkInterfaceClientContextE creates a new Network Interface client in the specified Azure Subscription.
 // The ctx parameter supports cancellation and timeouts.
 func GetNetworkInterfaceClientContextE(ctx context.Context, subscriptionID string) (*armnetwork.InterfacesClient, error) {
-	return CreateNewNetworkInterfacesClientContextE(ctx, subscriptionID)
+	return CreateNetworkInterfacesClientContextE(ctx, subscriptionID)
 }
 
 // GetNetworkInterfaceClientE creates a new Network Interface client in the specified Azure Subscription.

--- a/modules/azure/virtualnetwork.go
+++ b/modules/azure/virtualnetwork.go
@@ -315,7 +315,7 @@ func GetSubnetWithClient(ctx context.Context, client *armnetwork.SubnetsClient, 
 // GetSubnetClientContextE creates a subnet client.
 // The ctx parameter supports cancellation and timeouts.
 func GetSubnetClientContextE(ctx context.Context, subscriptionID string) (*armnetwork.SubnetsClient, error) {
-	return CreateNewSubnetClientContextE(ctx, subscriptionID)
+	return CreateSubnetClientContextE(ctx, subscriptionID)
 }
 
 // GetSubnetClientE creates a subnet client.
@@ -363,7 +363,7 @@ func GetVirtualNetworkWithClient(ctx context.Context, client *armnetwork.Virtual
 // GetVirtualNetworksClientContextE creates a virtual network client in the specified Azure Subscription.
 // The ctx parameter supports cancellation and timeouts.
 func GetVirtualNetworksClientContextE(ctx context.Context, subscriptionID string) (*armnetwork.VirtualNetworksClient, error) {
-	return CreateNewVirtualNetworkClientContextE(ctx, subscriptionID)
+	return CreateVirtualNetworkClientContextE(ctx, subscriptionID)
 }
 
 // GetVirtualNetworksClientE creates a virtual network client in the specified Azure Subscription.


### PR DESCRIPTION
## Summary

API surface cleanup before locking the Azure module into a stable v1.0.0 contract.

### Breaking changes

- **VMImage return type**: value → pointer (`VMImage` → `*VMImage`) for consistency with all other resource types that return pointers

### Non-breaking improvements

- **Renamed `CreateNew*` → `Create*`** (4 client factory functions): removes the inconsistent "New" infix. Old names kept as deprecated aliases — no breakage for existing callers.
  - `CreateNewNetworkInterfacesClientContextE` → `CreateNetworkInterfacesClientContextE`
  - `CreateNewNetworkInterfaceIPConfigurationClientContextE` → `CreateNetworkInterfaceIPConfigurationClientContextE`
  - `CreateNewSubnetClientContextE` → `CreateSubnetClientContextE`
  - `CreateNewVirtualNetworkClientContextE` → `CreateVirtualNetworkClientContextE`

### Cleanup

- Removed stale "BaseURI" comments from `client_factory.go`
- Removed `snippet-tag` markers from `client_factory.go` and `compute.go`

## Test plan

- [x] `go build ./...`
- [x] `go test ./modules/azure/...` — all tests pass
- [x] `go test -tags azure -c -o /dev/null ./modules/azure/...` — compiles
- [x] `go test -tags azure -c -o /dev/null ./test/azure/...` — compiles
- [x] `make lint` — 0 issues