### PR TITLE
docs: add godoc and Deprecated annotations for v1 surface

### DIFF
--- a/modules/aws/account.go
+++ b/modules/aws/account.go
@@ -59,6 +59,8 @@ func GetAccountIDE(t testing.TestingT) (string, error) {
 	return GetAccountIDContextE(t, context.Background())
 }
 
+// GetAccountId gets the Account ID for the currently logged in IAM User.
+//
 // Deprecated: Use [GetAccountID] instead.
 //
 //nolint:staticcheck,revive // preserving deprecated function name
@@ -66,6 +68,8 @@ func GetAccountId(t testing.TestingT) string {
 	return GetAccountID(t)
 }
 
+// GetAccountIdE gets the Account ID for the currently logged in IAM User.
+//
 // Deprecated: Use [GetAccountIDE] instead.
 //
 //nolint:staticcheck,revive // preserving deprecated function name

--- a/modules/aws/ami.go
+++ b/modules/aws/ami.go
@@ -209,6 +209,9 @@ func GetMostRecentAmiIDE(t testing.TestingT, region string, ownerID string, filt
 	return GetMostRecentAmiIDContextE(t, context.Background(), region, ownerID, filters)
 }
 
+// GetMostRecentAmiId gets the ID of the most recent AMI in the given region that has the given owner and matches
+// the given filters.
+//
 // Deprecated: Use [GetMostRecentAmiID] instead.
 //
 //nolint:staticcheck,revive // preserving deprecated function name
@@ -216,6 +219,9 @@ func GetMostRecentAmiId(t testing.TestingT, region string, ownerId string, filte
 	return GetMostRecentAmiID(t, region, ownerId, filters)
 }
 
+// GetMostRecentAmiIdE gets the ID of the most recent AMI in the given region that has the given owner and matches
+// the given filters.
+//
 // Deprecated: Use [GetMostRecentAmiIDE] instead.
 //
 //nolint:staticcheck,revive // preserving deprecated function name

--- a/modules/aws/auth.go
+++ b/modules/aws/auth.go
@@ -17,7 +17,9 @@ import (
 )
 
 const (
-	AuthAssumeRoleEnvVar = "TERRATEST_IAM_ROLE" // OS environment variable name through which Assume Role ARN may be passed for authentication
+	// AuthAssumeRoleEnvVar is the OS environment variable name through which an
+	// Assume Role ARN may be passed for authentication.
+	AuthAssumeRoleEnvVar = "TERRATEST_IAM_ROLE"
 )
 
 // NewAuthenticatedSessionContext creates an AWS Config following to standard AWS authentication workflow.

--- a/modules/aws/dynamodb.go
+++ b/modules/aws/dynamodb.go
@@ -74,6 +74,8 @@ func GetDynamoDBTableTagsE(t testing.TestingT, region string, tableName string) 
 	return GetDynamoDBTableTagsContextE(t, context.Background(), region, tableName)
 }
 
+// GetDynamoDbTableTags fetches resource tags of a specified dynamoDB table. This will fail the test if there are any errors.
+//
 // Deprecated: Use [GetDynamoDBTableTagsContext] instead.
 //
 //nolint:staticcheck,revive // preserving deprecated function name
@@ -82,6 +84,8 @@ func GetDynamoDbTableTags(t testing.TestingT, region string, tableName string) [
 	return GetDynamoDBTableTagsContext(t, context.Background(), region, tableName)
 }
 
+// GetDynamoDbTableTagsE fetches resource tags of a specified dynamoDB table.
+//
 // Deprecated: Use [GetDynamoDBTableTagsContextE] instead.
 //
 //nolint:staticcheck,revive // preserving deprecated function name

--- a/modules/aws/ec2-files.go
+++ b/modules/aws/ec2-files.go
@@ -394,6 +394,10 @@ func FetchFilesFromAsgsPE(t testing.TestingT, awsRegion string, spec *RemoteFile
 	return FetchFilesFromAsgsPContextE(t, context.Background(), awsRegion, spec)
 }
 
+// FetchFilesFromAsgs looks up the EC2 Instances in all the ASGs given in the
+// RemoteFileSpecification, downloads the matching files from each instance,
+// and stores them locally as described in [FetchFilesFromAsgsPContext].
+//
 // Deprecated: Use [FetchFilesFromAsgsPContext] instead.
 //
 //nolint:staticcheck,revive,gocritic // preserving deprecated function name
@@ -403,6 +407,8 @@ func FetchFilesFromAsgs(t testing.TestingT, awsRegion string, spec RemoteFileSpe
 	FetchFilesFromAsgsPContext(t, context.Background(), awsRegion, &spec)
 }
 
+// FetchFilesFromAsgsE is the error-returning equivalent of [FetchFilesFromAsgs].
+//
 // Deprecated: Use [FetchFilesFromAsgsPContextE] instead.
 //
 //nolint:staticcheck,revive,gocritic // preserving deprecated function name

--- a/modules/aws/errors.go
+++ b/modules/aws/errors.go
@@ -5,6 +5,8 @@ import (
 )
 
 // IpForEc2InstanceNotFound is an error that occurs when the IP for an EC2 instance is not found.
+//
+// Deprecated: Use [IPForEc2InstanceNotFound] instead.
 type IpForEc2InstanceNotFound struct { //nolint:staticcheck,revive // preserving deprecated type name
 	InstanceId string //nolint:staticcheck,revive // preserving existing field name
 	AwsRegion  string
@@ -40,6 +42,7 @@ func (err NotFoundError) Error() string {
 	return fmt.Sprintf("Object of type %s with id %s not found in region %s", err.objectType, err.objectID, err.region)
 }
 
+// NewNotFoundError returns a [NotFoundError] for the given object type, ID, and region.
 func NewNotFoundError(objectType string, objectID string, region string) NotFoundError {
 	return NotFoundError{objectType, objectID, region}
 }
@@ -60,6 +63,8 @@ func (err AsgCapacityNotMetError) Error() string {
 	)
 }
 
+// NewAsgCapacityNotMetError returns an [AsgCapacityNotMetError] describing
+// the given ASG's desired and current capacities.
 func NewAsgCapacityNotMetError(asgName string, desiredCapacity int64, currentCapacity int64) AsgCapacityNotMetError {
 	return AsgCapacityNotMetError{asgName, desiredCapacity, currentCapacity}
 }
@@ -80,6 +85,8 @@ func (err BucketVersioningNotEnabledError) Error() string {
 	)
 }
 
+// NewBucketVersioningNotEnabledError returns a [BucketVersioningNotEnabledError]
+// for the given S3 bucket, region, and observed versioning status.
 func NewBucketVersioningNotEnabledError(s3BucketName string, awsRegion string, versioningStatus string) BucketVersioningNotEnabledError {
 	return BucketVersioningNotEnabledError{s3BucketName: s3BucketName, awsRegion: awsRegion, versioningStatus: versioningStatus}
 }
@@ -99,6 +106,8 @@ func (err NoBucketPolicyError) Error() string {
 	)
 }
 
+// NewNoBucketPolicyError returns a [NoBucketPolicyError] for the given S3
+// bucket, region, and bucket policy.
 func NewNoBucketPolicyError(s3BucketName string, awsRegion string, bucketPolicy string) NoBucketPolicyError {
 	return NoBucketPolicyError{s3BucketName: s3BucketName, awsRegion: awsRegion, bucketPolicy: bucketPolicy}
 }

--- a/modules/aws/lambda.go
+++ b/modules/aws/lambda.go
@@ -12,13 +12,24 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// InvocationTypeOption identifies the invocation mode passed to AWS Lambda
+// when calling [InvokeFunctionWithParamsContextE]. See the
+// InvocationType-prefixed constants for the supported values.
 type InvocationTypeOption string
 
+// Supported [InvocationTypeOption] values for Lambda invocation modes.
 const (
+	// InvocationTypeRequestResponse invokes the function synchronously, keeping
+	// the connection open until the function returns a response or times out.
 	InvocationTypeRequestResponse InvocationTypeOption = "RequestResponse"
-	InvocationTypeDryRun          InvocationTypeOption = "DryRun"
+	// InvocationTypeDryRun validates parameter values and verifies that the user
+	// or role has permission to invoke the function, without actually invoking it.
+	InvocationTypeDryRun InvocationTypeOption = "DryRun"
 )
 
+// Value returns the string form of the [InvocationTypeOption], defaulting to
+// [InvocationTypeRequestResponse] when itype is nil. It returns an error if
+// itype is set to a value that is not one of the supported invocation types.
 func (itype *InvocationTypeOption) Value() (string, error) {
 	if itype != nil {
 		switch *itype {
@@ -212,6 +223,9 @@ func InvokeFunctionWithParamsE(t testing.TestingT, region, functionName string, 
 	return InvokeFunctionWithParamsContextE(t, context.Background(), region, functionName, input)
 }
 
+// FunctionError is returned when an AWS Lambda invocation reports a function
+// error in its response. It carries the error message, the HTTP status code,
+// and the raw payload returned by the function.
 type FunctionError struct {
 	Message    string
 	Payload    []byte

--- a/modules/aws/rds.go
+++ b/modules/aws/rds.go
@@ -698,6 +698,8 @@ func GetValidEngineVersionE(t testing.TestingT, region string, engine string, ma
 
 // ParameterForDbInstanceNotFound is an error that occurs when the parameter group specified is not found for the DB instance.
 //
+// Deprecated: Use [ParameterForDBInstanceNotFound] instead.
+//
 //nolint:staticcheck,revive // preserving existing type name
 type ParameterForDbInstanceNotFound struct {
 	ParameterName string
@@ -713,6 +715,8 @@ func (err ParameterForDbInstanceNotFound) Error() string {
 }
 
 // OptionGroupOptionSettingForDbInstanceNotFound is an error that occurs when the option setting specified is not found in the option group of the DB instance.
+//
+// Deprecated: Use [OptionGroupOptionSettingForDBInstanceNotFound] instead.
 //
 //nolint:staticcheck,revive // preserving existing type name
 type OptionGroupOptionSettingForDbInstanceNotFound struct {

--- a/modules/logger/logger.go
+++ b/modules/logger/logger.go
@@ -114,7 +114,6 @@ func (terratestLogger) Logf(t testing.TestingT, format string, args ...any) {
 	DoLog(t, callDepthWrapped, os.Stdout, fmt.Sprintf(format, args...))
 }
 
-// Deprecated: use Logger instead, as it provides more flexibility on logging.
 // Logf logs the given format and arguments, formatted using fmt.Sprintf, to stdout, along with a timestamp and information
 // about what test and file is doing the logging. Before Go 1.14, this is an alternative to t.Logf as it logs to stdout
 // immediately, rather than buffering all log output and only displaying it at the very end of the test. This is useful
@@ -132,6 +131,8 @@ func (terratestLogger) Logf(t testing.TestingT, format string, args ...any) {
 //     this log method, you get log output continuously.
 //
 // Although t.Logf now supports streaming output since Go 1.14, this is kept for compatibility purposes.
+//
+// Deprecated: use Logger instead, as it provides more flexibility on logging.
 func Logf(t testing.TestingT, format string, args ...any) {
 	if tt, ok := t.(helper); ok {
 		tt.Helper()

--- a/modules/opa/eval.go
+++ b/modules/opa/eval.go
@@ -49,9 +49,13 @@ type EvalOptions struct {
 // defined value (FailDefined), or not at all (NoFail).
 type FailMode int
 
+// FailMode values for [EvalOptions.FailMode] that control when `opa eval` should fail.
 const (
+	// FailUndefined causes `opa eval` to fail when the query returns an undefined value.
 	FailUndefined FailMode = iota
+	// FailDefined causes `opa eval` to fail when the query returns a defined value.
 	FailDefined
+	// NoFail causes `opa eval` not to fail based on the query result.
 	NoFail
 )
 

--- a/modules/shell/command.go
+++ b/modules/shell/command.go
@@ -183,6 +183,7 @@ func RunCommandContextAndGetStdOutErrE(t testing.TestingT, ctx context.Context, 
 	return output.Stdout(), output.Stderr(), nil
 }
 
+// ErrWithCmdOutput wraps an underlying error with the captured stdout and stderr from the command that produced it.
 type ErrWithCmdOutput struct {
 	Underlying error
 	Output     *output

--- a/modules/slack/validate.go
+++ b/modules/slack/validate.go
@@ -93,6 +93,7 @@ func checkMessageContainsText(msg *slack.Msg, expectedText string) bool {
 	return false
 }
 
+// MessageNotFoundErr is returned when the expected text cannot be found in any of the messages posted in a Slack channel.
 type MessageNotFoundErr struct{}
 
 func (err MessageNotFoundErr) Error() string {

--- a/modules/terraform/options.go
+++ b/modules/terraform/options.go
@@ -13,6 +13,10 @@ import (
 
 const defaultTimeBetweenRetries = 5 * time.Second
 
+// DefaultRetryableTerraformErrors is the default set of error patterns that
+// [Options.RetryableTerraformErrors] will be initialized with. The keys are
+// regular expressions matched against Terraform output, and the values are
+// human-friendly messages displayed when the matching error triggers a retry.
 var (
 	DefaultRetryableTerraformErrors = map[string]string{
 		// Helm related terraform calls may fail when too many tests run in parallel. While the exact cause is unknown,
@@ -80,6 +84,9 @@ type Options struct {
 	Lock                     bool              // The lock option to pass to the terraform command with -lock
 }
 
+// ExtraArgs holds additional command-line arguments to pass to specific
+// Terraform subcommands. Each field is appended to the corresponding
+// subcommand invocation (e.g. Apply args are appended to `terraform apply`).
 type ExtraArgs struct {
 	Apply           []string
 	Destroy         []string

--- a/modules/terraform/var.go
+++ b/modules/terraform/var.go
@@ -1,10 +1,16 @@
 package terraform
 
+// Var represents a Terraform variable assignment that can be rendered as
+// command-line arguments. Use [VarInline] to pass an inline value with -var,
+// or [VarFile] to reference a -var-file on disk.
 type Var interface {
+	// Args returns the command-line arguments that pass this variable to Terraform.
 	Args() []string
 	internal()
 }
 
+// VarInline returns a [Var] that passes the given name/value pair to Terraform
+// via a -var flag.
 func VarInline(name string, value any) Var {
 	return varInline{name: name, value: value}
 }
@@ -20,6 +26,8 @@ func (vi varInline) Args() []string {
 }
 func (vi varInline) internal() {}
 
+// VarFile returns a [Var] that passes the file at the given path to Terraform
+// via a -var-file flag.
 func VarFile(path string) Var {
 	return varFile(path)
 }


### PR DESCRIPTION
## Summary

Doc-only sweep ahead of v1.0.0. Adds godoc to previously-undocumented exported symbols, and adds `// Deprecated:` annotations to old-cased function/type pairs that have correctly-cased replacements. Once v1 ships, these doc gaps freeze.

## Changes

**Godoc on undocumented exported symbols (~16):**
- `modules/terraform/var.go`: `Var`, `VarInline`, `VarFile`
- `modules/terraform/options.go`: `DefaultRetryableTerraformErrors`, `ExtraArgs`
- `modules/shell/command.go`: `ErrWithCmdOutput`
- `modules/slack/validate.go`: `MessageNotFoundErr`
- `modules/opa/eval.go`: `FailMode` const block
- `modules/aws/lambda.go`: `InvocationTypeOption` and consts, `Value()`, `FunctionError`
- `modules/aws/auth.go`: `AuthAssumeRoleEnvVar`
- `modules/aws/errors.go`: error constructors `NewNotFoundError`, `NewAsgCapacityNotMetError`, `NewBucketVersioningNotEnabledError`, `NewNoBucketPolicyError`
- `modules/aws/account.go`, `dynamodb.go`, `ami.go`, `ec2-files.go`: summary line above existing `Deprecated:` notes
- `modules/logger/logger.go`: reordered `Logf` so summary precedes deprecation note (Go convention)

**`// Deprecated:` additions (3):**
- `modules/aws/errors.go`: `IpForEc2InstanceNotFound` -> `IPForEc2InstanceNotFound`
- `modules/aws/rds.go`: `ParameterForDbInstanceNotFound` -> `ParameterForDBInstanceNotFound`
- `modules/aws/rds.go`: `OptionGroupOptionSettingForDbInstanceNotFound` -> `OptionGroupOptionSettingForDBInstanceNotFound`

All renamed types referenced by the `Deprecated:` annotations exist as type aliases in the same files (verified). Other casing-pair doublets across `aws`, `azure`, `gcp`, `k8s`, `random`, `ssh`, `terraform`, `terragrunt`, `test-structure` already carry deprecation annotations.

## Test plan

- [x] `go build ./modules/...` clean
- [x] `go vet ./modules/...` clean
- [x] `golangci-lint run --enable revive` reports zero new "exported should have comment" findings

Linear: OSS-3391, OSS-3394