### PR TITLE
fix(azure): API cleanup and correctness fixes

### DIFF
--- a/modules/azure/client_factory.go
+++ b/modules/azure/client_factory.go
@@ -1,8 +1,6 @@
 // Package azure allows users to interact with resources on the Microsoft Azure platform.
 package azure
 
-// snippet-tag-start::client_factory_example.imports
-
 import (
 	"context"
 	"errors"
@@ -34,8 +32,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/synapse/armsynapse"
 )
-
-// snippet-tag-end::client_factory_example.imports
 
 const (
 	// AzureEnvironmentEnvName is the name of the Azure environment to use. Set to one of the following:
@@ -791,9 +787,9 @@ func CreateNsgCustomRulesClientE(subscriptionID string) (*armnetwork.SecurityRul
 	return CreateNsgCustomRulesClientContextE(context.Background(), subscriptionID)
 }
 
-// CreateNewNetworkInterfacesClientContextE returns a network interfaces client.
+// CreateNetworkInterfacesClientContextE returns a network interfaces client.
 // The ctx parameter supports cancellation and timeouts.
-func CreateNewNetworkInterfacesClientContextE(_ context.Context, subscriptionID string) (*armnetwork.InterfacesClient, error) {
+func CreateNetworkInterfacesClientContextE(_ context.Context, subscriptionID string) (*armnetwork.InterfacesClient, error) {
 	clientFactory, err := getArmNetworkClientFactory(subscriptionID)
 	if err != nil {
 		return nil, err
@@ -802,16 +798,30 @@ func CreateNewNetworkInterfacesClientContextE(_ context.Context, subscriptionID 
 	return clientFactory.NewInterfacesClient(), nil
 }
 
-// CreateNewNetworkInterfacesClientE returns a network interfaces client.
+// CreateNetworkInterfacesClientE returns a network interfaces client.
 //
-// Deprecated: Use [CreateNewNetworkInterfacesClientContextE] instead.
-func CreateNewNetworkInterfacesClientE(subscriptionID string) (*armnetwork.InterfacesClient, error) {
-	return CreateNewNetworkInterfacesClientContextE(context.Background(), subscriptionID)
+// Deprecated: Use [CreateNetworkInterfacesClientContextE] instead.
+func CreateNetworkInterfacesClientE(subscriptionID string) (*armnetwork.InterfacesClient, error) {
+	return CreateNetworkInterfacesClientContextE(context.Background(), subscriptionID)
 }
 
-// CreateNewNetworkInterfaceIPConfigurationClientContextE returns a NIC IP configuration client.
+// CreateNewNetworkInterfacesClientContextE is an alias for backward compatibility.
+//
+// Deprecated: Use [CreateNetworkInterfacesClientContextE] instead.
+func CreateNewNetworkInterfacesClientContextE(ctx context.Context, subscriptionID string) (*armnetwork.InterfacesClient, error) {
+	return CreateNetworkInterfacesClientContextE(ctx, subscriptionID)
+}
+
+// CreateNewNetworkInterfacesClientE is an alias for backward compatibility.
+//
+// Deprecated: Use [CreateNetworkInterfacesClientContextE] instead.
+func CreateNewNetworkInterfacesClientE(subscriptionID string) (*armnetwork.InterfacesClient, error) {
+	return CreateNetworkInterfacesClientContextE(context.Background(), subscriptionID)
+}
+
+// CreateNetworkInterfaceIPConfigurationClientContextE returns a NIC IP configuration client.
 // The ctx parameter supports cancellation and timeouts.
-func CreateNewNetworkInterfaceIPConfigurationClientContextE(_ context.Context, subscriptionID string) (*armnetwork.InterfaceIPConfigurationsClient, error) {
+func CreateNetworkInterfaceIPConfigurationClientContextE(_ context.Context, subscriptionID string) (*armnetwork.InterfaceIPConfigurationsClient, error) {
 	clientFactory, err := getArmNetworkClientFactory(subscriptionID)
 	if err != nil {
 		return nil, err
@@ -820,11 +830,25 @@ func CreateNewNetworkInterfaceIPConfigurationClientContextE(_ context.Context, s
 	return clientFactory.NewInterfaceIPConfigurationsClient(), nil
 }
 
-// CreateNewNetworkInterfaceIPConfigurationClientE returns a NIC IP configuration client.
+// CreateNetworkInterfaceIPConfigurationClientE returns a NIC IP configuration client.
 //
-// Deprecated: Use [CreateNewNetworkInterfaceIPConfigurationClientContextE] instead.
+// Deprecated: Use [CreateNetworkInterfaceIPConfigurationClientContextE] instead.
+func CreateNetworkInterfaceIPConfigurationClientE(subscriptionID string) (*armnetwork.InterfaceIPConfigurationsClient, error) {
+	return CreateNetworkInterfaceIPConfigurationClientContextE(context.Background(), subscriptionID)
+}
+
+// CreateNewNetworkInterfaceIPConfigurationClientContextE is an alias for backward compatibility.
+//
+// Deprecated: Use [CreateNetworkInterfaceIPConfigurationClientContextE] instead.
+func CreateNewNetworkInterfaceIPConfigurationClientContextE(ctx context.Context, subscriptionID string) (*armnetwork.InterfaceIPConfigurationsClient, error) {
+	return CreateNetworkInterfaceIPConfigurationClientContextE(ctx, subscriptionID)
+}
+
+// CreateNewNetworkInterfaceIPConfigurationClientE is an alias for backward compatibility.
+//
+// Deprecated: Use [CreateNetworkInterfaceIPConfigurationClientContextE] instead.
 func CreateNewNetworkInterfaceIPConfigurationClientE(subscriptionID string) (*armnetwork.InterfaceIPConfigurationsClient, error) {
-	return CreateNewNetworkInterfaceIPConfigurationClientContextE(context.Background(), subscriptionID)
+	return CreateNetworkInterfaceIPConfigurationClientContextE(context.Background(), subscriptionID)
 }
 
 // CreatePublicIPAddressesClientContextE returns a public IP addresses client.
@@ -881,9 +905,9 @@ func CreateLoadBalancerFrontendIPConfigClientE(subscriptionID string) (*armnetwo
 	return CreateLoadBalancerFrontendIPConfigClientContextE(context.Background(), subscriptionID)
 }
 
-// CreateNewSubnetClientContextE returns a subnet client.
+// CreateSubnetClientContextE returns a subnet client.
 // The ctx parameter supports cancellation and timeouts.
-func CreateNewSubnetClientContextE(_ context.Context, subscriptionID string) (*armnetwork.SubnetsClient, error) {
+func CreateSubnetClientContextE(_ context.Context, subscriptionID string) (*armnetwork.SubnetsClient, error) {
 	clientFactory, err := getArmNetworkClientFactory(subscriptionID)
 	if err != nil {
 		return nil, err
@@ -892,11 +916,25 @@ func CreateNewSubnetClientContextE(_ context.Context, subscriptionID string) (*a
 	return clientFactory.NewSubnetsClient(), nil
 }
 
-// CreateNewSubnetClientE returns a subnet client.
+// CreateSubnetClientE returns a subnet client.
 //
-// Deprecated: Use [CreateNewSubnetClientContextE] instead.
+// Deprecated: Use [CreateSubnetClientContextE] instead.
+func CreateSubnetClientE(subscriptionID string) (*armnetwork.SubnetsClient, error) {
+	return CreateSubnetClientContextE(context.Background(), subscriptionID)
+}
+
+// CreateNewSubnetClientContextE is an alias for backward compatibility.
+//
+// Deprecated: Use [CreateSubnetClientContextE] instead.
+func CreateNewSubnetClientContextE(ctx context.Context, subscriptionID string) (*armnetwork.SubnetsClient, error) {
+	return CreateSubnetClientContextE(ctx, subscriptionID)
+}
+
+// CreateNewSubnetClientE is an alias for backward compatibility.
+//
+// Deprecated: Use [CreateSubnetClientContextE] instead.
 func CreateNewSubnetClientE(subscriptionID string) (*armnetwork.SubnetsClient, error) {
-	return CreateNewSubnetClientContextE(context.Background(), subscriptionID)
+	return CreateSubnetClientContextE(context.Background(), subscriptionID)
 }
 
 // CreateNetworkManagementClientContextE returns a network management client.
@@ -917,9 +955,9 @@ func CreateNetworkManagementClientE(subscriptionID string) (*armnetwork.Manageme
 	return CreateNetworkManagementClientContextE(context.Background(), subscriptionID)
 }
 
-// CreateNewVirtualNetworkClientContextE returns a virtual network client.
+// CreateVirtualNetworkClientContextE returns a virtual network client.
 // The ctx parameter supports cancellation and timeouts.
-func CreateNewVirtualNetworkClientContextE(_ context.Context, subscriptionID string) (*armnetwork.VirtualNetworksClient, error) {
+func CreateVirtualNetworkClientContextE(_ context.Context, subscriptionID string) (*armnetwork.VirtualNetworksClient, error) {
 	clientFactory, err := getArmNetworkClientFactory(subscriptionID)
 	if err != nil {
 		return nil, err
@@ -928,15 +966,28 @@ func CreateNewVirtualNetworkClientContextE(_ context.Context, subscriptionID str
 	return clientFactory.NewVirtualNetworksClient(), nil
 }
 
-// CreateNewVirtualNetworkClientE returns a virtual network client.
+// CreateVirtualNetworkClientE returns a virtual network client.
 //
-// Deprecated: Use [CreateNewVirtualNetworkClientContextE] instead.
-func CreateNewVirtualNetworkClientE(subscriptionID string) (*armnetwork.VirtualNetworksClient, error) {
-	return CreateNewVirtualNetworkClientContextE(context.Background(), subscriptionID)
+// Deprecated: Use [CreateVirtualNetworkClientContextE] instead.
+func CreateVirtualNetworkClientE(subscriptionID string) (*armnetwork.VirtualNetworksClient, error) {
+	return CreateVirtualNetworkClientContextE(context.Background(), subscriptionID)
 }
 
-// CreateAppServiceClientContextE returns an App service client instance configured with the
-// correct BaseURI depending on the Azure environment that is currently setup (or "Public", if none is setup).
+// CreateNewVirtualNetworkClientContextE is an alias for backward compatibility.
+//
+// Deprecated: Use [CreateVirtualNetworkClientContextE] instead.
+func CreateNewVirtualNetworkClientContextE(ctx context.Context, subscriptionID string) (*armnetwork.VirtualNetworksClient, error) {
+	return CreateVirtualNetworkClientContextE(ctx, subscriptionID)
+}
+
+// CreateNewVirtualNetworkClientE is an alias for backward compatibility.
+//
+// Deprecated: Use [CreateVirtualNetworkClientContextE] instead.
+func CreateNewVirtualNetworkClientE(subscriptionID string) (*armnetwork.VirtualNetworksClient, error) {
+	return CreateVirtualNetworkClientContextE(context.Background(), subscriptionID)
+}
+
+// CreateAppServiceClientContextE returns an App Service client.
 // The ctx parameter supports cancellation and timeouts.
 func CreateAppServiceClientContextE(_ context.Context, subscriptionID string) (*armappservice.WebAppsClient, error) {
 	clientFactory, err := getArmAppServiceClientFactory(subscriptionID)
@@ -947,8 +998,7 @@ func CreateAppServiceClientContextE(_ context.Context, subscriptionID string) (*
 	return clientFactory.NewWebAppsClient(), nil
 }
 
-// CreateAppServiceClientE returns an App service client instance configured with the
-// correct BaseURI depending on the Azure environment that is currently setup (or "Public", if none is setup).
+// CreateAppServiceClientE returns an App Service client.
 //
 // Deprecated: Use [CreateAppServiceClientContextE] instead.
 func CreateAppServiceClientE(subscriptionID string) (*armappservice.WebAppsClient, error) {

--- a/modules/azure/compute.go
+++ b/modules/azure/compute.go
@@ -35,12 +35,10 @@ func GetVirtualMachineClient(t testing.TestingT, subscriptionID string) *armcomp
 // GetVirtualMachineClientContextE is a helper function that will setup an Azure Virtual Machine client on your behalf.
 // The ctx parameter supports cancellation and timeouts.
 func GetVirtualMachineClientContextE(ctx context.Context, subscriptionID string) (*armcompute.VirtualMachinesClient, error) {
-	// snippet-tag-start::client_factory_example.helper
 	vmClient, err := CreateVirtualMachinesClientContextE(ctx, subscriptionID)
 	if err != nil {
 		return nil, err
 	}
-	// snippet-tag-end::client_factory_example.helper
 
 	return vmClient, nil
 }
@@ -321,7 +319,7 @@ type VMImage struct {
 // This function would fail the test if there is an error.
 //
 // Deprecated: Use [GetVirtualMachineImageContext] instead.
-func GetVirtualMachineImage(t testing.TestingT, vmName string, resGroupName string, subscriptionID string) VMImage {
+func GetVirtualMachineImage(t testing.TestingT, vmName string, resGroupName string, subscriptionID string) *VMImage {
 	t.Helper()
 
 	return GetVirtualMachineImageContext(t, context.Background(), vmName, resGroupName, subscriptionID)
@@ -330,14 +328,14 @@ func GetVirtualMachineImage(t testing.TestingT, vmName string, resGroupName stri
 // GetVirtualMachineImageE gets the Image of the specified Azure Virtual Machine.
 //
 // Deprecated: Use [GetVirtualMachineImageContextE] instead.
-func GetVirtualMachineImageE(vmName string, resGroupName string, subscriptionID string) (VMImage, error) {
+func GetVirtualMachineImageE(vmName string, resGroupName string, subscriptionID string) (*VMImage, error) {
 	return GetVirtualMachineImageContextE(context.Background(), vmName, resGroupName, subscriptionID)
 }
 
 // GetVirtualMachineImageContext gets the Image of the specified Azure Virtual Machine.
 // This function would fail the test if there is an error.
 // The ctx parameter supports cancellation and timeouts.
-func GetVirtualMachineImageContext(t testing.TestingT, ctx context.Context, vmName string, resGroupName string, subscriptionID string) VMImage {
+func GetVirtualMachineImageContext(t testing.TestingT, ctx context.Context, vmName string, resGroupName string, subscriptionID string) *VMImage {
 	t.Helper()
 
 	vmImage, err := GetVirtualMachineImageContextE(ctx, vmName, resGroupName, subscriptionID)
@@ -348,10 +346,10 @@ func GetVirtualMachineImageContext(t testing.TestingT, ctx context.Context, vmNa
 
 // GetVirtualMachineImageContextE gets the Image of the specified Azure Virtual Machine.
 // The ctx parameter supports cancellation and timeouts.
-func GetVirtualMachineImageContextE(ctx context.Context, vmName string, resGroupName string, subscriptionID string) (VMImage, error) {
+func GetVirtualMachineImageContextE(ctx context.Context, vmName string, resGroupName string, subscriptionID string) (*VMImage, error) {
 	vm, err := GetVirtualMachineContextE(ctx, vmName, resGroupName, subscriptionID)
 	if err != nil {
-		return VMImage{}, err
+		return nil, err
 	}
 
 	return extractVMImage(vm), nil
@@ -359,10 +357,10 @@ func GetVirtualMachineImageContextE(ctx context.Context, vmName string, resGroup
 
 // extractVMImage extracts the Image reference from a Virtual Machine object.
 // For custom images where Publisher/Offer/SKU/Version may be nil, empty strings are returned.
-func extractVMImage(vm *armcompute.VirtualMachine) VMImage {
+func extractVMImage(vm *armcompute.VirtualMachine) *VMImage {
 	ref := vm.Properties.StorageProfile.ImageReference
 
-	var img VMImage
+	img := &VMImage{}
 
 	if ref.Publisher != nil {
 		img.Publisher = *ref.Publisher

--- a/modules/azure/compute_test.go
+++ b/modules/azure/compute_test.go
@@ -105,7 +105,7 @@ func TestFetchVirtualMachine(t *testing.T) {
 func TestExtractVMNics(t *testing.T) {
 	t.Parallel()
 
-	tests := []struct {
+	tests := []struct { //nolint:govet // fieldalignment not worth optimizing in test structs
 		name    string
 		vm      *armcompute.VirtualMachine
 		want    []string
@@ -278,10 +278,10 @@ func TestExtractVMAvailabilitySetID(t *testing.T) {
 func TestExtractVMImage(t *testing.T) {
 	t.Parallel()
 
-	tests := []struct {
+	tests := []struct { //nolint:govet // fieldalignment not worth optimizing in test structs
 		name string
 		vm   *armcompute.VirtualMachine
-		want VMImage
+		want *VMImage
 	}{
 		{
 			name: "MarketplaceImage",
@@ -297,7 +297,7 @@ func TestExtractVMImage(t *testing.T) {
 					},
 				},
 			},
-			want: VMImage{
+			want: &VMImage{
 				Publisher: "Canonical",
 				Offer:     "UbuntuServer",
 				SKU:       "18.04-LTS",
@@ -315,7 +315,7 @@ func TestExtractVMImage(t *testing.T) {
 					},
 				},
 			},
-			want: VMImage{},
+			want: &VMImage{},
 		},
 	}
 

--- a/modules/azure/container_apps.go
+++ b/modules/azure/container_apps.go
@@ -40,6 +40,10 @@ func ManagedEnvironmentExistsContextE(ctx context.Context, environmentName strin
 
 	_, err = client.Get(ctx, resourceGroupName, environmentName, nil)
 	if err != nil {
+		if ResourceNotFoundErrorExists(err) {
+			return false, nil
+		}
+
 		return false, err
 	}
 
@@ -136,6 +140,10 @@ func ContainerAppExistsContextE(ctx context.Context, containerAppName string, re
 
 	_, err = client.Get(ctx, resourceGroupName, containerAppName, nil)
 	if err != nil {
+		if ResourceNotFoundErrorExists(err) {
+			return false, nil
+		}
+
 		return false, err
 	}
 
@@ -232,6 +240,10 @@ func ContainerAppJobExistsContextE(ctx context.Context, containerAppName string,
 
 	_, err = client.Get(ctx, resourceGroupName, containerAppName, nil)
 	if err != nil {
+		if ResourceNotFoundErrorExists(err) {
+			return false, nil
+		}
+
 		return false, err
 	}
 

--- a/modules/azure/datafactory.go
+++ b/modules/azure/datafactory.go
@@ -55,7 +55,7 @@ func DataFactoryExistsE(dataFactoryName string, resourceGroupName string, subscr
 // GetDataFactoryContext returns the Data Factory object.
 // This function would fail the test if there is an error.
 // The ctx parameter supports cancellation and timeouts.
-func GetDataFactoryContext(t testing.TestingT, ctx context.Context, resGroupName string, factoryName string, subscriptionID string) *armdatafactory.Factory {
+func GetDataFactoryContext(t testing.TestingT, ctx context.Context, subscriptionID string, resGroupName string, factoryName string) *armdatafactory.Factory {
 	t.Helper()
 
 	factory, err := GetDataFactoryContextE(ctx, subscriptionID, resGroupName, factoryName)
@@ -71,7 +71,7 @@ func GetDataFactoryContext(t testing.TestingT, ctx context.Context, resGroupName
 func GetDataFactory(t testing.TestingT, resGroupName string, factoryName string, subscriptionID string) *armdatafactory.Factory {
 	t.Helper()
 
-	return GetDataFactoryContext(t, context.Background(), resGroupName, factoryName, subscriptionID) //nolint:staticcheck
+	return GetDataFactoryContext(t, context.Background(), subscriptionID, resGroupName, factoryName) //nolint:staticcheck
 }
 
 // GetDataFactoryContextE returns the Data Factory object.

--- a/modules/azure/mysql.go
+++ b/modules/azure/mysql.go
@@ -30,7 +30,7 @@ func GetMYSQLServerClientE(subscriptionID string) (*armmysql.ServersClient, erro
 // GetMYSQLServerContext is a helper function that gets the server.
 // This function would fail the test if there is an error.
 // The ctx parameter supports cancellation and timeouts.
-func GetMYSQLServerContext(t testing.TestingT, ctx context.Context, resGroupName string, serverName string, subscriptionID string) *armmysql.Server {
+func GetMYSQLServerContext(t testing.TestingT, ctx context.Context, subscriptionID string, resGroupName string, serverName string) *armmysql.Server {
 	t.Helper()
 
 	mysqlServer, err := GetMYSQLServerContextE(t, ctx, subscriptionID, resGroupName, serverName)
@@ -46,7 +46,7 @@ func GetMYSQLServerContext(t testing.TestingT, ctx context.Context, resGroupName
 func GetMYSQLServer(t testing.TestingT, resGroupName string, serverName string, subscriptionID string) *armmysql.Server {
 	t.Helper()
 
-	return GetMYSQLServerContext(t, context.Background(), resGroupName, serverName, subscriptionID) //nolint:staticcheck
+	return GetMYSQLServerContext(t, context.Background(), subscriptionID, resGroupName, serverName) //nolint:staticcheck
 }
 
 // GetMYSQLServerContextE is a helper function that gets the server.
@@ -99,7 +99,7 @@ func GetMYSQLDBClientE(subscriptionID string) (*armmysql.DatabasesClient, error)
 // GetMYSQLDBContext is a helper function that gets the database.
 // This function would fail the test if there is an error.
 // The ctx parameter supports cancellation and timeouts.
-func GetMYSQLDBContext(t testing.TestingT, ctx context.Context, resGroupName string, serverName string, dbName string, subscriptionID string) *armmysql.Database {
+func GetMYSQLDBContext(t testing.TestingT, ctx context.Context, subscriptionID string, resGroupName string, serverName string, dbName string) *armmysql.Database {
 	t.Helper()
 
 	database, err := GetMYSQLDBContextE(t, ctx, subscriptionID, resGroupName, serverName, dbName)
@@ -115,7 +115,7 @@ func GetMYSQLDBContext(t testing.TestingT, ctx context.Context, resGroupName str
 func GetMYSQLDB(t testing.TestingT, resGroupName string, serverName string, dbName string, subscriptionID string) *armmysql.Database {
 	t.Helper()
 
-	return GetMYSQLDBContext(t, context.Background(), resGroupName, serverName, dbName, subscriptionID) //nolint:staticcheck
+	return GetMYSQLDBContext(t, context.Background(), subscriptionID, resGroupName, serverName, dbName) //nolint:staticcheck
 }
 
 // GetMYSQLDBContextE is a helper function that gets the database.
@@ -150,7 +150,7 @@ func GetMYSQLDBE(t testing.TestingT, subscriptionID string, resGroupName string,
 // ListMySQLDBContext is a helper function that gets all databases per server.
 // This function would fail the test if there is an error.
 // The ctx parameter supports cancellation and timeouts.
-func ListMySQLDBContext(t testing.TestingT, ctx context.Context, resGroupName string, serverName string, subscriptionID string) []*armmysql.Database {
+func ListMySQLDBContext(t testing.TestingT, ctx context.Context, subscriptionID string, resGroupName string, serverName string) []*armmysql.Database {
 	t.Helper()
 
 	dblist, err := ListMySQLDBContextE(t, ctx, subscriptionID, resGroupName, serverName)
@@ -166,7 +166,7 @@ func ListMySQLDBContext(t testing.TestingT, ctx context.Context, resGroupName st
 func ListMySQLDB(t testing.TestingT, resGroupName string, serverName string, subscriptionID string) []*armmysql.Database {
 	t.Helper()
 
-	return ListMySQLDBContext(t, context.Background(), resGroupName, serverName, subscriptionID) //nolint:staticcheck
+	return ListMySQLDBContext(t, context.Background(), subscriptionID, resGroupName, serverName) //nolint:staticcheck
 }
 
 // ListMySQLDBContextE is a helper function that gets all databases per server.

--- a/modules/azure/networkinterface.go
+++ b/modules/azure/networkinterface.go
@@ -187,7 +187,7 @@ func GetNetworkInterfaceConfigurationContextE(ctx context.Context, nicName strin
 // GetNetworkInterfaceConfigurationClientContextE creates a new Network Interface Configuration client in the specified Azure Subscription.
 // The ctx parameter supports cancellation and timeouts.
 func GetNetworkInterfaceConfigurationClientContextE(ctx context.Context, subscriptionID string) (*armnetwork.InterfaceIPConfigurationsClient, error) {
-	return CreateNewNetworkInterfaceIPConfigurationClientContextE(ctx, subscriptionID)
+	return CreateNetworkInterfaceIPConfigurationClientContextE(ctx, subscriptionID)
 }
 
 // GetNetworkInterfaceConfigurationClientE creates a new Network Interface Configuration client in the specified Azure Subscription.
@@ -252,7 +252,7 @@ func ExtractNetworkInterfacePrivateIPs(nic *armnetwork.Interface) []string {
 // GetNetworkInterfaceClientContextE creates a new Network Interface client in the specified Azure Subscription.
 // The ctx parameter supports cancellation and timeouts.
 func GetNetworkInterfaceClientContextE(ctx context.Context, subscriptionID string) (*armnetwork.InterfacesClient, error) {
-	return CreateNewNetworkInterfacesClientContextE(ctx, subscriptionID)
+	return CreateNetworkInterfacesClientContextE(ctx, subscriptionID)
 }
 
 // GetNetworkInterfaceClientE creates a new Network Interface client in the specified Azure Subscription.

--- a/modules/azure/postgresql.go
+++ b/modules/azure/postgresql.go
@@ -30,7 +30,7 @@ func GetPostgreSQLServerClientE(subscriptionID string) (*armpostgresql.ServersCl
 // GetPostgreSQLServerContext is a helper function that gets the server.
 // This function would fail the test if there is an error.
 // The ctx parameter supports cancellation and timeouts.
-func GetPostgreSQLServerContext(t testing.TestingT, ctx context.Context, resGroupName string, serverName string, subscriptionID string) *armpostgresql.Server {
+func GetPostgreSQLServerContext(t testing.TestingT, ctx context.Context, subscriptionID string, resGroupName string, serverName string) *armpostgresql.Server {
 	t.Helper()
 
 	postgresqlServer, err := GetPostgreSQLServerContextE(t, ctx, subscriptionID, resGroupName, serverName)
@@ -46,7 +46,7 @@ func GetPostgreSQLServerContext(t testing.TestingT, ctx context.Context, resGrou
 func GetPostgreSQLServer(t testing.TestingT, resGroupName string, serverName string, subscriptionID string) *armpostgresql.Server {
 	t.Helper()
 
-	return GetPostgreSQLServerContext(t, context.Background(), resGroupName, serverName, subscriptionID) //nolint:staticcheck
+	return GetPostgreSQLServerContext(t, context.Background(), subscriptionID, resGroupName, serverName) //nolint:staticcheck
 }
 
 // GetPostgreSQLServerContextE is a helper function that gets the server.
@@ -99,7 +99,7 @@ func GetPostgreSQLDBClientE(subscriptionID string) (*armpostgresql.DatabasesClie
 // GetPostgreSQLDBContext is a helper function that gets the database.
 // This function would fail the test if there is an error.
 // The ctx parameter supports cancellation and timeouts.
-func GetPostgreSQLDBContext(t testing.TestingT, ctx context.Context, resGroupName string, serverName string, dbName string, subscriptionID string) *armpostgresql.Database {
+func GetPostgreSQLDBContext(t testing.TestingT, ctx context.Context, subscriptionID string, resGroupName string, serverName string, dbName string) *armpostgresql.Database {
 	t.Helper()
 
 	database, err := GetPostgreSQLDBContextE(t, ctx, subscriptionID, resGroupName, serverName, dbName)
@@ -115,7 +115,7 @@ func GetPostgreSQLDBContext(t testing.TestingT, ctx context.Context, resGroupNam
 func GetPostgreSQLDB(t testing.TestingT, resGroupName string, serverName string, dbName string, subscriptionID string) *armpostgresql.Database {
 	t.Helper()
 
-	return GetPostgreSQLDBContext(t, context.Background(), resGroupName, serverName, dbName, subscriptionID) //nolint:staticcheck
+	return GetPostgreSQLDBContext(t, context.Background(), subscriptionID, resGroupName, serverName, dbName) //nolint:staticcheck
 }
 
 // GetPostgreSQLDBContextE is a helper function that gets the database.

--- a/modules/azure/publicaddress.go
+++ b/modules/azure/publicaddress.go
@@ -118,9 +118,7 @@ func CheckPublicDNSNameAvailabilityContext(t testing.TestingT, ctx context.Conte
 	t.Helper()
 
 	available, err := CheckPublicDNSNameAvailabilityContextE(ctx, location, domainNameLabel, subscriptionID)
-	if err != nil {
-		return false
-	}
+	require.NoError(t, err)
 
 	return available
 }

--- a/modules/azure/resourcegroup.go
+++ b/modules/azure/resourcegroup.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
@@ -56,6 +57,7 @@ func ResourceGroupExistsE(resourceGroupName, subscriptionID string) (bool, error
 }
 
 // GetResourceGroupContextE checks whether a resource group name matches the one retrieved from the subscription.
+// Azure resource group names are case-insensitive, so the comparison is performed with EqualFold.
 // The ctx parameter supports cancellation and timeouts.
 func GetResourceGroupContextE(ctx context.Context, resourceGroupName, subscriptionID string) (bool, error) {
 	rg, err := GetAResourceGroupContextE(ctx, resourceGroupName, subscriptionID)
@@ -63,7 +65,11 @@ func GetResourceGroupContextE(ctx context.Context, resourceGroupName, subscripti
 		return false, err
 	}
 
-	return (resourceGroupName == *rg.Name), nil
+	if rg == nil || rg.Name == nil {
+		return false, nil
+	}
+
+	return strings.EqualFold(resourceGroupName, *rg.Name), nil
 }
 
 // GetResourceGroupE checks whether a resource group name matches the one retrieved from the subscription.

--- a/modules/azure/sql.go
+++ b/modules/azure/sql.go
@@ -24,7 +24,7 @@ func GetSQLServerClient(subscriptionID string) (*armsql.ServersClient, error) {
 // GetSQLServerContext is a helper function that gets the sql server object.
 // This function would fail the test if there is an error.
 // The ctx parameter supports cancellation and timeouts.
-func GetSQLServerContext(t testing.TestingT, ctx context.Context, resGroupName string, serverName string, subscriptionID string) *armsql.Server {
+func GetSQLServerContext(t testing.TestingT, ctx context.Context, subscriptionID string, resGroupName string, serverName string) *armsql.Server {
 	t.Helper()
 
 	sqlServer, err := GetSQLServerContextE(t, ctx, subscriptionID, resGroupName, serverName)
@@ -40,7 +40,7 @@ func GetSQLServerContext(t testing.TestingT, ctx context.Context, resGroupName s
 func GetSQLServer(t testing.TestingT, resGroupName string, serverName string, subscriptionID string) *armsql.Server {
 	t.Helper()
 
-	return GetSQLServerContext(t, context.Background(), resGroupName, serverName, subscriptionID)
+	return GetSQLServerContext(t, context.Background(), subscriptionID, resGroupName, serverName)
 }
 
 // GetSQLServerContextE is a helper function that gets the sql server object.
@@ -147,7 +147,7 @@ func ListSQLServerDatabasesE(t testing.TestingT, resGroupName string, serverName
 // GetSQLDatabaseContext is a helper function that gets the sql db.
 // This function would fail the test if there is an error.
 // The ctx parameter supports cancellation and timeouts.
-func GetSQLDatabaseContext(t testing.TestingT, ctx context.Context, resGroupName string, serverName string, dbName string, subscriptionID string) *armsql.Database {
+func GetSQLDatabaseContext(t testing.TestingT, ctx context.Context, subscriptionID string, resGroupName string, serverName string, dbName string) *armsql.Database {
 	t.Helper()
 
 	database, err := GetSQLDatabaseContextE(t, ctx, subscriptionID, resGroupName, serverName, dbName)
@@ -163,7 +163,7 @@ func GetSQLDatabaseContext(t testing.TestingT, ctx context.Context, resGroupName
 func GetSQLDatabase(t testing.TestingT, resGroupName string, serverName string, dbName string, subscriptionID string) *armsql.Database {
 	t.Helper()
 
-	return GetSQLDatabaseContext(t, context.Background(), resGroupName, serverName, dbName, subscriptionID)
+	return GetSQLDatabaseContext(t, context.Background(), subscriptionID, resGroupName, serverName, dbName)
 }
 
 // GetSQLDatabaseContextE is a helper function that gets the sql db.

--- a/modules/azure/synapse.go
+++ b/modules/azure/synapse.go
@@ -11,7 +11,7 @@ import (
 // GetSynapseWorkspaceContext retrieves the synapse workspace for the given subscription.
 // This function would fail the test if there is an error.
 // The ctx parameter supports cancellation and timeouts.
-func GetSynapseWorkspaceContext(t testing.TestingT, ctx context.Context, resGroupName string, workspaceName string, subscriptionID string) *armsynapse.Workspace {
+func GetSynapseWorkspaceContext(t testing.TestingT, ctx context.Context, subscriptionID string, resGroupName string, workspaceName string) *armsynapse.Workspace {
 	t.Helper()
 
 	workspace, err := GetSynapseWorkspaceContextE(ctx, subscriptionID, resGroupName, workspaceName)
@@ -48,7 +48,7 @@ func GetSynapseWorkspaceWithClient(ctx context.Context, client *armsynapse.Works
 func GetSynapseWorkspace(t testing.TestingT, resGroupName string, workspaceName string, subscriptionID string) *armsynapse.Workspace {
 	t.Helper()
 
-	return GetSynapseWorkspaceContext(t, context.Background(), resGroupName, workspaceName, subscriptionID)
+	return GetSynapseWorkspaceContext(t, context.Background(), subscriptionID, resGroupName, workspaceName)
 }
 
 // GetSynapseWorkspaceE retrieves the synapse workspace for the given subscription.
@@ -61,7 +61,7 @@ func GetSynapseWorkspaceE(t testing.TestingT, subscriptionID string, resGroupNam
 // GetSynapseSQLPoolContext retrieves the synapse SQL pool for the given subscription.
 // This function would fail the test if there is an error.
 // The ctx parameter supports cancellation and timeouts.
-func GetSynapseSQLPoolContext(t testing.TestingT, ctx context.Context, resGroupName string, workspaceName string, sqlPoolName string, subscriptionID string) *armsynapse.SQLPool {
+func GetSynapseSQLPoolContext(t testing.TestingT, ctx context.Context, subscriptionID string, resGroupName string, workspaceName string, sqlPoolName string) *armsynapse.SQLPool {
 	t.Helper()
 
 	sqlPool, err := GetSynapseSQLPoolContextE(ctx, subscriptionID, resGroupName, workspaceName, sqlPoolName)
@@ -98,7 +98,7 @@ func GetSynapseSQLPoolWithClient(ctx context.Context, client *armsynapse.SQLPool
 func GetSynapseSQLPool(t testing.TestingT, resGroupName string, workspaceName string, sqlPoolName string, subscriptionID string) *armsynapse.SQLPool {
 	t.Helper()
 
-	return GetSynapseSQLPoolContext(t, context.Background(), resGroupName, workspaceName, sqlPoolName, subscriptionID)
+	return GetSynapseSQLPoolContext(t, context.Background(), subscriptionID, resGroupName, workspaceName, sqlPoolName)
 }
 
 // GetSynapseSQLPoolE retrieves the synapse SQL pool for the given subscription.
@@ -115,7 +115,7 @@ func GetSynapseSQLPoolE(subscriptionID string, resGroupName string, workspaceNam
 func GetSynapseSqlPool(t testing.TestingT, resGroupName string, workspaceName string, sqlPoolName string, subscriptionID string) *armsynapse.SQLPool {
 	t.Helper()
 
-	return GetSynapseSQLPoolContext(t, context.Background(), resGroupName, workspaceName, sqlPoolName, subscriptionID)
+	return GetSynapseSQLPoolContext(t, context.Background(), subscriptionID, resGroupName, workspaceName, sqlPoolName)
 }
 
 // GetSynapseSqlPoolE retrieves the synapse SQL pool for the given subscription.

--- a/modules/azure/virtualnetwork.go
+++ b/modules/azure/virtualnetwork.go
@@ -315,7 +315,7 @@ func GetSubnetWithClient(ctx context.Context, client *armnetwork.SubnetsClient, 
 // GetSubnetClientContextE creates a subnet client.
 // The ctx parameter supports cancellation and timeouts.
 func GetSubnetClientContextE(ctx context.Context, subscriptionID string) (*armnetwork.SubnetsClient, error) {
-	return CreateNewSubnetClientContextE(ctx, subscriptionID)
+	return CreateSubnetClientContextE(ctx, subscriptionID)
 }
 
 // GetSubnetClientE creates a subnet client.
@@ -363,7 +363,7 @@ func GetVirtualNetworkWithClient(ctx context.Context, client *armnetwork.Virtual
 // GetVirtualNetworksClientContextE creates a virtual network client in the specified Azure Subscription.
 // The ctx parameter supports cancellation and timeouts.
 func GetVirtualNetworksClientContextE(ctx context.Context, subscriptionID string) (*armnetwork.VirtualNetworksClient, error) {
-	return CreateNewVirtualNetworkClientContextE(ctx, subscriptionID)
+	return CreateVirtualNetworkClientContextE(ctx, subscriptionID)
 }
 
 // GetVirtualNetworksClientE creates a virtual network client in the specified Azure Subscription.

--- a/test/azure/terraform_azure_datafactory_example_test.go
+++ b/test/azure/terraform_azure_datafactory_example_test.go
@@ -45,7 +45,7 @@ func TestTerraformAzureDataFactoryExample(t *testing.T) {
 	assert.True(t, actualDataFactoryExits)
 
 	// Get data factory details and assert them against the terraform output
-	actualDataFactory := azure.GetDataFactoryContext(t, t.Context(), expectedResourceGroupName, expectedDataFactoryName, "")
+	actualDataFactory := azure.GetDataFactoryContext(t, t.Context(), "", expectedResourceGroupName, expectedDataFactoryName)
 	assert.Equal(t, expectedDataFactoryName, *actualDataFactory.Name)
 	assert.Equal(t, expectedDataFactoryProvisioningState, *actualDataFactory.Properties.ProvisioningState)
 }

--- a/test/azure/terraform_azure_mysqldb_example_test.go
+++ b/test/azure/terraform_azure_mysqldb_example_test.go
@@ -52,7 +52,7 @@ func TestTerraformAzureMySQLDBExample(t *testing.T) {
 	expectedMYSQLDBName := terraform.OutputContext(t, t.Context(), terraformOptions, "mysql_database_name")
 
 	// website::tag::4:: Get mySQL server details and assert them against the terraform output
-	actualMYSQLServer := azure.GetMYSQLServerContext(t, t.Context(), expectedResourceGroupName, expectedMYSQLServerName, "")
+	actualMYSQLServer := azure.GetMYSQLServerContext(t, t.Context(), "", expectedResourceGroupName, expectedMYSQLServerName)
 
 	assert.Equal(t, expectedServerSkuName, *actualMYSQLServer.SKU.Name)
 	assert.Equal(t, expectedServerStoragemMb, strconv.Itoa(int(*actualMYSQLServer.Properties.StorageProfile.StorageMB)))
@@ -60,7 +60,7 @@ func TestTerraformAzureMySQLDBExample(t *testing.T) {
 	assert.Equal(t, armmysql.ServerStateReady, *actualMYSQLServer.Properties.UserVisibleState)
 
 	// website::tag::5:: Get  mySQL server DB details and assert them against the terraform output
-	actualDatabase := azure.GetMYSQLDBContext(t, t.Context(), expectedResourceGroupName, expectedMYSQLServerName, expectedMYSQLDBName, "")
+	actualDatabase := azure.GetMYSQLDBContext(t, t.Context(), "", expectedResourceGroupName, expectedMYSQLServerName, expectedMYSQLDBName)
 
 	assert.Equal(t, expectedDatabaseCharSet, *actualDatabase.Properties.Charset)
 	assert.Equal(t, expectedDatabaseCollation, *actualDatabase.Properties.Collation)

--- a/test/azure/terraform_azure_postgresql_example_test.go
+++ b/test/azure/terraform_azure_postgresql_example_test.go
@@ -45,7 +45,7 @@ func TestPostgreSQLDatabase(t *testing.T) {
 	expectedSkuName := terraform.OutputContext(t, t.Context(), terraformOptions, "sku_name")
 
 	// website::tag::4:: Get the Server details and assert them against the terraform output
-	actualServer := azure.GetPostgreSQLServerContext(t, t.Context(), rgName, actualServername, subscriptionID)
+	actualServer := azure.GetPostgreSQLServerContext(t, t.Context(), subscriptionID, rgName, actualServername)
 	// Verify
 	assert.NotNil(t, actualServer)
 	assert.Equal(t, expectedServername, actualServername)

--- a/test/azure/terraform_azure_sqldb_example_test.go
+++ b/test/azure/terraform_azure_sqldb_example_test.go
@@ -48,14 +48,14 @@ func TestTerraformAzureSQLDBExample(t *testing.T) {
 	expectedSQLDBStatus := "Online"
 
 	// website::tag::4:: Get the SQL server details and assert them against the terraform output
-	actualSQLServer := azure.GetSQLServerContext(t, t.Context(), expectedResourceGroupName, expectedSQLServerName, "")
+	actualSQLServer := azure.GetSQLServerContext(t, t.Context(), "", expectedResourceGroupName, expectedSQLServerName)
 
 	assert.Equal(t, expectedSQLServerID, *actualSQLServer.ID)
 	assert.Equal(t, expectedSQLServerFullDomainName, *actualSQLServer.Properties.FullyQualifiedDomainName)
 	assert.Equal(t, "Ready", *actualSQLServer.Properties.State)
 
 	// website::tag::5:: Get the SQL server DB details and assert them against the terraform output
-	actualSQLDatabase := azure.GetSQLDatabaseContext(t, t.Context(), expectedResourceGroupName, expectedSQLServerName, expectedSQLDBName, "")
+	actualSQLDatabase := azure.GetSQLDatabaseContext(t, t.Context(), "", expectedResourceGroupName, expectedSQLServerName, expectedSQLDBName)
 
 	assert.Equal(t, expectedSQLDBID, *actualSQLDatabase.ID)
 	assert.Equal(t, expectedSQLDBStatus, string(*actualSQLDatabase.Properties.Status))

--- a/test/azure/terraform_azure_synapse_example_test.go
+++ b/test/azure/terraform_azure_synapse_example_test.go
@@ -51,8 +51,8 @@ func TestTerraformAzureSynapseExample(t *testing.T) {
 	expectedSQLPoolName := terraform.OutputContext(t, t.Context(), terraformOptions, "synapse_sqlpool_name")
 
 	// website::tag::4:: Get synapse details and assert them against the terraform output
-	actualSynapseWorkspace := azure.GetSynapseWorkspaceContext(t, t.Context(), expectedResourceGroupName, expectedSyWorkspaceName, "")
-	actualSynapseSQLPool := azure.GetSynapseSQLPoolContext(t, t.Context(), expectedResourceGroupName, expectedSyWorkspaceName, expectedSQLPoolName, "")
+	actualSynapseWorkspace := azure.GetSynapseWorkspaceContext(t, t.Context(), "", expectedResourceGroupName, expectedSyWorkspaceName)
+	actualSynapseSQLPool := azure.GetSynapseSQLPoolContext(t, t.Context(), "", expectedResourceGroupName, expectedSyWorkspaceName, expectedSQLPoolName)
 
 	assert.Equal(t, expectedSyWorkspaceName, *actualSynapseWorkspace.Name)
 	assert.Equal(t, expectedSynapseSQLUser, *actualSynapseWorkspace.Properties.SQLAdministratorLogin)


### PR DESCRIPTION
## API cleanup

- `VMImage` return type changed from value to pointer (`*VMImage`)
- Renamed 4 `CreateNew*` client factories to `Create*` (old names kept as deprecated aliases)
- Removed stale `BaseURI` comments and `snippet-tag` markers

## Correctness fixes

- Aligned `Context`/`ContextE` parameter order in mysql, postgresql, sql, synapse, datafactory — eliminates silent-swap bug where `(resGroup, name, sub)` and `(sub, resGroup, name)` were both accepted
- `GetResourceGroupContextE` now uses `strings.EqualFold` (Azure RG names are case-insensitive)
- `ManagedEnvironmentExistsContextE`, `ContainerAppExistsContextE`, `ContainerAppJobExistsContextE` now convert 404 to `(false, nil)`
- `CheckPublicDNSNameAvailabilityContext` uses `require.NoError` instead of silently returning false

## Test plan

- [x] `go build ./...`
- [x] `go test ./modules/azure/...`
- [x] `go test -tags azure -c -o /dev/null ./modules/azure/...`
- [x] `go test -tags azure -c -o /dev/null ./test/azure/...`