### PR TITLE
fix(azure)!: rename NsgRuleSummary.SourceAdresssPrefixes typo

### DIFF
--- a/modules/azure/nsg.go
+++ b/modules/azure/nsg.go
@@ -40,7 +40,7 @@ type NsgRuleSummary struct {
 	SourcePortRanges           []string
 	DestinationPortRanges      []string
 	DestinationAddressPrefixes []string
-	SourceAdresssPrefixes      []string
+	SourceAddressPrefixes      []string
 	Priority                   int32
 }
 
@@ -265,7 +265,7 @@ func convertToNsgRuleSummary(name *string, rule *armnetwork.SecurityRuleProperti
 	summary.DestinationPortRange = safePtrToString(rule.DestinationPortRange)
 	summary.DestinationPortRanges = safePtrToList(rule.DestinationPortRanges)
 	summary.SourceAddressPrefix = safePtrToString(rule.SourceAddressPrefix)
-	summary.SourceAdresssPrefixes = safePtrToList(rule.SourceAddressPrefixes)
+	summary.SourceAddressPrefixes = safePtrToList(rule.SourceAddressPrefixes)
 	summary.DestinationAddressPrefix = safePtrToString(rule.DestinationAddressPrefix)
 	summary.DestinationAddressPrefixes = safePtrToList(rule.DestinationAddressPrefixes)
 	summary.Access = safeDerefString((*string)(rule.Access))

--- a/modules/azure/publicaddress.go
+++ b/modules/azure/publicaddress.go
@@ -2,6 +2,7 @@ package azure
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v6"
@@ -180,7 +181,7 @@ func GetPublicIPAddressWithClient(ctx context.Context, client *armnetwork.Public
 // ExtractIPOfPublicIPAddress gets the IP string from a PublicIPAddress.
 func ExtractIPOfPublicIPAddress(pip *armnetwork.PublicIPAddress) (string, error) {
 	if pip == nil {
-		return "", fmt.Errorf("public IP address is nil")
+		return "", errors.New("public IP address is nil")
 	}
 
 	if pip.Properties == nil || pip.Properties.IPAddress == nil {


### PR DESCRIPTION
## Why

Ship v1 without a typo in the public API — `NsgRuleSummary.SourceAdresssPrefixes` has an extra 's'.

## ⚠️ Breaking

Callers using `summary.SourceAdresssPrefixes` must rename to `summary.SourceAddressPrefixes`. No semantic change — the field carried data correctly; only the identifier was misspelled.

## Test plan

- [x] `go build / vet ./modules/azure/...`
- [x] `golangci-lint run ./modules/azure/...` — no new issues