### PR TITLE
fix(aws): honor context cancellation in IAM MFA sleeps

### DIFF
--- a/modules/aws/iam.go
+++ b/modules/aws/iam.go
@@ -244,7 +244,9 @@ func EnableMfaDeviceContextE(t testing.TestingT, ctx context.Context, iamClient 
 	const mfaEnableWait = 30 * time.Second
 
 	logger.Default.Logf(t, "Waiting 30 seconds for a new MFA Token to be generated...")
-	time.Sleep(mfaEnableWait)
+	if err := sleepContext(ctx, mfaEnableWait); err != nil {
+		return err
+	}
 
 	authCode2, err := GetTimeBasedOneTimePassword(mfaDevice)
 	if err != nil {
@@ -264,9 +266,22 @@ func EnableMfaDeviceContextE(t testing.TestingT, ctx context.Context, iamClient 
 	const mfaTokenWait = 10 * time.Second
 
 	logger.Log(t, "Waiting for MFA Device enablement to propagate.")
-	time.Sleep(mfaTokenWait)
+	if err := sleepContext(ctx, mfaTokenWait); err != nil {
+		return err
+	}
 
 	return nil
+}
+
+// sleepContext blocks for the given duration or until ctx is cancelled.
+// Returns ctx.Err() if the context is cancelled before the duration elapses; otherwise nil.
+func sleepContext(ctx context.Context, d time.Duration) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-time.After(d):
+		return nil
+	}
 }
 
 // EnableMfaDeviceContext enables a newly created MFA Device by supplying the first two one-time passwords, so that it can be used for future

--- a/modules/aws/iam_internal_test.go
+++ b/modules/aws/iam_internal_test.go
@@ -7,15 +7,10 @@ import (
 	"time"
 )
 
-// TestSleepContextHonorsCancellation verifies that sleepContext returns promptly
-// with context.Canceled when the context is cancelled mid-sleep, rather than
-// waiting the full duration.
 func TestSleepContextHonorsCancellation(t *testing.T) {
 	t.Parallel()
 
 	ctx, cancel := context.WithCancel(context.Background())
-
-	// Cancel after a short delay so we can verify the sleep is interrupted.
 	go func() {
 		time.Sleep(50 * time.Millisecond)
 		cancel()
@@ -23,24 +18,11 @@ func TestSleepContextHonorsCancellation(t *testing.T) {
 
 	start := time.Now()
 	err := sleepContext(ctx, 30*time.Second)
-	elapsed := time.Since(start)
 
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("expected context.Canceled, got %v", err)
 	}
-
-	if elapsed > 5*time.Second {
-		t.Fatalf("sleepContext did not return promptly after cancellation; took %v", elapsed)
-	}
-}
-
-// TestSleepContextCompletesNormally verifies that sleepContext returns nil
-// when the duration elapses before the context is cancelled.
-func TestSleepContextCompletesNormally(t *testing.T) {
-	t.Parallel()
-
-	ctx := context.Background()
-	if err := sleepContext(ctx, 10*time.Millisecond); err != nil {
-		t.Fatalf("expected nil error, got %v", err)
+	if time.Since(start) > 5*time.Second {
+		t.Fatalf("sleepContext did not return promptly after cancellation")
 	}
 }

--- a/modules/aws/iam_internal_test.go
+++ b/modules/aws/iam_internal_test.go
@@ -1,0 +1,46 @@
+package aws
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+// TestSleepContextHonorsCancellation verifies that sleepContext returns promptly
+// with context.Canceled when the context is cancelled mid-sleep, rather than
+// waiting the full duration.
+func TestSleepContextHonorsCancellation(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// Cancel after a short delay so we can verify the sleep is interrupted.
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+
+	start := time.Now()
+	err := sleepContext(ctx, 30*time.Second)
+	elapsed := time.Since(start)
+
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+
+	if elapsed > 5*time.Second {
+		t.Fatalf("sleepContext did not return promptly after cancellation; took %v", elapsed)
+	}
+}
+
+// TestSleepContextCompletesNormally verifies that sleepContext returns nil
+// when the duration elapses before the context is cancelled.
+func TestSleepContextCompletesNormally(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	if err := sleepContext(ctx, 10*time.Millisecond); err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

`EnableMfaDeviceContextE` accepts a `context.Context` but its two `time.Sleep` calls did not honor it. Cancelling a context could not interrupt a 30-second MFA propagation wait.

## Changes

- New unexported `sleepContext(ctx, d)` helper in `modules/aws/iam.go` that selects on `ctx.Done()` and `time.After(d)`, returning `ctx.Err()` on cancellation.
- Both sleeps in `EnableMfaDeviceContextE` now use the helper.
- `iam_internal_test.go`: one test verifying that cancelling mid-sleep returns promptly with `context.Canceled`.

## Note on SSM

The SSM waits I originally suspected as also non-honoring already use `retry.DoWithRetryableErrorsContextE`, which honors context internally. No change needed there.

## Test plan

- [ ] CI passes
- [x] `go test -run TestSleepContext ./modules/aws/...` passes locally

Linear: LIB-4933