### PR TITLE
fix(aws): paginate IAM, RDS, and ECR list calls

### DIFF
--- a/modules/aws/ecr.go
+++ b/modules/aws/ecr.go
@@ -119,23 +119,26 @@ func DeleteECRRepoContextE(t testing.TestingT, ctx context.Context, region strin
 		return err
 	}
 
-	resp, err := client.ListImages(ctx, &ecr.ListImagesInput{RepositoryName: repo.RepositoryName})
-	if err != nil {
-		return err
-	}
-
-	if len(resp.ImageIds) > 0 {
-		_, err = client.BatchDeleteImage(ctx, &ecr.BatchDeleteImageInput{
-			RepositoryName: repo.RepositoryName,
-			ImageIds:       resp.ImageIds,
-		})
+	paginator := ecr.NewListImagesPaginator(client, &ecr.ListImagesInput{RepositoryName: repo.RepositoryName})
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
 		if err != nil {
+			return err
+		}
+
+		if len(page.ImageIds) == 0 {
+			continue
+		}
+
+		if _, err := client.BatchDeleteImage(ctx, &ecr.BatchDeleteImageInput{
+			RepositoryName: repo.RepositoryName,
+			ImageIds:       page.ImageIds,
+		}); err != nil {
 			return err
 		}
 	}
 
-	_, err = client.DeleteRepository(ctx, &ecr.DeleteRepositoryInput{RepositoryName: repo.RepositoryName})
-	if err != nil {
+	if _, err := client.DeleteRepository(ctx, &ecr.DeleteRepositoryInput{RepositoryName: repo.RepositoryName}); err != nil {
 		return err
 	}
 

--- a/modules/aws/iam.go
+++ b/modules/aws/iam.go
@@ -110,18 +110,21 @@ func GetIamPolicyDocumentContextE(t testing.TestingT, ctx context.Context, regio
 		return "", err
 	}
 
-	versions, err := iamClient.ListPolicyVersions(ctx, &iam.ListPolicyVersionsInput{
-		PolicyArn: &policyARN,
-	})
-	if err != nil {
-		return "", err
-	}
-
 	var defaultVersion string
 
-	for _, version := range versions.Versions {
-		if version.IsDefaultVersion && version.VersionId != nil {
-			defaultVersion = *version.VersionId
+	paginator := iam.NewListPolicyVersionsPaginator(iamClient, &iam.ListPolicyVersionsInput{
+		PolicyArn: &policyARN,
+	})
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
+		if err != nil {
+			return "", err
+		}
+
+		for _, version := range page.Versions {
+			if version.IsDefaultVersion && version.VersionId != nil {
+				defaultVersion = *version.VersionId
+			}
 		}
 	}
 

--- a/modules/aws/rds.go
+++ b/modules/aws/rds.go
@@ -369,18 +369,21 @@ func GetOptionsOfOptionGroupContextE(t testing.TestingT, ctx context.Context, op
 		return []types.Option{}, err
 	}
 
-	input := rds.DescribeOptionGroupsInput{OptionGroupName: aws.String(optionGroupName)}
+	paginator := rds.NewDescribeOptionGroupsPaginator(rdsClient, &rds.DescribeOptionGroupsInput{
+		OptionGroupName: aws.String(optionGroupName),
+	})
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
+		if err != nil {
+			return []types.Option{}, err
+		}
 
-	output, err := rdsClient.DescribeOptionGroups(ctx, &input)
-	if err != nil {
-		return []types.Option{}, err
+		if len(page.OptionGroupsList) > 0 {
+			return page.OptionGroupsList[0].Options, nil
+		}
 	}
 
-	if len(output.OptionGroupsList) == 0 {
-		return []types.Option{}, fmt.Errorf("no option groups found for name %s in region %s", optionGroupName, awsRegion)
-	}
-
-	return output.OptionGroupsList[0].Options, nil
+	return []types.Option{}, fmt.Errorf("no option groups found for name %s in region %s", optionGroupName, awsRegion)
 }
 
 // GetOptionsOfOptionGroupContext gets the options of the option group specified.
@@ -624,19 +627,20 @@ func GetRecommendedRdsInstanceTypeWithClientE(t testing.TestingT, rdsClient *rds
 // instanceTypeExistsForEngineAndRegionContextE returns a boolean that represents whether the provided instance type (e.g. db.t2.micro) exists for the given region and db engine type.
 // This function will return an error if the RDS AWS SDK call fails.
 func instanceTypeExistsForEngineAndRegionContextE(ctx context.Context, client *rds.Client, engine string, engineVersion string, instanceType string) (bool, error) {
-	input := rds.DescribeOrderableDBInstanceOptionsInput{
+	paginator := rds.NewDescribeOrderableDBInstanceOptionsPaginator(client, &rds.DescribeOrderableDBInstanceOptionsInput{
 		Engine:          aws.String(engine),
 		EngineVersion:   aws.String(engineVersion),
 		DBInstanceClass: aws.String(instanceType),
-	}
+	})
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
+		if err != nil {
+			return false, err
+		}
 
-	out, err := client.DescribeOrderableDBInstanceOptions(ctx, &input)
-	if err != nil {
-		return false, err
-	}
-
-	if len(out.OrderableDBInstanceOptions) > 0 {
-		return true, nil
+		if len(page.OrderableDBInstanceOptions) > 0 {
+			return true, nil
+		}
 	}
 
 	return false, nil


### PR DESCRIPTION
## Summary
Four AWS list calls made a single API request without iterating pagination tokens, silently capping results at the first page. Same class of bug as the EC2 `DescribeInstances`/`DescribeTags` fixes already in v1.

- `iam.ListPolicyVersions` in `GetIamPolicyDocumentContextE`.
- `rds.DescribeOptionGroups` in `GetOptionsOfOptionGroupContextE`.
- `rds.DescribeOrderableDBInstanceOptions` in `instanceTypeExistsForEngineAndRegionContextE`.
- `ecr.ListImages` in `DeleteECRRepoContextE` (the most user-impacting: only the first page of images was deleted, leaking the rest and tripping DeleteRepository).

Switched each to the SDK's paginator helpers using the loop pattern already established in `modules/aws/ec2.go:338`.

Closes OSS-3454.

## Test plan
- [x] `go build ./modules/aws/...` passes
- [ ] AWS integration tests