### PR TITLE
fix(oci): nil-safety and pagination in list calls

### DIFF
--- a/modules/oci/compute.go
+++ b/modules/oci/compute.go
@@ -72,16 +72,35 @@ func GetMostRecentImageIDContextE(t testing.TestingT, ctx context.Context, compa
 		OperatingSystemVersion: &osVersion,
 	}
 
-	response, err := client.ListImages(ctx, request)
-	if err != nil {
-		return "", err
+	var allItems []core.Image
+
+	for {
+		response, err := client.ListImages(ctx, request)
+		if err != nil {
+			return "", err
+		}
+
+		allItems = append(allItems, response.Items...)
+
+		// Stop when no next page, when the server returns an empty token, or
+		// when it returns the same token we just requested (defensive: prevents
+		// an infinite loop on a misbehaving server).
+		if response.OpcNextPage == nil || *response.OpcNextPage == "" {
+			break
+		}
+
+		if request.Page != nil && *request.Page == *response.OpcNextPage {
+			break
+		}
+
+		request.Page = response.OpcNextPage
 	}
 
-	if len(response.Items) == 0 {
+	if len(allItems) == 0 {
 		return "", NoImagesFoundError{OSName: osName, OSVersion: osVersion, CompartmentID: compartmentID}
 	}
 
-	mostRecentImage := mostRecentImage(response.Items)
+	mostRecentImage := mostRecentImage(allItems)
 
 	return *mostRecentImage.Id, nil
 }
@@ -120,10 +139,14 @@ type imageSort []core.Image
 func (a imageSort) Len() int      { return len(a) }
 func (a imageSort) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
 func (a imageSort) Less(i, j int) bool {
-	iTime := a[i].TimeCreated.Unix()
-	jTime := a[j].TimeCreated.Unix()
-
-	return iTime < jTime
+	switch {
+	case a[i].TimeCreated == nil:
+		return true
+	case a[j].TimeCreated == nil:
+		return false
+	default:
+		return a[i].TimeCreated.Unix() < a[j].TimeCreated.Unix()
+	}
 }
 
 // mostRecentImage returns the most recent image out of a slice of images.

--- a/modules/oci/network.go
+++ b/modules/oci/network.go
@@ -23,16 +23,35 @@ func GetAllVcnIDsContextE(t testing.TestingT, ctx context.Context, compartmentID
 
 	request := core.ListVcnsRequest{CompartmentId: &compartmentID}
 
-	response, err := client.ListVcns(ctx, request)
-	if err != nil {
-		return nil, err
+	var allItems []core.Vcn
+
+	for {
+		response, err := client.ListVcns(ctx, request)
+		if err != nil {
+			return nil, err
+		}
+
+		allItems = append(allItems, response.Items...)
+
+		// Stop when no next page, when the server returns an empty token, or
+		// when it returns the same token we just requested (defensive: prevents
+		// an infinite loop on a misbehaving server).
+		if response.OpcNextPage == nil || *response.OpcNextPage == "" {
+			break
+		}
+
+		if request.Page != nil && *request.Page == *response.OpcNextPage {
+			break
+		}
+
+		request.Page = response.OpcNextPage
 	}
 
-	if len(response.Items) == 0 {
+	if len(allItems) == 0 {
 		return nil, NoVCNsFoundError{CompartmentID: compartmentID}
 	}
 
-	return vcnsIDs(response.Items), nil
+	return vcnsIDs(allItems), nil
 }
 
 // GetAllVcnIDsContext gets the list of VCNs available in the given compartment.


### PR DESCRIPTION
## Why
- `imageSort.Less` panics when an OCI image has nil `TimeCreated` (SDK field is `*common.SDKTime`).
- Two list helpers call `ListVcns` / `ListImages` once and ignore `OpcNextPage`, silently missing results past the first page.

## What
- Guard `TimeCreated` nil-deref in `imageSort.Less`; treat nil as oldest.
- Loop on `OpcNextPage` in `GetAllVcnIDsContextE` (`ListVcns`) and the `ListImages` caller in `compute.go`.
- `ListAvailabilityDomains` was not changed: the SDK's `ListAvailabilityDomainsRequest` in this version has no `Page` field, so there is no way to request subsequent pages. Availability domains per compartment are small (3-6 in all real regions) and fit in one response.

## Test plan
- [x] `go build ./modules/oci/...`
- [x] `go vet ./modules/oci/...`
- [x] `go test -count=1 -race ./modules/oci/...` (no unit tests in package; build-tagged integration tests unchanged)
- [x] `golangci-lint run ./modules/oci/...`