### PR TITLE
docs: refresh Go version and stability framing for v1

### DIFF
--- a/docs/_docs/01_getting-started/quick-start.md
+++ b/docs/_docs/01_getting-started/quick-start.md
@@ -16,7 +16,7 @@ custom_js:
 
 Terratest uses the Go testing framework. To use Terratest, you need to install:
 
-- [Go](https://golang.org/) (requires version >=1.21.1)
+- [Go](https://golang.org/) (requires version >=1.26)
 
 ## Setting up your project
 

--- a/docs/_docs/04_community/contributing.md
+++ b/docs/_docs/04_community/contributing.md
@@ -256,9 +256,9 @@ go test -timeout 30m -run "<TEST_NAME>"
 This repo follows the principles of [Semantic Versioning](http://semver.org/). You can find each new release,
 along with the changelog, in the [Releases Page](https://github.com/gruntwork-io/terratest/releases).
 
-During initial development, the major version will be 0 (e.g., `0.x.y`), which indicates the code does not yet have a
-stable API. Once we hit `1.0.0`, we will make every effort to maintain a backwards compatible API and use the MAJOR,
-MINOR, and PATCH versions on each release to indicate any incompatibilities.
+Starting with `1.0.0`, breaking changes to the public API only happen in major releases. Symbols renamed or replaced
+inside the v1 line are kept as `// Deprecated:` aliases so test code that compiled against an earlier v1.x.y release
+will keep compiling against later ones; full removal is deferred to v2.
 
 ### Developing For Azure
 


### PR DESCRIPTION
## Summary
- Update quick-start guide Go version requirement from 1.21.1 to 1.26 to match go.mod (raised in v0.56.0).
- Replace pre-1.0 stability framing in contributing guide with the post-1.0 semver commitment that matches the README and migration overview.

Closes OSS-3453 (standalone docs portion). The remaining doc edits for OSS-3453 (K8s reword in overview.md and the "one minor release" line in azure.md) are folded into PR #1807.

## Test plan
- [ ] Spot-check rendered docs site for both pages