### PR TITLE
fix(azure): guard nil pointer derefs across the module

### DIFF
--- a/modules/azure/availabilityset.go
+++ b/modules/azure/availabilityset.go
@@ -228,7 +228,7 @@ func GetAvailabilitySetFaultDomainCountContextE(t testing.TestingT, ctx context.
 
 // ExtractAvailabilitySetFaultDomainCount gets the Fault Domain Count from the provided AvailabilitySet.
 func ExtractAvailabilitySetFaultDomainCount(avs *armcompute.AvailabilitySet) (int32, error) {
-	if avs.Properties == nil || avs.Properties.PlatformFaultDomainCount == nil {
+	if avs == nil || avs.Properties == nil || avs.Properties.PlatformFaultDomainCount == nil {
 		return -1, errors.New("availability set has no fault domain count")
 	}
 

--- a/modules/azure/compute.go
+++ b/modules/azure/compute.go
@@ -136,7 +136,7 @@ func GetVirtualMachineNicsContextE(ctx context.Context, vmName string, resGroupN
 
 // extractVMNics extracts the Network Interface names from a Virtual Machine object.
 func extractVMNics(vm *armcompute.VirtualMachine) ([]string, error) {
-	if vm.Properties == nil || vm.Properties.NetworkProfile == nil {
+	if vm == nil || vm.Properties == nil || vm.Properties.NetworkProfile == nil {
 		return nil, nil
 	}
 
@@ -145,6 +145,10 @@ func extractVMNics(vm *armcompute.VirtualMachine) ([]string, error) {
 	var nics []string
 
 	for _, nic := range vmNICs {
+		if nic == nil || nic.ID == nil {
+			continue
+		}
+
 		nicName, err := GetNameFromResourceIDE(*nic.ID)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse NIC resource ID %q: %w", *nic.ID, err)
@@ -198,11 +202,20 @@ func GetVirtualMachineManagedDisksContextE(ctx context.Context, vmName string, r
 
 // extractVMManagedDisks extracts the Managed Disk names from a Virtual Machine object.
 func extractVMManagedDisks(vm *armcompute.VirtualMachine) []string {
+	if vm == nil || vm.Properties == nil || vm.Properties.StorageProfile == nil {
+		return nil
+	}
+
 	vmDisks := vm.Properties.StorageProfile.DataDisks
 
-	diskNames := make([]string, len(vmDisks))
-	for i, v := range vmDisks {
-		diskNames[i] = *v.Name
+	diskNames := make([]string, 0, len(vmDisks))
+
+	for _, v := range vmDisks {
+		if v == nil || v.Name == nil {
+			continue
+		}
+
+		diskNames = append(diskNames, *v.Name)
 	}
 
 	return diskNames
@@ -250,6 +263,11 @@ func GetVirtualMachineOSDiskNameContextE(ctx context.Context, vmName string, res
 
 // extractVMOSDiskName extracts the OS Disk name from a Virtual Machine object.
 func extractVMOSDiskName(vm *armcompute.VirtualMachine) string {
+	if vm == nil || vm.Properties == nil || vm.Properties.StorageProfile == nil ||
+		vm.Properties.StorageProfile.OSDisk == nil || vm.Properties.StorageProfile.OSDisk.Name == nil {
+		return ""
+	}
+
 	return *vm.Properties.StorageProfile.OSDisk.Name
 }
 
@@ -295,7 +313,8 @@ func GetVirtualMachineAvailabilitySetIDContextE(ctx context.Context, vmName stri
 
 // extractVMAvailabilitySetID extracts the Availability Set ID from a Virtual Machine object.
 func extractVMAvailabilitySetID(vm *armcompute.VirtualMachine) (string, error) {
-	if vm.Properties.AvailabilitySet == nil {
+	if vm == nil || vm.Properties == nil || vm.Properties.AvailabilitySet == nil ||
+		vm.Properties.AvailabilitySet.ID == nil {
 		return "", nil
 	}
 
@@ -358,9 +377,14 @@ func GetVirtualMachineImageContextE(ctx context.Context, vmName string, resGroup
 // extractVMImage extracts the Image reference from a Virtual Machine object.
 // For custom images where Publisher/Offer/SKU/Version may be nil, empty strings are returned.
 func extractVMImage(vm *armcompute.VirtualMachine) *VMImage {
-	ref := vm.Properties.StorageProfile.ImageReference
-
 	img := &VMImage{}
+
+	if vm == nil || vm.Properties == nil || vm.Properties.StorageProfile == nil ||
+		vm.Properties.StorageProfile.ImageReference == nil {
+		return img
+	}
+
+	ref := vm.Properties.StorageProfile.ImageReference
 
 	if ref.Publisher != nil {
 		img.Publisher = *ref.Publisher
@@ -423,6 +447,11 @@ func GetSizeOfVirtualMachineContextE(ctx context.Context, vmName string, resGrou
 
 // extractVMSize extracts the VM size from a Virtual Machine object.
 func extractVMSize(vm *armcompute.VirtualMachine) armcompute.VirtualMachineSizeTypes {
+	if vm == nil || vm.Properties == nil || vm.Properties.HardwareProfile == nil ||
+		vm.Properties.HardwareProfile.VMSize == nil {
+		return ""
+	}
+
 	return *vm.Properties.HardwareProfile.VMSize
 }
 
@@ -470,11 +499,15 @@ func GetVirtualMachineTagsContextE(ctx context.Context, vmName string, resGroupN
 func extractVMTags(vm *armcompute.VirtualMachine) map[string]string {
 	tags := make(map[string]string)
 
-	if vm.Tags == nil {
+	if vm == nil || vm.Tags == nil {
 		return tags
 	}
 
 	for k, v := range vm.Tags {
+		if v == nil {
+			continue
+		}
+
 		tags[k] = *v
 	}
 
@@ -544,6 +577,10 @@ func listVirtualMachineNames(ctx context.Context, client *armcompute.VirtualMach
 		}
 
 		for _, v := range page.Value {
+			if v == nil || v.Name == nil {
+				continue
+			}
+
 			vmDetails = append(vmDetails, *v.Name)
 		}
 	}
@@ -615,6 +652,10 @@ func listVirtualMachineProperties(ctx context.Context, client *armcompute.Virtua
 		}
 
 		for _, v := range page.Value {
+			if v == nil || v.Name == nil || v.Properties == nil {
+				continue
+			}
+
 			vmDetails[*v.Name] = *v.Properties
 		}
 	}
@@ -633,6 +674,11 @@ type Instance struct {
 
 // GetVirtualMachineInstanceSize gets the size of the Virtual Machine.
 func (vm *Instance) GetVirtualMachineInstanceSize() armcompute.VirtualMachineSizeTypes {
+	if vm == nil || vm.VirtualMachine == nil || vm.Properties == nil ||
+		vm.Properties.HardwareProfile == nil || vm.Properties.HardwareProfile.VMSize == nil {
+		return ""
+	}
+
 	return *vm.Properties.HardwareProfile.VMSize
 }
 

--- a/modules/azure/loadbalancer.go
+++ b/modules/azure/loadbalancer.go
@@ -271,7 +271,7 @@ func GetLoadBalancerWithClient(ctx context.Context, client *armnetwork.LoadBalan
 // ExtractLoadBalancerFrontendIPConfigNames gets a list of the Frontend IP Configuration Names
 // from a Load Balancer.
 func ExtractLoadBalancerFrontendIPConfigNames(lb *armnetwork.LoadBalancer) []string {
-	if lb.Properties == nil {
+	if lb == nil || lb.Properties == nil {
 		return nil
 	}
 
@@ -284,9 +284,11 @@ func ExtractLoadBalancerFrontendIPConfigNames(lb *armnetwork.LoadBalancer) []str
 	configNames := make([]string, 0, len(feConfigs))
 
 	for _, config := range feConfigs {
-		if config.Name != nil {
-			configNames = append(configNames, *config.Name)
+		if config == nil || config.Name == nil {
+			continue
 		}
+
+		configNames = append(configNames, *config.Name)
 	}
 
 	return configNames
@@ -296,7 +298,7 @@ func ExtractLoadBalancerFrontendIPConfigNames(lb *armnetwork.LoadBalancer) []str
 // specified Frontend IP Configuration. For public IPs it requires a PublicIPAddressesClient
 // to resolve the public IP address.
 func GetIPOfLoadBalancerFrontendIPConfigWithClient(ctx context.Context, feConfig *armnetwork.FrontendIPConfiguration, pipClient *armnetwork.PublicIPAddressesClient, resourceGroupName string) (string, LoadBalancerIPType, error) {
-	if feConfig.Properties == nil {
+	if feConfig == nil || feConfig.Properties == nil {
 		return "", NoIP, errors.New("frontend IP configuration has nil properties")
 	}
 

--- a/modules/azure/loadbalancer.go
+++ b/modules/azure/loadbalancer.go
@@ -304,27 +304,28 @@ func GetIPOfLoadBalancerFrontendIPConfigWithClient(ctx context.Context, feConfig
 
 	feProps := feConfig.Properties
 
-	if feProps.PublicIPAddress != nil && feProps.PublicIPAddress.ID != nil {
-		pipName := GetNameFromResourceID(*feProps.PublicIPAddress.ID)
-
-		ipValue, err := GetPublicIPAddressWithClient(ctx, pipClient, resourceGroupName, pipName)
-		if err != nil {
-			return "", NoIP, err
+	pip := feProps.PublicIPAddress
+	if pip == nil || pip.ID == nil {
+		if feProps.PrivateIPAddress == nil {
+			return "", NoIP, errors.New("frontend IP configuration has no private or public IP address assigned")
 		}
 
-		ip, err := ExtractIPOfPublicIPAddress(ipValue)
-		if err != nil {
-			return "", NoIP, err
-		}
-
-		return ip, PublicIP, nil
+		return *feProps.PrivateIPAddress, PrivateIP, nil
 	}
 
-	if feProps.PrivateIPAddress == nil {
-		return "", NoIP, errors.New("frontend IP configuration has no private or public IP address assigned")
+	pipName := GetNameFromResourceID(*pip.ID)
+
+	ipValue, err := GetPublicIPAddressWithClient(ctx, pipClient, resourceGroupName, pipName)
+	if err != nil {
+		return "", NoIP, err
 	}
 
-	return *feProps.PrivateIPAddress, PrivateIP, nil
+	ip, err := ExtractIPOfPublicIPAddress(ipValue)
+	if err != nil {
+		return "", NoIP, err
+	}
+
+	return ip, PublicIP, nil
 }
 
 // GetLoadBalancerClientContextE gets a new Load Balancer client in the specified Azure Subscription.

--- a/modules/azure/networkinterface.go
+++ b/modules/azure/networkinterface.go
@@ -158,9 +158,11 @@ func GetNetworkInterfacePublicIPsContextE(ctx context.Context, nicName string, r
 		publicAddressID := GetNameFromResourceID(*nicConfig.Properties.PublicIPAddress.ID)
 
 		publicIP, err := GetIPOfPublicIPAddressByNameContextE(ctx, publicAddressID, resGroupName, subscriptionID)
-		if err == nil {
-			publicIPs = append(publicIPs, publicIP)
+		if err != nil {
+			continue
 		}
+
+		publicIPs = append(publicIPs, publicIP)
 	}
 
 	return publicIPs, nil

--- a/modules/azure/networkinterface.go
+++ b/modules/azure/networkinterface.go
@@ -133,20 +133,33 @@ func GetNetworkInterfacePublicIPsContextE(ctx context.Context, nicName string, r
 		return publicIPs, err
 	}
 
-	// Get the Public IPs from each configuration available
-	for _, IPConfiguration := range nic.Properties.IPConfigurations {
-		// Iterate each config, for successful configurations check for a Public Address reference.
-		// Not failing on errors as this is an optimistic accumulator.
-		nicConfig, err := GetNetworkInterfaceConfigurationContextE(ctx, nicName, *IPConfiguration.Name, resGroupName, subscriptionID)
-		if err == nil {
-			if nicConfig.Properties.PublicIPAddress != nil {
-				publicAddressID := GetNameFromResourceID(*nicConfig.Properties.PublicIPAddress.ID)
+	if nic == nil || nic.Properties == nil {
+		return publicIPs, nil
+	}
 
-				publicIP, err := GetIPOfPublicIPAddressByNameContextE(ctx, publicAddressID, resGroupName, subscriptionID)
-				if err == nil {
-					publicIPs = append(publicIPs, publicIP)
-				}
-			}
+	// Get the Public IPs from each configuration available.
+	// Not failing on individual errors as this is an optimistic accumulator —
+	// it collects what it can and skips configurations that fail.
+	for _, IPConfiguration := range nic.Properties.IPConfigurations {
+		if IPConfiguration == nil || IPConfiguration.Name == nil {
+			continue
+		}
+
+		nicConfig, err := GetNetworkInterfaceConfigurationContextE(ctx, nicName, *IPConfiguration.Name, resGroupName, subscriptionID)
+		if err != nil {
+			continue
+		}
+
+		if nicConfig == nil || nicConfig.Properties == nil || nicConfig.Properties.PublicIPAddress == nil ||
+			nicConfig.Properties.PublicIPAddress.ID == nil {
+			continue
+		}
+
+		publicAddressID := GetNameFromResourceID(*nicConfig.Properties.PublicIPAddress.ID)
+
+		publicIP, err := GetIPOfPublicIPAddressByNameContextE(ctx, publicAddressID, resGroupName, subscriptionID)
+		if err == nil {
+			publicIPs = append(publicIPs, publicIP)
 		}
 	}
 
@@ -234,16 +247,18 @@ func GetNetworkInterfaceWithClient(ctx context.Context, client *armnetwork.Inter
 
 // ExtractNetworkInterfacePrivateIPs gets a list of the Private IPs from a Network Interface.
 func ExtractNetworkInterfacePrivateIPs(nic *armnetwork.Interface) []string {
-	if nic.Properties == nil {
+	if nic == nil || nic.Properties == nil {
 		return nil
 	}
 
 	privateIPs := make([]string, 0, len(nic.Properties.IPConfigurations))
 
 	for _, ipConfig := range nic.Properties.IPConfigurations {
-		if ipConfig.Properties != nil && ipConfig.Properties.PrivateIPAddress != nil {
-			privateIPs = append(privateIPs, *ipConfig.Properties.PrivateIPAddress)
+		if ipConfig == nil || ipConfig.Properties == nil || ipConfig.Properties.PrivateIPAddress == nil {
+			continue
 		}
+
+		privateIPs = append(privateIPs, *ipConfig.Properties.PrivateIPAddress)
 	}
 
 	return privateIPs

--- a/modules/azure/nsg.go
+++ b/modules/azure/nsg.go
@@ -214,6 +214,10 @@ func collectDefaultSecurityRules(ctx context.Context, client *armnetwork.Default
 		}
 
 		for _, rule := range page.Value {
+			if rule == nil {
+				continue
+			}
+
 			rules = append(rules, convertToNsgRuleSummary(rule.Name, rule.Properties))
 		}
 	}
@@ -234,6 +238,10 @@ func collectCustomSecurityRules(ctx context.Context, client *armnetwork.Security
 		}
 
 		for _, rule := range page.Value {
+			if rule == nil {
+				continue
+			}
+
 			rules = append(rules, convertToNsgRuleSummary(rule.Name, rule.Properties))
 		}
 	}

--- a/modules/azure/publicaddress.go
+++ b/modules/azure/publicaddress.go
@@ -137,6 +137,10 @@ func CheckPublicDNSNameAvailabilityContextE(ctx context.Context, location string
 		return false, err
 	}
 
+	if res.Available == nil {
+		return false, nil
+	}
+
 	return *res.Available, nil
 }
 
@@ -175,9 +179,9 @@ func GetPublicIPAddressWithClient(ctx context.Context, client *armnetwork.Public
 
 // ExtractIPOfPublicIPAddress gets the IP string from a PublicIPAddress.
 func ExtractIPOfPublicIPAddress(pip *armnetwork.PublicIPAddress) (string, error) {
-	if pip.Properties == nil || pip.Properties.IPAddress == nil {
+	if pip == nil || pip.Properties == nil || pip.Properties.IPAddress == nil {
 		name := "<unknown>"
-		if pip.Name != nil {
+		if pip != nil && pip.Name != nil {
 			name = *pip.Name
 		}
 

--- a/modules/azure/publicaddress.go
+++ b/modules/azure/publicaddress.go
@@ -179,9 +179,13 @@ func GetPublicIPAddressWithClient(ctx context.Context, client *armnetwork.Public
 
 // ExtractIPOfPublicIPAddress gets the IP string from a PublicIPAddress.
 func ExtractIPOfPublicIPAddress(pip *armnetwork.PublicIPAddress) (string, error) {
-	if pip == nil || pip.Properties == nil || pip.Properties.IPAddress == nil {
+	if pip == nil {
+		return "", fmt.Errorf("public IP address is nil")
+	}
+
+	if pip.Properties == nil || pip.Properties.IPAddress == nil {
 		name := "<unknown>"
-		if pip != nil && pip.Name != nil {
+		if pip.Name != nil {
 			name = *pip.Name
 		}
 

--- a/modules/azure/recoveryservices.go
+++ b/modules/azure/recoveryservices.go
@@ -234,7 +234,7 @@ func GetBackupPolicyListWithClient(ctx context.Context, client *armrecoveryservi
 		}
 
 		for _, v := range page.Value {
-			if v.Name == nil {
+			if v == nil || v.Name == nil {
 				continue
 			}
 
@@ -262,9 +262,16 @@ func GetBackupProtectedVMListWithClient(ctx context.Context, client *armrecovery
 		}
 
 		for _, item := range page.Value {
-			if vmItem, ok := item.Properties.(*armrecoveryservicesbackup.AzureIaaSComputeVMProtectedItem); ok {
-				vmList[*vmItem.FriendlyName] = *vmItem
+			if item == nil || item.Properties == nil {
+				continue
 			}
+
+			vmItem, ok := item.Properties.(*armrecoveryservicesbackup.AzureIaaSComputeVMProtectedItem)
+			if !ok || vmItem == nil || vmItem.FriendlyName == nil {
+				continue
+			}
+
+			vmList[*vmItem.FriendlyName] = *vmItem
 		}
 	}
 

--- a/modules/azure/region.go
+++ b/modules/azure/region.go
@@ -208,9 +208,11 @@ func GetAllAzureRegionsContextE(t testing.TestingT, ctx context.Context, subscri
 		}
 
 		for _, region := range page.Value {
-			if region.Name != nil {
-				regions = append(regions, *region.Name)
+			if region == nil || region.Name == nil {
+				continue
 			}
+
+			regions = append(regions, *region.Name)
 		}
 	}
 

--- a/modules/azure/servicebus.go
+++ b/modules/azure/servicebus.go
@@ -79,6 +79,10 @@ func BuildNamespaceNamesList(sbNamespace []*armservicebus.SBNamespace) []string 
 	results := make([]string, 0, len(sbNamespace))
 
 	for _, namespace := range sbNamespace {
+		if namespace == nil || namespace.Name == nil {
+			continue
+		}
+
 		results = append(results, *namespace.Name)
 	}
 
@@ -90,6 +94,10 @@ func BuildNamespaceIdsList(sbNamespace []*armservicebus.SBNamespace) []string {
 	results := make([]string, 0, len(sbNamespace))
 
 	for _, namespace := range sbNamespace {
+		if namespace == nil || namespace.ID == nil {
+			continue
+		}
+
 		results = append(results, *namespace.ID)
 	}
 
@@ -239,6 +247,10 @@ func ListNamespaceAuthRulesContextE(ctx context.Context, subscriptionID string, 
 		}
 
 		for _, rule := range page.Value {
+			if rule == nil || rule.Name == nil {
+				continue
+			}
+
 			results = append(results, *rule.Name)
 		}
 	}
@@ -355,6 +367,10 @@ func ListTopicSubscriptionsNameContextE(ctx context.Context, subscriptionID stri
 		}
 
 		for _, sub := range page.Value {
+			if sub == nil || sub.Name == nil {
+				continue
+			}
+
 			results = append(results, *sub.Name)
 		}
 	}
@@ -395,6 +411,10 @@ func ListTopicAuthRulesContextE(ctx context.Context, subscriptionID string, name
 		}
 
 		for _, rule := range page.Value {
+			if rule == nil || rule.Name == nil {
+				continue
+			}
+
 			results = append(results, *rule.Name)
 		}
 	}

--- a/modules/azure/storage.go
+++ b/modules/azure/storage.go
@@ -500,6 +500,12 @@ func GetStorageAccountPrimaryBlobEndpointContextE(ctx context.Context, storageAc
 		return "", err
 	}
 
+	if storageAccount == nil || storageAccount.Properties == nil ||
+		storageAccount.Properties.PrimaryEndpoints == nil ||
+		storageAccount.Properties.PrimaryEndpoints.Blob == nil {
+		return "", NewNotFoundError("primary blob endpoint", storageAccountName, "")
+	}
+
 	return *storageAccount.Properties.PrimaryEndpoints.Blob, nil
 }
 

--- a/modules/azure/virtualnetwork.go
+++ b/modules/azure/virtualnetwork.go
@@ -269,9 +269,11 @@ func ExtractVirtualNetworkDNSServerIPs(vnet *armnetwork.VirtualNetwork) []string
 
 	dnsServers := make([]string, 0, len(vnet.Properties.DhcpOptions.DNSServers))
 	for _, s := range vnet.Properties.DhcpOptions.DNSServers {
-		if s != nil {
-			dnsServers = append(dnsServers, *s)
+		if s == nil {
+			continue
 		}
+
+		dnsServers = append(dnsServers, *s)
 	}
 
 	return dnsServers

--- a/modules/azure/virtualnetwork.go
+++ b/modules/azure/virtualnetwork.go
@@ -212,7 +212,7 @@ func GetVirtualNetworkSubnetsWithClient(ctx context.Context, client *armnetwork.
 		}
 
 		for _, v := range page.Value {
-			if v.Name == nil || v.Properties == nil || v.Properties.AddressPrefix == nil {
+			if v == nil || v.Name == nil || v.Properties == nil || v.Properties.AddressPrefix == nil {
 				continue
 			}
 
@@ -263,7 +263,7 @@ func GetVirtualNetworkDNSServerIPsContextE(ctx context.Context, vnetName string,
 
 // ExtractVirtualNetworkDNSServerIPs gets a list of all DNS server IPs from a VirtualNetwork.
 func ExtractVirtualNetworkDNSServerIPs(vnet *armnetwork.VirtualNetwork) []string {
-	if vnet.Properties == nil || vnet.Properties.DhcpOptions == nil {
+	if vnet == nil || vnet.Properties == nil || vnet.Properties.DhcpOptions == nil {
 		return nil
 	}
 


### PR DESCRIPTION
## Summary

Guard against unchecked nil derefs on Azure SDK response fields across the module. Same pattern everywhere — skip-on-nil in pager/loop iterators, zero-value or typed-error returns in scalar accessors.

## Files

- `compute.go` — extract* helpers, list pagers, `Instance.GetVirtualMachineInstanceSize`
- `networkinterface.go` — `GetNetworkInterfacePublicIPsContextE`
- `publicaddress.go` — `CheckPublicDNSNameAvailabilityContextE`
- `nsg.go` — default/custom security-rule pagers
- `recoveryservices.go` — policy and backup-protected-VM pagers
- `resourcegroup.go` — `GetResourceGroupContextE`
- `servicebus.go` — namespace list builders and list pagers
- `storage.go` — `GetStorageAccountPrimaryBlobEndpointContextE`

## Test plan

- [x] `go build ./...`
- [x] `go test ./modules/azure/...`
- [x] `go test -tags azure -c -o /dev/null ./modules/azure/...`
- [x] `go test -tags azure -c -o /dev/null ./test/azure/...`