### PR TITLE
ci: add Azure workflow scoping OIDC tests via azureoidc build tag

### DIFF
--- a/.github/workflows/azure-integration-tests.yml
+++ b/.github/workflows/azure-integration-tests.yml
@@ -1,0 +1,94 @@
+name: Azure Integration Tests
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'modules/azure/**'
+      - 'test/azure/**'
+      - 'examples/azure/**'
+      - 'go.mod'
+      - 'go.sum'
+      - 'mise.toml'
+      - '.github/workflows/azure-integration-tests.yml'
+  pull_request:
+    paths:
+      - 'modules/azure/**'
+      - 'test/azure/**'
+      - 'examples/azure/**'
+      - 'go.mod'
+      - 'go.sum'
+      - 'mise.toml'
+      - '.github/workflows/azure-integration-tests.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: azure-integration-tests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  azure-integration-tests:
+    name: Azure Integration Tests
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Install mise
+        uses: jdx/mise-action@5228313ee0372e111a38da051671ca30fc5a96db # v3
+        with:
+          version: 2025.12.10
+          experimental: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Go module cache
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: Download Go modules
+        run: go mod download
+
+      - name: Azure login (OIDC)
+        uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Run Azure integration tests
+        env:
+          ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          ARM_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          ARM_USE_OIDC: "true"
+        run: |
+          set -o pipefail
+          mkdir -p /tmp/logs
+          # Scope: tests that opt into OIDC via the `azureoidc` build tag.
+          # AzureRM 2.x examples cannot authenticate via OIDC and are gated
+          # behind a follow-up provider-upgrade effort; they remain on the
+          # default `azure` tag.
+          go test -v -p 1 -tags azureoidc -count=1 -timeout 45m \
+            ./test/azure/... 2>&1 | tee /tmp/logs/azure-integration-tests.log
+
+      - name: Upload test logs
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: azure-integration-test-logs
+          path: /tmp/logs/
+          retention-days: 14

--- a/.github/workflows/gcp-integration-tests.yml
+++ b/.github/workflows/gcp-integration-tests.yml
@@ -35,10 +35,10 @@ jobs:
       GOOGLE_COMPUTE_ZONE: ${{ vars.GOOGLE_COMPUTE_ZONE }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install mise
-        uses: jdx/mise-action@v3
+        uses: jdx/mise-action@5228313ee0372e111a38da051671ca30fc5a96db # v3
         with:
           version: 2025.12.10
           experimental: true
@@ -46,7 +46,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Go module cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |
             ~/go/pkg/mod
@@ -59,14 +59,14 @@ jobs:
         run: go mod download
 
       - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2
         with:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER_ID }}
           service_account: ${{ secrets.GCP_SA_EMAIL }}
           audience: ${{ secrets.GCP_ALLOWED_AUDIENCES }}
 
       - name: Set up gcloud CLI
-        uses: google-github-actions/setup-gcloud@v2
+        uses: google-github-actions/setup-gcloud@e427ad8a34f8676edf47cf7d7925499adf3eb74f # v2
         with:
           project_id: ${{ secrets.GCP_PROJECT_ID }}
 
@@ -84,7 +84,7 @@ jobs:
 
       - name: Upload test logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: gcp-integration-test-logs
           path: /tmp/logs/

--- a/test/azure/terraform_azure_container_apps_example_test.go
+++ b/test/azure/terraform_azure_container_apps_example_test.go
@@ -1,5 +1,5 @@
-//go:build azure
-// +build azure
+//go:build azure || azureoidc
+// +build azure azureoidc
 
 package test_test
 

--- a/test/azure/terraform_azure_keyvault_example_test.go
+++ b/test/azure/terraform_azure_keyvault_example_test.go
@@ -1,5 +1,5 @@
-//go:build azure
-// +build azure
+//go:build azure || azureoidc
+// +build azure azureoidc
 
 package test_test
 


### PR DESCRIPTION
Addresses review feedback on #1794: https://github.com/gruntwork-io/terratest/pull/1794#discussion_r3163000677

## Summary

Replaces the brittle enumerated `-run '^(TestA|TestB)$'` regex with a new `azureoidc` build tag. Tests opt in by adding the tag, so adding or removing OIDC-compatible tests no longer requires editing the workflow.

## Changes

- `TerraformAzureContainerAppExample` and `TerraformAzureKeyVaultExample` carry `azure || azureoidc`, so they remain part of the default `azure` build while also being selectable via the narrower OIDC tag.
- Workflow runs `go test -tags azureoidc ./test/azure/...`.

## Verification

- `go test -tags azureoidc -count=1 -list '.*' ./test/azure/...` lists exactly the two OIDC-compatible tests.
- `go test -tags azure -count=1 -list '.*' ./test/azure/...` still includes both, so the default `azure` build is unchanged.

## Notes

This PR brings the Azure workflow file in directly, so #1794 can be closed once this lands.