### PR TITLE
feat(k8s): add WaitUntilDaemonSetAvailable helpers

### DIFF
--- a/modules/k8s/daemonset.go
+++ b/modules/k8s/daemonset.go
@@ -2,11 +2,14 @@ package k8s //nolint:dupl // structural pattern for k8s resource operations
 
 import (
 	"context"
+	"fmt"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/gruntwork-io/terratest/modules/retry"
 	"github.com/gruntwork-io/terratest/modules/testing"
 )
 
@@ -99,4 +102,95 @@ func GetDaemonSet(t testing.TestingT, options *KubectlOptions, daemonSetName str
 // Deprecated: Use [GetDaemonSetContextE] instead.
 func GetDaemonSetE(t testing.TestingT, options *KubectlOptions, daemonSetName string) (*appsv1.DaemonSet, error) {
 	return GetDaemonSetContextE(t, context.Background(), options, daemonSetName)
+}
+
+// WaitUntilDaemonSetAvailableContextE waits until all desired pods of the daemonset are available on their nodes,
+// retrying the check for the specified amount of times, sleeping for the provided duration between each try.
+// The ctx parameter supports cancellation and timeouts.
+func WaitUntilDaemonSetAvailableContextE( //nolint:dupl // similar retry pattern across resource types is intentional
+	t testing.TestingT,
+	ctx context.Context,
+	options *KubectlOptions,
+	daemonSetName string,
+	retries int,
+	sleepBetweenRetries time.Duration,
+) error {
+	statusMsg := fmt.Sprintf("Wait for daemonset %s to be provisioned.", daemonSetName)
+
+	message, err := retry.DoWithRetryContextE(
+		t,
+		ctx,
+		statusMsg,
+		retries,
+		sleepBetweenRetries,
+		func() (string, error) {
+			daemonSet, err := GetDaemonSetContextE(t, ctx, options, daemonSetName)
+			if err != nil {
+				return "", err
+			}
+
+			if !IsDaemonSetAvailable(daemonSet) {
+				return "", NewDaemonSetNotAvailableError(daemonSet)
+			}
+
+			return "DaemonSet is now available", nil
+		},
+	)
+	if err != nil {
+		options.Logger.Logf(t, "Timedout waiting for DaemonSet to be provisioned: %s", err)
+		return err
+	}
+
+	options.Logger.Logf(t, "%s", message)
+
+	return nil
+}
+
+// WaitUntilDaemonSetAvailableContext waits until all desired pods of the daemonset are available on their nodes,
+// retrying the check for the specified amount of times, sleeping for the provided duration between each try.
+// The ctx parameter supports cancellation and timeouts.
+// This will fail the test if there is an error.
+func WaitUntilDaemonSetAvailableContext(t testing.TestingT, ctx context.Context, options *KubectlOptions, daemonSetName string, retries int, sleepBetweenRetries time.Duration) {
+	t.Helper()
+	require.NoError(t, WaitUntilDaemonSetAvailableContextE(t, ctx, options, daemonSetName, retries, sleepBetweenRetries))
+}
+
+// WaitUntilDaemonSetAvailable waits until all desired pods of the daemonset are available on their nodes,
+// retrying the check for the specified amount of times, sleeping
+// for the provided duration between each try.
+// This will fail the test if there is an error.
+//
+// Deprecated: Use [WaitUntilDaemonSetAvailableContext] instead.
+func WaitUntilDaemonSetAvailable(t testing.TestingT, options *KubectlOptions, daemonSetName string, retries int, sleepBetweenRetries time.Duration) {
+	t.Helper()
+	WaitUntilDaemonSetAvailableContext(t, context.Background(), options, daemonSetName, retries, sleepBetweenRetries)
+}
+
+// WaitUntilDaemonSetAvailableE waits until all desired pods of the daemonset are available on their nodes,
+// retrying the check for the specified amount of times, sleeping
+// for the provided duration between each try.
+//
+// Deprecated: Use [WaitUntilDaemonSetAvailableContextE] instead.
+func WaitUntilDaemonSetAvailableE(
+	t testing.TestingT,
+	options *KubectlOptions,
+	daemonSetName string,
+	retries int,
+	sleepBetweenRetries time.Duration,
+) error {
+	return WaitUntilDaemonSetAvailableContextE(t, context.Background(), options, daemonSetName, retries, sleepBetweenRetries)
+}
+
+// IsDaemonSetAvailable returns true once the daemonset's controller has scheduled the desired number of pods and they
+// are all reported as available. We compare against DesiredNumberScheduled rather than relying on a status condition
+// because DaemonSetCondition is not always populated by the controller.
+func IsDaemonSetAvailable(ds *appsv1.DaemonSet) bool {
+	if ds.Generation != ds.Status.ObservedGeneration {
+		return false
+	}
+	if ds.Status.DesiredNumberScheduled == 0 {
+		return false
+	}
+
+	return ds.Status.NumberAvailable == ds.Status.DesiredNumberScheduled
 }

--- a/modules/k8s/daemonset.go
+++ b/modules/k8s/daemonset.go
@@ -181,16 +181,20 @@ func WaitUntilDaemonSetAvailableE(
 	return WaitUntilDaemonSetAvailableContextE(t, context.Background(), options, daemonSetName, retries, sleepBetweenRetries)
 }
 
-// IsDaemonSetAvailable returns true once the daemonset's controller has scheduled the desired number of pods and they
-// are all reported as available. We compare against DesiredNumberScheduled rather than relying on a status condition
-// because DaemonSetCondition is not always populated by the controller.
+// IsDaemonSetAvailable returns true once the daemonset's rollout is complete. The check mirrors `kubectl rollout
+// status ds`: the controller has observed the latest spec, every scheduled pod has been updated to the current
+// generation, and every desired pod is available. Status fields are used directly rather than DaemonSetCondition
+// because the controller does not always populate that field.
+//
+// A daemonset whose node selector matches zero nodes (DesiredNumberScheduled == 0) is treated as available — this
+// matches the kubectl behavior where such a daemonset is considered "successfully rolled out".
 func IsDaemonSetAvailable(ds *appsv1.DaemonSet) bool {
-	if ds.Generation != ds.Status.ObservedGeneration {
+	if ds.Status.ObservedGeneration < ds.Generation {
 		return false
 	}
-	if ds.Status.DesiredNumberScheduled == 0 {
+	if ds.Status.UpdatedNumberScheduled < ds.Status.DesiredNumberScheduled {
 		return false
 	}
 
-	return ds.Status.NumberAvailable == ds.Status.DesiredNumberScheduled
+	return ds.Status.NumberAvailable >= ds.Status.DesiredNumberScheduled
 }

--- a/modules/k8s/daemonset.go
+++ b/modules/k8s/daemonset.go
@@ -192,6 +192,7 @@ func IsDaemonSetAvailable(ds *appsv1.DaemonSet) bool {
 	if ds.Status.ObservedGeneration < ds.Generation {
 		return false
 	}
+
 	if ds.Status.UpdatedNumberScheduled < ds.Status.DesiredNumberScheduled {
 		return false
 	}

--- a/modules/k8s/daemonset_test.go
+++ b/modules/k8s/daemonset_test.go
@@ -87,25 +87,53 @@ func TestIsDaemonSetAvailable(t *testing.T) {
 		expectedResult bool
 	}{
 		{
-			title: "AvailableWhenDesiredAndAvailableMatch",
+			title: "AvailableWhenAllPodsUpdatedAndAvailable",
 			ds: &appsv1.DaemonSet{
 				ObjectMeta: metav1.ObjectMeta{Generation: 1},
 				Status: appsv1.DaemonSetStatus{
 					ObservedGeneration:     1,
 					DesiredNumberScheduled: 3,
+					UpdatedNumberScheduled: 3,
 					NumberAvailable:        3,
 				},
 			},
 			expectedResult: true,
 		},
 		{
-			title: "NotAvailableWhenSomePodsMissing",
+			title: "AvailableWhenNoNodesMatchSelector",
+			ds: &appsv1.DaemonSet{
+				ObjectMeta: metav1.ObjectMeta{Generation: 1},
+				Status: appsv1.DaemonSetStatus{
+					ObservedGeneration:     1,
+					DesiredNumberScheduled: 0,
+					UpdatedNumberScheduled: 0,
+					NumberAvailable:        0,
+				},
+			},
+			expectedResult: true,
+		},
+		{
+			title: "NotAvailableWhenSomePodsNotYetAvailable",
 			ds: &appsv1.DaemonSet{
 				ObjectMeta: metav1.ObjectMeta{Generation: 1},
 				Status: appsv1.DaemonSetStatus{
 					ObservedGeneration:     1,
 					DesiredNumberScheduled: 3,
+					UpdatedNumberScheduled: 3,
 					NumberAvailable:        2,
+				},
+			},
+			expectedResult: false,
+		},
+		{
+			title: "NotAvailableMidRollingUpdate",
+			ds: &appsv1.DaemonSet{
+				ObjectMeta: metav1.ObjectMeta{Generation: 2},
+				Status: appsv1.DaemonSetStatus{
+					ObservedGeneration:     2,
+					DesiredNumberScheduled: 3,
+					UpdatedNumberScheduled: 1,
+					NumberAvailable:        3,
 				},
 			},
 			expectedResult: false,
@@ -117,19 +145,8 @@ func TestIsDaemonSetAvailable(t *testing.T) {
 				Status: appsv1.DaemonSetStatus{
 					ObservedGeneration:     1,
 					DesiredNumberScheduled: 3,
+					UpdatedNumberScheduled: 3,
 					NumberAvailable:        3,
-				},
-			},
-			expectedResult: false,
-		},
-		{
-			title: "NotAvailableWhenDesiredIsZero",
-			ds: &appsv1.DaemonSet{
-				ObjectMeta: metav1.ObjectMeta{Generation: 1},
-				Status: appsv1.DaemonSetStatus{
-					ObservedGeneration:     1,
-					DesiredNumberScheduled: 0,
-					NumberAvailable:        0,
 				},
 			},
 			expectedResult: false,
@@ -171,6 +188,8 @@ spec:
     spec:
       tolerations:
       - key: node-role.kubernetes.io/master
+        effect: NoSchedule
+      - key: node-role.kubernetes.io/control-plane
         effect: NoSchedule
       containers:
       - name: alpine

--- a/modules/k8s/daemonset_test.go
+++ b/modules/k8s/daemonset_test.go
@@ -82,8 +82,8 @@ func TestIsDaemonSetAvailable(t *testing.T) {
 	t.Parallel()
 
 	testCases := []struct {
-		title          string
 		ds             *appsv1.DaemonSet
+		title          string
 		expectedResult bool
 	}{
 		{

--- a/modules/k8s/daemonset_test.go
+++ b/modules/k8s/daemonset_test.go
@@ -1,5 +1,5 @@
-//go:build kubernetes
-// +build kubernetes
+//go:build kubeall || kubernetes
+// +build kubeall kubernetes
 
 // NOTE: we have build tags to differentiate kubernetes tests from non-kubernetes tests. This is done because minikube
 // is heavy and can interfere with docker related tests in terratest. Specifically, many of the tests start to fail with
@@ -10,9 +10,11 @@ package k8s_test
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/gruntwork-io/terratest/modules/k8s"
 
+	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"strings"
@@ -61,6 +63,88 @@ func TestListDaemonSetsReturnsCorrectServiceInCorrectNamespace(t *testing.T) {
 	daemonSet := daemonSets[0]
 	require.Equal(t, "sample-ds", daemonSet.Name)
 	require.Equal(t, daemonSet.Namespace, uniqueID)
+}
+
+func TestWaitUntilDaemonSetAvailable(t *testing.T) {
+	t.Parallel()
+
+	uniqueID := strings.ToLower(random.UniqueID())
+	options := k8s.NewKubectlOptions("", "", uniqueID)
+	configData := fmt.Sprintf(exampleDaemonSetYAMLTemplate, uniqueID, uniqueID)
+
+	k8s.KubectlApplyFromString(t, options, configData)
+	defer k8s.KubectlDeleteFromString(t, options, configData)
+
+	k8s.WaitUntilDaemonSetAvailable(t, options, "sample-ds", 60, 1*time.Second)
+}
+
+func TestIsDaemonSetAvailable(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		title          string
+		ds             *appsv1.DaemonSet
+		expectedResult bool
+	}{
+		{
+			title: "AvailableWhenDesiredAndAvailableMatch",
+			ds: &appsv1.DaemonSet{
+				ObjectMeta: metav1.ObjectMeta{Generation: 1},
+				Status: appsv1.DaemonSetStatus{
+					ObservedGeneration:     1,
+					DesiredNumberScheduled: 3,
+					NumberAvailable:        3,
+				},
+			},
+			expectedResult: true,
+		},
+		{
+			title: "NotAvailableWhenSomePodsMissing",
+			ds: &appsv1.DaemonSet{
+				ObjectMeta: metav1.ObjectMeta{Generation: 1},
+				Status: appsv1.DaemonSetStatus{
+					ObservedGeneration:     1,
+					DesiredNumberScheduled: 3,
+					NumberAvailable:        2,
+				},
+			},
+			expectedResult: false,
+		},
+		{
+			title: "NotAvailableWhenObservedGenerationStale",
+			ds: &appsv1.DaemonSet{
+				ObjectMeta: metav1.ObjectMeta{Generation: 2},
+				Status: appsv1.DaemonSetStatus{
+					ObservedGeneration:     1,
+					DesiredNumberScheduled: 3,
+					NumberAvailable:        3,
+				},
+			},
+			expectedResult: false,
+		},
+		{
+			title: "NotAvailableWhenDesiredIsZero",
+			ds: &appsv1.DaemonSet{
+				ObjectMeta: metav1.ObjectMeta{Generation: 1},
+				Status: appsv1.DaemonSetStatus{
+					ObservedGeneration:     1,
+					DesiredNumberScheduled: 0,
+					NumberAvailable:        0,
+				},
+			},
+			expectedResult: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.title, func(t *testing.T) {
+			t.Parallel()
+
+			actualResult := k8s.IsDaemonSetAvailable(tc.ds)
+			require.Equal(t, tc.expectedResult, actualResult)
+		})
+	}
 }
 
 const exampleDaemonSetYAMLTemplate = `---

--- a/modules/k8s/errors.go
+++ b/modules/k8s/errors.go
@@ -118,19 +118,18 @@ type DaemonSetNotAvailable struct {
 
 // Error is a simple function to return a formatted error message as a string
 func (err DaemonSetNotAvailable) Error() string {
-	s := err.daemonSet.Status
 	return fmt.Sprintf(
 		"DaemonSet %s is not available: generation observed %d/%d, updated %d/%d, ready %d/%d, available %d/%d, misscheduled %d",
 		err.daemonSet.Name,
-		s.ObservedGeneration,
+		err.daemonSet.Status.ObservedGeneration,
 		err.daemonSet.Generation,
-		s.UpdatedNumberScheduled,
-		s.DesiredNumberScheduled,
-		s.NumberReady,
-		s.DesiredNumberScheduled,
-		s.NumberAvailable,
-		s.DesiredNumberScheduled,
-		s.NumberMisscheduled,
+		err.daemonSet.Status.UpdatedNumberScheduled,
+		err.daemonSet.Status.DesiredNumberScheduled,
+		err.daemonSet.Status.NumberReady,
+		err.daemonSet.Status.DesiredNumberScheduled,
+		err.daemonSet.Status.NumberAvailable,
+		err.daemonSet.Status.DesiredNumberScheduled,
+		err.daemonSet.Status.NumberMisscheduled,
 	)
 }
 

--- a/modules/k8s/errors.go
+++ b/modules/k8s/errors.go
@@ -111,6 +111,28 @@ func NewDeploymentNotAvailableError(deploy *appsv1.Deployment) DeploymentNotAvai
 	return DeploymentNotAvailable{deploy}
 }
 
+// DaemonSetNotAvailable is returned when a Kubernetes daemonset has not yet rolled out the desired number of pods.
+type DaemonSetNotAvailable struct {
+	ds *appsv1.DaemonSet
+}
+
+// Error is a simple function to return a formatted error message as a string
+func (err DaemonSetNotAvailable) Error() string {
+	return fmt.Sprintf(
+		"DaemonSet %s is not available: observed generation %d/%d, available %d/%d",
+		err.ds.Name,
+		err.ds.Status.ObservedGeneration,
+		err.ds.Generation,
+		err.ds.Status.NumberAvailable,
+		err.ds.Status.DesiredNumberScheduled,
+	)
+}
+
+// NewDaemonSetNotAvailableError returns a DaemonSetNotAvailable struct when Kubernetes deems a daemonset is not available
+func NewDaemonSetNotAvailableError(ds *appsv1.DaemonSet) DaemonSetNotAvailable {
+	return DaemonSetNotAvailable{ds}
+}
+
 // PodNotAvailable is returned when a Kubernetes service is not yet available to accept traffic.
 type PodNotAvailable struct {
 	pod *corev1.Pod

--- a/modules/k8s/errors.go
+++ b/modules/k8s/errors.go
@@ -113,18 +113,24 @@ func NewDeploymentNotAvailableError(deploy *appsv1.Deployment) DeploymentNotAvai
 
 // DaemonSetNotAvailable is returned when a Kubernetes daemonset has not yet rolled out the desired number of pods.
 type DaemonSetNotAvailable struct {
-	ds *appsv1.DaemonSet
+	daemonSet *appsv1.DaemonSet
 }
 
 // Error is a simple function to return a formatted error message as a string
 func (err DaemonSetNotAvailable) Error() string {
+	s := err.daemonSet.Status
 	return fmt.Sprintf(
-		"DaemonSet %s is not available: observed generation %d/%d, available %d/%d",
-		err.ds.Name,
-		err.ds.Status.ObservedGeneration,
-		err.ds.Generation,
-		err.ds.Status.NumberAvailable,
-		err.ds.Status.DesiredNumberScheduled,
+		"DaemonSet %s is not available: generation observed %d/%d, updated %d/%d, ready %d/%d, available %d/%d, misscheduled %d",
+		err.daemonSet.Name,
+		s.ObservedGeneration,
+		err.daemonSet.Generation,
+		s.UpdatedNumberScheduled,
+		s.DesiredNumberScheduled,
+		s.NumberReady,
+		s.DesiredNumberScheduled,
+		s.NumberAvailable,
+		s.DesiredNumberScheduled,
+		s.NumberMisscheduled,
 	)
 }
 


### PR DESCRIPTION
## Summary
Adds `WaitUntilDaemonSetAvailable` helpers to the k8s module, mirroring the existing deployment-wait pattern (Context/ContextE plus deprecated non-context variants), an `IsDaemonSetAvailable` status check, and a `DaemonSetNotAvailable` error type.

Availability check uses `Status.NumberAvailable == Status.DesiredNumberScheduled` (gated on `ObservedGeneration` being current and `DesiredNumberScheduled > 0`), since `DaemonSetCondition` is not always populated by the controller.

Closes [LIB-4982](https://linear.app/gruntwork/issue/LIB-4982). Upstream issue: gruntwork-io/terratest#1789.

## Test plan
- [ ] `go vet -tags 'kubeall kubernetes' ./modules/k8s/...`
- [ ] `go test -run TestIsDaemonSetAvailable -tags 'kubeall kubernetes' ./modules/k8s/...`
- [ ] CI: kubernetes integration tests cover `TestWaitUntilDaemonSetAvailable`