### PR TITLE
fix(k8s)!: fail fast on explicit kubeconfig load failure

### DIFF
--- a/modules/k8s/client.go
+++ b/modules/k8s/client.go
@@ -74,14 +74,7 @@ func GetKubernetesClientFromOptionsContextE(t testing.TestingT, ctx context.Cont
 		// Load API config (instead of more low level ClientConfig)
 		config, err = LoadAPIClientConfigE(kubeConfigPath, options.ContextName)
 		if err != nil {
-			options.Logger.Logf(t, "Error loading api client config, falling back to in-cluster authentication via serviceaccount token: %s", err)
-
-			config, err = rest.InClusterConfig()
-			if err != nil {
-				return nil, err
-			}
-
-			options.Logger.Logf(t, "Configuring Kubernetes client to use the in-cluster serviceaccount token")
+			return nil, err
 		}
 	}
 


### PR DESCRIPTION
## Why
When an explicit kubeconfig path+context fails to load, the code silently falls back to in-cluster service account authentication. A user pointing at cluster A with a typo'd path would instead run tests against the test runner's in-cluster identity (possibly a completely different cluster), with no error returned.

## What
Remove the silent `rest.InClusterConfig()` fallback in the explicit-kubeconfig code path of `GetKubernetesClientFromOptionsContextE`. Return the `LoadAPIClientConfigE` error instead.

## Behavioral change
Users who currently rely on the silent fallback will see an error instead of a cluster switch. The in-cluster path remains available as an explicit option (`KubectlOptions.InClusterAuth = true`, or use the `NewKubectlOptionsWithInClusterAuth()` constructor).

## Test plan
- [x] `go build ./modules/k8s/...`
- [x] `go vet ./modules/k8s/...`
- [x] `go test -count=1 -race ./modules/k8s/...`
- [x] `mise exec -- golangci-lint run ./modules/k8s/...`