### PR TITLE
fix(ssh): harden FetchContentsOfFile against injection and fix error-path bugs

### DIFF
--- a/modules/ssh/ssh.go
+++ b/modules/ssh/ssh.go
@@ -646,11 +646,18 @@ func FetchContentsOfFileContext(t testing.TestingT, ctx context.Context, host *H
 	return out
 }
 
+// shellQuote returns s wrapped in single quotes, with any embedded single quote
+// replaced by the four-character sequence quote-backslash-quote-quote.
+// Safe for POSIX sh, bash, zsh.
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
+
 // FetchContentsOfFileContextE connects to the given host via SSH and fetches the contents of the file at the given filePath.
 // If useSudo is true, then the contents will be retrieved using sudo. Returns the contents of that file.
 // The ctx parameter supports cancellation and timeouts.
 func FetchContentsOfFileContextE(t testing.TestingT, ctx context.Context, host *Host, useSudo bool, filePath string) (string, error) {
-	command := "cat " + filePath
+	command := "cat " + shellQuote(filePath)
 	if useSudo {
 		command = "sudo " + command
 	}
@@ -703,7 +710,9 @@ func listFileInRemoteDir(ctx context.Context, t testing.TestingT, sshSession *SS
 	// The last character returned is `\n` this results in an extra "" array
 	// member when we do the split below. Cut off the last character to avoid
 	// having to remove the blank entry in the array.
-	resultString = resultString[:len(resultString)-1]
+	if len(resultString) > 0 {
+		resultString = resultString[:len(resultString)-1]
+	}
 
 	return strings.Split(resultString, "\n"), nil
 }
@@ -726,12 +735,12 @@ func copyFileFromRemote(ctx context.Context, t testing.TestingT, sshSession *SSH
 
 	logger.Default.Logf(t, "Running command %s on %s@%s", command, sshSession.Options.Username, sshSession.Options.Address)
 
+	defer func() { _ = sshSession.Session.Close() }()
+
 	r, err := sshSession.Session.Output(command)
 	if err != nil {
-		logger.Default.Logf(t, "error reading from remote stdout: %s", err)
+		return fmt.Errorf("error reading from remote stdout: %w", err)
 	}
-
-	defer func() { _ = sshSession.Session.Close() }()
 
 	// Write to local file.
 	_, err = file.Write(r)

--- a/modules/ssh/ssh_unit_test.go
+++ b/modules/ssh/ssh_unit_test.go
@@ -1,0 +1,66 @@
+package ssh //nolint:testpackage // white-box test for unexported shellQuote helper
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestShellQuote(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "no special chars",
+			input:    "/etc/hostname",
+			expected: "'/etc/hostname'",
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			expected: "''",
+		},
+		{
+			name:     "single quote",
+			input:    "it's",
+			expected: `'it'\''s'`,
+		},
+		{
+			name:     "spaces",
+			input:    "/path with spaces/file.txt",
+			expected: "'/path with spaces/file.txt'",
+		},
+		{
+			name:     "path traversal attempt",
+			input:    "a; rm -rf /",
+			expected: "'a; rm -rf /'",
+		},
+		{
+			name:     "command substitution attempt",
+			input:    "$(rm -rf /)",
+			expected: "'$(rm -rf /)'",
+		},
+		{
+			name:     "backtick attempt",
+			input:    "`rm -rf /`",
+			expected: "'`rm -rf /`'",
+		},
+		{
+			name:     "injection with embedded single quote",
+			input:    "'; rm -rf / #",
+			expected: `''\''; rm -rf / #'`,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.expected, shellQuote(tc.input))
+		})
+	}
+}


### PR DESCRIPTION
## Why
Three defensive fixes in modules/ssh:
- Command injection via `FetchContentsOfFileContextE` interpolating user-supplied filePath directly into a shell command.
- Index-out-of-range panic in `listFileInRemoteDir` when the remote command returns empty output.
- `copyFileFromRemote` logs an SDK error but continues, writing nil/partial bytes to the local file.

## What
- Add an unexported `shellQuote` helper; use it around filePath in `FetchContentsOfFileContextE`.
- Guard the trailing-newline trim with `len > 0`.
- Return early on `ssh.Session.Output` error in `copyFileFromRemote`; close the session via defer placed before the Output call.
- Unit test for `shellQuote` covering special chars and injection attempts.

## Test plan
- [x] go build / vet / test -race / golangci-lint