### PR TITLE
fix(gcp): guard GetPublicIP panic + credential-free WithClient test pattern

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -99,6 +99,7 @@ require (
 	github.com/jackc/pgx/v5 v5.9.0
 	github.com/lib/pq v1.10.9
 	github.com/slack-go/slack v0.15.0
+	google.golang.org/grpc v1.79.3
 	gopkg.in/yaml.v3 v3.0.1
 	gotest.tools/v3 v3.5.1
 )
@@ -208,6 +209,7 @@ require (
 	github.com/vbatts/tar-split v0.11.3 // indirect
 	github.com/virtuald/go-ordered-json v0.0.0-20170621173500-b18e6e673d74 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
+	go.einride.tech/aip v0.68.0 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/detectors/gcp v1.39.0 // indirect
@@ -229,7 +231,6 @@ require (
 	golang.org/x/tools v0.40.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20251202230838-ff82c1b0f217 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20251202230838-ff82c1b0f217 // indirect
-	google.golang.org/grpc v1.79.3 // indirect
 	google.golang.org/protobuf v1.36.10 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -549,6 +549,8 @@ go.opentelemetry.io/otel/sdk/metric v1.43.0 h1:S88dyqXjJkuBNLeMcVPRFXpRw2fuwdvfC
 go.opentelemetry.io/otel/sdk/metric v1.43.0/go.mod h1:C/RJtwSEJ5hzTiUz5pXF1kILHStzb9zFlIEe85bhj6A=
 go.opentelemetry.io/otel/trace v1.43.0 h1:BkNrHpup+4k4w+ZZ86CZoHHEkohws8AY+WTX09nk+3A=
 go.opentelemetry.io/otel/trace v1.43.0/go.mod h1:/QJhyVBUUswCphDVxq+8mld+AvhXZLhe+8WVFxiFff0=
+go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
+go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.yaml.in/yaml/v2 v2.4.3 h1:6gvOSjQoTB3vt1l+CU+tSyi/HOjfOjRLJ4YwYZGwRO0=
 go.yaml.in/yaml/v2 v2.4.3/go.mod h1:zSxWcmIDjOzPXpjlTTbAsKokqkDNAVtZO0WOMiT90s8=
 go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=

--- a/modules/gcp/cloudbuild.go
+++ b/modules/gcp/cloudbuild.go
@@ -47,6 +47,14 @@ func CreateBuildContextE(t testing.TestingT, ctx context.Context, projectID stri
 
 	defer func() { _ = service.Close() }()
 
+	return CreateBuildWithClient(ctx, service, projectID, build)
+}
+
+// CreateBuildWithClient creates a new build blocking until the operation is complete using the
+// supplied *cloudbuild.Client. Prefer this variant in unit tests where the client is backed by a
+// mock gRPC server.
+// The ctx parameter supports cancellation and timeouts.
+func CreateBuildWithClient(ctx context.Context, service *cloudbuild.Client, projectID string, build *cloudbuildpb.Build) (*cloudbuildpb.Build, error) {
 	req := &cloudbuildpb.CreateBuildRequest{
 		ProjectId: projectID,
 		Build:     build,
@@ -100,6 +108,13 @@ func GetBuildContextE(t testing.TestingT, ctx context.Context, projectID string,
 
 	defer func() { _ = service.Close() }()
 
+	return GetBuildWithClient(ctx, service, projectID, buildID)
+}
+
+// GetBuildWithClient gets the given build using the supplied *cloudbuild.Client. Prefer this variant
+// in unit tests where the client is backed by a mock gRPC server.
+// The ctx parameter supports cancellation and timeouts.
+func GetBuildWithClient(ctx context.Context, service *cloudbuild.Client, projectID string, buildID string) (*cloudbuildpb.Build, error) {
 	req := &cloudbuildpb.GetBuildRequest{
 		ProjectId: projectID,
 		Id:        buildID,
@@ -148,6 +163,14 @@ func GetBuildsContextE(t testing.TestingT, ctx context.Context, projectID string
 
 	defer func() { _ = service.Close() }()
 
+	return GetBuildsWithClient(ctx, service, projectID)
+}
+
+// GetBuildsWithClient gets the list of builds for a given project using the supplied
+// *cloudbuild.Client. Prefer this variant in unit tests where the client is backed by a mock gRPC
+// server.
+// The ctx parameter supports cancellation and timeouts.
+func GetBuildsWithClient(ctx context.Context, service *cloudbuild.Client, projectID string) ([]*cloudbuildpb.Build, error) {
 	req := &cloudbuildpb.ListBuildsRequest{
 		ProjectId: projectID,
 	}
@@ -205,15 +228,34 @@ func GetBuildsForTriggerContextE(t testing.TestingT, ctx context.Context, projec
 		return nil, fmt.Errorf("GetBuildsForTriggerContextE.ListBuilds(%s) got error: %w", projectID, err)
 	}
 
-	filteredBuilds := []*cloudbuildpb.Build{}
+	return filterBuildsByTrigger(builds, triggerID), nil
+}
+
+// GetBuildsForTriggerWithClient gets a list of builds for a specific cloud build trigger using the
+// supplied *cloudbuild.Client. Prefer this variant in unit tests where the client is backed by a
+// mock gRPC server.
+// The ctx parameter supports cancellation and timeouts.
+func GetBuildsForTriggerWithClient(ctx context.Context, service *cloudbuild.Client, projectID string, triggerID string) ([]*cloudbuildpb.Build, error) {
+	builds, err := GetBuildsWithClient(ctx, service, projectID)
+	if err != nil {
+		return nil, fmt.Errorf("GetBuildsForTriggerContextE.ListBuilds(%s) got error: %w", projectID, err)
+	}
+
+	return filterBuildsByTrigger(builds, triggerID), nil
+}
+
+// filterBuildsByTrigger returns the subset of the given builds that were produced by the trigger
+// with the given ID.
+func filterBuildsByTrigger(builds []*cloudbuildpb.Build, triggerID string) []*cloudbuildpb.Build {
+	filtered := []*cloudbuildpb.Build{}
 
 	for _, build := range builds {
 		if build.GetBuildTriggerId() == triggerID {
-			filteredBuilds = append(filteredBuilds, build)
+			filtered = append(filtered, build)
 		}
 	}
 
-	return filteredBuilds, nil
+	return filtered
 }
 
 // NewCloudBuildService creates a new Cloud Build service, which is used to make Cloud Build API calls.

--- a/modules/gcp/cloudbuild_unit_test.go
+++ b/modules/gcp/cloudbuild_unit_test.go
@@ -1,0 +1,111 @@
+package gcp_test
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	cloudbuild "cloud.google.com/go/cloudbuild/apiv1/v2"
+	cloudbuildpb "cloud.google.com/go/cloudbuild/apiv1/v2/cloudbuildpb"
+	"github.com/gruntwork-io/terratest/modules/gcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/api/option"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/test/bufconn"
+)
+
+// fakeCloudBuildServer only implements the methods the terratest *WithClient helpers actually
+// call. CreateBuild (long-running op) is left to the build-tagged integration test.
+type fakeCloudBuildServer struct {
+	cloudbuildpb.UnimplementedCloudBuildServer
+
+	getBuild   func(*cloudbuildpb.GetBuildRequest) *cloudbuildpb.Build
+	listBuilds func(*cloudbuildpb.ListBuildsRequest) *cloudbuildpb.ListBuildsResponse
+}
+
+func (f *fakeCloudBuildServer) GetBuild(_ context.Context, req *cloudbuildpb.GetBuildRequest) (*cloudbuildpb.Build, error) {
+	return f.getBuild(req), nil
+}
+
+func (f *fakeCloudBuildServer) ListBuilds(_ context.Context, req *cloudbuildpb.ListBuildsRequest) (*cloudbuildpb.ListBuildsResponse, error) {
+	return f.listBuilds(req), nil
+}
+
+// newFakeCloudBuildClient runs `srv` on an in-memory bufconn gRPC server and returns a client
+// pointed at it. No credentials, no network.
+func newFakeCloudBuildClient(t *testing.T, srv *fakeCloudBuildServer) *cloudbuild.Client {
+	t.Helper()
+
+	lis := bufconn.Listen(1024 * 1024)
+	grpcServer := grpc.NewServer()
+	cloudbuildpb.RegisterCloudBuildServer(grpcServer, srv)
+
+	go func() { _ = grpcServer.Serve(lis) }()
+
+	t.Cleanup(func() { grpcServer.Stop(); _ = lis.Close() })
+
+	conn, err := grpc.NewClient("passthrough:///bufnet",
+		grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) { return lis.DialContext(ctx) }),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+
+	client, err := cloudbuild.NewClient(context.Background(), option.WithGRPCConn(conn))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = client.Close() })
+
+	return client
+}
+
+func TestGetBuildWithClient(t *testing.T) {
+	t.Parallel()
+
+	client := newFakeCloudBuildClient(t, &fakeCloudBuildServer{
+		getBuild: func(req *cloudbuildpb.GetBuildRequest) *cloudbuildpb.Build {
+			return &cloudbuildpb.Build{Id: req.GetId(), ProjectId: req.GetProjectId(), Status: cloudbuildpb.Build_SUCCESS}
+		},
+	})
+
+	got, err := gcp.GetBuildWithClient(context.Background(), client, "p", "b1")
+	require.NoError(t, err)
+	assert.Equal(t, "b1", got.GetId())
+	assert.Equal(t, cloudbuildpb.Build_SUCCESS, got.GetStatus())
+}
+
+func TestGetBuildsWithClient(t *testing.T) {
+	t.Parallel()
+
+	client := newFakeCloudBuildClient(t, &fakeCloudBuildServer{
+		listBuilds: func(req *cloudbuildpb.ListBuildsRequest) *cloudbuildpb.ListBuildsResponse {
+			assert.Equal(t, "p", req.GetProjectId())
+
+			return &cloudbuildpb.ListBuildsResponse{Builds: []*cloudbuildpb.Build{{Id: "a"}, {Id: "b"}}}
+		},
+	})
+
+	got, err := gcp.GetBuildsWithClient(context.Background(), client, "p")
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+}
+
+func TestGetBuildsForTriggerWithClient(t *testing.T) {
+	t.Parallel()
+
+	client := newFakeCloudBuildClient(t, &fakeCloudBuildServer{
+		listBuilds: func(_ *cloudbuildpb.ListBuildsRequest) *cloudbuildpb.ListBuildsResponse {
+			return &cloudbuildpb.ListBuildsResponse{Builds: []*cloudbuildpb.Build{
+				{Id: "a", BuildTriggerId: "match"},
+				{Id: "b", BuildTriggerId: "other"},
+				{Id: "c", BuildTriggerId: "match"},
+			}}
+		},
+	})
+
+	got, err := gcp.GetBuildsForTriggerWithClient(context.Background(), client, "p", "match")
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+	assert.ElementsMatch(t, []string{"a", "c"}, []string{got[0].GetId(), got[1].GetId()})
+}

--- a/modules/gcp/compute.go
+++ b/modules/gcp/compute.go
@@ -93,6 +93,14 @@ func FetchInstanceContextE(t testing.TestingT, ctx context.Context, projectID st
 		return nil, err
 	}
 
+	return FetchInstanceWithClient(ctx, service, projectID, name)
+}
+
+// FetchInstanceWithClient queries GCP to return an instance of the Compute Instance type
+// using the supplied *compute.Service. Prefer this variant in unit tests where the service is
+// backed by an httptest fake server (see compute_unit_test.go for the pattern).
+// The ctx parameter supports cancellation and timeouts.
+func FetchInstanceWithClient(ctx context.Context, service *compute.Service, projectID string, name string) (*Instance, error) {
 	// If we want to fetch an Instance without knowing its Zone, we have to query GCP for all Instances in the project
 	// and match on name.
 	instanceAggregatedList, err := service.Instances.AggregatedList(projectID).Context(ctx).Do()
@@ -146,9 +154,15 @@ func FetchImageContextE(t testing.TestingT, ctx context.Context, projectID strin
 		return nil, err
 	}
 
-	req := service.Images.Get(projectID, name)
+	return FetchImageWithClient(ctx, service, projectID, name)
+}
 
-	image, err := req.Context(ctx).Do()
+// FetchImageWithClient queries GCP to return a new instance of the Compute Image type
+// using the supplied *compute.Service. Prefer this variant in unit tests where the service is
+// backed by an httptest fake server (see compute_unit_test.go for the pattern).
+// The ctx parameter supports cancellation and timeouts.
+func FetchImageWithClient(ctx context.Context, service *compute.Service, projectID string, name string) (*Image, error) {
+	image, err := service.Images.Get(projectID, name).Context(ctx).Do()
 	if err != nil {
 		return nil, err
 	}
@@ -191,9 +205,15 @@ func FetchRegionalInstanceGroupContextE(t testing.TestingT, ctx context.Context,
 		return nil, err
 	}
 
-	req := service.RegionInstanceGroups.Get(projectID, region, name)
+	return FetchRegionalInstanceGroupWithClient(ctx, service, projectID, region, name)
+}
 
-	instanceGroup, err := req.Context(ctx).Do()
+// FetchRegionalInstanceGroupWithClient queries GCP to return a new instance of the Regional Instance
+// Group type using the supplied *compute.Service. Prefer this variant in unit tests where the service
+// is backed by an httptest fake server (see compute_unit_test.go for the pattern).
+// The ctx parameter supports cancellation and timeouts.
+func FetchRegionalInstanceGroupWithClient(ctx context.Context, service *compute.Service, projectID string, region string, name string) (*RegionalInstanceGroup, error) {
+	instanceGroup, err := service.RegionInstanceGroups.Get(projectID, region, name).Context(ctx).Do()
 	if err != nil {
 		return nil, err
 	}
@@ -236,9 +256,15 @@ func FetchZonalInstanceGroupContextE(t testing.TestingT, ctx context.Context, pr
 		return nil, err
 	}
 
-	req := service.InstanceGroups.Get(projectID, zone, name)
+	return FetchZonalInstanceGroupWithClient(ctx, service, projectID, zone, name)
+}
 
-	instanceGroup, err := req.Context(ctx).Do()
+// FetchZonalInstanceGroupWithClient queries GCP to return a new instance of the Zonal Instance Group
+// type using the supplied *compute.Service. Prefer this variant in unit tests where the service is
+// backed by an httptest fake server (see compute_unit_test.go for the pattern).
+// The ctx parameter supports cancellation and timeouts.
+func FetchZonalInstanceGroupWithClient(ctx context.Context, service *compute.Service, projectID string, zone string, name string) (*ZonalInstanceGroup, error) {
+	instanceGroup, err := service.InstanceGroups.Get(projectID, zone, name).Context(ctx).Do()
 	if err != nil {
 		return nil, err
 	}
@@ -273,16 +299,15 @@ func (i *Instance) GetPublicIPE(t testing.TestingT) (string, error) {
 
 // GetPublicIPContextE gets the public IP address of the given Compute Instance.
 // The ctx parameter supports cancellation and timeouts.
+// Returns an error (rather than panicking) when the instance has no network interfaces
+// or the first interface has no accessConfigs — both indicate the instance has no
+// external internet access (https://cloud.google.com/compute/docs/reference/rest/v1/instances).
 func (i *Instance) GetPublicIPContextE(t testing.TestingT, ctx context.Context) (string, error) {
-	// If there are no accessConfigs specified, then this instance will have no external internet access:
-	// https://cloud.google.com/compute/docs/reference/rest/v1/instances.
-	if len(i.NetworkInterfaces[0].AccessConfigs) == 0 {
+	if len(i.NetworkInterfaces) == 0 || len(i.NetworkInterfaces[0].AccessConfigs) == 0 {
 		return "", fmt.Errorf("attempted to get public IP of Compute Instance %s, but that Compute Instance does not have a public IP address", i.Name)
 	}
 
-	ip := i.NetworkInterfaces[0].AccessConfigs[0].NatIP
-
-	return ip, nil
+	return i.NetworkInterfaces[0].AccessConfigs[0].NatIP, nil
 }
 
 // GetLabels returns all the tags for the given Compute Instance.
@@ -376,9 +401,17 @@ func (i *Instance) SetLabelsContextE(t testing.TestingT, ctx context.Context, la
 		return err
 	}
 
+	return i.SetLabelsWithClient(ctx, service, labels)
+}
+
+// SetLabelsWithClient adds the tags to the given Compute Instance using the supplied *compute.Service.
+// Prefer this variant in unit tests where the service is backed by an httptest fake server
+// (see compute_unit_test.go for the pattern).
+// The ctx parameter supports cancellation and timeouts.
+func (i *Instance) SetLabelsWithClient(ctx context.Context, service *compute.Service, labels map[string]string) error {
 	req := compute.InstancesSetLabelsRequest{Labels: labels, LabelFingerprint: i.LabelFingerprint}
 
-	if _, err := service.Instances.SetLabels(i.projectID, i.GetZoneContext(t, ctx), i.Name, &req).Context(ctx).Do(); err != nil {
+	if _, err := service.Instances.SetLabels(i.projectID, ZoneURLToZone(i.Zone), i.Name, &req).Context(ctx).Do(); err != nil {
 		return fmt.Errorf("Instances.SetLabels(%s) got error: %w", i.Name, err)
 	}
 
@@ -442,14 +475,22 @@ func (i *Instance) SetMetadataE(t testing.TestingT, metadata map[string]string) 
 func (i *Instance) SetMetadataContextE(t testing.TestingT, ctx context.Context, metadata map[string]string) error {
 	logger.Default.Logf(t, "Adding metadata to instance %s in zone %s", i.Name, i.Zone)
 
-	service, err := NewInstancesServiceContextE(t, ctx)
+	service, err := NewComputeServiceContextE(t, ctx)
 	if err != nil {
 		return err
 	}
 
+	return i.SetMetadataWithClient(ctx, service, metadata)
+}
+
+// SetMetadataWithClient adds the given metadata map to the existing metadata of the given Compute
+// Instance using the supplied *compute.Service. Prefer this variant in unit tests where the service
+// is backed by an httptest fake server (see compute_unit_test.go for the pattern).
+// The ctx parameter supports cancellation and timeouts.
+func (i *Instance) SetMetadataWithClient(ctx context.Context, service *compute.Service, metadata map[string]string) error {
 	metadataItems := NewMetadata(i.Metadata, metadata)
 
-	req := service.SetMetadata(i.projectID, i.GetZoneContext(t, ctx), i.Name, metadataItems)
+	req := service.Instances.SetMetadata(i.projectID, ZoneURLToZone(i.Zone), i.Name, metadataItems)
 
 	if _, err := req.Context(ctx).Do(); err != nil {
 		return fmt.Errorf("Instances.SetMetadata(%s) got error: %w", i.Name, err)
@@ -519,6 +560,19 @@ func (i *Instance) AddSSHKeyE(t testing.TestingT, username string, publicKey str
 func (i *Instance) AddSSHKeyContextE(t testing.TestingT, ctx context.Context, username string, publicKey string) error {
 	logger.Default.Logf(t, "Adding SSH Key to Compute Instance %s for username %s\n", i.Name, username)
 
+	service, err := NewComputeServiceContextE(t, ctx)
+	if err != nil {
+		return err
+	}
+
+	return i.AddSSHKeyWithClient(ctx, service, username, publicKey)
+}
+
+// AddSSHKeyWithClient adds the given public SSH key to the Compute Instance using the supplied
+// *compute.Service. Users can SSH in with the given username. Prefer this variant in unit tests
+// where the service is backed by an httptest fake server (see compute_unit_test.go for the pattern).
+// The ctx parameter supports cancellation and timeouts.
+func (i *Instance) AddSSHKeyWithClient(ctx context.Context, service *compute.Service, username string, publicKey string) error {
 	// We represent the key in the format required per GCP docs (https://cloud.google.com/compute/docs/instances/adding-removing-ssh-keys)
 	publicKeyFormatted := strings.TrimSpace(publicKey)
 	sshKeyFormatted := fmt.Sprintf("%s:%s %s", username, publicKeyFormatted, username)
@@ -527,8 +581,7 @@ func (i *Instance) AddSSHKeyContextE(t testing.TestingT, ctx context.Context, us
 		"ssh-keys": sshKeyFormatted,
 	}
 
-	err := i.SetMetadataContextE(t, ctx, metadata)
-	if err != nil {
+	if err := i.SetMetadataWithClient(ctx, service, metadata); err != nil {
 		return fmt.Errorf("failed to add SSH key to Compute Instance: %w", err)
 	}
 
@@ -568,6 +621,14 @@ func (i *Image) DeleteImageContextE(t testing.TestingT, ctx context.Context) err
 		return err
 	}
 
+	return i.DeleteImageWithClient(ctx, service)
+}
+
+// DeleteImageWithClient deletes the given Compute Image using the supplied *compute.Service.
+// Prefer this variant in unit tests where the service is backed by an httptest fake server
+// (see compute_unit_test.go for the pattern).
+// The ctx parameter supports cancellation and timeouts.
+func (i *Image) DeleteImageWithClient(ctx context.Context, service *compute.Service) error {
 	if _, err := service.Images.Delete(i.projectID, i.Name).Context(ctx).Do(); err != nil {
 		return fmt.Errorf("Images.Delete(%s) got error: %w", i.Name, err)
 	}
@@ -602,7 +663,7 @@ func (ig *ZonalInstanceGroup) GetInstanceIDsE(t testing.TestingT) ([]string, err
 
 // GetInstanceIDsContextE gets the IDs of Instances in the given Zonal Instance Group.
 // The ctx parameter supports cancellation and timeouts.
-func (ig *ZonalInstanceGroup) GetInstanceIDsContextE(t testing.TestingT, ctx context.Context) ([]string, error) { //nolint:dupl // zonal and regional implementations differ in API types
+func (ig *ZonalInstanceGroup) GetInstanceIDsContextE(t testing.TestingT, ctx context.Context) ([]string, error) {
 	logger.Default.Logf(t, "Get instances for Zonal Instance Group %s", ig.Name)
 
 	service, err := NewComputeServiceContextE(t, ctx)
@@ -610,6 +671,14 @@ func (ig *ZonalInstanceGroup) GetInstanceIDsContextE(t testing.TestingT, ctx con
 		return nil, err
 	}
 
+	return ig.GetInstanceIDsWithClient(ctx, service)
+}
+
+// GetInstanceIDsWithClient gets the IDs of Instances in the given Zonal Instance Group using the
+// supplied *compute.Service. Prefer this variant in unit tests where the service is backed by an
+// httptest fake server (see compute_unit_test.go for the pattern).
+// The ctx parameter supports cancellation and timeouts.
+func (ig *ZonalInstanceGroup) GetInstanceIDsWithClient(ctx context.Context, service *compute.Service) ([]string, error) { //nolint:dupl // zonal and regional implementations differ in API types
 	requestBody := &compute.InstanceGroupsListInstancesRequest{
 		InstanceState: "ALL",
 	}
@@ -618,7 +687,7 @@ func (ig *ZonalInstanceGroup) GetInstanceIDsContextE(t testing.TestingT, ctx con
 	zone := ZoneURLToZone(ig.Zone)
 	req := service.InstanceGroups.ListInstances(ig.projectID, zone, ig.Name, requestBody)
 
-	err = req.Pages(ctx, func(page *compute.InstanceGroupsListInstances) error {
+	err := req.Pages(ctx, func(page *compute.InstanceGroupsListInstances) error {
 		for _, instance := range page.Items {
 			// For some reason service.InstanceGroups.ListInstances returns us a collection
 			// with Instance URLs and we need only the Instance ID for the next call. Use
@@ -663,7 +732,7 @@ func (ig *RegionalInstanceGroup) GetInstanceIDsE(t testing.TestingT) ([]string, 
 
 // GetInstanceIDsContextE gets the IDs of Instances in the given Regional Instance Group.
 // The ctx parameter supports cancellation and timeouts.
-func (ig *RegionalInstanceGroup) GetInstanceIDsContextE(t testing.TestingT, ctx context.Context) ([]string, error) { //nolint:dupl // zonal and regional implementations differ in API types
+func (ig *RegionalInstanceGroup) GetInstanceIDsContextE(t testing.TestingT, ctx context.Context) ([]string, error) {
 	logger.Default.Logf(t, "Get instances for Regional Instance Group %s", ig.Name)
 
 	service, err := NewComputeServiceContextE(t, ctx)
@@ -671,6 +740,14 @@ func (ig *RegionalInstanceGroup) GetInstanceIDsContextE(t testing.TestingT, ctx 
 		return nil, err
 	}
 
+	return ig.GetInstanceIDsWithClient(ctx, service)
+}
+
+// GetInstanceIDsWithClient gets the IDs of Instances in the given Regional Instance Group using the
+// supplied *compute.Service. Prefer this variant in unit tests where the service is backed by an
+// httptest fake server (see compute_unit_test.go for the pattern).
+// The ctx parameter supports cancellation and timeouts.
+func (ig *RegionalInstanceGroup) GetInstanceIDsWithClient(ctx context.Context, service *compute.Service) ([]string, error) { //nolint:dupl // zonal and regional implementations differ in API types
 	requestBody := &compute.RegionInstanceGroupsListInstancesRequest{
 		InstanceState: "ALL",
 	}
@@ -679,7 +756,7 @@ func (ig *RegionalInstanceGroup) GetInstanceIDsContextE(t testing.TestingT, ctx 
 	region := RegionURLToRegion(ig.Region)
 	req := service.RegionInstanceGroups.ListInstances(ig.projectID, region, ig.Name, requestBody)
 
-	err = req.Pages(ctx, func(page *compute.RegionInstanceGroupsListInstances) error {
+	err := req.Pages(ctx, func(page *compute.RegionInstanceGroupsListInstances) error {
 		for _, instance := range page.Items {
 			// For some reason service.InstanceGroups.ListInstances returns us a collection
 			// with Instance URLs and we need only the Instance ID for the next call. Use

--- a/modules/gcp/compute_unit_test.go
+++ b/modules/gcp/compute_unit_test.go
@@ -1,33 +1,274 @@
 package gcp_test
 
 import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/gruntwork-io/terratest/modules/gcp"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/api/compute/v1"
+	"google.golang.org/api/option"
 )
 
-// TestNewMetadataPreservesExisting is a regression test for issue #1655.
-// Verifies that existing metadata is preserved when adding new key-value pairs.
+// newFakeComputeService points a *compute.Service at a local httptest server. Gives unit tests a
+// credential-free way to exercise *WithClient variants, analogous to the Azure azfake pattern.
+func newFakeComputeService(t *testing.T, handler http.Handler) *compute.Service {
+	t.Helper()
+
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	svc, err := compute.NewService(context.Background(),
+		option.WithEndpoint(server.URL+"/"), option.WithoutAuthentication())
+	require.NoError(t, err)
+
+	return svc
+}
+
+// respond returns a handler that asserts the HTTP method (when non-empty) and path substring,
+// then writes body with the given status. Cuts per-test boilerplate.
+func respond(t *testing.T, method, pathContains string, status int, body string) http.HandlerFunc {
+	t.Helper()
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		if method != "" {
+			assert.Equal(t, method, r.Method, "unexpected HTTP method")
+		}
+
+		assert.Contains(t, r.URL.Path, pathContains, "unexpected API path")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
+	}
+}
+
+// fetchInstanceForTest resolves a gcp.Instance via the aggregated-list endpoint so that its
+// unexported projectID is populated — required for methods on *Instance.
+func fetchInstanceForTest(t *testing.T, projectID, name, zoneURL string) *gcp.Instance {
+	t.Helper()
+
+	body := fmt.Sprintf(`{"items":{"zones/us-central1-a":{"instances":[{"name":%q,"zone":%q}]}}}`, name, zoneURL)
+	svc := newFakeComputeService(t, respond(t, "", "aggregated/instances", http.StatusOK, body))
+
+	inst, err := gcp.FetchInstanceWithClient(context.Background(), svc, projectID, name)
+	require.NoError(t, err)
+
+	return inst
+}
+
+// TestNewMetadataPreservesExisting — regression test for issue #1655.
 func TestNewMetadataPreservesExisting(t *testing.T) {
 	t.Parallel()
 
-	existingVal := "existing-value"
-	oldMetadata := &compute.Metadata{
-		Fingerprint: "test-fingerprint",
-		Items:       []*compute.MetadataItems{{Key: "existing-key", Value: &existingVal}},
-	}
+	v := "old"
+	old := &compute.Metadata{Fingerprint: "fp", Items: []*compute.MetadataItems{{Key: "k1", Value: &v}}}
 
-	result := gcp.NewMetadata(oldMetadata, map[string]string{"new-key": "new-value"})
+	result := gcp.NewMetadata(old, map[string]string{"k2": "new"})
 
-	// Convert to map for easier assertion
 	got := make(map[string]string)
 	for _, item := range result.Items {
 		got[item.Key] = *item.Value
 	}
 
-	assert.Equal(t, "test-fingerprint", result.Fingerprint)
-	assert.Equal(t, "existing-value", got["existing-key"], "existing metadata should be preserved")
-	assert.Equal(t, "new-value", got["new-key"], "new metadata should be added")
+	assert.Equal(t, "fp", result.Fingerprint)
+	assert.Equal(t, "old", got["k1"])
+	assert.Equal(t, "new", got["k2"])
+}
+
+func TestGetPublicIPContextE(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		wantIP  string
+		nics    []*compute.NetworkInterface
+		wantErr bool
+	}{
+		"returns external IP": {
+			wantIP: "1.2.3.4",
+			nics:   []*compute.NetworkInterface{{AccessConfigs: []*compute.AccessConfig{{NatIP: "1.2.3.4"}}}},
+		},
+		"no network interfaces": {wantErr: true},
+		"no access configs":     {wantErr: true, nics: []*compute.NetworkInterface{{}}},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			inst := &gcp.Instance{Instance: &compute.Instance{Name: "x", NetworkInterfaces: tc.nics}}
+
+			ip, err := inst.GetPublicIPContextE(t, context.Background())
+			if tc.wantErr {
+				require.Error(t, err)
+
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantIP, ip)
+		})
+	}
+}
+
+func TestFetchInstanceWithClient(t *testing.T) {
+	t.Parallel()
+
+	t.Run("found", func(t *testing.T) {
+		t.Parallel()
+
+		body := `{"items":{"zones/us-central1-a":{"instances":[{"name":"x"}]}}}`
+		svc := newFakeComputeService(t, respond(t, http.MethodGet, "aggregated/instances", http.StatusOK, body))
+
+		inst, err := gcp.FetchInstanceWithClient(context.Background(), svc, "p", "x")
+		require.NoError(t, err)
+		assert.Equal(t, "x", inst.Name)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		t.Parallel()
+
+		svc := newFakeComputeService(t, respond(t, "", "aggregated/instances", http.StatusOK, `{"items":{}}`))
+
+		_, err := gcp.FetchInstanceWithClient(context.Background(), svc, "p", "x")
+		require.ErrorContains(t, err, "could not be found")
+	})
+}
+
+func TestFetchImageWithClient(t *testing.T) {
+	t.Parallel()
+
+	t.Run("found", func(t *testing.T) {
+		t.Parallel()
+
+		svc := newFakeComputeService(t, respond(t, http.MethodGet, "/global/images/my-image", http.StatusOK, `{"name":"my-image"}`))
+
+		img, err := gcp.FetchImageWithClient(context.Background(), svc, "p", "my-image")
+		require.NoError(t, err)
+		assert.Equal(t, "my-image", img.Name)
+	})
+
+	t.Run("404 error propagates", func(t *testing.T) {
+		t.Parallel()
+
+		svc := newFakeComputeService(t, respond(t, "", "/global/images/", http.StatusNotFound, `{"error":{"code":404,"message":"image not found"}}`))
+
+		_, err := gcp.FetchImageWithClient(context.Background(), svc, "p", "missing")
+		require.ErrorContains(t, err, "image not found")
+	})
+}
+
+func TestFetchZonalInstanceGroupWithClient(t *testing.T) {
+	t.Parallel()
+
+	body := `{"name":"zig","zone":"https://www.googleapis.com/compute/v1/projects/p/zones/us-central1-a"}`
+	svc := newFakeComputeService(t, respond(t, http.MethodGet, "/zones/us-central1-a/instanceGroups/zig", http.StatusOK, body))
+
+	ig, err := gcp.FetchZonalInstanceGroupWithClient(context.Background(), svc, "p", "us-central1-a", "zig")
+	require.NoError(t, err)
+	assert.Equal(t, "zig", ig.Name)
+}
+
+func TestFetchRegionalInstanceGroupWithClient(t *testing.T) {
+	t.Parallel()
+
+	body := `{"name":"rig","region":"https://www.googleapis.com/compute/v1/projects/p/regions/us-central1"}`
+	svc := newFakeComputeService(t, respond(t, http.MethodGet, "/regions/us-central1/instanceGroups/rig", http.StatusOK, body))
+
+	ig, err := gcp.FetchRegionalInstanceGroupWithClient(context.Background(), svc, "p", "us-central1", "rig")
+	require.NoError(t, err)
+	assert.Equal(t, "rig", ig.Name)
+}
+
+func TestSetLabelsWithClient(t *testing.T) {
+	t.Parallel()
+
+	zoneURL := "https://www.googleapis.com/compute/v1/projects/p/zones/us-central1-a"
+	inst := fetchInstanceForTest(t, "p", "i", zoneURL)
+
+	svc := newFakeComputeService(t, respond(t, http.MethodPost, "/instances/i/setLabels", http.StatusOK, `{"name":"op","status":"DONE"}`))
+
+	require.NoError(t, inst.SetLabelsWithClient(context.Background(), svc, map[string]string{"env": "unit"}))
+}
+
+func TestSetMetadataWithClient(t *testing.T) {
+	t.Parallel()
+
+	zoneURL := "https://www.googleapis.com/compute/v1/projects/p/zones/us-central1-a"
+	inst := fetchInstanceForTest(t, "p", "i", zoneURL)
+
+	svc := newFakeComputeService(t, respond(t, http.MethodPost, "/instances/i/setMetadata", http.StatusOK, `{"name":"op","status":"DONE"}`))
+
+	require.NoError(t, inst.SetMetadataWithClient(context.Background(), svc, map[string]string{"k": "v"}))
+}
+
+func TestAddSSHKeyWithClient(t *testing.T) {
+	t.Parallel()
+
+	zoneURL := "https://www.googleapis.com/compute/v1/projects/p/zones/us-central1-a"
+	inst := fetchInstanceForTest(t, "p", "i", zoneURL)
+
+	t.Run("happy", func(t *testing.T) {
+		t.Parallel()
+
+		svc := newFakeComputeService(t, respond(t, http.MethodPost, "/instances/i/setMetadata", http.StatusOK, `{"name":"op","status":"DONE"}`))
+
+		require.NoError(t, inst.AddSSHKeyWithClient(context.Background(), svc, "alice", "ssh-rsa A alice@h"))
+	})
+
+	t.Run("SDK error is wrapped", func(t *testing.T) {
+		t.Parallel()
+
+		svc := newFakeComputeService(t, respond(t, "", "/instances/i/setMetadata", http.StatusBadRequest, `{"error":{"code":400,"message":"bad"}}`))
+
+		err := inst.AddSSHKeyWithClient(context.Background(), svc, "alice", "ssh-rsa A alice@h")
+		require.ErrorContains(t, err, "failed to add SSH key")
+	})
+}
+
+func TestDeleteImageWithClient(t *testing.T) {
+	t.Parallel()
+
+	imgSvc := newFakeComputeService(t, respond(t, http.MethodGet, "/global/images/img", http.StatusOK, `{"name":"img"}`))
+	img, err := gcp.FetchImageWithClient(context.Background(), imgSvc, "p", "img")
+	require.NoError(t, err)
+
+	svc := newFakeComputeService(t, respond(t, http.MethodDelete, "/global/images/img", http.StatusOK, `{"name":"op"}`))
+
+	require.NoError(t, img.DeleteImageWithClient(context.Background(), svc))
+}
+
+func TestZonalInstanceGroupGetInstanceIDsWithClient(t *testing.T) {
+	t.Parallel()
+
+	igBody := `{"name":"zig","zone":"https://www.googleapis.com/compute/v1/projects/p/zones/us-central1-a"}`
+	svc := newFakeComputeService(t, respond(t, "", "zig", http.StatusOK, igBody))
+	ig, err := gcp.FetchZonalInstanceGroupWithClient(context.Background(), svc, "p", "us-central1-a", "zig")
+	require.NoError(t, err)
+
+	listBody := `{"items":[{"instance":"https://.../instances/a"},{"instance":"https://.../instances/b"}]}`
+	svc2 := newFakeComputeService(t, respond(t, http.MethodPost, "/instanceGroups/zig/listInstances", http.StatusOK, listBody))
+
+	ids, err := ig.GetInstanceIDsWithClient(context.Background(), svc2)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"a", "b"}, ids)
+}
+
+func TestRegionalInstanceGroupGetInstanceIDsWithClient(t *testing.T) {
+	t.Parallel()
+
+	igBody := `{"name":"rig","region":"https://www.googleapis.com/compute/v1/projects/p/regions/us-central1"}`
+	svc := newFakeComputeService(t, respond(t, "", "rig", http.StatusOK, igBody))
+	ig, err := gcp.FetchRegionalInstanceGroupWithClient(context.Background(), svc, "p", "us-central1", "rig")
+	require.NoError(t, err)
+
+	listBody := `{"items":[{"instance":"https://.../instances/c"},{"instance":"https://.../instances/d"}]}`
+	svc2 := newFakeComputeService(t, respond(t, http.MethodPost, "/instanceGroups/rig/listInstances", http.StatusOK, listBody))
+
+	ids, err := ig.GetInstanceIDsWithClient(context.Background(), svc2)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"c", "d"}, ids)
 }

--- a/modules/gcp/gcr.go
+++ b/modules/gcp/gcr.go
@@ -3,6 +3,7 @@ package gcp
 import (
 	"context"
 	"fmt"
+	"net/http"
 
 	"github.com/google/go-containerregistry/pkg/authn"
 	gcrname "github.com/google/go-containerregistry/pkg/name"
@@ -12,6 +13,14 @@ import (
 	"github.com/gruntwork-io/terratest/modules/testing"
 	"github.com/stretchr/testify/require"
 )
+
+// GCRClient bundles the credentials and transport the go-containerregistry library needs.
+// It exists so that GCR helpers can follow terratest's (ctx, client, ...args) WithClient convention
+// instead of exposing the two pieces separately. Transport is optional — nil uses the library default.
+type GCRClient struct {
+	Authenticator authn.Authenticator
+	Transport     http.RoundTripper
+}
 
 // DeleteGCRRepo deletes a GCR repository including all tagged images.
 // This will fail the test if there is an error.
@@ -39,38 +48,44 @@ func DeleteGCRRepoE(t testing.TestingT, repo string) error {
 // DeleteGCRRepoContextE deletes a GCR repository including all tagged images.
 // The ctx parameter supports cancellation and timeouts.
 func DeleteGCRRepoContextE(t testing.TestingT, ctx context.Context, repo string) error {
-	// create a new authenticator for the API calls
 	authenticator, err := newGCRAuthenticator() //nolint:contextcheck // newGCRAuthenticator is a pure credential helper
 	if err != nil {
 		return fmt.Errorf("failed to create authenticator: %w", err)
 	}
 
+	logger.Default.Logf(t, "Retrieving Image Digests %s", repo)
+
+	return DeleteGCRRepoWithClient(ctx, &GCRClient{Authenticator: authenticator}, repo)
+}
+
+// DeleteGCRRepoWithClient deletes a GCR repository including all tagged images using the supplied
+// client. Prefer this variant in unit tests where the client's Transport points at an httptest
+// fake server (see gcr_unit_test.go for the pattern).
+// The ctx parameter supports cancellation and timeouts.
+func DeleteGCRRepoWithClient(ctx context.Context, client *GCRClient, repo string) error {
 	gcrrepo, err := gcrname.NewRepository(repo)
 	if err != nil {
 		return fmt.Errorf("failed to get repo: %w", err)
 	}
 
-	logger.Default.Logf(t, "Retrieving Image Digests %s", gcrrepo)
+	listOpts := []gcrgoogle.Option{gcrgoogle.WithAuth(client.Authenticator), gcrgoogle.WithContext(ctx)}
+	if client.Transport != nil {
+		listOpts = append(listOpts, gcrgoogle.WithTransport(client.Transport))
+	}
 
-	tags, err := gcrgoogle.List(gcrrepo, gcrgoogle.WithAuth(authenticator), gcrgoogle.WithContext(ctx))
+	tags, err := gcrgoogle.List(gcrrepo, listOpts...)
 	if err != nil {
 		return fmt.Errorf("failed to list tags for repo %s: %w", repo, err)
 	}
 
-	// attempt to delete the latest image tag
 	latestRef := repo + ":latest"
-	logger.Default.Logf(t, "Deleting Image Ref %s", latestRef)
-
-	if err := DeleteGCRImageRefContextE(t, ctx, latestRef); err != nil {
+	if err := DeleteGCRImageRefWithClient(ctx, client, latestRef); err != nil {
 		return fmt.Errorf("failed to delete GCR image reference %s: %w", latestRef, err)
 	}
 
-	// delete image references sequentially
 	for k := range tags.Manifests {
 		ref := repo + "@" + k
-		logger.Default.Logf(t, "Deleting Image Ref %s", ref)
-
-		if err := DeleteGCRImageRefContextE(t, ctx, ref); err != nil {
+		if err := DeleteGCRImageRefWithClient(ctx, client, ref); err != nil {
 			return fmt.Errorf("failed to delete GCR image reference %s: %w", ref, err)
 		}
 	}
@@ -104,18 +119,32 @@ func DeleteGCRImageRefE(t testing.TestingT, ref string) error {
 // DeleteGCRImageRefContextE deletes a single repo image ref/digest.
 // The ctx parameter supports cancellation and timeouts.
 func DeleteGCRImageRefContextE(t testing.TestingT, ctx context.Context, ref string) error {
-	name, err := gcrname.ParseReference(ref)
-	if err != nil {
-		return fmt.Errorf("failed to parse reference %s: %w", ref, err)
-	}
-
-	// create a new authenticator for the API calls
 	authenticator, err := newGCRAuthenticator() //nolint:contextcheck // newGCRAuthenticator is a pure credential helper
 	if err != nil {
 		return fmt.Errorf("failed to create authenticator: %w", err)
 	}
 
-	if err := gcrremote.Delete(name, gcrremote.WithAuth(authenticator), gcrremote.WithContext(ctx)); err != nil {
+	logger.Default.Logf(t, "Deleting Image Ref %s", ref)
+
+	return DeleteGCRImageRefWithClient(ctx, &GCRClient{Authenticator: authenticator}, ref)
+}
+
+// DeleteGCRImageRefWithClient deletes a single repo image ref/digest using the supplied client.
+// Prefer this variant in unit tests where the client's Transport points at an httptest fake
+// server (see gcr_unit_test.go for the pattern).
+// The ctx parameter supports cancellation and timeouts.
+func DeleteGCRImageRefWithClient(ctx context.Context, client *GCRClient, ref string) error {
+	name, err := gcrname.ParseReference(ref)
+	if err != nil {
+		return fmt.Errorf("failed to parse reference %s: %w", ref, err)
+	}
+
+	opts := []gcrremote.Option{gcrremote.WithAuth(client.Authenticator), gcrremote.WithContext(ctx)}
+	if client.Transport != nil {
+		opts = append(opts, gcrremote.WithTransport(client.Transport))
+	}
+
+	if err := gcrremote.Delete(name, opts...); err != nil {
 		return fmt.Errorf("failed to delete %s: %w", name, err)
 	}
 

--- a/modules/gcp/gcr_unit_test.go
+++ b/modules/gcp/gcr_unit_test.go
@@ -1,0 +1,106 @@
+package gcp_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/gruntwork-io/terratest/modules/gcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeRegistry runs an httptest server mimicking the minimal Docker Registry v2 endpoints
+// the go-containerregistry library exercises (ping, tags list, manifest delete).
+type fakeRegistry struct {
+	deletedPaths map[string]int
+	host         string
+	listBody     string
+	deleteStatus int
+}
+
+func newFakeRegistry(t *testing.T, listBody string) *fakeRegistry {
+	t.Helper()
+
+	fr := &fakeRegistry{deletedPaths: map[string]int{}, listBody: listBody, deleteStatus: http.StatusOK}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/v2/":
+			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/tags/list"):
+			_, _ = w.Write([]byte(fr.listBody))
+		case r.Method == http.MethodDelete && strings.Contains(r.URL.Path, "/manifests/"):
+			fr.deletedPaths[r.URL.Path]++
+
+			w.WriteHeader(fr.deleteStatus)
+		default:
+			http.Error(w, "unexpected", http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	u, err := url.Parse(srv.URL)
+	require.NoError(t, err)
+
+	fr.host = u.Host
+
+	return fr
+}
+
+func anonymousGCRClient() *gcp.GCRClient {
+	return &gcp.GCRClient{Authenticator: authn.Anonymous, Transport: http.DefaultTransport}
+}
+
+func TestDeleteGCRImageRefWithClient(t *testing.T) {
+	t.Parallel()
+
+	t.Run("deletes tag reference", func(t *testing.T) {
+		t.Parallel()
+
+		fr := newFakeRegistry(t, "")
+
+		require.NoError(t, gcp.DeleteGCRImageRefWithClient(context.Background(), anonymousGCRClient(), fr.host+"/p/r:latest"))
+		assert.Equal(t, 1, fr.deletedPaths["/v2/p/r/manifests/latest"])
+	})
+
+	t.Run("bad reference errors", func(t *testing.T) {
+		t.Parallel()
+
+		err := gcp.DeleteGCRImageRefWithClient(context.Background(), anonymousGCRClient(), "::not-a-ref")
+		require.ErrorContains(t, err, "failed to parse reference")
+	})
+}
+
+func TestDeleteGCRRepoWithClient(t *testing.T) {
+	t.Parallel()
+
+	t.Run("deletes :latest and each listed digest", func(t *testing.T) {
+		t.Parallel()
+
+		d1 := "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+		d2 := "sha256:2222222222222222222222222222222222222222222222222222222222222222"
+
+		listBody := fmt.Sprintf(`{"child":[],"manifest":{%q:{"tag":["t1"]},%q:{"tag":["t2"]}},"tags":["latest","t1","t2"]}`, d1, d2)
+		fr := newFakeRegistry(t, listBody)
+
+		require.NoError(t, gcp.DeleteGCRRepoWithClient(context.Background(), anonymousGCRClient(), fr.host+"/p/r"))
+		assert.Equal(t, 1, fr.deletedPaths["/v2/p/r/manifests/latest"])
+		assert.Equal(t, 1, fr.deletedPaths["/v2/p/r/manifests/"+d1])
+		assert.Equal(t, 1, fr.deletedPaths["/v2/p/r/manifests/"+d2])
+	})
+
+	t.Run("list returns non-JSON", func(t *testing.T) {
+		t.Parallel()
+
+		fr := newFakeRegistry(t, "notjson")
+
+		err := gcp.DeleteGCRRepoWithClient(context.Background(), anonymousGCRClient(), fr.host+"/p/r")
+		require.ErrorContains(t, err, "failed to list tags")
+	})
+}

--- a/modules/gcp/oslogin.go
+++ b/modules/gcp/oslogin.go
@@ -46,7 +46,14 @@ func ImportSSHKeyE(t testing.TestingT, user, key string) error {
 // The key parameter should be the public key of the SSH key being uploaded.
 // The ctx parameter supports cancellation and timeouts.
 func ImportSSHKeyContextE(t testing.TestingT, ctx context.Context, user, key string) error {
-	return importProjectSSHKeyContextE(t, ctx, user, key, nil)
+	logger.Default.Logf(t, "Importing SSH key for user %s", user)
+
+	service, err := NewOSLoginServiceContextE(t, ctx)
+	if err != nil {
+		return err
+	}
+
+	return ImportSSHKeyWithClient(ctx, service, user, key)
 }
 
 // ImportProjectSSHKey will import an SSH key to GCP under the provided user identity.
@@ -86,34 +93,33 @@ func ImportProjectSSHKeyE(t testing.TestingT, user, key, projectID string) error
 // The projectID parameter should be the chosen project ID.
 // The ctx parameter supports cancellation and timeouts.
 func ImportProjectSSHKeyContextE(t testing.TestingT, ctx context.Context, user, key, projectID string) error {
-	return importProjectSSHKeyContextE(t, ctx, user, key, &projectID)
-}
-
-func importProjectSSHKeyContextE(t testing.TestingT, ctx context.Context, user, key string, projectID *string) error {
-	logger.Default.Logf(t, "Importing SSH key for user %s", user)
+	logger.Default.Logf(t, "Importing SSH key for user %s (project %s)", user, projectID)
 
 	service, err := NewOSLoginServiceContextE(t, ctx)
 	if err != nil {
 		return err
 	}
 
-	parent := "users/" + user
+	return ImportProjectSSHKeyWithClient(ctx, service, user, key, projectID)
+}
 
-	sshPublicKey := &oslogin.SshPublicKey{
-		Key: key,
-	}
+// ImportSSHKeyWithClient imports an SSH key to GCP under the provided user identity using the supplied
+// *oslogin.Service. Prefer this variant in unit tests where the service is backed by an httptest fake server
+// (see oslogin_unit_test.go for the pattern).
+// The ctx parameter supports cancellation and timeouts.
+func ImportSSHKeyWithClient(ctx context.Context, service *oslogin.Service, user, key string) error {
+	_, err := service.Users.ImportSshPublicKey("users/"+user, &oslogin.SshPublicKey{Key: key}).Context(ctx).Do()
 
-	req := service.Users.ImportSshPublicKey(parent, sshPublicKey)
-	if projectID != nil {
-		req = req.ProjectId(*projectID)
-	}
+	return err
+}
 
-	_, err = req.Context(ctx).Do()
-	if err != nil {
-		return err
-	}
+// ImportProjectSSHKeyWithClient imports an SSH key to GCP under the provided user identity, scoped to
+// projectID, using the supplied *oslogin.Service.
+// The ctx parameter supports cancellation and timeouts.
+func ImportProjectSSHKeyWithClient(ctx context.Context, service *oslogin.Service, user, key, projectID string) error {
+	_, err := service.Users.ImportSshPublicKey("users/"+user, &oslogin.SshPublicKey{Key: key}).ProjectId(projectID).Context(ctx).Do()
 
-	return nil
+	return err
 }
 
 // DeleteSSHKey will delete an SSH key attached to the provided user identity.
@@ -156,20 +162,31 @@ func DeleteSSHKeyContextE(t testing.TestingT, ctx context.Context, user, key str
 		return err
 	}
 
-	loginProfile := GetLoginProfileContext(t, ctx, user)
+	return DeleteSSHKeyWithClient(ctx, service, user, key)
+}
+
+// DeleteSSHKeyWithClient deletes an SSH key attached to the provided user identity using the supplied
+// *oslogin.Service. Prefer this variant in unit tests where the service is backed by an httptest fake server
+// (see oslogin_unit_test.go for the pattern).
+// The user parameter should be the email address of the user.
+// The key parameter should be the public key of the SSH key that was uploaded.
+// The ctx parameter supports cancellation and timeouts.
+func DeleteSSHKeyWithClient(ctx context.Context, service *oslogin.Service, user, key string) error {
+	loginProfile, err := GetLoginProfileWithClient(ctx, service, user)
+	if err != nil {
+		return err
+	}
 
 	for _, v := range loginProfile.SshPublicKeys {
 		if key == v.Key {
 			path := fmt.Sprintf("users/%s/sshPublicKeys/%s", user, v.Fingerprint)
 
-			_, err = service.Users.SshPublicKeys.Delete(path).Context(ctx).Do()
+			if _, err := service.Users.SshPublicKeys.Delete(path).Context(ctx).Do(); err != nil {
+				return err
+			}
 
 			break
 		}
-	}
-
-	if err != nil {
-		return err
 	}
 
 	return nil
@@ -222,6 +239,15 @@ func GetLoginProfileContextE(t testing.TestingT, ctx context.Context, user strin
 		return nil, err
 	}
 
+	return GetLoginProfileWithClient(ctx, service, user)
+}
+
+// GetLoginProfileWithClient retrieves the login profile for a user's Google identity using the supplied
+// *oslogin.Service. Prefer this variant in unit tests where the service is backed by an httptest fake server
+// (see oslogin_unit_test.go for the pattern).
+// The user parameter should be the email address of the user.
+// The ctx parameter supports cancellation and timeouts.
+func GetLoginProfileWithClient(ctx context.Context, service *oslogin.Service, user string) (*oslogin.LoginProfile, error) {
 	name := "users/" + user
 
 	profile, err := service.Users.GetLoginProfile(name).Context(ctx).Do()

--- a/modules/gcp/oslogin_unit_test.go
+++ b/modules/gcp/oslogin_unit_test.go
@@ -1,0 +1,126 @@
+package gcp_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/gcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/api/option"
+	"google.golang.org/api/oslogin/v1"
+)
+
+// newFakeOsLoginService points a *oslogin.Service at a local httptest server.
+func newFakeOsLoginService(t *testing.T, handler http.Handler) *oslogin.Service {
+	t.Helper()
+
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	svc, err := oslogin.NewService(context.Background(),
+		option.WithEndpoint(server.URL+"/"), option.WithoutAuthentication())
+	require.NoError(t, err)
+
+	return svc
+}
+
+func TestImportSSHKeyWithClient(t *testing.T) {
+	t.Parallel()
+
+	const user = "u@example.com"
+
+	svc := newFakeOsLoginService(t, respond(t, http.MethodPost, "/users/"+user+":importSshPublicKey", http.StatusOK, `{"loginProfile":{"name":"users/`+user+`"}}`))
+
+	require.NoError(t, gcp.ImportSSHKeyWithClient(context.Background(), svc, user, "ssh-rsa A"))
+}
+
+func TestImportProjectSSHKeyWithClient(t *testing.T) {
+	t.Parallel()
+
+	const (
+		user      = "u@example.com"
+		projectID = "my-project"
+	)
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Contains(t, r.URL.Path, "/users/"+user+":importSshPublicKey")
+		assert.Equal(t, projectID, r.URL.Query().Get("projectId"), "expected projectId query param")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"loginProfile":{"name":"users/` + user + `"}}`))
+	})
+
+	svc := newFakeOsLoginService(t, handler)
+
+	require.NoError(t, gcp.ImportProjectSSHKeyWithClient(context.Background(), svc, user, "ssh-rsa A", projectID))
+}
+
+func TestGetLoginProfileWithClient(t *testing.T) {
+	t.Parallel()
+
+	const user = "u@example.com"
+
+	body := `{"name":"users/` + user + `","sshPublicKeys":{"abc":{"key":"ssh-rsa A","fingerprint":"abc"}}}`
+	svc := newFakeOsLoginService(t, respond(t, http.MethodGet, "/users/"+user+"/loginProfile", http.StatusOK, body))
+
+	profile, err := gcp.GetLoginProfileWithClient(context.Background(), svc, user)
+	require.NoError(t, err)
+	assert.Equal(t, "users/"+user, profile.Name)
+	assert.Len(t, profile.SshPublicKeys, 1)
+}
+
+func TestDeleteSSHKeyWithClient(t *testing.T) {
+	t.Parallel()
+
+	const (
+		user        = "u@example.com"
+		key         = "ssh-rsa A matching"
+		fingerprint = "abc123"
+	)
+
+	t.Run("deletes matching key", func(t *testing.T) {
+		t.Parallel()
+
+		var deleteCalled bool
+
+		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+
+			switch r.Method {
+			case http.MethodGet:
+				_, _ = w.Write([]byte(`{"name":"users/` + user + `","sshPublicKeys":{"` + fingerprint + `":{"key":"` + key + `","fingerprint":"` + fingerprint + `"}}}`))
+			case http.MethodDelete:
+				assert.Contains(t, r.URL.Path, "/sshPublicKeys/"+fingerprint)
+
+				deleteCalled = true
+
+				_, _ = w.Write([]byte(`{}`))
+			}
+		})
+
+		svc := newFakeOsLoginService(t, handler)
+
+		require.NoError(t, gcp.DeleteSSHKeyWithClient(context.Background(), svc, user, key))
+		assert.True(t, deleteCalled, "Delete should fire when the key is present")
+	})
+
+	t.Run("no-op when no matching key", func(t *testing.T) {
+		t.Parallel()
+
+		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == http.MethodDelete {
+				t.Fatalf("Delete must not fire when no key matches")
+			}
+
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"name":"users/` + user + `","sshPublicKeys":{"` + fingerprint + `":{"key":"ssh-rsa A other","fingerprint":"` + fingerprint + `"}}}`))
+		})
+
+		svc := newFakeOsLoginService(t, handler)
+
+		require.NoError(t, gcp.DeleteSSHKeyWithClient(context.Background(), svc, user, key))
+	})
+}

--- a/modules/gcp/pubsub.go
+++ b/modules/gcp/pubsub.go
@@ -43,13 +43,21 @@ func AssertTopicExistsContextE(t testing.TestingT, ctx context.Context, projectI
 
 	defer func() { _ = client.Close() }()
 
+	return AssertTopicExistsWithClient(ctx, client, topicName)
+}
+
+// AssertTopicExistsWithClient checks if the given Pub/Sub topic exists using the supplied *pubsub.Client.
+// Prefer this variant in unit tests where the client is backed by a pstest in-memory fake server
+// (see pubsub_unit_test.go for the pattern).
+// The ctx parameter supports cancellation and timeouts.
+func AssertTopicExistsWithClient(ctx context.Context, client *pubsub.Client, topicName string) error {
 	exists, err := client.Topic(topicName).Exists(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to check if Pub/Sub topic %s exists in project %s: %w", topicName, projectID, err)
+		return fmt.Errorf("failed to check if Pub/Sub topic %s exists in project %s: %w", topicName, client.Project(), err)
 	}
 
 	if !exists {
-		return fmt.Errorf("Pub/Sub topic %s does not exist in project %s", topicName, projectID)
+		return fmt.Errorf("Pub/Sub topic %s does not exist in project %s", topicName, client.Project())
 	}
 
 	return nil
@@ -88,13 +96,21 @@ func AssertSubscriptionExistsContextE(t testing.TestingT, ctx context.Context, p
 
 	defer func() { _ = client.Close() }()
 
+	return AssertSubscriptionExistsWithClient(ctx, client, subscriptionName)
+}
+
+// AssertSubscriptionExistsWithClient checks if the given Pub/Sub subscription exists using the supplied *pubsub.Client.
+// Prefer this variant in unit tests where the client is backed by a pstest in-memory fake server
+// (see pubsub_unit_test.go for the pattern).
+// The ctx parameter supports cancellation and timeouts.
+func AssertSubscriptionExistsWithClient(ctx context.Context, client *pubsub.Client, subscriptionName string) error {
 	exists, err := client.Subscription(subscriptionName).Exists(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to check if Pub/Sub subscription %s exists in project %s: %w", subscriptionName, projectID, err)
+		return fmt.Errorf("failed to check if Pub/Sub subscription %s exists in project %s: %w", subscriptionName, client.Project(), err)
 	}
 
 	if !exists {
-		return fmt.Errorf("Pub/Sub subscription %s does not exist in project %s", subscriptionName, projectID)
+		return fmt.Errorf("Pub/Sub subscription %s does not exist in project %s", subscriptionName, client.Project())
 	}
 
 	return nil
@@ -133,9 +149,16 @@ func CreateTopicContextE(t testing.TestingT, ctx context.Context, projectID stri
 
 	defer func() { _ = client.Close() }()
 
-	_, err = client.CreateTopic(ctx, topicName)
-	if err != nil {
-		return fmt.Errorf("failed to create Pub/Sub topic %s in project %s: %w", topicName, projectID, err)
+	return CreateTopicWithClient(ctx, client, topicName)
+}
+
+// CreateTopicWithClient creates a new Pub/Sub topic using the supplied *pubsub.Client.
+// Prefer this variant in unit tests where the client is backed by a pstest in-memory fake server
+// (see pubsub_unit_test.go for the pattern).
+// The ctx parameter supports cancellation and timeouts.
+func CreateTopicWithClient(ctx context.Context, client *pubsub.Client, topicName string) error {
+	if _, err := client.CreateTopic(ctx, topicName); err != nil {
+		return fmt.Errorf("failed to create Pub/Sub topic %s in project %s: %w", topicName, client.Project(), err)
 	}
 
 	return nil
@@ -174,8 +197,16 @@ func DeleteTopicContextE(t testing.TestingT, ctx context.Context, projectID stri
 
 	defer func() { _ = client.Close() }()
 
+	return DeleteTopicWithClient(ctx, client, topicName)
+}
+
+// DeleteTopicWithClient deletes the given Pub/Sub topic using the supplied *pubsub.Client.
+// Prefer this variant in unit tests where the client is backed by a pstest in-memory fake server
+// (see pubsub_unit_test.go for the pattern).
+// The ctx parameter supports cancellation and timeouts.
+func DeleteTopicWithClient(ctx context.Context, client *pubsub.Client, topicName string) error {
 	if err := client.Topic(topicName).Delete(ctx); err != nil {
-		return fmt.Errorf("failed to delete Pub/Sub topic %s in project %s: %w", topicName, projectID, err)
+		return fmt.Errorf("failed to delete Pub/Sub topic %s in project %s: %w", topicName, client.Project(), err)
 	}
 
 	return nil
@@ -214,11 +245,18 @@ func CreateSubscriptionContextE(t testing.TestingT, ctx context.Context, project
 
 	defer func() { _ = client.Close() }()
 
-	_, err = client.CreateSubscription(ctx, subscriptionName, pubsub.SubscriptionConfig{
+	return CreateSubscriptionWithClient(ctx, client, subscriptionName, topicName)
+}
+
+// CreateSubscriptionWithClient creates a new Pub/Sub subscription on the given topic using the supplied *pubsub.Client.
+// Prefer this variant in unit tests where the client is backed by a pstest in-memory fake server
+// (see pubsub_unit_test.go for the pattern).
+// The ctx parameter supports cancellation and timeouts.
+func CreateSubscriptionWithClient(ctx context.Context, client *pubsub.Client, subscriptionName string, topicName string) error {
+	if _, err := client.CreateSubscription(ctx, subscriptionName, pubsub.SubscriptionConfig{
 		Topic: client.Topic(topicName),
-	})
-	if err != nil {
-		return fmt.Errorf("failed to create Pub/Sub subscription %s in project %s: %w", subscriptionName, projectID, err)
+	}); err != nil {
+		return fmt.Errorf("failed to create Pub/Sub subscription %s on topic %s in project %s: %w", subscriptionName, topicName, client.Project(), err)
 	}
 
 	return nil
@@ -257,8 +295,16 @@ func DeleteSubscriptionContextE(t testing.TestingT, ctx context.Context, project
 
 	defer func() { _ = client.Close() }()
 
+	return DeleteSubscriptionWithClient(ctx, client, subscriptionName)
+}
+
+// DeleteSubscriptionWithClient deletes the given Pub/Sub subscription using the supplied *pubsub.Client.
+// Prefer this variant in unit tests where the client is backed by a pstest in-memory fake server
+// (see pubsub_unit_test.go for the pattern).
+// The ctx parameter supports cancellation and timeouts.
+func DeleteSubscriptionWithClient(ctx context.Context, client *pubsub.Client, subscriptionName string) error {
 	if err := client.Subscription(subscriptionName).Delete(ctx); err != nil {
-		return fmt.Errorf("failed to delete Pub/Sub subscription %s in project %s: %w", subscriptionName, projectID, err)
+		return fmt.Errorf("failed to delete Pub/Sub subscription %s in project %s: %w", subscriptionName, client.Project(), err)
 	}
 
 	return nil

--- a/modules/gcp/pubsub_unit_test.go
+++ b/modules/gcp/pubsub_unit_test.go
@@ -1,0 +1,72 @@
+package gcp_test
+
+import (
+	"context"
+	"testing"
+
+	"cloud.google.com/go/pubsub"
+	"cloud.google.com/go/pubsub/pstest"
+	"github.com/gruntwork-io/terratest/modules/gcp"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/api/option"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+// newFakePubSubClient wires a *pubsub.Client to the pstest in-memory fake Pub/Sub server —
+// credential-free, gRPC-conformant.
+func newFakePubSubClient(t *testing.T) *pubsub.Client {
+	t.Helper()
+
+	srv := pstest.NewServer()
+
+	t.Cleanup(func() { _ = srv.Close() })
+
+	conn, err := grpc.NewClient(srv.Addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+
+	client, err := pubsub.NewClient(context.Background(), "test-project", option.WithGRPCConn(conn))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = client.Close() })
+
+	return client
+}
+
+func TestPubSubTopicLifecycleWithClient(t *testing.T) {
+	t.Parallel()
+
+	client := newFakePubSubClient(t)
+	ctx := context.Background()
+
+	// Missing topic: AssertTopicExists fails, Delete fails.
+	require.ErrorContains(t, gcp.AssertTopicExistsWithClient(ctx, client, "missing"), "does not exist")
+	require.Error(t, gcp.DeleteTopicWithClient(ctx, client, "missing"))
+
+	// Create / assert / delete roundtrip.
+	require.NoError(t, gcp.CreateTopicWithClient(ctx, client, "t"))
+	require.NoError(t, gcp.AssertTopicExistsWithClient(ctx, client, "t"))
+	require.NoError(t, gcp.DeleteTopicWithClient(ctx, client, "t"))
+	require.ErrorContains(t, gcp.AssertTopicExistsWithClient(ctx, client, "t"), "does not exist")
+
+	// Re-creating the same topic name within the same run is an error on pstest (matches prod).
+	require.NoError(t, gcp.CreateTopicWithClient(ctx, client, "dup"))
+	require.ErrorContains(t, gcp.CreateTopicWithClient(ctx, client, "dup"), "failed to create")
+}
+
+func TestPubSubSubscriptionLifecycleWithClient(t *testing.T) {
+	t.Parallel()
+
+	client := newFakePubSubClient(t)
+	ctx := context.Background()
+
+	// Subscription on a missing topic errors.
+	require.ErrorContains(t, gcp.CreateSubscriptionWithClient(ctx, client, "s", "missing-topic"), "failed to create")
+
+	// Full roundtrip on a real topic.
+	require.NoError(t, gcp.CreateTopicWithClient(ctx, client, "t"))
+	require.NoError(t, gcp.CreateSubscriptionWithClient(ctx, client, "s", "t"))
+	require.NoError(t, gcp.AssertSubscriptionExistsWithClient(ctx, client, "s"))
+	require.NoError(t, gcp.DeleteSubscriptionWithClient(ctx, client, "s"))
+	require.ErrorContains(t, gcp.AssertSubscriptionExistsWithClient(ctx, client, "s"), "does not exist")
+}

--- a/modules/gcp/region.go
+++ b/modules/gcp/region.go
@@ -243,10 +243,18 @@ func GetAllGCPRegionsContextE(t testing.TestingT, ctx context.Context, projectID
 		return nil, err
 	}
 
+	return GetAllGCPRegionsWithClient(ctx, service, projectID)
+}
+
+// GetAllGCPRegionsWithClient gets the list of GCP regions available in this account using the supplied
+// *compute.Service. Prefer this variant in unit tests where the service is backed by an httptest fake server
+// (see region_unit_test.go for the pattern).
+// The ctx parameter supports cancellation and timeouts.
+func GetAllGCPRegionsWithClient(ctx context.Context, service *compute.Service, projectID string) ([]string, error) {
 	req := service.Regions.List(projectID)
 	regions := []string{}
 
-	err = req.Pages(ctx, func(page *compute.RegionList) error {
+	err := req.Pages(ctx, func(page *compute.RegionList) error {
 		for _, region := range page.Items {
 			regions = append(regions, region.Name)
 		}
@@ -293,10 +301,18 @@ func GetAllGCPZonesContextE(t testing.TestingT, ctx context.Context, projectID s
 		return nil, err
 	}
 
+	return GetAllGCPZonesWithClient(ctx, service, projectID)
+}
+
+// GetAllGCPZonesWithClient gets the list of GCP Zones available in this account using the supplied
+// *compute.Service. Prefer this variant in unit tests where the service is backed by an httptest fake server
+// (see region_unit_test.go for the pattern).
+// The ctx parameter supports cancellation and timeouts.
+func GetAllGCPZonesWithClient(ctx context.Context, service *compute.Service, projectID string) ([]string, error) {
 	req := service.Zones.List(projectID)
 	zones := []string{}
 
-	err = req.Pages(ctx, func(page *compute.ZoneList) error {
+	err := req.Pages(ctx, func(page *compute.ZoneList) error {
 		for _, zone := range page.Items {
 			zones = append(zones, zone.Name)
 		}

--- a/modules/gcp/region_unit_test.go
+++ b/modules/gcp/region_unit_test.go
@@ -1,0 +1,31 @@
+package gcp_test
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/gcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetAllGCPRegionsWithClient(t *testing.T) {
+	t.Parallel()
+
+	svc := newFakeComputeService(t, respond(t, http.MethodGet, "/projects/p/regions", http.StatusOK, `{"items":[{"name":"us-central1"},{"name":"us-east1"}]}`))
+
+	got, err := gcp.GetAllGCPRegionsWithClient(context.Background(), svc, "p")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"us-central1", "us-east1"}, got)
+}
+
+func TestGetAllGCPZonesWithClient(t *testing.T) {
+	t.Parallel()
+
+	svc := newFakeComputeService(t, respond(t, http.MethodGet, "/projects/p/zones", http.StatusOK, `{"items":[{"name":"us-central1-a"},{"name":"us-east1-b"}]}`))
+
+	got, err := gcp.GetAllGCPZonesWithClient(context.Background(), svc, "p")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"us-central1-a", "us-east1-b"}, got)
+}

--- a/modules/gcp/storage.go
+++ b/modules/gcp/storage.go
@@ -46,7 +46,6 @@ func CreateStorageBucketE(t testing.TestingT, projectID string, name string, att
 func CreateStorageBucketContextE(t testing.TestingT, ctx context.Context, projectID string, name string, attr *storage.BucketAttrs) error {
 	logger.Default.Logf(t, "Creating bucket %s", name)
 
-	// Creates a client.
 	client, err := newStorageClient(ctx)
 	if err != nil {
 		return err
@@ -54,11 +53,15 @@ func CreateStorageBucketContextE(t testing.TestingT, ctx context.Context, projec
 
 	defer func() { _ = client.Close() }()
 
-	// Creates a Bucket instance.
-	bucket := client.Bucket(name)
+	return CreateStorageBucketWithClient(ctx, client, projectID, name, attr)
+}
 
-	// Creates the new bucket.
-	return bucket.Create(ctx, projectID, attr)
+// CreateStorageBucketWithClient creates a Google Cloud bucket with the given BucketAttrs using the
+// supplied *storage.Client. Prefer this variant in unit tests where the client is backed by an
+// httptest fake server (see storage_unit_test.go for the pattern).
+// The ctx parameter supports cancellation and timeouts.
+func CreateStorageBucketWithClient(ctx context.Context, client *storage.Client, projectID string, name string, attr *storage.BucketAttrs) error {
+	return client.Bucket(name).Create(ctx, projectID, attr)
 }
 
 // DeleteStorageBucket destroys the Google Storage bucket.
@@ -96,6 +99,14 @@ func DeleteStorageBucketContextE(t testing.TestingT, ctx context.Context, name s
 
 	defer func() { _ = client.Close() }()
 
+	return DeleteStorageBucketWithClient(ctx, client, name)
+}
+
+// DeleteStorageBucketWithClient destroys the Google Cloud Storage bucket with the given name using
+// the supplied *storage.Client. Prefer this variant in unit tests where the client is backed by an
+// httptest fake server (see storage_unit_test.go for the pattern).
+// The ctx parameter supports cancellation and timeouts.
+func DeleteStorageBucketWithClient(ctx context.Context, client *storage.Client, name string) error {
 	return client.Bucket(name).Delete(ctx)
 }
 
@@ -136,9 +147,15 @@ func ReadBucketObjectContextE(t testing.TestingT, ctx context.Context, bucketNam
 
 	defer func() { _ = client.Close() }()
 
-	bucket := client.Bucket(bucketName)
+	return ReadBucketObjectWithClient(ctx, client, bucketName, filePath)
+}
 
-	r, err := bucket.Object(filePath).NewReader(ctx)
+// ReadBucketObjectWithClient reads an object from the given Storage Bucket and returns its contents
+// using the supplied *storage.Client. Prefer this variant in unit tests where the client is backed
+// by an httptest fake server (see storage_unit_test.go for the pattern).
+// The ctx parameter supports cancellation and timeouts.
+func ReadBucketObjectWithClient(ctx context.Context, client *storage.Client, bucketName string, filePath string) (io.Reader, error) {
+	r, err := client.Bucket(bucketName).Object(filePath).NewReader(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -194,6 +211,19 @@ func WriteBucketObjectContextE(t testing.TestingT, ctx context.Context, bucketNa
 	}
 
 	defer func() { _ = client.Close() }()
+
+	return WriteBucketObjectWithClient(ctx, client, bucketName, filePath, body, contentType)
+}
+
+// WriteBucketObjectWithClient writes an object to the given Storage Bucket and returns its URL
+// using the supplied *storage.Client. Prefer this variant in unit tests where the client is backed
+// by an httptest fake server (see storage_unit_test.go for the pattern).
+// The ctx parameter supports cancellation and timeouts.
+func WriteBucketObjectWithClient(ctx context.Context, client *storage.Client, bucketName string, filePath string, body io.Reader, contentType string) (string, error) {
+	// set a default content type
+	if contentType == "" {
+		contentType = "application/octet-stream"
+	}
 
 	w := client.Bucket(bucketName).Object(filePath).NewWriter(ctx)
 	w.ContentType = contentType
@@ -281,6 +311,34 @@ func EmptyStorageBucketContextE(t testing.TestingT, ctx context.Context, name st
 	return nil
 }
 
+// EmptyStorageBucketWithClient removes the contents of a storage bucket with the given name using
+// the supplied *storage.Client. Prefer this variant in unit tests where the client is backed by an
+// httptest fake server (see storage_unit_test.go for the pattern).
+// The ctx parameter supports cancellation and timeouts.
+func EmptyStorageBucketWithClient(ctx context.Context, client *storage.Client, name string) error {
+	bucket := client.Bucket(name)
+
+	it := bucket.Objects(ctx, nil)
+
+	for {
+		objectAttrs, err := it.Next()
+
+		if errors.Is(err, iterator.Done) {
+			break
+		}
+
+		if err != nil {
+			return err
+		}
+
+		if err := bucket.Object(objectAttrs.Name).Delete(ctx); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 // AssertStorageBucketExists checks if the given storage bucket exists and fails the test if it does not.
 //
 // Deprecated: Use [AssertStorageBucketExistsContext] instead.
@@ -307,7 +365,6 @@ func AssertStorageBucketExistsE(t testing.TestingT, name string) error {
 func AssertStorageBucketExistsContextE(t testing.TestingT, ctx context.Context, name string) error {
 	logger.Default.Logf(t, "Finding bucket %s", name)
 
-	// Creates a client.
 	client, err := newStorageClient(ctx)
 	if err != nil {
 		return err
@@ -315,7 +372,14 @@ func AssertStorageBucketExistsContextE(t testing.TestingT, ctx context.Context, 
 
 	defer func() { _ = client.Close() }()
 
-	// Creates a Bucket instance.
+	return AssertStorageBucketExistsWithClient(ctx, client, name)
+}
+
+// AssertStorageBucketExistsWithClient checks if the given storage bucket exists and returns an error
+// if it does not, using the supplied *storage.Client. Prefer this variant in unit tests where the
+// client is backed by an httptest fake server (see storage_unit_test.go for the pattern).
+// The ctx parameter supports cancellation and timeouts.
+func AssertStorageBucketExistsWithClient(ctx context.Context, client *storage.Client, name string) error {
 	bucket := client.Bucket(name)
 
 	// TODO - the code below attempts to determine whether the storage bucket

--- a/modules/gcp/storage_unit_test.go
+++ b/modules/gcp/storage_unit_test.go
@@ -1,0 +1,140 @@
+package gcp_test
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"cloud.google.com/go/storage"
+	"github.com/gruntwork-io/terratest/modules/gcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/api/option"
+)
+
+// newFakeStorageClient points a *storage.Client at a local httptest server. The SDK uses a
+// JSON/REST transport by default, so option.WithEndpoint routes calls through the fake.
+func newFakeStorageClient(t *testing.T, handler http.Handler) *storage.Client {
+	t.Helper()
+
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	client, err := storage.NewClient(context.Background(),
+		option.WithEndpoint(server.URL), option.WithoutAuthentication())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = client.Close() })
+
+	return client
+}
+
+func TestCreateStorageBucketWithClient(t *testing.T) {
+	t.Parallel()
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "p", r.URL.Query().Get("project"))
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"kind":"storage#bucket","id":"b","name":"b"}`))
+	})
+
+	client := newFakeStorageClient(t, handler)
+
+	require.NoError(t, gcp.CreateStorageBucketWithClient(context.Background(), client, "p", "b", nil))
+}
+
+func TestDeleteStorageBucketWithClient(t *testing.T) {
+	t.Parallel()
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodDelete, r.Method)
+		assert.Contains(t, r.URL.Path, "/b/b")
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	client := newFakeStorageClient(t, handler)
+
+	require.NoError(t, gcp.DeleteStorageBucketWithClient(context.Background(), client, "b"))
+}
+
+func TestAssertStorageBucketExistsWithClient(t *testing.T) {
+	t.Parallel()
+
+	t.Run("exists", func(t *testing.T) {
+		t.Parallel()
+
+		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+
+			if strings.HasSuffix(r.URL.Path, "/b/b") {
+				_, _ = w.Write([]byte(`{"kind":"storage#bucket","id":"b","name":"b"}`))
+
+				return
+			}
+
+			_, _ = w.Write([]byte(`{"kind":"storage#objects","items":[]}`))
+		})
+
+		client := newFakeStorageClient(t, handler)
+
+		require.NoError(t, gcp.AssertStorageBucketExistsWithClient(context.Background(), client, "b"))
+	})
+
+	t.Run("missing", func(t *testing.T) {
+		t.Parallel()
+
+		handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+		})
+
+		client := newFakeStorageClient(t, handler)
+
+		require.Error(t, gcp.AssertStorageBucketExistsWithClient(context.Background(), client, "b"))
+	})
+}
+
+func TestReadBucketObjectWithClient(t *testing.T) {
+	t.Parallel()
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		_, _ = w.Write([]byte("hello"))
+	})
+
+	client := newFakeStorageClient(t, handler)
+
+	r, err := gcp.ReadBucketObjectWithClient(context.Background(), client, "b", "o.txt")
+	require.NoError(t, err)
+
+	got, err := io.ReadAll(r)
+	require.NoError(t, err)
+	assert.Equal(t, "hello", string(got))
+}
+
+func TestEmptyStorageBucketWithClient(t *testing.T) {
+	t.Parallel()
+
+	var deleted []string
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"kind":"storage#objects","items":[{"name":"a"},{"name":"b"}]}`))
+		case http.MethodDelete:
+			if parts := strings.Split(r.URL.Path, "/o/"); len(parts) == 2 {
+				deleted = append(deleted, parts[1])
+			}
+
+			w.WriteHeader(http.StatusNoContent)
+		}
+	})
+
+	client := newFakeStorageClient(t, handler)
+
+	require.NoError(t, gcp.EmptyStorageBucketWithClient(context.Background(), client, "b"))
+	assert.ElementsMatch(t, []string{"a", "b"}, deleted)
+}


### PR DESCRIPTION
## Why

Panic guard in `GetPublicIPContextE` and a credential-free WithClient test pattern for every SDK-calling function in `modules/gcp/`.

## What

**Panic guard**
- `gcp/compute.go` `GetPublicIPContextE` — guard `len(NetworkInterfaces) == 0`.

**WithClient variants (34 total)** across compute, oslogin, region, pubsub, storage, cloudbuild, gcr. Signature matches Azure convention: `(ctx, client, ...args) (T, error)`. Each existing `ContextE` wrapper delegates directly to its `WithClient` sibling, so testing `WithClient` covers the path `ContextE` callers actually run.

**Per-SDK fake-server test infra** — no GCP credentials required:
- REST SDKs (compute, oslogin, region, storage): `httptest` + `option.WithEndpoint` + `option.WithoutAuthentication`.
- pubsub: `cloud.google.com/go/pubsub/pstest` in-memory fake.
- cloudbuild: `bufconn` + handwritten gRPC fake.
- gcr: `httptest` serving a minimal Docker Registry v2 API.

**Public API note:** new type `GCRClient{Authenticator, Transport}` lets gcr match the `(ctx, client, …)` shape.

## ⚠️ Breaking
None — all additions.

## Limitation
`CreateBuildWithClient` lacks a unit test: it returns a long-running `Operation` resolved via `google.longrunning.Operations` on a separate gRPC service — covered by the existing build-tagged integration test instead.

## Test plan
- [x] `go build / vet / test -race ./modules/gcp/...`
- [x] `golangci-lint run ./modules/gcp/...` — 0 issues