### PR TITLE
ci: add Azure integration tests GitHub Actions workflow

### DIFF
--- a/.github/workflows/azure-integration-tests.yml
+++ b/.github/workflows/azure-integration-tests.yml
@@ -1,0 +1,88 @@
+name: Azure Integration Tests
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'modules/azure/**'
+      - 'test/azure/**'
+      - 'examples/azure/**'
+      - 'go.mod'
+      - 'go.sum'
+      - 'mise.toml'
+      - '.github/workflows/azure-integration-tests.yml'
+  pull_request:
+    paths:
+      - 'modules/azure/**'
+      - 'test/azure/**'
+      - 'examples/azure/**'
+      - 'go.mod'
+      - 'go.sum'
+      - 'mise.toml'
+      - '.github/workflows/azure-integration-tests.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: azure-integration-tests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  azure-integration-tests:
+    name: Azure Integration Tests
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install mise
+        uses: jdx/mise-action@v3
+        with:
+          version: 2025.12.10
+          experimental: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Go module cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: Download Go modules
+        run: go mod download
+
+      - name: Azure login (OIDC)
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Run Azure integration tests
+        env:
+          ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          ARM_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          ARM_USE_OIDC: "true"
+        run: |
+          mkdir -p /tmp/logs
+          go test -v -p 1 -tags azure -count=1 -timeout 45m ./test/azure/... 2>&1 | tee /tmp/logs/azure-integration-tests.log
+
+      - name: Upload test logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: azure-integration-test-logs
+          path: /tmp/logs/
+          retention-days: 14


### PR DESCRIPTION
## Summary

Adds `.github/workflows/azure-integration-tests.yml` to run `go test -tags azure ./test/azure/...` against a real Azure subscription.

- Triggers: push to `main`, same-repo PRs, `workflow_dispatch` (paths-filtered to Azure-relevant changes).
- Auth: OIDC via `azure/login@v2` using the `AZURE_CLIENT_ID` / `AZURE_TENANT_ID` / `AZURE_SUBSCRIPTION_ID` repo secrets — no client secret stored.
- Fork-PR exposure blocked at job level (`if: head.repo.full_name == github.repository`).
- `concurrency:` group cancels superseded runs on the same ref to avoid overlapping Azure resource provisioning.
- 27/28 tests in `test/azure/` will run; `terraform_azure_sqlmanagedinstance_example_test.go` is excluded by its `azure_ci_excluded` build tag (6–8h provision time).
- Complementary to existing `azure-tests.yml`, which only compiles `./test/azure/` and runs `./modules/azure/...` unit tests.

## Out of scope

- Verifying the Azure AD federated credential trust policy is scoped (single-subject vs. wildcard) — Azure-side configuration owned by Yousif.
- Deleting the stale `AZURE_CREDENTIALS` secret (2 years old, unused now that OIDC is wired up).

## Test plan

- [ ] Workflow runs on this PR and Azure login step authenticates.
- [ ] Integration test job completes (or fails informatively) within the 60m timeout.
- [ ] Fork PRs do not see secrets (verified by `if:` guard; cannot test without a fork PR).