### PR TITLE
fix(api): rename *Context functions returning errors to *ContextE

### DIFF
--- a/modules/aws/account.go
+++ b/modules/aws/account.go
@@ -93,7 +93,7 @@ func ExtractAccountIDFromARN(arn string) (string, error) {
 // NewStsClientContextE creates a new STS client.
 // The ctx parameter supports cancellation and timeouts.
 func NewStsClientContextE(t testing.TestingT, ctx context.Context, region string) (*sts.Client, error) {
-	sess, err := NewAuthenticatedSessionContext(ctx, region)
+	sess, err := NewAuthenticatedSessionContextE(ctx, region)
 	if err != nil {
 		return nil, err
 	}

--- a/modules/aws/acm.go
+++ b/modules/aws/acm.go
@@ -87,7 +87,7 @@ func GetAcmCertificateArnE(t testing.TestingT, awsRegion string, certDomainName 
 // NewAcmClientContextE creates a new ACM client.
 // The ctx parameter supports cancellation and timeouts.
 func NewAcmClientContextE(t testing.TestingT, ctx context.Context, region string) (*acm.Client, error) {
-	sess, err := NewAuthenticatedSessionContext(ctx, region)
+	sess, err := NewAuthenticatedSessionContextE(ctx, region)
 	if err != nil {
 		return nil, err
 	}

--- a/modules/aws/asg.go
+++ b/modules/aws/asg.go
@@ -216,7 +216,7 @@ func WaitForCapacityE(
 // NewAsgClientContextE creates an Auto Scaling Group client.
 // The ctx parameter supports cancellation and timeouts.
 func NewAsgClientContextE(t testing.TestingT, ctx context.Context, region string) (*autoscaling.Client, error) {
-	sess, err := NewAuthenticatedSessionContext(ctx, region)
+	sess, err := NewAuthenticatedSessionContextE(ctx, region)
 	if err != nil {
 		return nil, err
 	}

--- a/modules/aws/auth.go
+++ b/modules/aws/auth.go
@@ -22,28 +22,35 @@ const (
 	AuthAssumeRoleEnvVar = "TERRATEST_IAM_ROLE"
 )
 
-// NewAuthenticatedSessionContext creates an AWS Config following to standard AWS authentication workflow.
+// NewAuthenticatedSessionContextE creates an AWS Config following to standard AWS authentication workflow.
 // If AuthAssumeIamRoleEnvVar environment variable is set, assumes IAM role specified in it.
 // The ctx parameter supports cancellation and timeouts.
-func NewAuthenticatedSessionContext(ctx context.Context, region string) (*aws.Config, error) {
+func NewAuthenticatedSessionContextE(ctx context.Context, region string) (*aws.Config, error) {
 	if assumeRoleArn, ok := os.LookupEnv(AuthAssumeRoleEnvVar); ok {
-		return NewAuthenticatedSessionFromRoleContext(ctx, region, assumeRoleArn)
+		return NewAuthenticatedSessionFromRoleContextE(ctx, region, assumeRoleArn)
 	}
 
-	return NewAuthenticatedSessionFromDefaultCredentialsContext(ctx, region)
+	return NewAuthenticatedSessionFromDefaultCredentialsContextE(ctx, region)
+}
+
+// NewAuthenticatedSessionContext is a backwards-compatible alias for [NewAuthenticatedSessionContextE].
+//
+// Deprecated: Use [NewAuthenticatedSessionContextE] instead.
+func NewAuthenticatedSessionContext(ctx context.Context, region string) (*aws.Config, error) {
+	return NewAuthenticatedSessionContextE(ctx, region)
 }
 
 // NewAuthenticatedSession creates an AWS Config following to standard AWS authentication workflow.
 // If AuthAssumeIamRoleEnvVar environment variable is set, assumes IAM role specified in it.
 //
-// Deprecated: Use [NewAuthenticatedSessionContext] instead.
+// Deprecated: Use [NewAuthenticatedSessionContextE] instead.
 func NewAuthenticatedSession(region string) (*aws.Config, error) {
-	return NewAuthenticatedSessionContext(context.Background(), region)
+	return NewAuthenticatedSessionContextE(context.Background(), region)
 }
 
-// NewAuthenticatedSessionFromDefaultCredentialsContext gets an AWS Config, checking that the user has credentials properly configured in their environment.
+// NewAuthenticatedSessionFromDefaultCredentialsContextE gets an AWS Config, checking that the user has credentials properly configured in their environment.
 // The ctx parameter supports cancellation and timeouts.
-func NewAuthenticatedSessionFromDefaultCredentialsContext(ctx context.Context, region string) (*aws.Config, error) {
+func NewAuthenticatedSessionFromDefaultCredentialsContextE(ctx context.Context, region string) (*aws.Config, error) {
 	cfg, err := config.LoadDefaultConfig(ctx, config.WithRegion(region))
 	if err != nil {
 		return nil, CredentialsError{UnderlyingErr: err}
@@ -52,19 +59,26 @@ func NewAuthenticatedSessionFromDefaultCredentialsContext(ctx context.Context, r
 	return &cfg, nil
 }
 
-// NewAuthenticatedSessionFromDefaultCredentials gets an AWS Config, checking that the user has credentials properly configured in their environment.
+// NewAuthenticatedSessionFromDefaultCredentialsContext is a backwards-compatible alias for [NewAuthenticatedSessionFromDefaultCredentialsContextE].
 //
-// Deprecated: Use [NewAuthenticatedSessionFromDefaultCredentialsContext] instead.
-func NewAuthenticatedSessionFromDefaultCredentials(region string) (*aws.Config, error) {
-	return NewAuthenticatedSessionFromDefaultCredentialsContext(context.Background(), region)
+// Deprecated: Use [NewAuthenticatedSessionFromDefaultCredentialsContextE] instead.
+func NewAuthenticatedSessionFromDefaultCredentialsContext(ctx context.Context, region string) (*aws.Config, error) {
+	return NewAuthenticatedSessionFromDefaultCredentialsContextE(ctx, region)
 }
 
-// NewAuthenticatedSessionFromRoleContext returns a new AWS Config after assuming the
+// NewAuthenticatedSessionFromDefaultCredentials gets an AWS Config, checking that the user has credentials properly configured in their environment.
+//
+// Deprecated: Use [NewAuthenticatedSessionFromDefaultCredentialsContextE] instead.
+func NewAuthenticatedSessionFromDefaultCredentials(region string) (*aws.Config, error) {
+	return NewAuthenticatedSessionFromDefaultCredentialsContextE(context.Background(), region)
+}
+
+// NewAuthenticatedSessionFromRoleContextE returns a new AWS Config after assuming the
 // role whose ARN is provided in roleARN. If the credentials are not properly
 // configured in the underlying environment, an error is returned.
 // The ctx parameter supports cancellation and timeouts.
-func NewAuthenticatedSessionFromRoleContext(ctx context.Context, region string, roleARN string) (*aws.Config, error) {
-	cfg, err := NewAuthenticatedSessionFromDefaultCredentialsContext(ctx, region)
+func NewAuthenticatedSessionFromRoleContextE(ctx context.Context, region string, roleARN string) (*aws.Config, error) {
+	cfg, err := NewAuthenticatedSessionFromDefaultCredentialsContextE(ctx, region)
 	if err != nil {
 		return nil, err
 	}
@@ -86,36 +100,50 @@ func NewAuthenticatedSessionFromRoleContext(ctx context.Context, region string, 
 	}, nil
 }
 
+// NewAuthenticatedSessionFromRoleContext is a backwards-compatible alias for [NewAuthenticatedSessionFromRoleContextE].
+//
+// Deprecated: Use [NewAuthenticatedSessionFromRoleContextE] instead.
+func NewAuthenticatedSessionFromRoleContext(ctx context.Context, region string, roleARN string) (*aws.Config, error) {
+	return NewAuthenticatedSessionFromRoleContextE(ctx, region, roleARN)
+}
+
 // NewAuthenticatedSessionFromRole returns a new AWS Config after assuming the
 // role whose ARN is provided in roleARN. If the credentials are not properly
 // configured in the underlying environment, an error is returned.
 //
-// Deprecated: Use [NewAuthenticatedSessionFromRoleContext] instead.
+// Deprecated: Use [NewAuthenticatedSessionFromRoleContextE] instead.
 func NewAuthenticatedSessionFromRole(region string, roleARN string) (*aws.Config, error) {
-	return NewAuthenticatedSessionFromRoleContext(context.Background(), region, roleARN)
+	return NewAuthenticatedSessionFromRoleContextE(context.Background(), region, roleARN)
 }
 
-// CreateAwsSessionWithCredsContext creates a new AWS Config using explicit credentials. This is useful if you want to create an IAM User dynamically and
+// CreateAwsSessionWithCredsContextE creates a new AWS Config using explicit credentials. This is useful if you want to create an IAM User dynamically and
 // create an AWS Config authenticated as the new IAM User.
 // The ctx parameter is accepted for API consistency but not currently used.
-func CreateAwsSessionWithCredsContext(ctx context.Context, region string, accessKeyID string, secretAccessKey string) (*aws.Config, error) {
+func CreateAwsSessionWithCredsContextE(_ context.Context, region string, accessKeyID string, secretAccessKey string) (*aws.Config, error) {
 	return &aws.Config{
 		Region:      region,
 		Credentials: aws.NewCredentialsCache(credentials.NewStaticCredentialsProvider(accessKeyID, secretAccessKey, "")),
 	}, nil
 }
 
+// CreateAwsSessionWithCredsContext is a backwards-compatible alias for [CreateAwsSessionWithCredsContextE].
+//
+// Deprecated: Use [CreateAwsSessionWithCredsContextE] instead.
+func CreateAwsSessionWithCredsContext(ctx context.Context, region string, accessKeyID string, secretAccessKey string) (*aws.Config, error) {
+	return CreateAwsSessionWithCredsContextE(ctx, region, accessKeyID, secretAccessKey)
+}
+
 // CreateAwsSessionWithCreds creates a new AWS Config using explicit credentials. This is useful if you want to create an IAM User dynamically and
 // create an AWS Config authenticated as the new IAM User.
 //
-// Deprecated: Use [CreateAwsSessionWithCredsContext] instead.
+// Deprecated: Use [CreateAwsSessionWithCredsContextE] instead.
 func CreateAwsSessionWithCreds(region string, accessKeyID string, secretAccessKey string) (*aws.Config, error) {
-	return CreateAwsSessionWithCredsContext(context.Background(), region, accessKeyID, secretAccessKey)
+	return CreateAwsSessionWithCredsContextE(context.Background(), region, accessKeyID, secretAccessKey)
 }
 
-// CreateAwsSessionWithMfaContext creates a new AWS Config authenticated using an MFA token retrieved using the given STS client and MFA Device.
+// CreateAwsSessionWithMfaContextE creates a new AWS Config authenticated using an MFA token retrieved using the given STS client and MFA Device.
 // The ctx parameter supports cancellation and timeouts.
-func CreateAwsSessionWithMfaContext(ctx context.Context, region string, stsClient *sts.Client, mfaDevice *types.VirtualMFADevice) (*aws.Config, error) {
+func CreateAwsSessionWithMfaContextE(ctx context.Context, region string, stsClient *sts.Client, mfaDevice *types.VirtualMFADevice) (*aws.Config, error) {
 	tokenCode, err := GetTimeBasedOneTimePassword(mfaDevice)
 	if err != nil {
 		return nil, err
@@ -139,11 +167,18 @@ func CreateAwsSessionWithMfaContext(ctx context.Context, region string, stsClien
 	}, nil
 }
 
+// CreateAwsSessionWithMfaContext is a backwards-compatible alias for [CreateAwsSessionWithMfaContextE].
+//
+// Deprecated: Use [CreateAwsSessionWithMfaContextE] instead.
+func CreateAwsSessionWithMfaContext(ctx context.Context, region string, stsClient *sts.Client, mfaDevice *types.VirtualMFADevice) (*aws.Config, error) {
+	return CreateAwsSessionWithMfaContextE(ctx, region, stsClient, mfaDevice)
+}
+
 // CreateAwsSessionWithMfa creates a new AWS Config authenticated using an MFA token retrieved using the given STS client and MFA Device.
 //
-// Deprecated: Use [CreateAwsSessionWithMfaContext] instead.
+// Deprecated: Use [CreateAwsSessionWithMfaContextE] instead.
 func CreateAwsSessionWithMfa(region string, stsClient *sts.Client, mfaDevice *types.VirtualMFADevice) (*aws.Config, error) {
-	return CreateAwsSessionWithMfaContext(context.Background(), region, stsClient, mfaDevice)
+	return CreateAwsSessionWithMfaContextE(context.Background(), region, stsClient, mfaDevice)
 }
 
 // GetTimeBasedOneTimePassword gets a One-Time Password from the given mfaDevice. Per the RFC 6238 standard, this value will be different every 30 seconds.
@@ -158,9 +193,9 @@ func GetTimeBasedOneTimePassword(mfaDevice *types.VirtualMFADevice) (string, err
 	return otp, nil
 }
 
-// ReadPasswordPolicyMinPasswordLengthContext returns the minimal password length.
+// ReadPasswordPolicyMinPasswordLengthContextE returns the minimal password length.
 // The ctx parameter supports cancellation and timeouts.
-func ReadPasswordPolicyMinPasswordLengthContext(ctx context.Context, iamClient *iam.Client) (int, error) {
+func ReadPasswordPolicyMinPasswordLengthContextE(ctx context.Context, iamClient *iam.Client) (int, error) {
 	output, err := iamClient.GetAccountPasswordPolicy(ctx, &iam.GetAccountPasswordPolicyInput{})
 	if err != nil {
 		return -1, err
@@ -169,11 +204,18 @@ func ReadPasswordPolicyMinPasswordLengthContext(ctx context.Context, iamClient *
 	return int(*output.PasswordPolicy.MinimumPasswordLength), nil
 }
 
+// ReadPasswordPolicyMinPasswordLengthContext is a backwards-compatible alias for [ReadPasswordPolicyMinPasswordLengthContextE].
+//
+// Deprecated: Use [ReadPasswordPolicyMinPasswordLengthContextE] instead.
+func ReadPasswordPolicyMinPasswordLengthContext(ctx context.Context, iamClient *iam.Client) (int, error) {
+	return ReadPasswordPolicyMinPasswordLengthContextE(ctx, iamClient)
+}
+
 // ReadPasswordPolicyMinPasswordLength returns the minimal password length.
 //
-// Deprecated: Use [ReadPasswordPolicyMinPasswordLengthContext] instead.
+// Deprecated: Use [ReadPasswordPolicyMinPasswordLengthContextE] instead.
 func ReadPasswordPolicyMinPasswordLength(iamClient *iam.Client) (int, error) {
-	return ReadPasswordPolicyMinPasswordLengthContext(context.Background(), iamClient)
+	return ReadPasswordPolicyMinPasswordLengthContextE(context.Background(), iamClient)
 }
 
 // CredentialsError is an error that occurs because AWS credentials can't be found.

--- a/modules/aws/auth.go
+++ b/modules/aws/auth.go
@@ -33,8 +33,6 @@ func NewAuthenticatedSessionContextE(ctx context.Context, region string) (*aws.C
 	return NewAuthenticatedSessionFromDefaultCredentialsContextE(ctx, region)
 }
 
-// NewAuthenticatedSessionContext is a backwards-compatible alias for [NewAuthenticatedSessionContextE].
-//
 // Deprecated: Use [NewAuthenticatedSessionContextE] instead.
 func NewAuthenticatedSessionContext(ctx context.Context, region string) (*aws.Config, error) {
 	return NewAuthenticatedSessionContextE(ctx, region)
@@ -59,8 +57,6 @@ func NewAuthenticatedSessionFromDefaultCredentialsContextE(ctx context.Context, 
 	return &cfg, nil
 }
 
-// NewAuthenticatedSessionFromDefaultCredentialsContext is a backwards-compatible alias for [NewAuthenticatedSessionFromDefaultCredentialsContextE].
-//
 // Deprecated: Use [NewAuthenticatedSessionFromDefaultCredentialsContextE] instead.
 func NewAuthenticatedSessionFromDefaultCredentialsContext(ctx context.Context, region string) (*aws.Config, error) {
 	return NewAuthenticatedSessionFromDefaultCredentialsContextE(ctx, region)
@@ -100,8 +96,6 @@ func NewAuthenticatedSessionFromRoleContextE(ctx context.Context, region string,
 	}, nil
 }
 
-// NewAuthenticatedSessionFromRoleContext is a backwards-compatible alias for [NewAuthenticatedSessionFromRoleContextE].
-//
 // Deprecated: Use [NewAuthenticatedSessionFromRoleContextE] instead.
 func NewAuthenticatedSessionFromRoleContext(ctx context.Context, region string, roleARN string) (*aws.Config, error) {
 	return NewAuthenticatedSessionFromRoleContextE(ctx, region, roleARN)
@@ -126,8 +120,6 @@ func CreateAwsSessionWithCredsContextE(_ context.Context, region string, accessK
 	}, nil
 }
 
-// CreateAwsSessionWithCredsContext is a backwards-compatible alias for [CreateAwsSessionWithCredsContextE].
-//
 // Deprecated: Use [CreateAwsSessionWithCredsContextE] instead.
 func CreateAwsSessionWithCredsContext(ctx context.Context, region string, accessKeyID string, secretAccessKey string) (*aws.Config, error) {
 	return CreateAwsSessionWithCredsContextE(ctx, region, accessKeyID, secretAccessKey)
@@ -167,8 +159,6 @@ func CreateAwsSessionWithMfaContextE(ctx context.Context, region string, stsClie
 	}, nil
 }
 
-// CreateAwsSessionWithMfaContext is a backwards-compatible alias for [CreateAwsSessionWithMfaContextE].
-//
 // Deprecated: Use [CreateAwsSessionWithMfaContextE] instead.
 func CreateAwsSessionWithMfaContext(ctx context.Context, region string, stsClient *sts.Client, mfaDevice *types.VirtualMFADevice) (*aws.Config, error) {
 	return CreateAwsSessionWithMfaContextE(ctx, region, stsClient, mfaDevice)
@@ -204,8 +194,6 @@ func ReadPasswordPolicyMinPasswordLengthContextE(ctx context.Context, iamClient 
 	return int(*output.PasswordPolicy.MinimumPasswordLength), nil
 }
 
-// ReadPasswordPolicyMinPasswordLengthContext is a backwards-compatible alias for [ReadPasswordPolicyMinPasswordLengthContextE].
-//
 // Deprecated: Use [ReadPasswordPolicyMinPasswordLengthContextE] instead.
 func ReadPasswordPolicyMinPasswordLengthContext(ctx context.Context, iamClient *iam.Client) (int, error) {
 	return ReadPasswordPolicyMinPasswordLengthContextE(ctx, iamClient)

--- a/modules/aws/cloudwatch.go
+++ b/modules/aws/cloudwatch.go
@@ -79,7 +79,7 @@ func GetCloudWatchLogEntriesE(t testing.TestingT, awsRegion string, logStreamNam
 // NewCloudWatchLogsClientContextE creates a new CloudWatch Logs client.
 // The ctx parameter supports cancellation and timeouts.
 func NewCloudWatchLogsClientContextE(t testing.TestingT, ctx context.Context, region string) (*cloudwatchlogs.Client, error) {
-	sess, err := NewAuthenticatedSessionContext(ctx, region)
+	sess, err := NewAuthenticatedSessionContextE(ctx, region)
 	if err != nil {
 		return nil, err
 	}

--- a/modules/aws/dynamodb.go
+++ b/modules/aws/dynamodb.go
@@ -196,7 +196,7 @@ func GetDynamoDBTableE(t testing.TestingT, region string, tableName string) (*ty
 // NewDynamoDBClientContextE creates a DynamoDB client.
 // The ctx parameter supports cancellation and timeouts.
 func NewDynamoDBClientContextE(t testing.TestingT, ctx context.Context, region string) (*dynamodb.Client, error) {
-	sess, err := NewAuthenticatedSessionContext(ctx, region)
+	sess, err := NewAuthenticatedSessionContextE(ctx, region)
 	if err != nil {
 		return nil, err
 	}

--- a/modules/aws/ebs.go
+++ b/modules/aws/ebs.go
@@ -21,7 +21,7 @@ type EbsAPI interface {
 func DeleteEbsSnapshotContextE(t testing.TestingT, ctx context.Context, region string, snapshot string) error {
 	logger.Default.Logf(t, "Deleting EBS snapshot %s", snapshot)
 
-	sess, err := NewAuthenticatedSessionContext(ctx, region)
+	sess, err := NewAuthenticatedSessionContextE(ctx, region)
 	if err != nil {
 		return err
 	}

--- a/modules/aws/ec2-syslog.go
+++ b/modules/aws/ec2-syslog.go
@@ -32,7 +32,7 @@ func GetSyslogForInstanceContextE(t testing.TestingT, ctx context.Context, insta
 
 	logger.Default.Logf(t, "%s", description)
 
-	sess, err := NewAuthenticatedSessionContext(ctx, region)
+	sess, err := NewAuthenticatedSessionContextE(ctx, region)
 	if err != nil {
 		return "", err
 	}

--- a/modules/aws/ec2.go
+++ b/modules/aws/ec2.go
@@ -956,7 +956,7 @@ func getInstanceFieldMapContextE(t testing.TestingT, ctx context.Context, instan
 // NewEc2ClientContextE creates an EC2 client.
 // The ctx parameter supports cancellation and timeouts.
 func NewEc2ClientContextE(t testing.TestingT, ctx context.Context, region string) (*ec2.Client, error) {
-	sess, err := NewAuthenticatedSessionContext(ctx, region)
+	sess, err := NewAuthenticatedSessionContextE(ctx, region)
 	if err != nil {
 		return nil, err
 	}

--- a/modules/aws/ecr.go
+++ b/modules/aws/ecr.go
@@ -172,7 +172,7 @@ func DeleteECRRepoE(t testing.TestingT, region string, repo *types.Repository) e
 // NewECRClientContextE returns a client for the Elastic Container Registry.
 // The ctx parameter supports cancellation and timeouts.
 func NewECRClientContextE(t testing.TestingT, ctx context.Context, region string) (*ecr.Client, error) {
-	sess, err := NewAuthenticatedSessionContext(ctx, region)
+	sess, err := NewAuthenticatedSessionContextE(ctx, region)
 	if err != nil {
 		return nil, err
 	}

--- a/modules/aws/ecs.go
+++ b/modules/aws/ecs.go
@@ -308,7 +308,7 @@ func GetEcsTaskDefinitionE(t testing.TestingT, region string, taskDefinition str
 // NewEcsClientContextE creates an ECS client.
 // The ctx parameter supports cancellation and timeouts.
 func NewEcsClientContextE(t testing.TestingT, ctx context.Context, region string) (*ecs.Client, error) {
-	sess, err := NewAuthenticatedSessionContext(ctx, region)
+	sess, err := NewAuthenticatedSessionContextE(ctx, region)
 	if err != nil {
 		return nil, err
 	}

--- a/modules/aws/iam.go
+++ b/modules/aws/iam.go
@@ -301,7 +301,7 @@ func EnableMfaDeviceE(t testing.TestingT, iamClient *iam.Client, mfaDevice *type
 // NewIamClientContextE creates a new IAM client.
 // The ctx parameter supports cancellation and timeouts.
 func NewIamClientContextE(t testing.TestingT, ctx context.Context, region string) (*iam.Client, error) {
-	sess, err := NewAuthenticatedSessionContext(ctx, region)
+	sess, err := NewAuthenticatedSessionContextE(ctx, region)
 	if err != nil {
 		return nil, err
 	}

--- a/modules/aws/keypair.go
+++ b/modules/aws/keypair.go
@@ -64,7 +64,7 @@ func CreateAndImportEC2KeyPairE(t testing.TestingT, region string, name string) 
 func ImportEC2KeyPairContextE(t testing.TestingT, ctx context.Context, region string, name string, keyPair *ssh.KeyPair) (*Ec2Keypair, error) {
 	logger.Default.Logf(t, "Creating new Key Pair in EC2 region %s named %s", region, name)
 
-	sess, err := NewAuthenticatedSessionContext(ctx, region)
+	sess, err := NewAuthenticatedSessionContextE(ctx, region)
 	if err != nil {
 		return nil, err
 	}
@@ -117,7 +117,7 @@ func ImportEC2KeyPairE(t testing.TestingT, region string, name string, keyPair *
 func DeleteEC2KeyPairContextE(t testing.TestingT, ctx context.Context, keyPair *Ec2Keypair) error {
 	logger.Default.Logf(t, "Deleting Key Pair in EC2 region %s named %s", keyPair.Region, keyPair.Name)
 
-	sess, err := NewAuthenticatedSessionContext(ctx, keyPair.Region)
+	sess, err := NewAuthenticatedSessionContextE(ctx, keyPair.Region)
 	if err != nil {
 		return err
 	}

--- a/modules/aws/kms.go
+++ b/modules/aws/kms.go
@@ -75,7 +75,7 @@ func GetCmkArnE(t testing.TestingT, region string, cmkID string) (string, error)
 // NewKmsClientContextE creates a KMS client.
 // The ctx parameter supports cancellation and timeouts.
 func NewKmsClientContextE(t testing.TestingT, ctx context.Context, region string) (*kms.Client, error) {
-	sess, err := NewAuthenticatedSessionContext(ctx, region)
+	sess, err := NewAuthenticatedSessionContextE(ctx, region)
 	if err != nil {
 		return nil, err
 	}

--- a/modules/aws/lambda.go
+++ b/modules/aws/lambda.go
@@ -239,7 +239,7 @@ func (err *FunctionError) Error() string {
 // NewLambdaClientContextE creates a new Lambda client.
 // The ctx parameter supports cancellation and timeouts.
 func NewLambdaClientContextE(t testing.TestingT, ctx context.Context, region string) (*lambda.Client, error) {
-	sess, err := NewAuthenticatedSessionContext(ctx, region)
+	sess, err := NewAuthenticatedSessionContextE(ctx, region)
 	if err != nil {
 		return nil, err
 	}

--- a/modules/aws/rds.go
+++ b/modules/aws/rds.go
@@ -510,7 +510,7 @@ func GetRdsInstanceDetailsE(t testing.TestingT, dbInstanceID string, awsRegion s
 // NewRdsClientContextE creates an RDS client.
 // The ctx parameter supports cancellation and timeouts.
 func NewRdsClientContextE(t testing.TestingT, ctx context.Context, region string) (*rds.Client, error) {
-	sess, err := NewAuthenticatedSessionContext(ctx, region)
+	sess, err := NewAuthenticatedSessionContextE(ctx, region)
 	if err != nil {
 		return nil, err
 	}

--- a/modules/aws/route53.go
+++ b/modules/aws/route53.go
@@ -73,7 +73,7 @@ func GetRoute53RecordE(t ttesting.TestingT, hostedZoneID, recordName, recordType
 func NewRoute53ClientContextE(t ttesting.TestingT, ctx context.Context, region string) (*route53.Client, error) {
 	t.Helper()
 
-	sess, err := NewAuthenticatedSessionContext(ctx, region)
+	sess, err := NewAuthenticatedSessionContextE(ctx, region)
 	if err != nil {
 		return nil, err
 	}

--- a/modules/aws/s3.go
+++ b/modules/aws/s3.go
@@ -915,7 +915,7 @@ func AssertS3BucketPolicyExistsE(t testing.TestingT, region string, bucketName s
 // NewS3ClientContextE creates an S3 client.
 // The ctx parameter supports cancellation and timeouts.
 func NewS3ClientContextE(t testing.TestingT, ctx context.Context, region string) (*s3.Client, error) {
-	sess, err := NewAuthenticatedSessionContext(ctx, region)
+	sess, err := NewAuthenticatedSessionContextE(ctx, region)
 	if err != nil {
 		return nil, err
 	}
@@ -954,7 +954,7 @@ func NewS3ClientE(t testing.TestingT, region string) (*s3.Client, error) {
 // NewS3UploaderContextE creates an S3 transfer manager client for uploading objects.
 // The ctx parameter supports cancellation and timeouts.
 func NewS3UploaderContextE(t testing.TestingT, ctx context.Context, region string) (*transfermanager.Client, error) {
-	sess, err := NewAuthenticatedSessionContext(ctx, region)
+	sess, err := NewAuthenticatedSessionContextE(ctx, region)
 	if err != nil {
 		return nil, err
 	}

--- a/modules/aws/secretsmanager.go
+++ b/modules/aws/secretsmanager.go
@@ -191,7 +191,7 @@ func DeleteSecretE(t testing.TestingT, awsRegion, id string, forceDelete bool) e
 // NewSecretsManagerClientContextE creates a new SecretsManager client.
 // The ctx parameter supports cancellation and timeouts.
 func NewSecretsManagerClientContextE(t testing.TestingT, ctx context.Context, region string) (*secretsmanager.Client, error) {
-	sess, err := NewAuthenticatedSessionContext(ctx, region)
+	sess, err := NewAuthenticatedSessionContextE(ctx, region)
 	if err != nil {
 		return nil, err
 	}

--- a/modules/aws/sns.go
+++ b/modules/aws/sns.go
@@ -108,7 +108,7 @@ func DeleteSNSTopicE(t testing.TestingT, region string, snsTopicArn string) erro
 // NewSnsClientContextE creates a new SNS client.
 // The ctx parameter supports cancellation and timeouts.
 func NewSnsClientContextE(t testing.TestingT, ctx context.Context, region string) (*sns.Client, error) {
-	sess, err := NewAuthenticatedSessionContext(ctx, region)
+	sess, err := NewAuthenticatedSessionContextE(ctx, region)
 	if err != nil {
 		return nil, err
 	}

--- a/modules/aws/sqs.go
+++ b/modules/aws/sqs.go
@@ -383,7 +383,7 @@ func WaitForQueueMessage(t testing.TestingT, awsRegion string, queueURL string, 
 // NewSqsClientContextE creates a new SQS client.
 // The ctx parameter supports cancellation and timeouts.
 func NewSqsClientContextE(t testing.TestingT, ctx context.Context, region string) (*sqs.Client, error) {
-	sess, err := NewAuthenticatedSessionContext(ctx, region)
+	sess, err := NewAuthenticatedSessionContextE(ctx, region)
 	if err != nil {
 		return nil, err
 	}

--- a/modules/aws/ssm.go
+++ b/modules/aws/ssm.go
@@ -188,7 +188,7 @@ func DeleteParameterWithClientE(t testing.TestingT, client *ssm.Client, keyName 
 // NewSsmClientContextE creates an SSM client.
 // The ctx parameter supports cancellation and timeouts.
 func NewSsmClientContextE(t testing.TestingT, ctx context.Context, region string) (*ssm.Client, error) {
-	sess, err := NewAuthenticatedSessionContext(ctx, region)
+	sess, err := NewAuthenticatedSessionContextE(ctx, region)
 	if err != nil {
 		return nil, err
 	}

--- a/modules/azure/actiongroup.go
+++ b/modules/azure/actiongroup.go
@@ -32,7 +32,7 @@ func GetActionGroupResourceContextE(ctx context.Context, ruleName string, resGro
 		return nil, err
 	}
 
-	client, err := CreateActionGroupClientContext(ctx, subscriptionID)
+	client, err := CreateActionGroupClientContextE(ctx, subscriptionID)
 	if err != nil {
 		return nil, err
 	}

--- a/modules/azure/client_factory.go
+++ b/modules/azure/client_factory.go
@@ -482,8 +482,6 @@ func CreateSQLServerClientContextE(_ context.Context, subscriptionID string) (*a
 	return clientFactory.NewServersClient(), nil
 }
 
-// CreateSQLServerClientContext is a backwards-compatible alias for [CreateSQLServerClientContextE].
-//
 // Deprecated: Use [CreateSQLServerClientContextE] instead.
 func CreateSQLServerClientContext(ctx context.Context, subscriptionID string) (*armsql.ServersClient, error) {
 	return CreateSQLServerClientContextE(ctx, subscriptionID)
@@ -507,8 +505,6 @@ func CreateSQLMangedInstanceClientContextE(_ context.Context, subscriptionID str
 	return clientFactory.NewManagedInstancesClient(), nil
 }
 
-// CreateSQLMangedInstanceClientContext is a backwards-compatible alias for [CreateSQLMangedInstanceClientContextE].
-//
 // Deprecated: Use [CreateSQLMangedInstanceClientContextE] instead.
 func CreateSQLMangedInstanceClientContext(ctx context.Context, subscriptionID string) (*armsql.ManagedInstancesClient, error) { //nolint:revive,staticcheck // preserving deprecated function name
 	return CreateSQLMangedInstanceClientContextE(ctx, subscriptionID)
@@ -532,8 +528,6 @@ func CreateSQLMangedDatabasesClientContextE(_ context.Context, subscriptionID st
 	return clientFactory.NewManagedDatabasesClient(), nil
 }
 
-// CreateSQLMangedDatabasesClientContext is a backwards-compatible alias for [CreateSQLMangedDatabasesClientContextE].
-//
 // Deprecated: Use [CreateSQLMangedDatabasesClientContextE] instead.
 func CreateSQLMangedDatabasesClientContext(ctx context.Context, subscriptionID string) (*armsql.ManagedDatabasesClient, error) { //nolint:revive,staticcheck // preserving deprecated function name
 	return CreateSQLMangedDatabasesClientContextE(ctx, subscriptionID)
@@ -585,8 +579,6 @@ func CreateDatabaseClientContextE(_ context.Context, subscriptionID string) (*ar
 	return clientFactory.NewDatabasesClient(), nil
 }
 
-// CreateDatabaseClientContext is a backwards-compatible alias for [CreateDatabaseClientContextE].
-//
 // Deprecated: Use [CreateDatabaseClientContextE] instead.
 func CreateDatabaseClientContext(ctx context.Context, subscriptionID string) (*armsql.DatabasesClient, error) {
 	return CreateDatabaseClientContextE(ctx, subscriptionID)
@@ -684,8 +676,6 @@ func CreateActionGroupClientContextE(_ context.Context, subscriptionID string) (
 	return armmonitor.NewActionGroupsClient(subID, cred, opts)
 }
 
-// CreateActionGroupClientContext is a backwards-compatible alias for [CreateActionGroupClientContextE].
-//
 // Deprecated: Use [CreateActionGroupClientContextE] instead.
 func CreateActionGroupClientContext(ctx context.Context, subscriptionID string) (*armmonitor.ActionGroupsClient, error) {
 	return CreateActionGroupClientContextE(ctx, subscriptionID)

--- a/modules/azure/client_factory.go
+++ b/modules/azure/client_factory.go
@@ -471,9 +471,9 @@ func CreateResourceGroupClientE(subscriptionID string) (*armresources.ResourceGr
 	return CreateResourceGroupClientContextE(context.Background(), subscriptionID)
 }
 
-// CreateSQLServerClientContext is a helper function that will create and setup a sql server client.
+// CreateSQLServerClientContextE is a helper function that will create and setup a sql server client.
 // The ctx parameter supports cancellation and timeouts.
-func CreateSQLServerClientContext(_ context.Context, subscriptionID string) (*armsql.ServersClient, error) {
+func CreateSQLServerClientContextE(_ context.Context, subscriptionID string) (*armsql.ServersClient, error) {
 	clientFactory, err := getArmSQLClientFactory(subscriptionID)
 	if err != nil {
 		return nil, err
@@ -482,16 +482,23 @@ func CreateSQLServerClientContext(_ context.Context, subscriptionID string) (*ar
 	return clientFactory.NewServersClient(), nil
 }
 
-// CreateSQLServerClient is a helper function that will create and setup a sql server client.
+// CreateSQLServerClientContext is a backwards-compatible alias for [CreateSQLServerClientContextE].
 //
-// Deprecated: Use [CreateSQLServerClientContext] instead.
-func CreateSQLServerClient(subscriptionID string) (*armsql.ServersClient, error) {
-	return CreateSQLServerClientContext(context.Background(), subscriptionID)
+// Deprecated: Use [CreateSQLServerClientContextE] instead.
+func CreateSQLServerClientContext(ctx context.Context, subscriptionID string) (*armsql.ServersClient, error) {
+	return CreateSQLServerClientContextE(ctx, subscriptionID)
 }
 
-// CreateSQLMangedInstanceClientContext is a helper function that will create and setup a sql managed instance client.
+// CreateSQLServerClient is a helper function that will create and setup a sql server client.
+//
+// Deprecated: Use [CreateSQLServerClientContextE] instead.
+func CreateSQLServerClient(subscriptionID string) (*armsql.ServersClient, error) {
+	return CreateSQLServerClientContextE(context.Background(), subscriptionID)
+}
+
+// CreateSQLMangedInstanceClientContextE is a helper function that will create and setup a sql managed instance client.
 // The ctx parameter supports cancellation and timeouts.
-func CreateSQLMangedInstanceClientContext(_ context.Context, subscriptionID string) (*armsql.ManagedInstancesClient, error) {
+func CreateSQLMangedInstanceClientContextE(_ context.Context, subscriptionID string) (*armsql.ManagedInstancesClient, error) { //nolint:revive,staticcheck // preserving deprecated function name
 	clientFactory, err := getArmSQLClientFactory(subscriptionID)
 	if err != nil {
 		return nil, err
@@ -500,16 +507,23 @@ func CreateSQLMangedInstanceClientContext(_ context.Context, subscriptionID stri
 	return clientFactory.NewManagedInstancesClient(), nil
 }
 
-// CreateSQLMangedInstanceClient is a helper function that will create and setup a sql managed instance client.
+// CreateSQLMangedInstanceClientContext is a backwards-compatible alias for [CreateSQLMangedInstanceClientContextE].
 //
-// Deprecated: Use [CreateSQLMangedInstanceClientContext] instead.
-func CreateSQLMangedInstanceClient(subscriptionID string) (*armsql.ManagedInstancesClient, error) {
-	return CreateSQLMangedInstanceClientContext(context.Background(), subscriptionID)
+// Deprecated: Use [CreateSQLMangedInstanceClientContextE] instead.
+func CreateSQLMangedInstanceClientContext(ctx context.Context, subscriptionID string) (*armsql.ManagedInstancesClient, error) { //nolint:revive,staticcheck // preserving deprecated function name
+	return CreateSQLMangedInstanceClientContextE(ctx, subscriptionID)
 }
 
-// CreateSQLMangedDatabasesClientContext is a helper function that will create and setup a sql managed databases client.
+// CreateSQLMangedInstanceClient is a helper function that will create and setup a sql managed instance client.
+//
+// Deprecated: Use [CreateSQLMangedInstanceClientContextE] instead.
+func CreateSQLMangedInstanceClient(subscriptionID string) (*armsql.ManagedInstancesClient, error) { //nolint:revive,staticcheck // preserving deprecated function name
+	return CreateSQLMangedInstanceClientContextE(context.Background(), subscriptionID)
+}
+
+// CreateSQLMangedDatabasesClientContextE is a helper function that will create and setup a sql managed databases client.
 // The ctx parameter supports cancellation and timeouts.
-func CreateSQLMangedDatabasesClientContext(_ context.Context, subscriptionID string) (*armsql.ManagedDatabasesClient, error) {
+func CreateSQLMangedDatabasesClientContextE(_ context.Context, subscriptionID string) (*armsql.ManagedDatabasesClient, error) { //nolint:revive,staticcheck // preserving deprecated function name
 	clientFactory, err := getArmSQLClientFactory(subscriptionID)
 	if err != nil {
 		return nil, err
@@ -518,11 +532,18 @@ func CreateSQLMangedDatabasesClientContext(_ context.Context, subscriptionID str
 	return clientFactory.NewManagedDatabasesClient(), nil
 }
 
+// CreateSQLMangedDatabasesClientContext is a backwards-compatible alias for [CreateSQLMangedDatabasesClientContextE].
+//
+// Deprecated: Use [CreateSQLMangedDatabasesClientContextE] instead.
+func CreateSQLMangedDatabasesClientContext(ctx context.Context, subscriptionID string) (*armsql.ManagedDatabasesClient, error) { //nolint:revive,staticcheck // preserving deprecated function name
+	return CreateSQLMangedDatabasesClientContextE(ctx, subscriptionID)
+}
+
 // CreateSQLMangedDatabasesClient is a helper function that will create and setup a sql managed databases client.
 //
-// Deprecated: Use [CreateSQLMangedDatabasesClientContext] instead.
-func CreateSQLMangedDatabasesClient(subscriptionID string) (*armsql.ManagedDatabasesClient, error) {
-	return CreateSQLMangedDatabasesClientContext(context.Background(), subscriptionID)
+// Deprecated: Use [CreateSQLMangedDatabasesClientContextE] instead.
+func CreateSQLMangedDatabasesClient(subscriptionID string) (*armsql.ManagedDatabasesClient, error) { //nolint:revive,staticcheck // preserving deprecated function name
+	return CreateSQLMangedDatabasesClientContextE(context.Background(), subscriptionID)
 }
 
 // getArmSQLClientFactory gets an arm sql client factory
@@ -553,9 +574,9 @@ func getArmSQLClientFactory(subscriptionID string) (*armsql.ClientFactory, error
 	})
 }
 
-// CreateDatabaseClientContext is a helper function that will create and setup a SQL DB client.
+// CreateDatabaseClientContextE is a helper function that will create and setup a SQL DB client.
 // The ctx parameter supports cancellation and timeouts.
-func CreateDatabaseClientContext(_ context.Context, subscriptionID string) (*armsql.DatabasesClient, error) {
+func CreateDatabaseClientContextE(_ context.Context, subscriptionID string) (*armsql.DatabasesClient, error) {
 	clientFactory, err := getArmSQLClientFactory(subscriptionID)
 	if err != nil {
 		return nil, err
@@ -564,11 +585,18 @@ func CreateDatabaseClientContext(_ context.Context, subscriptionID string) (*arm
 	return clientFactory.NewDatabasesClient(), nil
 }
 
+// CreateDatabaseClientContext is a backwards-compatible alias for [CreateDatabaseClientContextE].
+//
+// Deprecated: Use [CreateDatabaseClientContextE] instead.
+func CreateDatabaseClientContext(ctx context.Context, subscriptionID string) (*armsql.DatabasesClient, error) {
+	return CreateDatabaseClientContextE(ctx, subscriptionID)
+}
+
 // CreateDatabaseClient is a helper function that will create and setup a SQL DB client.
 //
-// Deprecated: Use [CreateDatabaseClientContext] instead.
+// Deprecated: Use [CreateDatabaseClientContextE] instead.
 func CreateDatabaseClient(subscriptionID string) (*armsql.DatabasesClient, error) {
-	return CreateDatabaseClientContext(context.Background(), subscriptionID)
+	return CreateDatabaseClientContextE(context.Background(), subscriptionID)
 }
 
 // CreateMySQLServerClientContextE is a helper function that will setup a mysql server client.
@@ -635,9 +663,9 @@ func CreateDisksClientE(subscriptionID string) (*armcompute.DisksClient, error) 
 	return CreateDisksClientContextE(context.Background(), subscriptionID)
 }
 
-// CreateActionGroupClientContext creates an Action Groups client for Azure Monitor.
+// CreateActionGroupClientContextE creates an Action Groups client for Azure Monitor.
 // The ctx parameter supports cancellation and timeouts.
-func CreateActionGroupClientContext(_ context.Context, subscriptionID string) (*armmonitor.ActionGroupsClient, error) {
+func CreateActionGroupClientContextE(_ context.Context, subscriptionID string) (*armmonitor.ActionGroupsClient, error) {
 	subID, err := getTargetAzureSubscription(subscriptionID)
 	if err != nil {
 		return nil, err
@@ -656,11 +684,18 @@ func CreateActionGroupClientContext(_ context.Context, subscriptionID string) (*
 	return armmonitor.NewActionGroupsClient(subID, cred, opts)
 }
 
+// CreateActionGroupClientContext is a backwards-compatible alias for [CreateActionGroupClientContextE].
+//
+// Deprecated: Use [CreateActionGroupClientContextE] instead.
+func CreateActionGroupClientContext(ctx context.Context, subscriptionID string) (*armmonitor.ActionGroupsClient, error) {
+	return CreateActionGroupClientContextE(ctx, subscriptionID)
+}
+
 // CreateActionGroupClient creates an Action Groups client for Azure Monitor.
 //
-// Deprecated: Use [CreateActionGroupClientContext] instead.
+// Deprecated: Use [CreateActionGroupClientContextE] instead.
 func CreateActionGroupClient(subscriptionID string) (*armmonitor.ActionGroupsClient, error) {
-	return CreateActionGroupClientContext(context.Background(), subscriptionID)
+	return CreateActionGroupClientContextE(context.Background(), subscriptionID)
 }
 
 // CreateVMInsightsClientContextE gets a VM Insights client.

--- a/modules/azure/sql.go
+++ b/modules/azure/sql.go
@@ -14,8 +14,6 @@ func GetSQLServerClientContextE(ctx context.Context, subscriptionID string) (*ar
 	return CreateSQLServerClientContextE(ctx, subscriptionID)
 }
 
-// GetSQLServerClientContext is a backwards-compatible alias for [GetSQLServerClientContextE].
-//
 // Deprecated: Use [GetSQLServerClientContextE] instead.
 func GetSQLServerClientContext(ctx context.Context, subscriptionID string) (*armsql.ServersClient, error) {
 	return GetSQLServerClientContextE(ctx, subscriptionID)
@@ -85,8 +83,6 @@ func GetDatabaseClientContextE(ctx context.Context, subscriptionID string) (*arm
 	return CreateDatabaseClientContextE(ctx, subscriptionID)
 }
 
-// GetDatabaseClientContext is a backwards-compatible alias for [GetDatabaseClientContextE].
-//
 // Deprecated: Use [GetDatabaseClientContextE] instead.
 func GetDatabaseClientContext(ctx context.Context, subscriptionID string) (*armsql.DatabasesClient, error) {
 	return GetDatabaseClientContextE(ctx, subscriptionID)

--- a/modules/azure/sql.go
+++ b/modules/azure/sql.go
@@ -8,17 +8,24 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// GetSQLServerClientContext is a helper function that will setup a sql server client.
+// GetSQLServerClientContextE is a helper function that will setup a sql server client.
 // The ctx parameter supports cancellation and timeouts.
+func GetSQLServerClientContextE(ctx context.Context, subscriptionID string) (*armsql.ServersClient, error) {
+	return CreateSQLServerClientContextE(ctx, subscriptionID)
+}
+
+// GetSQLServerClientContext is a backwards-compatible alias for [GetSQLServerClientContextE].
+//
+// Deprecated: Use [GetSQLServerClientContextE] instead.
 func GetSQLServerClientContext(ctx context.Context, subscriptionID string) (*armsql.ServersClient, error) {
-	return CreateSQLServerClientContext(ctx, subscriptionID)
+	return GetSQLServerClientContextE(ctx, subscriptionID)
 }
 
 // GetSQLServerClient is a helper function that will setup a sql server client.
 //
-// Deprecated: Use [GetSQLServerClientContext] instead.
+// Deprecated: Use [GetSQLServerClientContextE] instead.
 func GetSQLServerClient(subscriptionID string) (*armsql.ServersClient, error) {
-	return GetSQLServerClientContext(context.Background(), subscriptionID)
+	return GetSQLServerClientContextE(context.Background(), subscriptionID)
 }
 
 // GetSQLServerContext is a helper function that gets the sql server object.
@@ -47,7 +54,7 @@ func GetSQLServer(t testing.TestingT, resGroupName string, serverName string, su
 // The ctx parameter supports cancellation and timeouts.
 func GetSQLServerContextE(t testing.TestingT, ctx context.Context, subscriptionID string, resGroupName string, serverName string) (*armsql.Server, error) {
 	// Create a SQL Server client
-	sqlClient, err := CreateSQLServerClientContext(ctx, subscriptionID)
+	sqlClient, err := CreateSQLServerClientContextE(ctx, subscriptionID)
 	if err != nil {
 		return nil, err
 	}
@@ -72,17 +79,24 @@ func GetSQLServerE(t testing.TestingT, subscriptionID string, resGroupName strin
 	return GetSQLServerContextE(t, context.Background(), subscriptionID, resGroupName, serverName)
 }
 
-// GetDatabaseClientContext is a helper function that will setup a sql DB client.
+// GetDatabaseClientContextE is a helper function that will setup a sql DB client.
 // The ctx parameter supports cancellation and timeouts.
+func GetDatabaseClientContextE(ctx context.Context, subscriptionID string) (*armsql.DatabasesClient, error) {
+	return CreateDatabaseClientContextE(ctx, subscriptionID)
+}
+
+// GetDatabaseClientContext is a backwards-compatible alias for [GetDatabaseClientContextE].
+//
+// Deprecated: Use [GetDatabaseClientContextE] instead.
 func GetDatabaseClientContext(ctx context.Context, subscriptionID string) (*armsql.DatabasesClient, error) {
-	return CreateDatabaseClientContext(ctx, subscriptionID)
+	return GetDatabaseClientContextE(ctx, subscriptionID)
 }
 
 // GetDatabaseClient is a helper function that will setup a sql DB client.
 //
-// Deprecated: Use [GetDatabaseClientContext] instead.
+// Deprecated: Use [GetDatabaseClientContextE] instead.
 func GetDatabaseClient(subscriptionID string) (*armsql.DatabasesClient, error) {
-	return GetDatabaseClientContext(context.Background(), subscriptionID)
+	return GetDatabaseClientContextE(context.Background(), subscriptionID)
 }
 
 // ListSQLServerDatabasesContext is a helper function that gets a list of databases on a sql server.
@@ -111,7 +125,7 @@ func ListSQLServerDatabases(t testing.TestingT, resGroupName string, serverName 
 // The ctx parameter supports cancellation and timeouts.
 func ListSQLServerDatabasesContextE(t testing.TestingT, ctx context.Context, resGroupName string, serverName string, subscriptionID string) ([]*armsql.Database, error) {
 	// Create a SQL db client
-	sqlClient, err := CreateDatabaseClientContext(ctx, subscriptionID)
+	sqlClient, err := CreateDatabaseClientContextE(ctx, subscriptionID)
 	if err != nil {
 		return nil, err
 	}
@@ -170,7 +184,7 @@ func GetSQLDatabase(t testing.TestingT, resGroupName string, serverName string, 
 // The ctx parameter supports cancellation and timeouts.
 func GetSQLDatabaseContextE(t testing.TestingT, ctx context.Context, subscriptionID string, resGroupName string, serverName string, dbName string) (*armsql.Database, error) {
 	// Create a SQL db client
-	sqlClient, err := CreateDatabaseClientContext(ctx, subscriptionID)
+	sqlClient, err := CreateDatabaseClientContextE(ctx, subscriptionID)
 	if err != nil {
 		return nil, err
 	}

--- a/modules/azure/sql_managedinstance.go
+++ b/modules/azure/sql_managedinstance.go
@@ -67,7 +67,7 @@ func GetManagedInstanceContext(t testing.TestingT, ctx context.Context, resGroup
 // GetManagedInstanceContextE retrieves the SQL managed instance object for the given subscription.
 // The ctx parameter supports cancellation and timeouts.
 func GetManagedInstanceContextE(ctx context.Context, subscriptionID string, resGroupName string, managedInstanceName string) (*armsql.ManagedInstance, error) {
-	sqlmiClient, err := CreateSQLMangedInstanceClientContext(ctx, subscriptionID)
+	sqlmiClient, err := CreateSQLMangedInstanceClientContextE(ctx, subscriptionID) //nolint:revive,staticcheck // preserving deprecated function name
 	if err != nil {
 		return nil, err
 	}
@@ -117,7 +117,7 @@ func GetManagedInstanceDatabaseContext(t testing.TestingT, ctx context.Context, 
 // GetManagedInstanceDatabaseContextE retrieves the SQL managed database object for the given subscription.
 // The ctx parameter supports cancellation and timeouts.
 func GetManagedInstanceDatabaseContextE(ctx context.Context, subscriptionID string, resGroupName string, managedInstanceName string, databaseName string) (*armsql.ManagedDatabase, error) {
-	sqlmiDBClient, err := CreateSQLMangedDatabasesClientContext(ctx, subscriptionID)
+	sqlmiDBClient, err := CreateSQLMangedDatabasesClientContextE(ctx, subscriptionID) //nolint:revive,staticcheck // preserving deprecated function name
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary
Thirteen exported functions returned `(T, error)` under names ending in `*Context`, violating the `*ContextE` convention used elsewhere. Tagging v1.0 with the convention violation would lock it into the stable API.

For each function:
- The body moves to a new canonical `*ContextE` function.
- The original `*Context` name stays as a `// Deprecated:` alias delegating to the new one, so existing callers keep compiling.
- Internal callers and the pre-existing non-Context deprecated wrappers are repointed at the new `*ContextE` directly.

Renamed (full list in commit message):
- `modules/aws/auth.go`: 6 functions in the `NewAuthenticatedSession*`, `CreateAwsSession*`, and `ReadPasswordPolicyMinPasswordLength` families.
- `modules/azure/client_factory.go`: 5 SQL/database/Action Group factories.
- `modules/azure/sql.go`: `GetSQLServerClientContext`, `GetDatabaseClientContext`.

Closes OSS-3451.

## Test plan
- [x] `go build ./modules/aws/... ./modules/azure/...` passes
- [ ] CI lint + integration tests