### PR TITLE
chore: replace interface{} with any across modules and internal

### DIFF
--- a/internal/lib/formatting/format.go
+++ b/internal/lib/formatting/format.go
@@ -10,7 +10,7 @@ import (
 
 // FormatBackendConfigAsArgs formats backend configuration as Terraform CLI args.
 // Example: {"bucket": "my-bucket"} -> ["-backend-config=bucket=my-bucket"]
-func FormatBackendConfigAsArgs(vars map[string]interface{}) []string {
+func FormatBackendConfigAsArgs(vars map[string]any) []string {
 	return formatTerraformArgs(vars, "-backend-config", false, true)
 }
 
@@ -25,7 +25,7 @@ func FormatPluginDirAsArgs(pluginDir string) []string {
 }
 
 // formatTerraformArgs formats vars as CLI args with the given prefix.
-func formatTerraformArgs(vars map[string]interface{}, prefix string, useSpaceAsSeparator bool, omitNil bool) []string {
+func formatTerraformArgs(vars map[string]any, prefix string, useSpaceAsSeparator bool, omitNil bool) []string {
 	var args []string
 
 	for key, value := range vars {
@@ -49,7 +49,7 @@ func formatTerraformArgs(vars map[string]interface{}, prefix string, useSpaceAsS
 
 // ToHCLString converts Go values to HCL-formatted strings for Terraform CLI arguments.
 // Handles primitives, slices, and maps. Example: []int{1,2,3} -> "[1, 2, 3]"
-func ToHCLString(value interface{}, isNested bool) string {
+func ToHCLString(value any, isNested bool) string {
 	if slice, isSlice := tryToConvertToGenericSlice(value); isSlice {
 		return sliceToHclString(slice)
 	} else if m, isMap := tryToConvertToGenericMap(value); isMap {
@@ -59,14 +59,14 @@ func ToHCLString(value interface{}, isNested bool) string {
 	}
 }
 
-// tryToConvertToGenericSlice converts any slice type to []interface{} using reflection.
-func tryToConvertToGenericSlice(value interface{}) ([]interface{}, bool) {
+// tryToConvertToGenericSlice converts any slice type to []any using reflection.
+func tryToConvertToGenericSlice(value any) ([]any, bool) {
 	reflectValue := reflect.ValueOf(value)
 	if reflectValue.Kind() != reflect.Slice {
-		return []interface{}{}, false
+		return []any{}, false
 	}
 
-	genericSlice := make([]interface{}, reflectValue.Len())
+	genericSlice := make([]any, reflectValue.Len())
 
 	for i := 0; i < reflectValue.Len(); i++ {
 		genericSlice[i] = reflectValue.Index(i).Interface()
@@ -75,19 +75,19 @@ func tryToConvertToGenericSlice(value interface{}) ([]interface{}, bool) {
 	return genericSlice, true
 }
 
-// tryToConvertToGenericMap converts any map[string]T to map[string]interface{} using reflection.
-func tryToConvertToGenericMap(value interface{}) (map[string]interface{}, bool) {
+// tryToConvertToGenericMap converts any map[string]T to map[string]any using reflection.
+func tryToConvertToGenericMap(value any) (map[string]any, bool) {
 	reflectValue := reflect.ValueOf(value)
 	if reflectValue.Kind() != reflect.Map {
-		return map[string]interface{}{}, false
+		return map[string]any{}, false
 	}
 
 	reflectType := reflect.TypeOf(value)
 	if reflectType.Key().Kind() != reflect.String {
-		return map[string]interface{}{}, false
+		return map[string]any{}, false
 	}
 
-	genericMap := make(map[string]interface{}, reflectValue.Len())
+	genericMap := make(map[string]any, reflectValue.Len())
 
 	mapKeys := reflectValue.MapKeys()
 	for _, key := range mapKeys {
@@ -97,7 +97,7 @@ func tryToConvertToGenericMap(value interface{}) (map[string]interface{}, bool) 
 	return genericMap, true
 }
 
-func sliceToHclString(slice []interface{}) string {
+func sliceToHclString(slice []any) string {
 	hclValues := make([]string, 0, len(slice))
 
 	for _, value := range slice {
@@ -108,7 +108,7 @@ func sliceToHclString(slice []interface{}) string {
 	return fmt.Sprintf("[%s]", strings.Join(hclValues, ", "))
 }
 
-func mapToHclString(m map[string]interface{}) string {
+func mapToHclString(m map[string]any) string {
 	keyValuePairs := make([]string, 0, len(m))
 
 	for key, value := range m {
@@ -119,7 +119,7 @@ func mapToHclString(m map[string]interface{}) string {
 	return fmt.Sprintf("{%s}", strings.Join(keyValuePairs, ", "))
 }
 
-func primitiveToHclString(value interface{}, isNested bool) string {
+func primitiveToHclString(value any, isNested bool) string {
 	if value == nil {
 		return "null"
 	}

--- a/internal/lib/formatting/format_test.go
+++ b/internal/lib/formatting/format_test.go
@@ -12,27 +12,27 @@ func TestFormatBackendConfigAsArgs(t *testing.T) {
 
 	tests := []struct {
 		name   string
-		input  map[string]interface{}
+		input  map[string]any
 		expect []string
 	}{
 		{
 			name:   "empty config",
-			input:  map[string]interface{}{},
+			input:  map[string]any{},
 			expect: []string{},
 		},
 		{
 			name:   "string value",
-			input:  map[string]interface{}{"bucket": "my-bucket"},
+			input:  map[string]any{"bucket": "my-bucket"},
 			expect: []string{"-backend-config=bucket=my-bucket"},
 		},
 		{
 			name:   "nil value omitted",
-			input:  map[string]interface{}{"key": nil},
+			input:  map[string]any{"key": nil},
 			expect: []string{"-backend-config=key"},
 		},
 		{
 			name:   "multiple values",
-			input:  map[string]interface{}{"region": "us-east-1", "bucket": "state"},
+			input:  map[string]any{"region": "us-east-1", "bucket": "state"},
 			expect: []string{"-backend-config=bucket=state", "-backend-config=region=us-east-1"},
 		},
 	}
@@ -82,7 +82,7 @@ func TestToHclString(t *testing.T) {
 
 	tests := []struct {
 		name   string
-		input  interface{}
+		input  any
 		expect string
 	}{
 		{"nil", nil, "null"},
@@ -93,7 +93,7 @@ func TestToHclString(t *testing.T) {
 		{"list of strings", []string{"a", "b"}, `["a", "b"]`},
 		{"list of ints", []int{1, 2, 3}, "[1, 2, 3]"},
 		{"map", map[string]string{"key": "value"}, `{"key" = "value"}`},
-		{"nested list", []interface{}{[]int{1, 2}}, "[[1, 2]]"},
+		{"nested list", []any{[]int{1, 2}}, "[[1, 2]]"},
 	}
 
 	for _, tt := range tests {

--- a/modules/aws/lambda.go
+++ b/modules/aws/lambda.go
@@ -50,7 +50,7 @@ type LambdaOptions struct {
 	InvocationType *InvocationTypeOption
 
 	// Lambda function input; will be converted to JSON.
-	Payload interface{}
+	Payload any
 }
 
 // LambdaOutput contains the output from InvokeFunctionWithParams().  The
@@ -68,7 +68,7 @@ type LambdaOutput struct {
 
 // InvokeFunctionContextE invokes a lambda function.
 // The ctx parameter supports cancellation and timeouts.
-func InvokeFunctionContextE(t testing.TestingT, ctx context.Context, region, functionName string, payload interface{}) ([]byte, error) {
+func InvokeFunctionContextE(t testing.TestingT, ctx context.Context, region, functionName string, payload any) ([]byte, error) {
 	lambdaClient, err := NewLambdaClientContextE(t, ctx, region)
 	if err != nil {
 		return nil, err
@@ -102,7 +102,7 @@ func InvokeFunctionContextE(t testing.TestingT, ctx context.Context, region, fun
 // InvokeFunctionContext invokes a lambda function.
 // This function will fail the test if there is an error.
 // The ctx parameter supports cancellation and timeouts.
-func InvokeFunctionContext(t testing.TestingT, ctx context.Context, region, functionName string, payload interface{}) []byte {
+func InvokeFunctionContext(t testing.TestingT, ctx context.Context, region, functionName string, payload any) []byte {
 	t.Helper()
 	out, err := InvokeFunctionContextE(t, ctx, region, functionName, payload)
 	require.NoError(t, err)
@@ -113,7 +113,7 @@ func InvokeFunctionContext(t testing.TestingT, ctx context.Context, region, func
 // InvokeFunction invokes a lambda function.
 //
 // Deprecated: Use [InvokeFunctionContext] instead.
-func InvokeFunction(t testing.TestingT, region, functionName string, payload interface{}) []byte {
+func InvokeFunction(t testing.TestingT, region, functionName string, payload any) []byte {
 	t.Helper()
 	return InvokeFunctionContext(t, context.Background(), region, functionName, payload)
 }
@@ -121,7 +121,7 @@ func InvokeFunction(t testing.TestingT, region, functionName string, payload int
 // InvokeFunctionE invokes a lambda function.
 //
 // Deprecated: Use [InvokeFunctionContextE] instead.
-func InvokeFunctionE(t testing.TestingT, region, functionName string, payload interface{}) ([]byte, error) {
+func InvokeFunctionE(t testing.TestingT, region, functionName string, payload any) ([]byte, error) {
 	return InvokeFunctionContextE(t, context.Background(), region, functionName, payload)
 }
 

--- a/modules/helm/template.go
+++ b/modules/helm/template.go
@@ -233,7 +233,7 @@ func UnmarshalK8SYamlsE[T any](t testing.TestingT, yamlData string, destinationO
 }
 
 // UnmarshalK8SYaml is the same as UnmarshalK8SYamlE, but will fail the test if there is an error.
-func UnmarshalK8SYaml(t testing.TestingT, yamlData string, destinationObj interface{}) {
+func UnmarshalK8SYaml(t testing.TestingT, yamlData string, destinationObj any) {
 	require.NoError(t, UnmarshalK8SYamlE(t, yamlData, destinationObj))
 }
 
@@ -244,7 +244,7 @@ func UnmarshalK8SYaml(t testing.TestingT, yamlData string, destinationObj interf
 //	UnmarshalK8SYamlE(t, renderedOutput, &deployment)
 //
 // At the end of this, the deployment variable will be populated.
-func UnmarshalK8SYamlE(t testing.TestingT, yamlData string, destinationObj interface{}) error {
+func UnmarshalK8SYamlE(t testing.TestingT, yamlData string, destinationObj any) error {
 	decoder := goyaml.NewDecoder(strings.NewReader(yamlData))
 
 	// Ensure destinationObj is a pointer
@@ -258,7 +258,7 @@ func UnmarshalK8SYamlE(t testing.TestingT, yamlData string, destinationObj inter
 	// Handle single object or list as root
 	if destElem.Kind() != reflect.Slice {
 		// Decode only the first document
-		var rawYaml interface{}
+		var rawYaml any
 		if err := decoder.Decode(&rawYaml); err != nil {
 			return goerrors.WithStackTrace(err)
 		}
@@ -285,7 +285,7 @@ func UnmarshalK8SYamlE(t testing.TestingT, yamlData string, destinationObj inter
 	sliceVal := slicePtr.Elem()
 
 	for {
-		var rawYaml interface{}
+		var rawYaml any
 		if err := decoder.Decode(&rawYaml); err != nil {
 			if errors.Is(err, io.EOF) {
 				break // No more documents

--- a/modules/packer/packer.go
+++ b/modules/packer/packer.go
@@ -367,7 +367,7 @@ type packerManifestBuild struct {
 	BuilderType   string                    `json:"builder_type"`
 	ArtifactID    string                    `json:"artifact_id"`
 	PackerRunUUID string                    `json:"packer_run_uuid"`
-	CustomData    map[string]interface{}    `json:"custom_data"`
+	CustomData    map[string]any            `json:"custom_data"`
 	Files         []packerManifestBuildFile `json:"files"`
 	BuildTime     int64                     `json:"build_time"`
 }

--- a/modules/ssh/session.go
+++ b/modules/ssh/session.go
@@ -114,6 +114,6 @@ func Close(t testing.TestingT, closeable Closeable, ignoreErrors ...string) {
 // interfaceIsNil checks whether the given interface value is nil. A direct nil comparison does not work for interface
 // values that wrap a typed nil pointer, so reflection is used.
 // See https://go.dev/doc/faq#nil_error for details.
-func interfaceIsNil(i interface{}) bool {
+func interfaceIsNil(i any) bool {
 	return i == nil || reflect.ValueOf(i).IsNil()
 }

--- a/modules/terraform/var-file.go
+++ b/modules/terraform/var-file.go
@@ -72,12 +72,13 @@ func GetVariableAsMapFromVarFileE(t testing.TestingT, fileName string, key strin
 		return nil, InputFileKeyNotFound{FilePath: fileName, Key: key}
 	}
 
-	if reflect.TypeOf(variable).String() != "map[string]interface {}" {
-		return nil, UnexpectedOutputType{Key: key, ExpectedType: "map[string]interface {}", ActualType: reflect.TypeOf(variable).String()}
+	mapVariable, ok := variable.(map[string]any)
+	if !ok {
+		return nil, UnexpectedOutputType{Key: key, ExpectedType: "map[string]any", ActualType: reflect.TypeOf(variable).String()}
 	}
 
 	resultMap := make(map[string]string)
-	for mapKey, mapVal := range variable.(map[string]any) {
+	for mapKey, mapVal := range mapVariable {
 		resultMap[mapKey] = fmt.Sprintf("%v", mapVal)
 	}
 
@@ -109,12 +110,13 @@ func GetVariableAsListFromVarFileE(t testing.TestingT, fileName string, key stri
 		return nil, InputFileKeyNotFound{FilePath: fileName, Key: key}
 	}
 
-	if reflect.TypeOf(variable).String() != "[]interface {}" {
-		return nil, UnexpectedOutputType{Key: key, ExpectedType: "[]interface {}", ActualType: reflect.TypeOf(variable).String()}
+	listVariable, ok := variable.([]any)
+	if !ok {
+		return nil, UnexpectedOutputType{Key: key, ExpectedType: "[]any", ActualType: reflect.TypeOf(variable).String()}
 	}
 
 	resultArray := []string{}
-	for _, item := range variable.([]any) {
+	for _, item := range listVariable {
 		resultArray = append(resultArray, fmt.Sprintf("%v", item))
 	}
 

--- a/modules/terragrunt/json_helpers.go
+++ b/modules/terragrunt/json_helpers.go
@@ -161,7 +161,7 @@ func CleanTerragruntJSON(input string) (string, error) {
 	}
 
 	// Parse JSON
-	var jsonObj interface{}
+	var jsonObj any
 	if err := json.Unmarshal([]byte(cleaned), &jsonObj); err != nil {
 		return "", err
 	}

--- a/modules/terragrunt/options.go
+++ b/modules/terragrunt/options.go
@@ -71,7 +71,7 @@ type Options struct {
 	Logger *logger.Logger // Logger for command output
 
 	// Complex configuration that requires special formatting (NOT raw command-line args)
-	BackendConfig map[string]interface{} // Backend configuration (formatted specially)
+	BackendConfig map[string]any // Backend configuration (formatted specially)
 
 	// Test framework configuration (NOT passed to tg command line)
 	TerragruntBinary string // The tg binary to use (should be "terragrunt")

--- a/modules/terragrunt/render_test.go
+++ b/modules/terragrunt/render_test.go
@@ -40,7 +40,7 @@ func TestRenderJSON(t *testing.T) {
 		TerragruntBinary: "terragrunt",
 	})
 
-	var parsed map[string]interface{}
+	var parsed map[string]any
 	require.NoError(t, json.Unmarshal([]byte(output), &parsed), "output should be valid JSON")
 	require.Contains(t, parsed, "terraform")
 }

--- a/modules/terragrunt/stack_output.go
+++ b/modules/terragrunt/stack_output.go
@@ -131,26 +131,26 @@ func StackOutputJsonE(t testing.TestingT, options *Options, key string) (string,
 	return StackOutputJSONContextE(t, context.Background(), options, key)
 }
 
-// StackOutputAllContext gets all stack outputs and returns them as a map[string]interface{}.
+// StackOutputAllContext gets all stack outputs and returns them as a map[string]any.
 // The provided context is passed through to the underlying command execution, allowing for timeout
 // and cancellation control.
-func StackOutputAllContext(t testing.TestingT, ctx context.Context, options *Options) map[string]interface{} {
+func StackOutputAllContext(t testing.TestingT, ctx context.Context, options *Options) map[string]any {
 	outputs, err := StackOutputAllContextE(t, ctx, options)
 	require.NoError(t, err)
 
 	return outputs
 }
 
-// StackOutputAllContextE gets all stack outputs and returns them as a map[string]interface{}.
+// StackOutputAllContextE gets all stack outputs and returns them as a map[string]any.
 // The provided context is passed through to the underlying command execution, allowing for timeout
 // and cancellation control.
-func StackOutputAllContextE(t testing.TestingT, ctx context.Context, options *Options) (map[string]interface{}, error) {
+func StackOutputAllContextE(t testing.TestingT, ctx context.Context, options *Options) (map[string]any, error) {
 	jsonOutput, err := StackOutputJSONContextE(t, ctx, options, "")
 	if err != nil {
 		return nil, err
 	}
 
-	var outputs map[string]interface{}
+	var outputs map[string]any
 	if err := json.Unmarshal([]byte(jsonOutput), &outputs); err != nil {
 		return nil, err
 	}
@@ -158,17 +158,17 @@ func StackOutputAllContextE(t testing.TestingT, ctx context.Context, options *Op
 	return outputs, nil
 }
 
-// StackOutputAll gets all stack outputs and returns them as a map[string]interface{}.
+// StackOutputAll gets all stack outputs and returns them as a map[string]any.
 //
 // Deprecated: Use [StackOutputAllContext] instead.
-func StackOutputAll(t testing.TestingT, options *Options) map[string]interface{} {
+func StackOutputAll(t testing.TestingT, options *Options) map[string]any {
 	return StackOutputAllContext(t, context.Background(), options)
 }
 
-// StackOutputAllE gets all stack outputs and returns them as a map[string]interface{}.
+// StackOutputAllE gets all stack outputs and returns them as a map[string]any.
 //
 // Deprecated: Use [StackOutputAllContextE] instead.
-func StackOutputAllE(t testing.TestingT, options *Options) (map[string]interface{}, error) {
+func StackOutputAllE(t testing.TestingT, options *Options) (map[string]any, error) {
 	return StackOutputAllContextE(t, context.Background(), options)
 }
 

--- a/modules/terragrunt/stack_output_test.go
+++ b/modules/terragrunt/stack_output_test.go
@@ -75,7 +75,7 @@ func TestStackOutputIntegration(t *testing.T) {
 	// The JSON structure should be valid and contain our expected data
 	if strings.Contains(allOutputsJSON, "{") {
 		// Parse and validate the JSON structure
-		var allOutputs map[string]interface{}
+		var allOutputs map[string]any
 
 		err = json.Unmarshal([]byte(allOutputsJSON), &allOutputs)
 		require.NoError(t, err)
@@ -87,7 +87,7 @@ func TestStackOutputIntegration(t *testing.T) {
 		require.Contains(t, allOutputs, "chick_2")
 
 		// Verify the structure of outputs
-		motherOutputMap := allOutputs["mother"].(map[string]interface{})
+		motherOutputMap := allOutputs["mother"].(map[string]any)
 		assert.Equal(t, "./test.txt", motherOutputMap["output"])
 	} else {
 		// If not JSON format, at least verify it contains our expected values
@@ -198,7 +198,7 @@ func TestStackOutputAll(t *testing.T) {
 	require.Contains(t, allOutputs, "chick_2")
 
 	// Verify we can access specific output values
-	motherOutput := allOutputs["mother"].(map[string]interface{})
+	motherOutput := allOutputs["mother"].(map[string]any)
 	assert.Equal(t, "./test.txt", motherOutput["output"])
 }
 

--- a/modules/test-structure/save_test_data.go
+++ b/modules/test-structure/save_test_data.go
@@ -215,7 +215,7 @@ func FormatTestDataPath(testFolder string, filename string) string {
 // (e.g., TerraformOptions) during setup and to reuse this data later during validation and teardown. If `overwrite` is `true`,
 // any contents that exist in the file found at `path` will be overwritten. This has the potential for causing duplicated resources
 // and should be used with caution. If `overwrite` is `false`, the save will be skipped and a warning will be logged.
-func SaveTestData(t testing.TestingT, path string, overwrite bool, value interface{}) {
+func SaveTestData(t testing.TestingT, path string, overwrite bool, value any) {
 	saveTestData(t, path, overwrite, value, true)
 }
 
@@ -224,7 +224,7 @@ func SaveTestData(t testing.TestingT, path string, overwrite bool, value interfa
 // any contents that exist in the file found at `path` will be overwritten. This has the potential for causing duplicated resources
 // and should be used with caution. If `overwrite` is `false`, the save will be skipped and a warning will be logged.
 // If `loggedVal` is `true`, the value will be logged as JSON.
-func saveTestData(t testing.TestingT, path string, overwrite bool, value interface{}, loggedVal bool) {
+func saveTestData(t testing.TestingT, path string, overwrite bool, value any, loggedVal bool) {
 	logger.Default.Logf(t, "Storing test data in %s so it can be reused later", path)
 
 	if IsTestDataPresent(t, path) {
@@ -260,7 +260,7 @@ func saveTestData(t testing.TestingT, path string, overwrite bool, value interfa
 // LoadTestData loads and unserializes a value stored at the given path. The value should be a pointer to a struct into which the
 // value will be deserialized. This allows you to reuse some sort of test data (e.g., TerraformOptions) from earlier
 // setup steps in later validation and teardown steps.
-func LoadTestData(t testing.TestingT, path string, value interface{}) {
+func LoadTestData(t testing.TestingT, path string, value any) {
 	logger.Default.Logf(t, "Loading test data from %s", path)
 
 	bytes, err := os.ReadFile(path)
@@ -299,7 +299,7 @@ func IsTestDataPresent(t testing.TestingT, path string) bool {
 // IsEmptyJSON returns true if the given bytes are empty, or in a valid JSON format that can reasonably be considered empty.
 // The types used are based on the type possibilities listed at https://golang.org/src/encoding/json/decode.go?s=4062:4110#L51
 func IsEmptyJSON(t testing.TestingT, bytes []byte) bool {
-	var value interface{}
+	var value any
 
 	if len(bytes) == 0 {
 		return true
@@ -328,12 +328,12 @@ func IsEmptyJSON(t testing.TestingT, bytes []byte) bool {
 		return true
 	}
 
-	valueSlice, ok := value.([]interface{})
+	valueSlice, ok := value.([]any)
 	if ok && len(valueSlice) == 0 {
 		return true
 	}
 
-	valueMap, ok := value.(map[string]interface{})
+	valueMap, ok := value.(map[string]any)
 	if ok && len(valueMap) == 0 {
 		return true
 	}

--- a/modules/test-structure/save_test_data_test.go
+++ b/modules/test-structure/save_test_data_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 type testData struct {
-	Baz map[string]interface{}
+	Baz map[string]any
 	Foo string
 	Bar bool
 }
@@ -36,7 +36,7 @@ func TestSaveAndLoadTestData(t *testing.T) {
 	expectedData := testData{
 		Foo: "foo",
 		Bar: true,
-		Baz: map[string]interface{}{"abc": "def", "ghi": 1.0, "klm": false},
+		Baz: map[string]any{"abc": "def", "ghi": 1.0, "klm": false},
 	}
 
 	isTestDataPresent = teststructure.IsTestDataPresent(t, tmpFile)
@@ -55,7 +55,7 @@ func TestSaveAndLoadTestData(t *testing.T) {
 	overwritingData := testData{
 		Foo: "foo",
 		Bar: false,
-		Baz: map[string]interface{}{"123": "456", "789": 1.0, "0": false},
+		Baz: map[string]any{"123": "456", "789": 1.0, "0": false},
 	}
 	teststructure.SaveTestData(t, tmpFile, !overwrite, overwritingData)
 	teststructure.LoadTestData(t, tmpFile, &actualData)
@@ -116,7 +116,7 @@ func TestSaveAndLoadTerraformOptions(t *testing.T) {
 
 	expectedData := &terraform.Options{
 		TerraformDir: "/abc/def/ghi",
-		Vars:         map[string]interface{}{},
+		Vars:         map[string]any{},
 	}
 	teststructure.SaveTerraformOptions(t, tmpFolder, expectedData)
 
@@ -131,13 +131,13 @@ func TestSaveTerraformOptionsIfNotPresent(t *testing.T) {
 
 	expectedData := &terraform.Options{
 		TerraformDir: "/abc/def/ghi",
-		Vars:         map[string]interface{}{},
+		Vars:         map[string]any{},
 	}
 	teststructure.SaveTerraformOptionsIfNotPresent(t, tmpFolder, expectedData)
 
 	overwritingData := &terraform.Options{
 		TerraformDir: "/123/456/789",
-		Vars:         map[string]interface{}{},
+		Vars:         map[string]any{},
 	}
 	teststructure.SaveTerraformOptionsIfNotPresent(t, tmpFolder, overwritingData)
 
@@ -152,13 +152,13 @@ func TestSaveTerraformOptionsOverwrite(t *testing.T) {
 
 	originaData := &terraform.Options{
 		TerraformDir: "/abc/def/ghi",
-		Vars:         map[string]interface{}{},
+		Vars:         map[string]any{},
 	}
 	teststructure.SaveTerraformOptions(t, tmpFolder, originaData)
 
 	overwritingData := &terraform.Options{
 		TerraformDir: "/123/456/789",
-		Vars:         map[string]interface{}{},
+		Vars:         map[string]any{},
 	}
 	teststructure.SaveTerraformOptions(t, tmpFolder, overwritingData)
 
@@ -284,7 +284,7 @@ type tStringLogger struct {
 	sb strings.Builder
 }
 
-func (l *tStringLogger) Logf(t gotesting.TestingT, format string, args ...interface{}) {
+func (l *tStringLogger) Logf(t gotesting.TestingT, format string, args ...any) {
 	t.Helper()
 	fmt.Fprintf(&l.sb, format, args...)
 	l.sb.WriteRune('\n')

--- a/modules/testing/types.go
+++ b/modules/testing/types.go
@@ -17,13 +17,13 @@ type TestingT interface {
 	// created during the test. Calling FailNow does not stop
 	// those other goroutines.
 	FailNow()
-	Fatal(args ...interface{})
+	Fatal(args ...any)
 	// Fatalf is equivalent to Logf followed by FailNow.
-	Fatalf(format string, args ...interface{})
+	Fatalf(format string, args ...any)
 	// Error is equivalent to Log followed by Fail.
-	Error(args ...interface{})
+	Error(args ...any)
 	// Errorf is equivalent to Logf followed by Fail.
-	Errorf(format string, args ...interface{})
+	Errorf(format string, args ...any)
 	// Name returns the name of the running test or benchmark.
 	Name() string
 	// Helper marks the calling function as a test helper function.


### PR DESCRIPTION
## Summary

Mechanical sweep replacing `interface{}` with the `any` alias across `modules/` and `internal/`. Identical at runtime; `any` is the standard since Go 1.18 and the repo's `go.mod` is on `go 1.26`.

## Changes

- `gofmt -r 'interface{} -> any' -w modules/ internal/` for the bulk of the rename across 15 files (75 ins / 73 del).
- Doc comments referencing `interface{}` updated for consistency in `stack_output.go` and `format.go`.
- `modules/terraform/var-file.go`: replaced two `reflect.TypeOf(variable).String() != "..."` checks with proper type assertions (`_, ok := variable.(map[string]any)` and `_, ok := variable.([]any)`). The `reflect` import is retained because the error message still uses `reflect.TypeOf(variable).String()` to report the actual runtime type.

## Caller-visible string change

The `UnexpectedOutputType.ExpectedType` field string changes:
- Before: `"map[string]interface {}"`
- After: `"map[string]any"`

Same for `[]interface {}` to `[]any`. Anyone asserting on the exact substring will need to update; everyone else is unaffected.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `gofmt -d .` no diff
- [x] `go test ./modules/terraform/...` passes (var-file tests cover both happy and error paths)

Linear: OSS-3296