### PR TITLE
docs: add version pinning guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ variety of helper functions and patterns for common infrastructure testing tasks
 go get github.com/gruntwork-io/terratest@latest
 ```
 
-Requires Go 1.26 or later.
+Requires Go 1.26 or later. To lock to a specific release instead of `@latest`, see [Pinning a Terratest version](https://terratest.gruntwork.io/docs/getting-started/version-pinning/).
 
 ## Stability and versioning
 

--- a/docs/_docs/01_getting-started/quick-start.md
+++ b/docs/_docs/01_getting-started/quick-start.md
@@ -41,6 +41,8 @@ types of infrastructure code you can test (e.g., Packer, Kubernetes, etc).
     Where `<MODULE_NAME>` is the name of your module, typically in the format
     `github.com/<YOUR_USERNAME>/<YOUR_REPO_NAME>`.
 
+    To lock your tests to a specific Terratest release, see [Pinning a Terratest version]({{ site.baseurl }}/docs/getting-started/version-pinning/).
+
 1. To run the tests:
 
     ```bash

--- a/docs/_docs/01_getting-started/version-pinning.md
+++ b/docs/_docs/01_getting-started/version-pinning.md
@@ -1,0 +1,52 @@
+---
+layout: collection-browser-doc
+title: Pinning a Terratest version
+category: getting-started
+excerpt: Lock your tests to a known-good Terratest release and upgrade safely.
+tags: ["versioning", "go-modules", "pinning"]
+order: 106
+nav_title: Documentation
+nav_title_link: /docs/
+---
+
+## Why pin a version?
+
+Terratest is a Go library, so the version your tests build against is whatever your test module's `go.mod` resolves to. Without an explicit pin, `go get` will pick up the newest published release the next time the module graph is recomputed, which means a regression in a future release can fail builds you did not change. Pinning makes the version a deliberate choice and keeps CI reproducible.
+
+Starting with v1.0.0, Terratest follows [semantic versioning](https://semver.org/) and breaking changes only happen in major releases. Pinning is still useful when you want to control _when_ you take a minor or patch bump.
+
+## Pin to a specific release
+
+From the directory that contains your test module's `go.mod`, run:
+
+```bash
+go get github.com/gruntwork-io/terratest@v0.56.0
+go mod tidy
+```
+
+Replace `v0.56.0` with the release tag you want. See the [Releases page](https://github.com/gruntwork-io/terratest/releases) for the full list. Always commit both `go.mod` and `go.sum` so the pin and its checksums travel with your code. Anyone who runs `go test` against the same `go.mod`/`go.sum` will resolve to the exact same Terratest version.
+
+To downgrade or revert to an earlier release, run the same command with the older tag.
+
+## Use the root module path
+
+Use the root module path `github.com/gruntwork-io/terratest`, not submodule paths like `github.com/gruntwork-io/terratest/modules/terraform`. Terratest publishes a single Go module at the repository root; submodule-style paths such as `modules/terraform/v0.51.0` are not valid Go module versions and will fail with `unknown revision`:
+
+```text
+reading github.com/gruntwork-io/terratest/modules/terraform/go.mod
+at revision modules/terraform/v0.51.0: unknown revision
+```
+
+If you import individual subpackages in your tests (for example `github.com/gruntwork-io/terratest/modules/terraform`), that is fine. They all resolve through the single root module pin.
+
+## Upgrading
+
+When you are ready to take a newer release, bump the pin explicitly and run the test suite:
+
+```bash
+go get github.com/gruntwork-io/terratest@v0.56.0
+go mod tidy
+go test ./...
+```
+
+If a release introduces a regression, revert the pin to the last known-good version and open an issue at [github.com/gruntwork-io/terratest/issues](https://github.com/gruntwork-io/terratest/issues). For history of breaking changes between v0.x and v1.0.0, see [`MIGRATION.md`](https://github.com/gruntwork-io/terratest/blob/main/MIGRATION.md).

--- a/docs/_docs/01_getting-started/version-pinning.md
+++ b/docs/_docs/01_getting-started/version-pinning.md
@@ -22,6 +22,6 @@ go mod tidy
 
 Replace `v0.56.0` with the tag you want from the [Releases page](https://github.com/gruntwork-io/terratest/releases). The same command upgrades, downgrades, or reverts the pin. Always commit `go.mod` and `go.sum` so the pin travels with your code; avoid `@latest` if you need reproducibility.
 
-## Use the root module path
+## Use `go get`, not subpath requires
 
-Pin `github.com/gruntwork-io/terratest`, not submodule paths like `github.com/gruntwork-io/terratest/modules/terraform`. Terratest publishes a single Go module at the repository root, so submodule-style versions (e.g. `modules/terraform/v0.51.0`) fail with `unknown revision`. Subpackage imports in your test code are fine; they all resolve through the root module pin.
+`go get github.com/gruntwork-io/terratest@<tag>` is enough; the pin applies to every subpackage your tests import. Avoid writing subpath requires by hand (e.g. `go mod edit -require github.com/gruntwork-io/terratest/modules/terraform@<tag>`); Go searches for a `modules/terraform/<tag>` tag and fails with `unknown revision`.

--- a/docs/_docs/01_getting-started/version-pinning.md
+++ b/docs/_docs/01_getting-started/version-pinning.md
@@ -2,51 +2,26 @@
 layout: collection-browser-doc
 title: Pinning a Terratest version
 category: getting-started
-excerpt: Lock your tests to a known-good Terratest release and upgrade safely.
+excerpt: Lock your tests to a specific Terratest release.
 tags: ["versioning", "go-modules", "pinning"]
 order: 106
 nav_title: Documentation
 nav_title_link: /docs/
 ---
 
-## Why pin a version?
+Pin Terratest if you need reproducible test builds and deliberate control over when you adopt a new release.
 
-Terratest is a Go library, so the version your tests build against is whatever your test module's `go.mod` resolves to. Without an explicit pin, `go get` will pick up the newest published release the next time the module graph is recomputed, which means a regression in a future release can fail builds you did not change. Pinning makes the version a deliberate choice and keeps CI reproducible.
+## Pin to a release
 
-Starting with v1.0.0, Terratest follows [semantic versioning](https://semver.org/) and breaking changes only happen in major releases. Pinning is still useful when you want to control _when_ you take a minor or patch bump.
-
-## Pin to a specific release
-
-From the directory that contains your test module's `go.mod`, run:
+From the directory that contains your test module's `go.mod`:
 
 ```bash
 go get github.com/gruntwork-io/terratest@v0.56.0
 go mod tidy
 ```
 
-Replace `v0.56.0` with the release tag you want. See the [Releases page](https://github.com/gruntwork-io/terratest/releases) for the full list. Always commit both `go.mod` and `go.sum` so the pin and its checksums travel with your code. Anyone who runs `go test` against the same `go.mod`/`go.sum` will resolve to the exact same Terratest version.
-
-To downgrade or revert to an earlier release, run the same command with the older tag.
+Replace `v0.56.0` with the tag you want from the [Releases page](https://github.com/gruntwork-io/terratest/releases). The same command upgrades, downgrades, or reverts the pin. Always commit `go.mod` and `go.sum` so the pin travels with your code; avoid `@latest` if you need reproducibility.
 
 ## Use the root module path
 
-Use the root module path `github.com/gruntwork-io/terratest`, not submodule paths like `github.com/gruntwork-io/terratest/modules/terraform`. Terratest publishes a single Go module at the repository root; submodule-style paths such as `modules/terraform/v0.51.0` are not valid Go module versions and will fail with `unknown revision`:
-
-```text
-reading github.com/gruntwork-io/terratest/modules/terraform/go.mod
-at revision modules/terraform/v0.51.0: unknown revision
-```
-
-If you import individual subpackages in your tests (for example `github.com/gruntwork-io/terratest/modules/terraform`), that is fine. They all resolve through the single root module pin.
-
-## Upgrading
-
-When you are ready to take a newer release, bump the pin explicitly and run the test suite:
-
-```bash
-go get github.com/gruntwork-io/terratest@v0.56.0
-go mod tidy
-go test ./...
-```
-
-If a release introduces a regression, revert the pin to the last known-good version and open an issue at [github.com/gruntwork-io/terratest/issues](https://github.com/gruntwork-io/terratest/issues). For history of breaking changes between v0.x and v1.0.0, see [`MIGRATION.md`](https://github.com/gruntwork-io/terratest/blob/main/MIGRATION.md).
+Pin `github.com/gruntwork-io/terratest`, not submodule paths like `github.com/gruntwork-io/terratest/modules/terraform`. Terratest publishes a single Go module at the repository root, so submodule-style versions (e.g. `modules/terraform/v0.51.0`) fail with `unknown revision`. Subpackage imports in your test code are fine; they all resolve through the root module pin.


### PR DESCRIPTION
## Summary

- New getting-started page `version-pinning.md` covering: pin with `go get @<tag>` + `go mod tidy`, commit `go.sum`, prefer `go get` over hand-written subpath requires, and how to upgrade/revert.
- One-line pointers to the new page from the README Install section and the Quick Start `go mod tidy` step so it is discoverable.

Resolves [LIB-3792](https://linear.app/gruntwork/issue/LIB-3792) and closes #1615 (customer asked for this in official docs after running into the v0.52.0 module-path regression).

## Test plan

- [ ] Render the docs site locally (`docs/jekyll-serve.sh`) and confirm the new page appears in the Getting Started section and the Quick Start / README links resolve.
- [x] Sanity-check the example commands in scratch Go modules.

### What was tested

Smoke-tested in scratch Go modules to validate the doc:

1. Happy path: `go get github.com/gruntwork-io/terratest@v0.56.0` + `go mod tidy`, with a test file importing `terratest/modules/random` and `terratest/modules/terraform`. Result: `go.mod` pins `github.com/gruntwork-io/terratest v0.56.0`, both subpackage imports resolve.
2. Subpath via `go get`: `go get github.com/gruntwork-io/terratest/modules/terraform@v0.51.0` succeeds and also pins the root module at v0.51.0. So a blanket "subpaths fail" warning would have been wrong; the second section was reframed to target the actual foot-gun.
3. Customer's reported failure: `go mod edit -require github.com/gruntwork-io/terratest/modules/terraform@v0.51.0` + `go mod tidy` (with subpackage imports). Reproduces the exact error from #1615:
   ```
   reading github.com/gruntwork-io/terratest/modules/terraform/go.mod
   at revision modules/terraform/v0.51.0: unknown revision modules/terraform/v0.51.0
   ```