### PR TITLE
fix(azure): correct Manged typo in SQL client factory functions

### DIFF
--- a/modules/azure/client_factory.go
+++ b/modules/azure/client_factory.go
@@ -507,15 +507,11 @@ func CreateSQLManagedInstanceClient(subscriptionID string) (*armsql.ManagedInsta
 	return CreateSQLManagedInstanceClientContext(context.Background(), subscriptionID)
 }
 
-// CreateSQLMangedInstanceClientContext is a backwards-compatible alias for [CreateSQLManagedInstanceClientContext].
-//
 // Deprecated: Use [CreateSQLManagedInstanceClientContext] instead.
 func CreateSQLMangedInstanceClientContext(ctx context.Context, subscriptionID string) (*armsql.ManagedInstancesClient, error) { //nolint:revive,staticcheck // preserving deprecated function name
 	return CreateSQLManagedInstanceClientContext(ctx, subscriptionID)
 }
 
-// CreateSQLMangedInstanceClient is a backwards-compatible alias for [CreateSQLManagedInstanceClient].
-//
 // Deprecated: Use [CreateSQLManagedInstanceClient] instead.
 func CreateSQLMangedInstanceClient(subscriptionID string) (*armsql.ManagedInstancesClient, error) { //nolint:revive,staticcheck // preserving deprecated function name
 	return CreateSQLManagedInstanceClient(subscriptionID)
@@ -539,15 +535,11 @@ func CreateSQLManagedDatabasesClient(subscriptionID string) (*armsql.ManagedData
 	return CreateSQLManagedDatabasesClientContext(context.Background(), subscriptionID)
 }
 
-// CreateSQLMangedDatabasesClientContext is a backwards-compatible alias for [CreateSQLManagedDatabasesClientContext].
-//
 // Deprecated: Use [CreateSQLManagedDatabasesClientContext] instead.
 func CreateSQLMangedDatabasesClientContext(ctx context.Context, subscriptionID string) (*armsql.ManagedDatabasesClient, error) { //nolint:revive,staticcheck // preserving deprecated function name
 	return CreateSQLManagedDatabasesClientContext(ctx, subscriptionID)
 }
 
-// CreateSQLMangedDatabasesClient is a backwards-compatible alias for [CreateSQLManagedDatabasesClient].
-//
 // Deprecated: Use [CreateSQLManagedDatabasesClient] instead.
 func CreateSQLMangedDatabasesClient(subscriptionID string) (*armsql.ManagedDatabasesClient, error) { //nolint:revive,staticcheck // preserving deprecated function name
 	return CreateSQLManagedDatabasesClient(subscriptionID)

--- a/modules/azure/client_factory.go
+++ b/modules/azure/client_factory.go
@@ -489,9 +489,9 @@ func CreateSQLServerClient(subscriptionID string) (*armsql.ServersClient, error)
 	return CreateSQLServerClientContext(context.Background(), subscriptionID)
 }
 
-// CreateSQLMangedInstanceClientContext is a helper function that will create and setup a sql managed instance client.
+// CreateSQLManagedInstanceClientContext is a helper function that will create and setup a sql managed instance client.
 // The ctx parameter supports cancellation and timeouts.
-func CreateSQLMangedInstanceClientContext(_ context.Context, subscriptionID string) (*armsql.ManagedInstancesClient, error) {
+func CreateSQLManagedInstanceClientContext(_ context.Context, subscriptionID string) (*armsql.ManagedInstancesClient, error) {
 	clientFactory, err := getArmSQLClientFactory(subscriptionID)
 	if err != nil {
 		return nil, err
@@ -500,16 +500,30 @@ func CreateSQLMangedInstanceClientContext(_ context.Context, subscriptionID stri
 	return clientFactory.NewManagedInstancesClient(), nil
 }
 
-// CreateSQLMangedInstanceClient is a helper function that will create and setup a sql managed instance client.
+// CreateSQLManagedInstanceClient is a helper function that will create and setup a sql managed instance client.
 //
-// Deprecated: Use [CreateSQLMangedInstanceClientContext] instead.
-func CreateSQLMangedInstanceClient(subscriptionID string) (*armsql.ManagedInstancesClient, error) {
-	return CreateSQLMangedInstanceClientContext(context.Background(), subscriptionID)
+// Deprecated: Use [CreateSQLManagedInstanceClientContext] instead.
+func CreateSQLManagedInstanceClient(subscriptionID string) (*armsql.ManagedInstancesClient, error) {
+	return CreateSQLManagedInstanceClientContext(context.Background(), subscriptionID)
 }
 
-// CreateSQLMangedDatabasesClientContext is a helper function that will create and setup a sql managed databases client.
+// CreateSQLMangedInstanceClientContext is a backwards-compatible alias for [CreateSQLManagedInstanceClientContext].
+//
+// Deprecated: Use [CreateSQLManagedInstanceClientContext] instead.
+func CreateSQLMangedInstanceClientContext(ctx context.Context, subscriptionID string) (*armsql.ManagedInstancesClient, error) { //nolint:revive,staticcheck // preserving deprecated function name
+	return CreateSQLManagedInstanceClientContext(ctx, subscriptionID)
+}
+
+// CreateSQLMangedInstanceClient is a backwards-compatible alias for [CreateSQLManagedInstanceClient].
+//
+// Deprecated: Use [CreateSQLManagedInstanceClient] instead.
+func CreateSQLMangedInstanceClient(subscriptionID string) (*armsql.ManagedInstancesClient, error) { //nolint:revive,staticcheck // preserving deprecated function name
+	return CreateSQLManagedInstanceClient(subscriptionID)
+}
+
+// CreateSQLManagedDatabasesClientContext is a helper function that will create and setup a sql managed databases client.
 // The ctx parameter supports cancellation and timeouts.
-func CreateSQLMangedDatabasesClientContext(_ context.Context, subscriptionID string) (*armsql.ManagedDatabasesClient, error) {
+func CreateSQLManagedDatabasesClientContext(_ context.Context, subscriptionID string) (*armsql.ManagedDatabasesClient, error) {
 	clientFactory, err := getArmSQLClientFactory(subscriptionID)
 	if err != nil {
 		return nil, err
@@ -518,11 +532,25 @@ func CreateSQLMangedDatabasesClientContext(_ context.Context, subscriptionID str
 	return clientFactory.NewManagedDatabasesClient(), nil
 }
 
-// CreateSQLMangedDatabasesClient is a helper function that will create and setup a sql managed databases client.
+// CreateSQLManagedDatabasesClient is a helper function that will create and setup a sql managed databases client.
 //
-// Deprecated: Use [CreateSQLMangedDatabasesClientContext] instead.
-func CreateSQLMangedDatabasesClient(subscriptionID string) (*armsql.ManagedDatabasesClient, error) {
-	return CreateSQLMangedDatabasesClientContext(context.Background(), subscriptionID)
+// Deprecated: Use [CreateSQLManagedDatabasesClientContext] instead.
+func CreateSQLManagedDatabasesClient(subscriptionID string) (*armsql.ManagedDatabasesClient, error) {
+	return CreateSQLManagedDatabasesClientContext(context.Background(), subscriptionID)
+}
+
+// CreateSQLMangedDatabasesClientContext is a backwards-compatible alias for [CreateSQLManagedDatabasesClientContext].
+//
+// Deprecated: Use [CreateSQLManagedDatabasesClientContext] instead.
+func CreateSQLMangedDatabasesClientContext(ctx context.Context, subscriptionID string) (*armsql.ManagedDatabasesClient, error) { //nolint:revive,staticcheck // preserving deprecated function name
+	return CreateSQLManagedDatabasesClientContext(ctx, subscriptionID)
+}
+
+// CreateSQLMangedDatabasesClient is a backwards-compatible alias for [CreateSQLManagedDatabasesClient].
+//
+// Deprecated: Use [CreateSQLManagedDatabasesClient] instead.
+func CreateSQLMangedDatabasesClient(subscriptionID string) (*armsql.ManagedDatabasesClient, error) { //nolint:revive,staticcheck // preserving deprecated function name
+	return CreateSQLManagedDatabasesClient(subscriptionID)
 }
 
 // getArmSQLClientFactory gets an arm sql client factory

--- a/modules/azure/sql_managedinstance.go
+++ b/modules/azure/sql_managedinstance.go
@@ -67,7 +67,7 @@ func GetManagedInstanceContext(t testing.TestingT, ctx context.Context, resGroup
 // GetManagedInstanceContextE retrieves the SQL managed instance object for the given subscription.
 // The ctx parameter supports cancellation and timeouts.
 func GetManagedInstanceContextE(ctx context.Context, subscriptionID string, resGroupName string, managedInstanceName string) (*armsql.ManagedInstance, error) {
-	sqlmiClient, err := CreateSQLMangedInstanceClientContext(ctx, subscriptionID)
+	sqlmiClient, err := CreateSQLManagedInstanceClientContext(ctx, subscriptionID)
 	if err != nil {
 		return nil, err
 	}
@@ -117,7 +117,7 @@ func GetManagedInstanceDatabaseContext(t testing.TestingT, ctx context.Context, 
 // GetManagedInstanceDatabaseContextE retrieves the SQL managed database object for the given subscription.
 // The ctx parameter supports cancellation and timeouts.
 func GetManagedInstanceDatabaseContextE(ctx context.Context, subscriptionID string, resGroupName string, managedInstanceName string, databaseName string) (*armsql.ManagedDatabase, error) {
-	sqlmiDBClient, err := CreateSQLMangedDatabasesClientContext(ctx, subscriptionID)
+	sqlmiDBClient, err := CreateSQLManagedDatabasesClientContext(ctx, subscriptionID)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary
- Add correctly-spelled `CreateSQLManagedInstanceClient{,Context}` and `CreateSQLManagedDatabasesClient{,Context}` as canonical names.
- Convert the misspelled `CreateSQLManged*` quartet to `// Deprecated:` aliases delegating to the new functions.
- Update internal call sites in `modules/azure/sql_managedinstance.go` to use the new spellings.

Tagging v1.0 with the typo would lock it into the stable API until a major version bump.

Closes OSS-3452.

## Test plan
- [x] `go build ./modules/azure/...` passes
- [ ] CI lint + Azure integration tests