### PR TITLE
fix(azure): guard nil Properties on availability set responses

### DIFF
--- a/modules/azure/availabilityset.go
+++ b/modules/azure/availabilityset.go
@@ -106,6 +106,10 @@ func CheckAvailabilitySetContainsVMWithClient(ctx context.Context, client *armco
 		return false, err
 	}
 
+	if resp.Properties == nil {
+		return false, NewNotFoundError("Virtual Machine", vmName, avsName)
+	}
+
 	for _, vm := range resp.Properties.VirtualMachines {
 		if vm.ID == nil {
 			continue
@@ -170,6 +174,10 @@ func GetAvailabilitySetVMNamesInCapsWithClient(ctx context.Context, client *armc
 	}
 
 	vms := []string{}
+
+	if resp.Properties == nil {
+		return vms, nil
+	}
 
 	for _, vm := range resp.Properties.VirtualMachines {
 		if vm.ID == nil {


### PR DESCRIPTION
## Summary
- `CheckAvailabilitySetContainsVMWithClient` and `GetAvailabilitySetVMNamesInCapsWithClient` dereferenced `resp.Properties.VirtualMachines` without first checking `resp.Properties != nil`. The armcompute SDK can leave `Properties` nil for AvailabilitySets in degraded or partially-provisioned states, panicking the helper.
- Mirror the nil-guard pattern already in `compute.go`, `networkinterface.go`, and friends: return `NewNotFoundError` (containment check) or an empty slice (name listing) when `Properties` is missing.

Closes OSS-3456.

## Test plan
- [x] `go build ./modules/azure/...` passes
- [ ] Azure integration tests