### PR TITLE
fix(aws): prevent RDS/IAM panics and paginate ACM certificate lookups

### DIFF
--- a/modules/aws/acm.go
+++ b/modules/aws/acm.go
@@ -32,20 +32,28 @@ func GetAcmCertificateArnContextE(t testing.TestingT, ctx context.Context, awsRe
 // a mock.
 // The ctx parameter supports cancellation and timeouts.
 func GetAcmCertificateArnWithClientContextE(t testing.TestingT, ctx context.Context, client AcmAPI, certDomainName string) (string, error) {
-	result, err := client.ListCertificates(ctx, &acm.ListCertificatesInput{})
-	if err != nil {
-		return "", err
-	}
+	input := &acm.ListCertificatesInput{}
 
-	for i := range result.CertificateSummaryList {
-		summary := &result.CertificateSummaryList[i]
-
-		if *summary.DomainName == certDomainName {
-			return *summary.CertificateArn, nil
+	for {
+		result, err := client.ListCertificates(ctx, input)
+		if err != nil {
+			return "", err
 		}
-	}
 
-	return "", nil
+		for i := range result.CertificateSummaryList {
+			summary := &result.CertificateSummaryList[i]
+
+			if *summary.DomainName == certDomainName {
+				return *summary.CertificateArn, nil
+			}
+		}
+
+		if result.NextToken == nil || *result.NextToken == "" {
+			return "", nil
+		}
+
+		input.NextToken = result.NextToken
+	}
 }
 
 // GetAcmCertificateArnContext gets the ACM certificate for the given domain name in the given region.

--- a/modules/aws/acm_test.go
+++ b/modules/aws/acm_test.go
@@ -3,6 +3,7 @@ package aws_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	awsSDK "github.com/aws/aws-sdk-go-v2/aws"
@@ -14,14 +15,29 @@ import (
 )
 
 // mockAcmClient is a test double for aws.AcmAPI that returns canned responses.
+// When ListCertificatesPages is non-empty, it returns one page per call in order,
+// advancing on each invocation; otherwise it returns ListCertificatesOutput on every call.
 type mockAcmClient struct {
 	ListCertificatesOutput *acm.ListCertificatesOutput
 	ListCertificatesErr    error
+	ListCertificatesPages  []*acm.ListCertificatesOutput
+	callCount              int
 }
 
 func (m *mockAcmClient) ListCertificates(_ context.Context, _ *acm.ListCertificatesInput, _ ...func(*acm.Options)) (*acm.ListCertificatesOutput, error) {
 	if m.ListCertificatesErr != nil {
 		return nil, m.ListCertificatesErr
+	}
+
+	if len(m.ListCertificatesPages) > 0 {
+		if m.callCount >= len(m.ListCertificatesPages) {
+			return nil, fmt.Errorf("mockAcmClient: ListCertificates called %d times but only %d page(s) configured", m.callCount+1, len(m.ListCertificatesPages))
+		}
+
+		page := m.ListCertificatesPages[m.callCount]
+		m.callCount++
+
+		return page, nil
 	}
 
 	return m.ListCertificatesOutput, nil
@@ -40,6 +56,18 @@ func TestGetAcmCertificateArnWithClientContextE(t *testing.T) {
 	twoCerts := &acm.ListCertificatesOutput{
 		CertificateSummaryList: []types.CertificateSummary{
 			{DomainName: awsSDK.String(domain1), CertificateArn: awsSDK.String(arn1)},
+			{DomainName: awsSDK.String(domain2), CertificateArn: awsSDK.String(arn2)},
+		},
+	}
+
+	page1 := &acm.ListCertificatesOutput{
+		CertificateSummaryList: []types.CertificateSummary{
+			{DomainName: awsSDK.String(domain1), CertificateArn: awsSDK.String(arn1)},
+		},
+		NextToken: awsSDK.String("page-2-token"),
+	}
+	page2 := &acm.ListCertificatesOutput{
+		CertificateSummaryList: []types.CertificateSummary{
 			{DomainName: awsSDK.String(domain2), CertificateArn: awsSDK.String(arn2)},
 		},
 	}
@@ -74,6 +102,18 @@ func TestGetAcmCertificateArnWithClientContextE(t *testing.T) {
 			client:    &mockAcmClient{ListCertificatesErr: errors.New("AccessDenied")},
 			query:     domain1,
 			expectErr: true,
+		},
+		"finds arn on second page via next token": {
+			client:      &mockAcmClient{ListCertificatesPages: []*acm.ListCertificatesOutput{page1, page2}},
+			query:       domain2,
+			expectedArn: arn2,
+		},
+		"stops paginating when last page has no next token": {
+			// page2 has no NextToken, so the caller must stop after page 2 rather
+			// than calling the mock a third time and over-running ListCertificatesPages.
+			client:      &mockAcmClient{ListCertificatesPages: []*acm.ListCertificatesOutput{page1, page2}},
+			query:       "nonexistent.example.com",
+			expectedArn: "",
 		},
 	}
 

--- a/modules/aws/iam.go
+++ b/modules/aws/iam.go
@@ -120,9 +120,13 @@ func GetIamPolicyDocumentContextE(t testing.TestingT, ctx context.Context, regio
 	var defaultVersion string
 
 	for _, version := range versions.Versions {
-		if version.IsDefaultVersion {
+		if version.IsDefaultVersion && version.VersionId != nil {
 			defaultVersion = *version.VersionId
 		}
+	}
+
+	if defaultVersion == "" {
+		return "", fmt.Errorf("no default version found for IAM policy %s", policyARN)
 	}
 
 	document, err := iamClient.GetPolicyVersion(ctx, &iam.GetPolicyVersionInput{

--- a/modules/aws/rds.go
+++ b/modules/aws/rds.go
@@ -327,6 +327,10 @@ func GetOptionGroupNameOfRdsInstanceContextE(t testing.TestingT, ctx context.Con
 		return "", err
 	}
 
+	if len(dbInstance.OptionGroupMemberships) == 0 {
+		return "", fmt.Errorf("RDS instance %s in region %s has no option group memberships", dbInstanceID, awsRegion)
+	}
+
 	return aws.ToString(dbInstance.OptionGroupMemberships[0].OptionGroupName), nil
 }
 
@@ -372,6 +376,10 @@ func GetOptionsOfOptionGroupContextE(t testing.TestingT, ctx context.Context, op
 		return []types.Option{}, err
 	}
 
+	if len(output.OptionGroupsList) == 0 {
+		return []types.Option{}, fmt.Errorf("no option groups found for name %s in region %s", optionGroupName, awsRegion)
+	}
+
 	return output.OptionGroupsList[0].Options, nil
 }
 
@@ -408,6 +416,10 @@ func GetAllParametersOfRdsInstanceContextE(t testing.TestingT, ctx context.Conte
 	dbInstance, dbInstanceErr := GetRdsInstanceDetailsContextE(t, ctx, dbInstanceID, awsRegion)
 	if dbInstanceErr != nil {
 		return []types.Parameter{}, dbInstanceErr
+	}
+
+	if len(dbInstance.DBParameterGroups) == 0 {
+		return []types.Parameter{}, fmt.Errorf("RDS instance %s in region %s has no parameter groups", dbInstanceID, awsRegion)
 	}
 
 	parameterGroupName := aws.ToString(dbInstance.DBParameterGroups[0].DBParameterGroupName)
@@ -479,6 +491,10 @@ func GetRdsInstanceDetailsContextE(t testing.TestingT, ctx context.Context, dbIn
 	output, err := rdsClient.DescribeDBInstances(ctx, &input)
 	if err != nil {
 		return nil, err
+	}
+
+	if len(output.DBInstances) == 0 {
+		return nil, fmt.Errorf("RDS instance %s not found in region %s", dbInstanceID, awsRegion)
 	}
 
 	return &output.DBInstances[0], nil

--- a/modules/aws/rds_test.go
+++ b/modules/aws/rds_test.go
@@ -1,7 +1,6 @@
 package aws_test
 
 import (
-	"fmt"
 	"testing"
 
 	aws "github.com/gruntwork-io/terratest/modules/aws"
@@ -146,7 +145,6 @@ func TestGetRecommendedRdsInstanceTypeErrors(t *testing.T) {
 			t.Parallel()
 
 			_, err := aws.GetRecommendedRdsInstanceTypeE(t, scenerio.region, scenerio.databaseEngine, scenerio.databaseEngineVersion, scenerio.instanceTypes)
-			fmt.Println(err)
 			assert.EqualError(t, err, aws.NoRdsInstanceTypeError{InstanceTypeOptions: scenerio.instanceTypes, DatabaseEngine: scenerio.databaseEngine, DatabaseEngineVersion: scenerio.databaseEngineVersion}.Error())
 		})
 	}


### PR DESCRIPTION
## Why

Three correctness bugs in AWS helpers that panic or silently return wrong results.

## What

- **RDS** — guard four unchecked `[0]` slice accesses in `GetOptionGroupNameOfRdsInstanceContextE`, `GetOptionsOfOptionGroupContextE`, `GetAllParametersOfRdsInstanceContextE`, `GetRdsInstanceDetailsContextE`. Return a descriptive error instead of panicking.
- **ACM** — `GetAcmCertificateArnWithClientContextE` now paginates on `NextToken` so matches past page 1 are no longer missed. Extends the existing mock test with a two-page case.
- **IAM** — `GetIamPolicyDocumentContextE` guards `*version.VersionId` against nil, and fails fast with a clear error when no default version is found (previously fell through with an empty `VersionId` and surfaced a generic AWS validation error).
- Drops a stray `fmt.Println(err)` in `rds_test.go`.

## Test plan

- [x] `go build / vet / test -race ./modules/aws/...`
- [x] `golangci-lint run ./modules/aws/...` — 0 issues

Stacks on #1771.