### PR TITLE
fix(aws): align auth.go with package convention for v1 readiness

### DIFF
--- a/modules/aws/account.go
+++ b/modules/aws/account.go
@@ -75,7 +75,7 @@ func ExtractAccountIDFromARN(arn string) (string, error) {
 // NewStsClientContextE creates a new STS client.
 // The ctx parameter supports cancellation and timeouts.
 func NewStsClientContextE(t testing.TestingT, ctx context.Context, region string) (*sts.Client, error) {
-	sess, err := NewAuthenticatedSessionContext(ctx, region)
+	sess, err := NewAuthConfigContextE(t, ctx, region)
 	if err != nil {
 		return nil, err
 	}

--- a/modules/aws/acm.go
+++ b/modules/aws/acm.go
@@ -64,7 +64,7 @@ func GetAcmCertificateArnE(t testing.TestingT, awsRegion string, certDomainName 
 // NewAcmClientContextE creates a new ACM client.
 // The ctx parameter supports cancellation and timeouts.
 func NewAcmClientContextE(t testing.TestingT, ctx context.Context, region string) (*acm.Client, error) {
-	sess, err := NewAuthenticatedSessionContext(ctx, region)
+	sess, err := NewAuthConfigContextE(t, ctx, region)
 	if err != nil {
 		return nil, err
 	}

--- a/modules/aws/asg.go
+++ b/modules/aws/asg.go
@@ -216,7 +216,7 @@ func WaitForCapacityE(
 // NewAsgClientContextE creates an Auto Scaling Group client.
 // The ctx parameter supports cancellation and timeouts.
 func NewAsgClientContextE(t testing.TestingT, ctx context.Context, region string) (*autoscaling.Client, error) {
-	sess, err := NewAuthenticatedSessionContext(ctx, region)
+	sess, err := NewAuthConfigContextE(t, ctx, region)
 	if err != nil {
 		return nil, err
 	}

--- a/modules/aws/auth.go
+++ b/modules/aws/auth.go
@@ -13,16 +13,276 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 	"github.com/aws/aws-sdk-go-v2/service/iam/types"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
+	"github.com/gruntwork-io/terratest/modules/testing"
 	"github.com/pquerna/otp/totp"
+	"github.com/stretchr/testify/require"
 )
 
 const (
 	AuthAssumeRoleEnvVar = "TERRATEST_IAM_ROLE" // OS environment variable name through which Assume Role ARN may be passed for authentication
 )
 
+// NewAuthConfigContextE creates an AWS Config following the standard AWS authentication workflow.
+// If AuthAssumeRoleEnvVar is set, assumes the IAM role specified in it; otherwise falls back to
+// the default credential chain.
+// The ctx parameter supports cancellation and timeouts.
+func NewAuthConfigContextE(t testing.TestingT, ctx context.Context, region string) (*aws.Config, error) {
+	if assumeRoleArn, ok := os.LookupEnv(AuthAssumeRoleEnvVar); ok {
+		return NewAuthConfigFromRoleContextE(t, ctx, region, assumeRoleArn)
+	}
+
+	return NewAuthConfigFromDefaultCredentialsContextE(t, ctx, region)
+}
+
+// NewAuthConfigContext creates an AWS Config following the standard AWS authentication workflow.
+// This function will fail the test if there is an error.
+// The ctx parameter supports cancellation and timeouts.
+func NewAuthConfigContext(t testing.TestingT, ctx context.Context, region string) *aws.Config {
+	t.Helper()
+	cfg, err := NewAuthConfigContextE(t, ctx, region)
+	require.NoError(t, err)
+	return cfg
+}
+
+// NewAuthConfigE creates an AWS Config following the standard AWS authentication workflow.
+func NewAuthConfigE(t testing.TestingT, region string) (*aws.Config, error) {
+	return NewAuthConfigContextE(t, context.Background(), region)
+}
+
+// NewAuthConfig creates an AWS Config following the standard AWS authentication workflow.
+// This function will fail the test if there is an error.
+func NewAuthConfig(t testing.TestingT, region string) *aws.Config {
+	t.Helper()
+	return NewAuthConfigContext(t, context.Background(), region)
+}
+
+// NewAuthConfigFromDefaultCredentialsContextE gets an AWS Config using the default credential
+// chain, checking that the user has credentials properly configured in their environment.
+// The ctx parameter supports cancellation and timeouts.
+func NewAuthConfigFromDefaultCredentialsContextE(t testing.TestingT, ctx context.Context, region string) (*aws.Config, error) {
+	cfg, err := config.LoadDefaultConfig(ctx, config.WithRegion(region))
+	if err != nil {
+		return nil, CredentialsError{UnderlyingErr: err}
+	}
+
+	return &cfg, nil
+}
+
+// NewAuthConfigFromDefaultCredentialsContext gets an AWS Config using the default credential chain.
+// This function will fail the test if there is an error.
+// The ctx parameter supports cancellation and timeouts.
+func NewAuthConfigFromDefaultCredentialsContext(t testing.TestingT, ctx context.Context, region string) *aws.Config {
+	t.Helper()
+	cfg, err := NewAuthConfigFromDefaultCredentialsContextE(t, ctx, region)
+	require.NoError(t, err)
+	return cfg
+}
+
+// NewAuthConfigFromDefaultCredentialsE gets an AWS Config using the default credential chain.
+func NewAuthConfigFromDefaultCredentialsE(t testing.TestingT, region string) (*aws.Config, error) {
+	return NewAuthConfigFromDefaultCredentialsContextE(t, context.Background(), region)
+}
+
+// NewAuthConfigFromDefaultCredentials gets an AWS Config using the default credential chain.
+// This function will fail the test if there is an error.
+func NewAuthConfigFromDefaultCredentials(t testing.TestingT, region string) *aws.Config {
+	t.Helper()
+	return NewAuthConfigFromDefaultCredentialsContext(t, context.Background(), region)
+}
+
+// NewAuthConfigFromRoleContextE returns a new AWS Config after assuming the role whose ARN
+// is provided in roleARN. If the credentials are not properly configured in the underlying
+// environment, an error is returned.
+// The ctx parameter supports cancellation and timeouts.
+func NewAuthConfigFromRoleContextE(t testing.TestingT, ctx context.Context, region string, roleARN string) (*aws.Config, error) {
+	cfg, err := NewAuthConfigFromDefaultCredentialsContextE(t, ctx, region)
+	if err != nil {
+		return nil, err
+	}
+
+	client := sts.NewFromConfig(*cfg)
+	roleProvider := stscreds.NewAssumeRoleProvider(client, roleARN)
+
+	retrieve, err := roleProvider.Retrieve(ctx)
+	if err != nil {
+		return nil, CredentialsError{UnderlyingErr: err}
+	}
+
+	return &aws.Config{
+		Region: region,
+		Credentials: aws.NewCredentialsCache(credentials.StaticCredentialsProvider{
+			Value: retrieve,
+		}),
+	}, nil
+}
+
+// NewAuthConfigFromRoleContext returns a new AWS Config after assuming the role whose ARN is provided in roleARN.
+// This function will fail the test if there is an error.
+// The ctx parameter supports cancellation and timeouts.
+func NewAuthConfigFromRoleContext(t testing.TestingT, ctx context.Context, region string, roleARN string) *aws.Config {
+	t.Helper()
+	cfg, err := NewAuthConfigFromRoleContextE(t, ctx, region, roleARN)
+	require.NoError(t, err)
+	return cfg
+}
+
+// NewAuthConfigFromRoleE returns a new AWS Config after assuming the role whose ARN is provided in roleARN.
+func NewAuthConfigFromRoleE(t testing.TestingT, region string, roleARN string) (*aws.Config, error) {
+	return NewAuthConfigFromRoleContextE(t, context.Background(), region, roleARN)
+}
+
+// NewAuthConfigFromRole returns a new AWS Config after assuming the role whose ARN is provided in roleARN.
+// This function will fail the test if there is an error.
+func NewAuthConfigFromRole(t testing.TestingT, region string, roleARN string) *aws.Config {
+	t.Helper()
+	return NewAuthConfigFromRoleContext(t, context.Background(), region, roleARN)
+}
+
+// NewAuthConfigWithCredsE creates a new AWS Config using explicit static credentials. Useful for
+// authenticating as a dynamically-created IAM User. No context variant is provided because this
+// function performs no I/O — it only constructs an aws.Config.
+func NewAuthConfigWithCredsE(t testing.TestingT, region string, accessKeyID string, secretAccessKey string) (*aws.Config, error) {
+	return &aws.Config{
+		Region:      region,
+		Credentials: aws.NewCredentialsCache(credentials.NewStaticCredentialsProvider(accessKeyID, secretAccessKey, "")),
+	}, nil
+}
+
+// NewAuthConfigWithCreds creates a new AWS Config using explicit static credentials.
+// This function will fail the test if there is an error.
+func NewAuthConfigWithCreds(t testing.TestingT, region string, accessKeyID string, secretAccessKey string) *aws.Config {
+	t.Helper()
+	cfg, err := NewAuthConfigWithCredsE(t, region, accessKeyID, secretAccessKey)
+	require.NoError(t, err)
+	return cfg
+}
+
+// NewAuthConfigWithMfaContextE creates a new AWS Config authenticated with an MFA session token
+// obtained via the given STS client and MFA device.
+// The ctx parameter supports cancellation and timeouts.
+func NewAuthConfigWithMfaContextE(t testing.TestingT, ctx context.Context, region string, stsClient *sts.Client, mfaDevice *types.VirtualMFADevice) (*aws.Config, error) {
+	tokenCode, err := GenerateMfaTokenE(t, mfaDevice)
+	if err != nil {
+		return nil, err
+	}
+
+	output, err := stsClient.GetSessionToken(ctx, &sts.GetSessionTokenInput{
+		SerialNumber: mfaDevice.SerialNumber,
+		TokenCode:    aws.String(tokenCode),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	accessKeyID := *output.Credentials.AccessKeyId
+	secretAccessKey := *output.Credentials.SecretAccessKey
+	sessionToken := *output.Credentials.SessionToken
+
+	return &aws.Config{
+		Region:      region,
+		Credentials: aws.NewCredentialsCache(credentials.NewStaticCredentialsProvider(accessKeyID, secretAccessKey, sessionToken)),
+	}, nil
+}
+
+// NewAuthConfigWithMfaContext creates a new AWS Config authenticated with an MFA session token.
+// This function will fail the test if there is an error.
+// The ctx parameter supports cancellation and timeouts.
+func NewAuthConfigWithMfaContext(t testing.TestingT, ctx context.Context, region string, stsClient *sts.Client, mfaDevice *types.VirtualMFADevice) *aws.Config {
+	t.Helper()
+	cfg, err := NewAuthConfigWithMfaContextE(t, ctx, region, stsClient, mfaDevice)
+	require.NoError(t, err)
+	return cfg
+}
+
+// NewAuthConfigWithMfaE creates a new AWS Config authenticated with an MFA session token.
+func NewAuthConfigWithMfaE(t testing.TestingT, region string, stsClient *sts.Client, mfaDevice *types.VirtualMFADevice) (*aws.Config, error) {
+	return NewAuthConfigWithMfaContextE(t, context.Background(), region, stsClient, mfaDevice)
+}
+
+// NewAuthConfigWithMfa creates a new AWS Config authenticated with an MFA session token.
+// This function will fail the test if there is an error.
+func NewAuthConfigWithMfa(t testing.TestingT, region string, stsClient *sts.Client, mfaDevice *types.VirtualMFADevice) *aws.Config {
+	t.Helper()
+	return NewAuthConfigWithMfaContext(t, context.Background(), region, stsClient, mfaDevice)
+}
+
+// GenerateMfaTokenE returns a time-based one-time password for the given MFA device, per RFC 6238.
+// The returned value changes every 30 seconds.
+func GenerateMfaTokenE(t testing.TestingT, mfaDevice *types.VirtualMFADevice) (string, error) {
+	base32StringSeed := string(mfaDevice.Base32StringSeed)
+
+	otp, err := totp.GenerateCode(base32StringSeed, time.Now())
+	if err != nil {
+		return "", err
+	}
+
+	return otp, nil
+}
+
+// GenerateMfaToken returns a time-based one-time password for the given MFA device, per RFC 6238.
+// This function will fail the test if there is an error.
+func GenerateMfaToken(t testing.TestingT, mfaDevice *types.VirtualMFADevice) string {
+	t.Helper()
+	token, err := GenerateMfaTokenE(t, mfaDevice)
+	require.NoError(t, err)
+	return token
+}
+
+// GetPasswordPolicyMinLengthContextE returns the minimum password length from the account's
+// IAM password policy.
+// The ctx parameter supports cancellation and timeouts.
+func GetPasswordPolicyMinLengthContextE(t testing.TestingT, ctx context.Context, iamClient *iam.Client) (int, error) {
+	output, err := iamClient.GetAccountPasswordPolicy(ctx, &iam.GetAccountPasswordPolicyInput{})
+	if err != nil {
+		return -1, err
+	}
+
+	return int(*output.PasswordPolicy.MinimumPasswordLength), nil
+}
+
+// GetPasswordPolicyMinLengthContext returns the minimum password length from the account's IAM password policy.
+// This function will fail the test if there is an error.
+// The ctx parameter supports cancellation and timeouts.
+func GetPasswordPolicyMinLengthContext(t testing.TestingT, ctx context.Context, iamClient *iam.Client) int {
+	t.Helper()
+	n, err := GetPasswordPolicyMinLengthContextE(t, ctx, iamClient)
+	require.NoError(t, err)
+	return n
+}
+
+// GetPasswordPolicyMinLengthE returns the minimum password length from the account's IAM password policy.
+func GetPasswordPolicyMinLengthE(t testing.TestingT, iamClient *iam.Client) (int, error) {
+	return GetPasswordPolicyMinLengthContextE(t, context.Background(), iamClient)
+}
+
+// GetPasswordPolicyMinLength returns the minimum password length from the account's IAM password policy.
+// This function will fail the test if there is an error.
+func GetPasswordPolicyMinLength(t testing.TestingT, iamClient *iam.Client) int {
+	t.Helper()
+	return GetPasswordPolicyMinLengthContext(t, context.Background(), iamClient)
+}
+
+// CredentialsError is an error that occurs because AWS credentials can't be found.
+type CredentialsError struct {
+	UnderlyingErr error
+}
+
+func (err CredentialsError) Error() string {
+	return fmt.Sprintf("Error finding AWS credentials. Did you set the AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment variables or configure an AWS profile? Underlying error: %v", err.UnderlyingErr)
+}
+
+// -----------------------------------------------------------------------------
+// Deprecated: legacy surface preserved for backwards compatibility.
+//
+// These functions predate the package's testing.TestingT + Context[E] convention.
+// New callers should use the NewAuthConfig* / GenerateMfaToken / GetPasswordPolicyMinLength
+// families above. The shims below will be removed in a future major release.
+// -----------------------------------------------------------------------------
+
 // NewAuthenticatedSessionContext creates an AWS Config following to standard AWS authentication workflow.
 // If AuthAssumeIamRoleEnvVar environment variable is set, assumes IAM role specified in it.
-// The ctx parameter supports cancellation and timeouts.
+//
+// Deprecated: Use [NewAuthConfigContextE] (or [NewAuthConfigContext] for panic-on-error semantics) instead.
 func NewAuthenticatedSessionContext(ctx context.Context, region string) (*aws.Config, error) {
 	if assumeRoleArn, ok := os.LookupEnv(AuthAssumeRoleEnvVar); ok {
 		return NewAuthenticatedSessionFromRoleContext(ctx, region, assumeRoleArn)
@@ -34,13 +294,14 @@ func NewAuthenticatedSessionContext(ctx context.Context, region string) (*aws.Co
 // NewAuthenticatedSession creates an AWS Config following to standard AWS authentication workflow.
 // If AuthAssumeIamRoleEnvVar environment variable is set, assumes IAM role specified in it.
 //
-// Deprecated: Use [NewAuthenticatedSessionContext] instead.
+// Deprecated: Use [NewAuthConfigE] (or [NewAuthConfig] for panic-on-error semantics) instead.
 func NewAuthenticatedSession(region string) (*aws.Config, error) {
 	return NewAuthenticatedSessionContext(context.Background(), region)
 }
 
 // NewAuthenticatedSessionFromDefaultCredentialsContext gets an AWS Config, checking that the user has credentials properly configured in their environment.
-// The ctx parameter supports cancellation and timeouts.
+//
+// Deprecated: Use [NewAuthConfigFromDefaultCredentialsContextE] instead.
 func NewAuthenticatedSessionFromDefaultCredentialsContext(ctx context.Context, region string) (*aws.Config, error) {
 	cfg, err := config.LoadDefaultConfig(ctx, config.WithRegion(region))
 	if err != nil {
@@ -52,7 +313,7 @@ func NewAuthenticatedSessionFromDefaultCredentialsContext(ctx context.Context, r
 
 // NewAuthenticatedSessionFromDefaultCredentials gets an AWS Config, checking that the user has credentials properly configured in their environment.
 //
-// Deprecated: Use [NewAuthenticatedSessionFromDefaultCredentialsContext] instead.
+// Deprecated: Use [NewAuthConfigFromDefaultCredentialsE] instead.
 func NewAuthenticatedSessionFromDefaultCredentials(region string) (*aws.Config, error) {
 	return NewAuthenticatedSessionFromDefaultCredentialsContext(context.Background(), region)
 }
@@ -60,7 +321,8 @@ func NewAuthenticatedSessionFromDefaultCredentials(region string) (*aws.Config, 
 // NewAuthenticatedSessionFromRoleContext returns a new AWS Config after assuming the
 // role whose ARN is provided in roleARN. If the credentials are not properly
 // configured in the underlying environment, an error is returned.
-// The ctx parameter supports cancellation and timeouts.
+//
+// Deprecated: Use [NewAuthConfigFromRoleContextE] instead.
 func NewAuthenticatedSessionFromRoleContext(ctx context.Context, region string, roleARN string) (*aws.Config, error) {
 	cfg, err := NewAuthenticatedSessionFromDefaultCredentialsContext(ctx, region)
 	if err != nil {
@@ -88,14 +350,15 @@ func NewAuthenticatedSessionFromRoleContext(ctx context.Context, region string, 
 // role whose ARN is provided in roleARN. If the credentials are not properly
 // configured in the underlying environment, an error is returned.
 //
-// Deprecated: Use [NewAuthenticatedSessionFromRoleContext] instead.
+// Deprecated: Use [NewAuthConfigFromRoleE] instead.
 func NewAuthenticatedSessionFromRole(region string, roleARN string) (*aws.Config, error) {
 	return NewAuthenticatedSessionFromRoleContext(context.Background(), region, roleARN)
 }
 
-// CreateAwsSessionWithCredsContext creates a new AWS Config using explicit credentials. This is useful if you want to create an IAM User dynamically and
-// create an AWS Config authenticated as the new IAM User.
-// The ctx parameter is accepted for API consistency but not currently used.
+// CreateAwsSessionWithCredsContext creates a new AWS Config using explicit credentials.
+//
+// Deprecated: Use [NewAuthConfigWithCredsE] instead. The Context variant was a placeholder
+// for API symmetry — the underlying operation performs no I/O, so no context is needed.
 func CreateAwsSessionWithCredsContext(ctx context.Context, region string, accessKeyID string, secretAccessKey string) (*aws.Config, error) {
 	return &aws.Config{
 		Region:      region,
@@ -103,16 +366,16 @@ func CreateAwsSessionWithCredsContext(ctx context.Context, region string, access
 	}, nil
 }
 
-// CreateAwsSessionWithCreds creates a new AWS Config using explicit credentials. This is useful if you want to create an IAM User dynamically and
-// create an AWS Config authenticated as the new IAM User.
+// CreateAwsSessionWithCreds creates a new AWS Config using explicit credentials.
 //
-// Deprecated: Use [CreateAwsSessionWithCredsContext] instead.
+// Deprecated: Use [NewAuthConfigWithCredsE] instead.
 func CreateAwsSessionWithCreds(region string, accessKeyID string, secretAccessKey string) (*aws.Config, error) {
 	return CreateAwsSessionWithCredsContext(context.Background(), region, accessKeyID, secretAccessKey)
 }
 
 // CreateAwsSessionWithMfaContext creates a new AWS Config authenticated using an MFA token retrieved using the given STS client and MFA Device.
-// The ctx parameter supports cancellation and timeouts.
+//
+// Deprecated: Use [NewAuthConfigWithMfaContextE] instead.
 func CreateAwsSessionWithMfaContext(ctx context.Context, region string, stsClient *sts.Client, mfaDevice *types.VirtualMFADevice) (*aws.Config, error) {
 	tokenCode, err := GetTimeBasedOneTimePassword(mfaDevice)
 	if err != nil {
@@ -139,12 +402,14 @@ func CreateAwsSessionWithMfaContext(ctx context.Context, region string, stsClien
 
 // CreateAwsSessionWithMfa creates a new AWS Config authenticated using an MFA token retrieved using the given STS client and MFA Device.
 //
-// Deprecated: Use [CreateAwsSessionWithMfaContext] instead.
+// Deprecated: Use [NewAuthConfigWithMfaE] instead.
 func CreateAwsSessionWithMfa(region string, stsClient *sts.Client, mfaDevice *types.VirtualMFADevice) (*aws.Config, error) {
 	return CreateAwsSessionWithMfaContext(context.Background(), region, stsClient, mfaDevice)
 }
 
 // GetTimeBasedOneTimePassword gets a One-Time Password from the given mfaDevice. Per the RFC 6238 standard, this value will be different every 30 seconds.
+//
+// Deprecated: Use [GenerateMfaTokenE] instead.
 func GetTimeBasedOneTimePassword(mfaDevice *types.VirtualMFADevice) (string, error) {
 	base32StringSeed := string(mfaDevice.Base32StringSeed)
 
@@ -157,7 +422,8 @@ func GetTimeBasedOneTimePassword(mfaDevice *types.VirtualMFADevice) (string, err
 }
 
 // ReadPasswordPolicyMinPasswordLengthContext returns the minimal password length.
-// The ctx parameter supports cancellation and timeouts.
+//
+// Deprecated: Use [GetPasswordPolicyMinLengthContextE] instead.
 func ReadPasswordPolicyMinPasswordLengthContext(ctx context.Context, iamClient *iam.Client) (int, error) {
 	output, err := iamClient.GetAccountPasswordPolicy(ctx, &iam.GetAccountPasswordPolicyInput{})
 	if err != nil {
@@ -169,16 +435,7 @@ func ReadPasswordPolicyMinPasswordLengthContext(ctx context.Context, iamClient *
 
 // ReadPasswordPolicyMinPasswordLength returns the minimal password length.
 //
-// Deprecated: Use [ReadPasswordPolicyMinPasswordLengthContext] instead.
+// Deprecated: Use [GetPasswordPolicyMinLengthE] instead.
 func ReadPasswordPolicyMinPasswordLength(iamClient *iam.Client) (int, error) {
 	return ReadPasswordPolicyMinPasswordLengthContext(context.Background(), iamClient)
-}
-
-// CredentialsError is an error that occurs because AWS credentials can't be found.
-type CredentialsError struct {
-	UnderlyingErr error
-}
-
-func (err CredentialsError) Error() string {
-	return fmt.Sprintf("Error finding AWS credentials. Did you set the AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment variables or configure an AWS profile? Underlying error: %v", err.UnderlyingErr)
 }

--- a/modules/aws/cloudwatch.go
+++ b/modules/aws/cloudwatch.go
@@ -65,7 +65,7 @@ func GetCloudWatchLogEntriesE(t testing.TestingT, awsRegion string, logStreamNam
 // NewCloudWatchLogsClientContextE creates a new CloudWatch Logs client.
 // The ctx parameter supports cancellation and timeouts.
 func NewCloudWatchLogsClientContextE(t testing.TestingT, ctx context.Context, region string) (*cloudwatchlogs.Client, error) {
-	sess, err := NewAuthenticatedSessionContext(ctx, region)
+	sess, err := NewAuthConfigContextE(t, ctx, region)
 	if err != nil {
 		return nil, err
 	}

--- a/modules/aws/dynamodb.go
+++ b/modules/aws/dynamodb.go
@@ -162,7 +162,7 @@ func GetDynamoDBTableE(t testing.TestingT, region string, tableName string) (*ty
 // NewDynamoDBClientContextE creates a DynamoDB client.
 // The ctx parameter supports cancellation and timeouts.
 func NewDynamoDBClientContextE(t testing.TestingT, ctx context.Context, region string) (*dynamodb.Client, error) {
-	sess, err := NewAuthenticatedSessionContext(ctx, region)
+	sess, err := NewAuthConfigContextE(t, ctx, region)
 	if err != nil {
 		return nil, err
 	}

--- a/modules/aws/ebs.go
+++ b/modules/aws/ebs.go
@@ -15,7 +15,7 @@ import (
 func DeleteEbsSnapshotContextE(t testing.TestingT, ctx context.Context, region string, snapshot string) error {
 	logger.Default.Logf(t, "Deleting EBS snapshot %s", snapshot)
 
-	sess, err := NewAuthenticatedSessionContext(ctx, region)
+	sess, err := NewAuthConfigContextE(t, ctx, region)
 	if err != nil {
 		return err
 	}

--- a/modules/aws/ec2-syslog.go
+++ b/modules/aws/ec2-syslog.go
@@ -25,7 +25,7 @@ func GetSyslogForInstanceContextE(t testing.TestingT, ctx context.Context, insta
 
 	logger.Default.Logf(t, "%s", description)
 
-	sess, err := NewAuthenticatedSessionContext(ctx, region)
+	sess, err := NewAuthConfigContextE(t, ctx, region)
 	if err != nil {
 		return "", err
 	}

--- a/modules/aws/ec2.go
+++ b/modules/aws/ec2.go
@@ -920,7 +920,7 @@ func getInstanceFieldMapContextE(t testing.TestingT, ctx context.Context, instan
 // NewEc2ClientContextE creates an EC2 client.
 // The ctx parameter supports cancellation and timeouts.
 func NewEc2ClientContextE(t testing.TestingT, ctx context.Context, region string) (*ec2.Client, error) {
-	sess, err := NewAuthenticatedSessionContext(ctx, region)
+	sess, err := NewAuthConfigContextE(t, ctx, region)
 	if err != nil {
 		return nil, err
 	}

--- a/modules/aws/ecr.go
+++ b/modules/aws/ecr.go
@@ -172,7 +172,7 @@ func DeleteECRRepoE(t testing.TestingT, region string, repo *types.Repository) e
 // NewECRClientContextE returns a client for the Elastic Container Registry.
 // The ctx parameter supports cancellation and timeouts.
 func NewECRClientContextE(t testing.TestingT, ctx context.Context, region string) (*ecr.Client, error) {
-	sess, err := NewAuthenticatedSessionContext(ctx, region)
+	sess, err := NewAuthConfigContextE(t, ctx, region)
 	if err != nil {
 		return nil, err
 	}

--- a/modules/aws/ecs.go
+++ b/modules/aws/ecs.go
@@ -308,7 +308,7 @@ func GetEcsTaskDefinitionE(t testing.TestingT, region string, taskDefinition str
 // NewEcsClientContextE creates an ECS client.
 // The ctx parameter supports cancellation and timeouts.
 func NewEcsClientContextE(t testing.TestingT, ctx context.Context, region string) (*ecs.Client, error) {
-	sess, err := NewAuthenticatedSessionContext(ctx, region)
+	sess, err := NewAuthConfigContextE(t, ctx, region)
 	if err != nil {
 		return nil, err
 	}

--- a/modules/aws/iam.go
+++ b/modules/aws/iam.go
@@ -232,7 +232,7 @@ func EnableMfaDeviceContextE(t testing.TestingT, ctx context.Context, iamClient 
 		return err
 	}
 
-	authCode1, err := GetTimeBasedOneTimePassword(mfaDevice)
+	authCode1, err := GenerateMfaTokenE(t, mfaDevice)
 	if err != nil {
 		return err
 	}
@@ -242,7 +242,7 @@ func EnableMfaDeviceContextE(t testing.TestingT, ctx context.Context, iamClient 
 	logger.Default.Logf(t, "Waiting 30 seconds for a new MFA Token to be generated...")
 	time.Sleep(mfaEnableWait)
 
-	authCode2, err := GetTimeBasedOneTimePassword(mfaDevice)
+	authCode2, err := GenerateMfaTokenE(t, mfaDevice)
 	if err != nil {
 		return err
 	}
@@ -297,7 +297,7 @@ func EnableMfaDeviceE(t testing.TestingT, iamClient *iam.Client, mfaDevice *type
 // NewIamClientContextE creates a new IAM client.
 // The ctx parameter supports cancellation and timeouts.
 func NewIamClientContextE(t testing.TestingT, ctx context.Context, region string) (*iam.Client, error) {
-	sess, err := NewAuthenticatedSessionContext(ctx, region)
+	sess, err := NewAuthConfigContextE(t, ctx, region)
 	if err != nil {
 		return nil, err
 	}

--- a/modules/aws/keypair.go
+++ b/modules/aws/keypair.go
@@ -64,7 +64,7 @@ func CreateAndImportEC2KeyPairE(t testing.TestingT, region string, name string) 
 func ImportEC2KeyPairContextE(t testing.TestingT, ctx context.Context, region string, name string, keyPair *ssh.KeyPair) (*Ec2Keypair, error) {
 	logger.Default.Logf(t, "Creating new Key Pair in EC2 region %s named %s", region, name)
 
-	sess, err := NewAuthenticatedSessionContext(ctx, region)
+	sess, err := NewAuthConfigContextE(t, ctx, region)
 	if err != nil {
 		return nil, err
 	}
@@ -117,7 +117,7 @@ func ImportEC2KeyPairE(t testing.TestingT, region string, name string, keyPair *
 func DeleteEC2KeyPairContextE(t testing.TestingT, ctx context.Context, keyPair *Ec2Keypair) error {
 	logger.Default.Logf(t, "Deleting Key Pair in EC2 region %s named %s", keyPair.Region, keyPair.Name)
 
-	sess, err := NewAuthenticatedSessionContext(ctx, keyPair.Region)
+	sess, err := NewAuthConfigContextE(t, ctx, keyPair.Region)
 	if err != nil {
 		return err
 	}

--- a/modules/aws/kms.go
+++ b/modules/aws/kms.go
@@ -62,7 +62,7 @@ func GetCmkArnE(t testing.TestingT, region string, cmkID string) (string, error)
 // NewKmsClientContextE creates a KMS client.
 // The ctx parameter supports cancellation and timeouts.
 func NewKmsClientContextE(t testing.TestingT, ctx context.Context, region string) (*kms.Client, error) {
-	sess, err := NewAuthenticatedSessionContext(ctx, region)
+	sess, err := NewAuthConfigContextE(t, ctx, region)
 	if err != nil {
 		return nil, err
 	}

--- a/modules/aws/lambda.go
+++ b/modules/aws/lambda.go
@@ -225,7 +225,7 @@ func (err *FunctionError) Error() string {
 // NewLambdaClientContextE creates a new Lambda client.
 // The ctx parameter supports cancellation and timeouts.
 func NewLambdaClientContextE(t testing.TestingT, ctx context.Context, region string) (*lambda.Client, error) {
-	sess, err := NewAuthenticatedSessionContext(ctx, region)
+	sess, err := NewAuthConfigContextE(t, ctx, region)
 	if err != nil {
 		return nil, err
 	}

--- a/modules/aws/rds.go
+++ b/modules/aws/rds.go
@@ -494,7 +494,7 @@ func GetRdsInstanceDetailsE(t testing.TestingT, dbInstanceID string, awsRegion s
 // NewRdsClientContextE creates an RDS client.
 // The ctx parameter supports cancellation and timeouts.
 func NewRdsClientContextE(t testing.TestingT, ctx context.Context, region string) (*rds.Client, error) {
-	sess, err := NewAuthenticatedSessionContext(ctx, region)
+	sess, err := NewAuthConfigContextE(t, ctx, region)
 	if err != nil {
 		return nil, err
 	}

--- a/modules/aws/route53.go
+++ b/modules/aws/route53.go
@@ -73,7 +73,7 @@ func GetRoute53RecordE(t ttesting.TestingT, hostedZoneID, recordName, recordType
 func NewRoute53ClientContextE(t ttesting.TestingT, ctx context.Context, region string) (*route53.Client, error) {
 	t.Helper()
 
-	sess, err := NewAuthenticatedSessionContext(ctx, region)
+	sess, err := NewAuthConfigContextE(t, ctx, region)
 	if err != nil {
 		return nil, err
 	}

--- a/modules/aws/s3.go
+++ b/modules/aws/s3.go
@@ -913,7 +913,7 @@ func AssertS3BucketPolicyExistsE(t testing.TestingT, region string, bucketName s
 // NewS3ClientContextE creates an S3 client.
 // The ctx parameter supports cancellation and timeouts.
 func NewS3ClientContextE(t testing.TestingT, ctx context.Context, region string) (*s3.Client, error) {
-	sess, err := NewAuthenticatedSessionContext(ctx, region)
+	sess, err := NewAuthConfigContextE(t, ctx, region)
 	if err != nil {
 		return nil, err
 	}
@@ -952,7 +952,7 @@ func NewS3ClientE(t testing.TestingT, region string) (*s3.Client, error) {
 // NewS3UploaderContextE creates an S3 Uploader.
 // The ctx parameter supports cancellation and timeouts.
 func NewS3UploaderContextE(t testing.TestingT, ctx context.Context, region string) (*manager.Uploader, error) {
-	sess, err := NewAuthenticatedSessionContext(ctx, region)
+	sess, err := NewAuthConfigContextE(t, ctx, region)
 	if err != nil {
 		return nil, err
 	}

--- a/modules/aws/secretsmanager.go
+++ b/modules/aws/secretsmanager.go
@@ -191,7 +191,7 @@ func DeleteSecretE(t testing.TestingT, awsRegion, id string, forceDelete bool) e
 // NewSecretsManagerClientContextE creates a new SecretsManager client.
 // The ctx parameter supports cancellation and timeouts.
 func NewSecretsManagerClientContextE(t testing.TestingT, ctx context.Context, region string) (*secretsmanager.Client, error) {
-	sess, err := NewAuthenticatedSessionContext(ctx, region)
+	sess, err := NewAuthConfigContextE(t, ctx, region)
 	if err != nil {
 		return nil, err
 	}

--- a/modules/aws/sns.go
+++ b/modules/aws/sns.go
@@ -108,7 +108,7 @@ func DeleteSNSTopicE(t testing.TestingT, region string, snsTopicArn string) erro
 // NewSnsClientContextE creates a new SNS client.
 // The ctx parameter supports cancellation and timeouts.
 func NewSnsClientContextE(t testing.TestingT, ctx context.Context, region string) (*sns.Client, error) {
-	sess, err := NewAuthenticatedSessionContext(ctx, region)
+	sess, err := NewAuthConfigContextE(t, ctx, region)
 	if err != nil {
 		return nil, err
 	}

--- a/modules/aws/sqs.go
+++ b/modules/aws/sqs.go
@@ -383,7 +383,7 @@ func WaitForQueueMessage(t testing.TestingT, awsRegion string, queueURL string, 
 // NewSqsClientContextE creates a new SQS client.
 // The ctx parameter supports cancellation and timeouts.
 func NewSqsClientContextE(t testing.TestingT, ctx context.Context, region string) (*sqs.Client, error) {
-	sess, err := NewAuthenticatedSessionContext(ctx, region)
+	sess, err := NewAuthConfigContextE(t, ctx, region)
 	if err != nil {
 		return nil, err
 	}

--- a/modules/aws/ssm.go
+++ b/modules/aws/ssm.go
@@ -188,7 +188,7 @@ func DeleteParameterWithClientE(t testing.TestingT, client *ssm.Client, keyName 
 // NewSsmClientContextE creates an SSM client.
 // The ctx parameter supports cancellation and timeouts.
 func NewSsmClientContextE(t testing.TestingT, ctx context.Context, region string) (*ssm.Client, error) {
-	sess, err := NewAuthenticatedSessionContext(ctx, region)
+	sess, err := NewAuthConfigContextE(t, ctx, region)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Why

The auth.go surface shipped with three deviations from the convention every other module in `modules/aws` follows:

- No `testing.TestingT` parameter on any function
- No panic variants (only error-returning forms)
- `Context` suffix meant "takes ctx, returns error" — the opposite of the rest of the package, where `Context` panics and `ContextE` errors

v1.0.0 freezes the public surface, so this is the last window to land the idiomatic shape without a compat story.

Adding the idiomatic variants in place wasn't possible: the existing names were already taken by non-idiomatic signatures and Go can't overload. So the new canonical surface lands under renamed families that sidestep each collision — and every pre-existing public function is preserved byte-for-byte as a `// Deprecated:` shim pointing at its replacement, so no external caller breaks.

## Renames

| Old (kept as deprecated shim)              | New canonical                     | Reason                                                                        |
| ------------------------------------------ | --------------------------------- | ----------------------------------------------------------------------------- |
| `NewAuthenticatedSession*`                 | `NewAuthConfig*`                  | Name collision; also aligns with v2 SDK terminology (`*aws.Config`, not Session) |
| `CreateAwsSessionWith{Creds,Mfa}*`         | `NewAuthConfigWith{Creds,Mfa}*`   | Naming consistency within the family                                          |
| `GetTimeBasedOneTimePassword`              | `GenerateMfaToken[E]`             | Name collision                                                                |
| `ReadPasswordPolicyMinPasswordLength*`     | `GetPasswordPolicyMinLength*`     | Name collision                                                                |

The canonical surface now provides the standard 4-variant shape (panic / error / with-ctx-panic / with-ctx-error), with `testing.TestingT` as the first parameter. `NewAuthConfigWithCreds` intentionally has no `Context` variant — the function performs no I/O.

## Internal migration

22 call sites across 21 files moved from `NewAuthenticatedSessionContext(ctx, region)` → `NewAuthConfigContextE(t, ctx, region)`, and 2 `GetTimeBasedOneTimePassword(mfaDevice)` calls in `iam.go` → `GenerateMfaTokenE(t, mfaDevice)`. Every call site was inside a `New*ClientContextE(t, ctx, region)` helper where `t` was already in scope, so migrations are mechanical single-line swaps.

## Test plan

- [x] `go build ./modules/aws/...` — clean
- [x] `go vet ./modules/aws/...` — clean
- [x] `go test -count=1 -run='^$' ./modules/aws/...` — tests compile
- [x] Grepped for remaining references to old names outside `auth.go` — none
- [x] Confirmed all 13 pre-existing public functions still present with original signatures
- [x] Confirmed `CredentialsError` struct defined exactly once
- [ ] Integration smoke on any auth-dependent test in CI