### PR TITLE
fix(gcp): merge instead of clobber when setting instance labels

### DIFF
--- a/modules/gcp/compute.go
+++ b/modules/gcp/compute.go
@@ -426,17 +426,35 @@ func (i *Instance) SetLabelsContextE(t testing.TestingT, ctx context.Context, la
 }
 
 // SetLabelsWithClient adds the tags to the given Compute Instance using the supplied *compute.Service.
+// New labels are merged into the instance's existing labels; passing a key that is already set
+// overwrites it, but other existing labels are preserved.
 // Prefer this variant in unit tests where the service is backed by an httptest fake server
 // (see compute_unit_test.go for the pattern).
 // The ctx parameter supports cancellation and timeouts.
 func (i *Instance) SetLabelsWithClient(ctx context.Context, service *compute.Service, labels map[string]string) error {
-	req := compute.InstancesSetLabelsRequest{Labels: labels, LabelFingerprint: i.LabelFingerprint}
+	merged := mergeLabels(i.Labels, labels)
+	req := compute.InstancesSetLabelsRequest{Labels: merged, LabelFingerprint: i.LabelFingerprint}
 
 	if _, err := service.Instances.SetLabels(i.projectID, ZoneURLToZone(i.Zone), i.Name, &req).Context(ctx).Do(); err != nil {
 		return fmt.Errorf("Instances.SetLabels(%s) got error: %w", i.Name, err)
 	}
 
 	return nil
+}
+
+// mergeLabels merges new key-value pairs into existing labels, preserving any keys not in the new set.
+// Keys present in newLabels overwrite the existing values.
+func mergeLabels(existing, newLabels map[string]string) map[string]string {
+	merged := make(map[string]string, len(existing)+len(newLabels))
+	for k, v := range existing {
+		merged[k] = v
+	}
+
+	for k, v := range newLabels {
+		merged[k] = v
+	}
+
+	return merged
 }
 
 // GetMetadata gets the given Compute Instance's metadata.

--- a/modules/gcp/compute.go
+++ b/modules/gcp/compute.go
@@ -425,14 +425,21 @@ func (i *Instance) SetLabelsContextE(t testing.TestingT, ctx context.Context, la
 	return i.SetLabelsWithClient(ctx, service, labels)
 }
 
-// SetLabelsWithClient adds the tags to the given Compute Instance using the supplied *compute.Service.
-// New labels are merged into the instance's existing labels; passing a key that is already set
-// overwrites it, but other existing labels are preserved.
-// Prefer this variant in unit tests where the service is backed by an httptest fake server
-// (see compute_unit_test.go for the pattern).
+// SetLabelsWithClient merges the given labels into the instance's existing labels using the
+// supplied *compute.Service. Keys present in labels overwrite existing values; other labels
+// are preserved. Prefer this variant in unit tests where the service is backed by an httptest
+// fake server (see compute_unit_test.go for the pattern).
 // The ctx parameter supports cancellation and timeouts.
 func (i *Instance) SetLabelsWithClient(ctx context.Context, service *compute.Service, labels map[string]string) error {
-	merged := mergeLabels(i.Labels, labels)
+	merged := make(map[string]string, len(i.Labels)+len(labels))
+	for k, v := range i.Labels {
+		merged[k] = v
+	}
+
+	for k, v := range labels {
+		merged[k] = v
+	}
+
 	req := compute.InstancesSetLabelsRequest{Labels: merged, LabelFingerprint: i.LabelFingerprint}
 
 	if _, err := service.Instances.SetLabels(i.projectID, ZoneURLToZone(i.Zone), i.Name, &req).Context(ctx).Do(); err != nil {
@@ -440,20 +447,6 @@ func (i *Instance) SetLabelsWithClient(ctx context.Context, service *compute.Ser
 	}
 
 	return nil
-}
-
-// mergeLabels returns a new map with existing labels overlaid by newLabels.
-func mergeLabels(existing, newLabels map[string]string) map[string]string {
-	merged := make(map[string]string, len(existing)+len(newLabels))
-	for k, v := range existing {
-		merged[k] = v
-	}
-
-	for k, v := range newLabels {
-		merged[k] = v
-	}
-
-	return merged
 }
 
 // GetMetadata gets the given Compute Instance's metadata.

--- a/modules/gcp/compute.go
+++ b/modules/gcp/compute.go
@@ -442,8 +442,7 @@ func (i *Instance) SetLabelsWithClient(ctx context.Context, service *compute.Ser
 	return nil
 }
 
-// mergeLabels merges new key-value pairs into existing labels, preserving any keys not in the new set.
-// Keys present in newLabels overwrite the existing values.
+// mergeLabels returns a new map with existing labels overlaid by newLabels.
 func mergeLabels(existing, newLabels map[string]string) map[string]string {
 	merged := make(map[string]string, len(existing)+len(newLabels))
 	for k, v := range existing {

--- a/modules/gcp/compute_test.go
+++ b/modules/gcp/compute_test.go
@@ -195,9 +195,6 @@ func TestSetLabelsWithClient(t *testing.T) {
 	require.NoError(t, inst.SetLabelsWithClient(context.Background(), svc, map[string]string{"env": "unit"}))
 }
 
-// TestSetLabelsWithClientMergesExisting — regression test for the SetLabels-clobbers-existing bug.
-// The instance already carries a label; SetLabels should merge the new label in, not drop the
-// existing one.
 func TestSetLabelsWithClientMergesExisting(t *testing.T) {
 	t.Parallel()
 

--- a/modules/gcp/compute_test.go
+++ b/modules/gcp/compute_test.go
@@ -209,10 +209,9 @@ func TestSetLabelsWithClientMergesExisting(t *testing.T) {
 		assert.Contains(t, r.URL.Path, "/instances/i/setLabels")
 
 		var req compute.InstancesSetLabelsRequest
-
-		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
-
+		assert.NoError(t, json.NewDecoder(r.Body).Decode(&req))
 		sentLabels = req.Labels
+
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte(`{"name":"op","status":"DONE"}`))

--- a/modules/gcp/compute_test.go
+++ b/modules/gcp/compute_test.go
@@ -2,6 +2,7 @@ package gcp_test
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -192,6 +193,40 @@ func TestSetLabelsWithClient(t *testing.T) {
 	svc := newFakeComputeService(t, respond(t, http.MethodPost, "/instances/i/setLabels", http.StatusOK, `{"name":"op","status":"DONE"}`))
 
 	require.NoError(t, inst.SetLabelsWithClient(context.Background(), svc, map[string]string{"env": "unit"}))
+}
+
+// TestSetLabelsWithClientMergesExisting — regression test for the SetLabels-clobbers-existing bug.
+// The instance already carries a label; SetLabels should merge the new label in, not drop the
+// existing one.
+func TestSetLabelsWithClientMergesExisting(t *testing.T) {
+	t.Parallel()
+
+	zoneURL := "https://www.googleapis.com/compute/v1/projects/p/zones/us-central1-a"
+	inst := fetchInstanceForTest(t, "p", "i", zoneURL)
+	inst.Labels = map[string]string{"team": "platform"}
+
+	var sentLabels map[string]string
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Contains(t, r.URL.Path, "/instances/i/setLabels")
+
+		var req compute.InstancesSetLabelsRequest
+
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+
+		sentLabels = req.Labels
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"name":"op","status":"DONE"}`))
+	}
+
+	svc := newFakeComputeService(t, http.HandlerFunc(handler))
+
+	require.NoError(t, inst.SetLabelsWithClient(context.Background(), svc, map[string]string{"env": "unit"}))
+
+	assert.Equal(t, "platform", sentLabels["team"], "existing label should be preserved")
+	assert.Equal(t, "unit", sentLabels["env"], "new label should be set")
 }
 
 func TestSetMetadataWithClient(t *testing.T) {


### PR DESCRIPTION
## Summary
- `Instance.SetLabelsWithClient` was sending the caller's labels map directly to GCP's `SetLabels` API, which replaces all labels server-side. Calling SetLabels to add one label silently destroyed every other label on the instance.
- Add a `mergeLabels` helper paralleling `NewMetadata` and route `SetLabelsWithClient` through it.
- Regression test `TestSetLabelsWithClientMergesExisting` decodes the captured request body and asserts existing and new labels both make it through.

Closes OSS-3455.

## Test plan
- [x] `go test ./modules/gcp/...` passes