### PR TITLE
feat(azure): add WithClient siblings for KeyVault and Storage helpers

### DIFF
--- a/modules/azure/keyvault.go
+++ b/modules/azure/keyvault.go
@@ -92,22 +92,28 @@ func KeyVaultCertificateExistsContextE(ctx context.Context, keyVaultName, certif
 		return false, err
 	}
 
+	return KeyVaultCertificateExistsWithClient(ctx, client, certificateName)
+}
+
+// KeyVaultCertificateExistsWithClient indicates whether a certificate exists in the key vault
+// using the provided azcertificates.Client. Useful in unit tests with an azfake-backed client.
+// The ctx parameter supports cancellation and timeouts.
+func KeyVaultCertificateExistsWithClient(ctx context.Context, client *azcertificates.Client, certificateName string) (bool, error) {
 	pager := client.NewListCertificatePropertiesVersionsPager(certificateName, nil)
 
-	if pager.More() {
-		_, err := pager.NextPage(ctx)
-		if err != nil {
-			if ResourceNotFoundErrorExists(err) {
-				return false, nil
-			}
-
-			return false, err
-		}
-
-		return true, nil
+	if !pager.More() {
+		return false, nil
 	}
 
-	return false, nil
+	if _, err := pager.NextPage(ctx); err != nil {
+		if ResourceNotFoundErrorExists(err) {
+			return false, nil
+		}
+
+		return false, err
+	}
+
+	return true, nil
 }
 
 // KeyVaultCertificateExistsE indicates whether a certificate exists in key vault; otherwise false.
@@ -125,22 +131,28 @@ func KeyVaultKeyExistsContextE(ctx context.Context, keyVaultName, keyName string
 		return false, err
 	}
 
+	return KeyVaultKeyExistsWithClient(ctx, client, keyName)
+}
+
+// KeyVaultKeyExistsWithClient indicates whether a key exists in the key vault using the
+// provided azkeys.Client. Useful in unit tests with an azfake-backed client.
+// The ctx parameter supports cancellation and timeouts.
+func KeyVaultKeyExistsWithClient(ctx context.Context, client *azkeys.Client, keyName string) (bool, error) {
 	pager := client.NewListKeyPropertiesVersionsPager(keyName, nil)
 
-	if pager.More() {
-		_, err := pager.NextPage(ctx)
-		if err != nil {
-			if ResourceNotFoundErrorExists(err) {
-				return false, nil
-			}
-
-			return false, err
-		}
-
-		return true, nil
+	if !pager.More() {
+		return false, nil
 	}
 
-	return false, nil
+	if _, err := pager.NextPage(ctx); err != nil {
+		if ResourceNotFoundErrorExists(err) {
+			return false, nil
+		}
+
+		return false, err
+	}
+
+	return true, nil
 }
 
 // KeyVaultKeyExistsE indicates whether a key exists in the key vault; otherwise false.
@@ -158,22 +170,28 @@ func KeyVaultSecretExistsContextE(ctx context.Context, keyVaultName, secretName 
 		return false, err
 	}
 
+	return KeyVaultSecretExistsWithClient(ctx, client, secretName)
+}
+
+// KeyVaultSecretExistsWithClient indicates whether a secret exists in the key vault using
+// the provided azsecrets.Client. Useful in unit tests with an azfake-backed client.
+// The ctx parameter supports cancellation and timeouts.
+func KeyVaultSecretExistsWithClient(ctx context.Context, client *azsecrets.Client, secretName string) (bool, error) {
 	pager := client.NewListSecretPropertiesVersionsPager(secretName, nil)
 
-	if pager.More() {
-		_, err := pager.NextPage(ctx)
-		if err != nil {
-			if ResourceNotFoundErrorExists(err) {
-				return false, nil
-			}
-
-			return false, err
-		}
-
-		return true, nil
+	if !pager.More() {
+		return false, nil
 	}
 
-	return false, nil
+	if _, err := pager.NextPage(ctx); err != nil {
+		if ResourceNotFoundErrorExists(err) {
+			return false, nil
+		}
+
+		return false, err
+	}
+
+	return true, nil
 }
 
 // KeyVaultSecretExistsE indicates whether a secret exists in the key vault; otherwise false.

--- a/modules/azure/keyvault.go
+++ b/modules/azure/keyvault.go
@@ -96,7 +96,7 @@ func KeyVaultCertificateExistsContextE(ctx context.Context, keyVaultName, certif
 }
 
 // KeyVaultCertificateExistsWithClient indicates whether a certificate exists in the key vault
-// using the provided azcertificates.Client. Useful in unit tests with an azfake-backed client.
+// using the provided azcertificates.Client.
 // The ctx parameter supports cancellation and timeouts.
 func KeyVaultCertificateExistsWithClient(ctx context.Context, client *azcertificates.Client, certificateName string) (bool, error) {
 	pager := client.NewListCertificatePropertiesVersionsPager(certificateName, nil)
@@ -135,7 +135,7 @@ func KeyVaultKeyExistsContextE(ctx context.Context, keyVaultName, keyName string
 }
 
 // KeyVaultKeyExistsWithClient indicates whether a key exists in the key vault using the
-// provided azkeys.Client. Useful in unit tests with an azfake-backed client.
+// provided azkeys.Client.
 // The ctx parameter supports cancellation and timeouts.
 func KeyVaultKeyExistsWithClient(ctx context.Context, client *azkeys.Client, keyName string) (bool, error) {
 	pager := client.NewListKeyPropertiesVersionsPager(keyName, nil)
@@ -174,7 +174,7 @@ func KeyVaultSecretExistsContextE(ctx context.Context, keyVaultName, secretName 
 }
 
 // KeyVaultSecretExistsWithClient indicates whether a secret exists in the key vault using
-// the provided azsecrets.Client. Useful in unit tests with an azfake-backed client.
+// the provided azsecrets.Client.
 // The ctx parameter supports cancellation and timeouts.
 func KeyVaultSecretExistsWithClient(ctx context.Context, client *azsecrets.Client, secretName string) (bool, error) {
 	pager := client.NewListSecretPropertiesVersionsPager(secretName, nil)

--- a/modules/azure/storage.go
+++ b/modules/azure/storage.go
@@ -250,7 +250,7 @@ func StorageAccountExistsContextE(ctx context.Context, storageAccountName, resou
 }
 
 // StorageAccountExistsWithClient indicates whether the storage account exists using the provided
-// AccountsClient. Useful in unit tests with an azfake-backed client.
+// AccountsClient.
 // The ctx parameter supports cancellation and timeouts.
 func StorageAccountExistsWithClient(ctx context.Context, client *armstorage.AccountsClient, storageAccountName, resourceGroupName string) (bool, error) {
 	_, err := FetchStorageAccountProperties(ctx, client, resourceGroupName, storageAccountName)
@@ -303,7 +303,7 @@ func StorageBlobContainerExistsContextE(ctx context.Context, containerName, stor
 }
 
 // StorageBlobContainerExistsWithClient returns true if the container name exists using the
-// provided BlobContainersClient. Useful in unit tests with an azfake-backed client.
+// provided BlobContainersClient.
 // The ctx parameter supports cancellation and timeouts.
 func StorageBlobContainerExistsWithClient(ctx context.Context, client *armstorage.BlobContainersClient, containerName, storageAccountName, resourceGroupName string) (bool, error) {
 	_, err := FetchBlobContainer(ctx, client, resourceGroupName, storageAccountName, containerName)
@@ -334,7 +334,7 @@ func GetStorageBlobContainerPublicAccessContextE(ctx context.Context, containerN
 }
 
 // GetStorageBlobContainerPublicAccessWithClient returns whether the container has public access
-// using the provided BlobContainersClient. Useful in unit tests with an azfake-backed client.
+// using the provided BlobContainersClient.
 // The ctx parameter supports cancellation and timeouts.
 func GetStorageBlobContainerPublicAccessWithClient(ctx context.Context, client *armstorage.BlobContainersClient, containerName, storageAccountName, resourceGroupName string) (bool, error) {
 	container, err := FetchBlobContainer(ctx, client, resourceGroupName, storageAccountName, containerName)
@@ -361,7 +361,7 @@ func GetStorageAccountKindContextE(ctx context.Context, storageAccountName, reso
 }
 
 // GetStorageAccountKindWithClient returns the storage account kind using the provided AccountsClient.
-// Useful in unit tests with an azfake-backed client.
+//
 // The ctx parameter supports cancellation and timeouts.
 func GetStorageAccountKindWithClient(ctx context.Context, client *armstorage.AccountsClient, storageAccountName, resourceGroupName string) (string, error) {
 	storageAccount, err := FetchStorageAccountProperties(ctx, client, resourceGroupName, storageAccountName)
@@ -384,7 +384,7 @@ func GetStorageAccountSkuTierContextE(ctx context.Context, storageAccountName, r
 }
 
 // GetStorageAccountSkuTierWithClient returns the storage account sku tier using the provided
-// AccountsClient. Useful in unit tests with an azfake-backed client.
+// AccountsClient.
 // The ctx parameter supports cancellation and timeouts.
 func GetStorageAccountSkuTierWithClient(ctx context.Context, client *armstorage.AccountsClient, storageAccountName, resourceGroupName string) (string, error) {
 	storageAccount, err := FetchStorageAccountProperties(ctx, client, resourceGroupName, storageAccountName)
@@ -602,7 +602,7 @@ func GetStorageDNSStringContextE(ctx context.Context, storageAccountName, resour
 }
 
 // GetStorageDNSStringWithClient builds and returns the storage account dns string using the provided
-// AccountsClient. Useful in unit tests with an azfake-backed client.
+// AccountsClient.
 // The ctx parameter supports cancellation and timeouts.
 func GetStorageDNSStringWithClient(ctx context.Context, client *armstorage.AccountsClient, storageAccountName, resourceGroupName string) (string, error) {
 	exists, err := StorageAccountExistsWithClient(ctx, client, storageAccountName, resourceGroupName)

--- a/modules/azure/storage.go
+++ b/modules/azure/storage.go
@@ -249,6 +249,22 @@ func StorageAccountExistsContextE(ctx context.Context, storageAccountName, resou
 	return true, nil
 }
 
+// StorageAccountExistsWithClient indicates whether the storage account exists using the provided
+// AccountsClient. Useful in unit tests with an azfake-backed client.
+// The ctx parameter supports cancellation and timeouts.
+func StorageAccountExistsWithClient(ctx context.Context, client *armstorage.AccountsClient, storageAccountName, resourceGroupName string) (bool, error) {
+	_, err := FetchStorageAccountProperties(ctx, client, resourceGroupName, storageAccountName)
+	if err != nil {
+		if ResourceNotFoundErrorExists(err) {
+			return false, nil
+		}
+
+		return false, err
+	}
+
+	return true, nil
+}
+
 // GetStorageAccountContextE gets a storage account; otherwise error.
 // See https://docs.microsoft.com/rest/api/storagerp/storageaccounts/getproperties for more information.
 // The ctx parameter supports cancellation and timeouts.
@@ -286,10 +302,42 @@ func StorageBlobContainerExistsContextE(ctx context.Context, containerName, stor
 	return true, nil
 }
 
+// StorageBlobContainerExistsWithClient returns true if the container name exists using the
+// provided BlobContainersClient. Useful in unit tests with an azfake-backed client.
+// The ctx parameter supports cancellation and timeouts.
+func StorageBlobContainerExistsWithClient(ctx context.Context, client *armstorage.BlobContainersClient, containerName, storageAccountName, resourceGroupName string) (bool, error) {
+	_, err := FetchBlobContainer(ctx, client, resourceGroupName, storageAccountName, containerName)
+	if err != nil {
+		if ResourceNotFoundErrorExists(err) {
+			return false, nil
+		}
+
+		return false, err
+	}
+
+	return true, nil
+}
+
 // GetStorageBlobContainerPublicAccessContextE indicates whether a storage container has public access; otherwise false.
 // The ctx parameter supports cancellation and timeouts.
 func GetStorageBlobContainerPublicAccessContextE(ctx context.Context, containerName, storageAccountName, resourceGroupName, subscriptionID string) (bool, error) {
 	container, err := GetStorageBlobContainerContextE(ctx, containerName, storageAccountName, resourceGroupName, subscriptionID)
+	if err != nil {
+		if ResourceNotFoundErrorExists(err) {
+			return false, nil
+		}
+
+		return false, err
+	}
+
+	return ExtractBlobContainerPublicAccess(container), nil
+}
+
+// GetStorageBlobContainerPublicAccessWithClient returns whether the container has public access
+// using the provided BlobContainersClient. Useful in unit tests with an azfake-backed client.
+// The ctx parameter supports cancellation and timeouts.
+func GetStorageBlobContainerPublicAccessWithClient(ctx context.Context, client *armstorage.BlobContainersClient, containerName, storageAccountName, resourceGroupName string) (bool, error) {
+	container, err := FetchBlobContainer(ctx, client, resourceGroupName, storageAccountName, containerName)
 	if err != nil {
 		if ResourceNotFoundErrorExists(err) {
 			return false, nil
@@ -312,10 +360,34 @@ func GetStorageAccountKindContextE(ctx context.Context, storageAccountName, reso
 	return ExtractStorageAccountKind(storageAccount), nil
 }
 
+// GetStorageAccountKindWithClient returns the storage account kind using the provided AccountsClient.
+// Useful in unit tests with an azfake-backed client.
+// The ctx parameter supports cancellation and timeouts.
+func GetStorageAccountKindWithClient(ctx context.Context, client *armstorage.AccountsClient, storageAccountName, resourceGroupName string) (string, error) {
+	storageAccount, err := FetchStorageAccountProperties(ctx, client, resourceGroupName, storageAccountName)
+	if err != nil {
+		return "", err
+	}
+
+	return ExtractStorageAccountKind(storageAccount), nil
+}
+
 // GetStorageAccountSkuTierContextE returns the storage account sku tier as Standard or Premium.
 // The ctx parameter supports cancellation and timeouts.
 func GetStorageAccountSkuTierContextE(ctx context.Context, storageAccountName, resourceGroupName, subscriptionID string) (string, error) {
 	storageAccount, err := GetStorageAccountPropertyContextE(ctx, storageAccountName, resourceGroupName, subscriptionID)
+	if err != nil {
+		return "", err
+	}
+
+	return ExtractStorageAccountSkuTier(storageAccount), nil
+}
+
+// GetStorageAccountSkuTierWithClient returns the storage account sku tier using the provided
+// AccountsClient. Useful in unit tests with an azfake-backed client.
+// The ctx parameter supports cancellation and timeouts.
+func GetStorageAccountSkuTierWithClient(ctx context.Context, client *armstorage.AccountsClient, storageAccountName, resourceGroupName string) (string, error) {
+	storageAccount, err := FetchStorageAccountProperties(ctx, client, resourceGroupName, storageAccountName)
 	if err != nil {
 		return "", err
 	}
@@ -527,4 +599,25 @@ func GetStorageDNSStringContextE(ctx context.Context, storageAccountName, resour
 	}
 
 	return "", NewNotFoundError("storage account", storageAccountName, "")
+}
+
+// GetStorageDNSStringWithClient builds and returns the storage account dns string using the provided
+// AccountsClient. Useful in unit tests with an azfake-backed client.
+// The ctx parameter supports cancellation and timeouts.
+func GetStorageDNSStringWithClient(ctx context.Context, client *armstorage.AccountsClient, storageAccountName, resourceGroupName string) (string, error) {
+	exists, err := StorageAccountExistsWithClient(ctx, client, storageAccountName, resourceGroupName)
+	if err != nil {
+		return "", err
+	}
+
+	if !exists {
+		return "", NewNotFoundError("storage account", storageAccountName, "")
+	}
+
+	storageSuffix, err := GetStorageURISuffixE() //nolint:contextcheck
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("https://%s.blob.%s/", storageAccountName, storageSuffix), nil
 }


### PR DESCRIPTION
## Summary
Closes the gap between the v1 release notes' mockability promise and the actual API surface. Adds 9 `*WithClient` siblings on Azure helpers that previously had `*ContextE` coverage but no client-injection variant.

`modules/azure/keyvault.go`:
- `KeyVaultCertificateExistsWithClient`
- `KeyVaultKeyExistsWithClient`
- `KeyVaultSecretExistsWithClient`

`modules/azure/storage.go`:
- `StorageAccountExistsWithClient`
- `StorageBlobContainerExistsWithClient`
- `GetStorageBlobContainerPublicAccessWithClient`
- `GetStorageAccountKindWithClient`
- `GetStorageAccountSkuTierWithClient`
- `GetStorageDNSStringWithClient`

Existing `*ContextE` wrappers route through the new functions where convenient.

Closes OSS-3457.

## Test plan
- [x] `go build ./modules/azure/...` passes
- [ ] Azure integration + unit tests