### PR TITLE
docs(readme): add Install, Stability and versioning sections for v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,24 @@ variety of helper functions and patterns for common infrastructure testing tasks
 - Running shell commands
 - And much more
 
-Please see the following for more info:
+## Install
+
+```bash
+go get github.com/gruntwork-io/terratest@latest
+```
+
+Requires Go 1.26 or later.
+
+## Stability and versioning
+
+Starting with v1.0.0, Terratest follows [semantic versioning](https://semver.org/). Breaking changes to the public API
+only happen in major releases (e.g. v2.0.0).
+
+Symbols renamed or replaced in v1 are kept with `// Deprecated:` annotations pointing at the new name; removals happen
+in v2. Migrating from v0.x: see the [v1 release notes and migration guide](https://terratest.gruntwork.io/docs/) on the
+Terratest docs site.
+
+## More info
 
 - [Terratest Website](https://terratest.gruntwork.io)
 - [Getting started with Terratest](https://terratest.gruntwork.io/docs/getting-started/quick-start/)

--- a/README.md
+++ b/README.md
@@ -36,8 +36,7 @@ Starting with v1.0.0, Terratest follows [semantic versioning](https://semver.org
 only happen in major releases (e.g. v2.0.0).
 
 Symbols renamed or replaced in v1 are kept with `// Deprecated:` annotations pointing at the new name; removals happen
-in v2. Migrating from v0.x: see the [v1 release notes and migration guide](https://terratest.gruntwork.io/docs/) on the
-Terratest docs site.
+in v2. Migrating from v0.x: see [`MIGRATION.md`](./MIGRATION.md).
 
 ## More info
 


### PR DESCRIPTION
## Summary

Adds two new README sections ahead of v1.0.0:

- **Install**: explicit `go get` command and minimum supported Go version (1.26)
- **Stability and versioning**: states the SemVer commitment and the deprecate-don't-delete policy. Points migrators at the docs site for v1 release notes and the Azure migration guide.

## Note on the CircleCI badge

PR #1796 already removes the dead CircleCI badge from this README. To avoid a merge conflict, this PR doesn't touch it. Whichever PR lands second will rebase trivially.

## Diff

1 file changed, +18/-1.

Linear: OSS-3393