### PR TITLE
feat(aws): add AssertS3BucketServerSideEncryption helpers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -92,6 +92,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sqs v1.42.26
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.68.5
 	github.com/aws/aws-sdk-go-v2/service/sts v1.42.0
+	github.com/aws/smithy-go v1.25.0
 	github.com/gonvenience/ytbx v1.4.4
 	github.com/hashicorp/go-getter/v2 v2.2.3
 	github.com/homeport/dyff v1.6.0
@@ -136,7 +137,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/signin v1.0.10 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.30.16 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.20 // indirect
-	github.com/aws/smithy-go v1.25.0 // indirect
 	github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d // indirect
 	github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/modules/aws/errors.go
+++ b/modules/aws/errors.go
@@ -2,6 +2,8 @@ package aws
 
 import (
 	"fmt"
+
+	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
 )
 
 // IpForEc2InstanceNotFound is an error that occurs when the IP for an EC2 instance is not found.
@@ -110,6 +112,46 @@ func (err NoBucketPolicyError) Error() string {
 // bucket, region, and bucket policy.
 func NewNoBucketPolicyError(s3BucketName string, awsRegion string, bucketPolicy string) NoBucketPolicyError {
 	return NoBucketPolicyError{s3BucketName: s3BucketName, awsRegion: awsRegion, bucketPolicy: bucketPolicy}
+}
+
+// BucketServerSideEncryptionNotEnabledError is returned when an S3 bucket that should have server-side encryption with
+// the expected algorithm is not configured to do so.
+type BucketServerSideEncryptionNotEnabledError struct {
+	s3BucketName      string
+	awsRegion         string
+	expectedAlgorithm s3types.ServerSideEncryption
+	observedAlgorithm s3types.ServerSideEncryption
+}
+
+func (err BucketServerSideEncryptionNotEnabledError) Error() string {
+	if err.observedAlgorithm == "" {
+		return fmt.Sprintf(
+			"Server-side encryption with algorithm %s is not enabled for bucket %s in region %s",
+			err.expectedAlgorithm,
+			err.s3BucketName,
+			err.awsRegion,
+		)
+	}
+
+	return fmt.Sprintf(
+		"Server-side encryption for bucket %s in region %s uses algorithm %s, expected %s",
+		err.s3BucketName,
+		err.awsRegion,
+		err.observedAlgorithm,
+		err.expectedAlgorithm,
+	)
+}
+
+// NewBucketServerSideEncryptionNotEnabledError returns a [BucketServerSideEncryptionNotEnabledError] for the given S3
+// bucket, region, and expected/observed SSE algorithms. Pass an empty observed algorithm when no default-encryption
+// rule was found.
+func NewBucketServerSideEncryptionNotEnabledError(s3BucketName string, awsRegion string, expectedAlgorithm s3types.ServerSideEncryption, observedAlgorithm s3types.ServerSideEncryption) BucketServerSideEncryptionNotEnabledError {
+	return BucketServerSideEncryptionNotEnabledError{
+		s3BucketName:      s3BucketName,
+		awsRegion:         awsRegion,
+		expectedAlgorithm: expectedAlgorithm,
+		observedAlgorithm: observedAlgorithm,
+	}
 }
 
 // NoInstanceTypeError is returned when none of the given instance type options are available in all AZs in a region

--- a/modules/aws/errors.go
+++ b/modules/aws/errors.go
@@ -120,37 +120,24 @@ type BucketServerSideEncryptionNotEnabledError struct {
 	s3BucketName      string
 	awsRegion         string
 	expectedAlgorithm s3types.ServerSideEncryption
-	observedAlgorithm s3types.ServerSideEncryption
 }
 
 func (err BucketServerSideEncryptionNotEnabledError) Error() string {
-	if err.observedAlgorithm == "" {
-		return fmt.Sprintf(
-			"Server-side encryption with algorithm %s is not enabled for bucket %s in region %s",
-			err.expectedAlgorithm,
-			err.s3BucketName,
-			err.awsRegion,
-		)
-	}
-
 	return fmt.Sprintf(
-		"Server-side encryption for bucket %s in region %s uses algorithm %s, expected %s",
+		"Server-side encryption with algorithm %s is not enabled for bucket %s in region %s",
+		err.expectedAlgorithm,
 		err.s3BucketName,
 		err.awsRegion,
-		err.observedAlgorithm,
-		err.expectedAlgorithm,
 	)
 }
 
 // NewBucketServerSideEncryptionNotEnabledError returns a [BucketServerSideEncryptionNotEnabledError] for the given S3
-// bucket, region, and expected/observed SSE algorithms. Pass an empty observed algorithm when no default-encryption
-// rule was found.
-func NewBucketServerSideEncryptionNotEnabledError(s3BucketName string, awsRegion string, expectedAlgorithm s3types.ServerSideEncryption, observedAlgorithm s3types.ServerSideEncryption) BucketServerSideEncryptionNotEnabledError {
+// bucket, region, and expected SSE algorithm.
+func NewBucketServerSideEncryptionNotEnabledError(s3BucketName string, awsRegion string, expectedAlgorithm s3types.ServerSideEncryption) BucketServerSideEncryptionNotEnabledError {
 	return BucketServerSideEncryptionNotEnabledError{
 		s3BucketName:      s3BucketName,
 		awsRegion:         awsRegion,
 		expectedAlgorithm: expectedAlgorithm,
-		observedAlgorithm: observedAlgorithm,
 	}
 }
 

--- a/modules/aws/s3.go
+++ b/modules/aws/s3.go
@@ -912,6 +912,64 @@ func AssertS3BucketPolicyExistsE(t testing.TestingT, region string, bucketName s
 	return AssertS3BucketPolicyExistsContextE(t, context.Background(), region, bucketName)
 }
 
+// AssertS3BucketServerSideEncryptionContextE checks if the given S3 bucket has server-side encryption configured with
+// the given algorithm, and returns an error if it does not. The ctx parameter supports cancellation and timeouts.
+func AssertS3BucketServerSideEncryptionContextE(t testing.TestingT, ctx context.Context, region string, bucketName string, algorithm types.ServerSideEncryption) error {
+	s3Client, err := NewS3ClientContextE(t, ctx, region)
+	if err != nil {
+		return err
+	}
+
+	out, err := s3Client.GetBucketEncryption(ctx, &s3.GetBucketEncryptionInput{
+		Bucket: aws.String(bucketName),
+	})
+	if err != nil {
+		return err
+	}
+
+	if out.ServerSideEncryptionConfiguration == nil {
+		return NewBucketServerSideEncryptionNotEnabledError(bucketName, region, algorithm, "")
+	}
+
+	for _, rule := range out.ServerSideEncryptionConfiguration.Rules {
+		if rule.ApplyServerSideEncryptionByDefault == nil {
+			continue
+		}
+		if rule.ApplyServerSideEncryptionByDefault.SSEAlgorithm == algorithm {
+			return nil
+		}
+	}
+
+	return NewBucketServerSideEncryptionNotEnabledError(bucketName, region, algorithm, "")
+}
+
+// AssertS3BucketServerSideEncryptionContext checks if the given S3 bucket has server-side encryption configured with
+// the given algorithm, and fails the test if it does not. The ctx parameter supports cancellation and timeouts.
+func AssertS3BucketServerSideEncryptionContext(t testing.TestingT, ctx context.Context, region string, bucketName string, algorithm types.ServerSideEncryption) {
+	t.Helper()
+
+	err := AssertS3BucketServerSideEncryptionContextE(t, ctx, region, bucketName, algorithm)
+	require.NoError(t, err)
+}
+
+// AssertS3BucketServerSideEncryption checks if the given S3 bucket has server-side encryption configured with the
+// given algorithm and fails the test if it does not.
+//
+// Deprecated: Use [AssertS3BucketServerSideEncryptionContext] instead.
+func AssertS3BucketServerSideEncryption(t testing.TestingT, region string, bucketName string, algorithm types.ServerSideEncryption) {
+	t.Helper()
+
+	AssertS3BucketServerSideEncryptionContext(t, context.Background(), region, bucketName, algorithm)
+}
+
+// AssertS3BucketServerSideEncryptionE checks if the given S3 bucket has server-side encryption configured with the
+// given algorithm and returns an error if it does not.
+//
+// Deprecated: Use [AssertS3BucketServerSideEncryptionContextE] instead.
+func AssertS3BucketServerSideEncryptionE(t testing.TestingT, region string, bucketName string, algorithm types.ServerSideEncryption) error {
+	return AssertS3BucketServerSideEncryptionContextE(t, context.Background(), region, bucketName, algorithm)
+}
+
 // NewS3ClientContextE creates an S3 client.
 // The ctx parameter supports cancellation and timeouts.
 func NewS3ClientContextE(t testing.TestingT, ctx context.Context, region string) (*s3.Client, error) {

--- a/modules/aws/s3.go
+++ b/modules/aws/s3.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -11,6 +12,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+	smithy "github.com/aws/smithy-go"
 	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/testing"
 	"github.com/stretchr/testify/require"
@@ -914,6 +916,9 @@ func AssertS3BucketPolicyExistsE(t testing.TestingT, region string, bucketName s
 
 // AssertS3BucketServerSideEncryptionContextE checks if the given S3 bucket has server-side encryption configured with
 // the given algorithm, and returns an error if it does not. The ctx parameter supports cancellation and timeouts.
+//
+// The algorithm is matched exactly: an expectation of `aws:kms` will not match a bucket configured with
+// `aws:kms:dsse`, and vice versa.
 func AssertS3BucketServerSideEncryptionContextE(t testing.TestingT, ctx context.Context, region string, bucketName string, algorithm types.ServerSideEncryption) error {
 	s3Client, err := NewS3ClientContextE(t, ctx, region)
 	if err != nil {
@@ -924,11 +929,17 @@ func AssertS3BucketServerSideEncryptionContextE(t testing.TestingT, ctx context.
 		Bucket: aws.String(bucketName),
 	})
 	if err != nil {
+		// A bucket with no SSE configuration surfaces as ServerSideEncryptionConfigurationNotFoundError. Translate
+		// that to our typed error so callers can match on the failure mode regardless of SDK version.
+		var apiErr smithy.APIError
+		if errors.As(err, &apiErr) && apiErr.ErrorCode() == "ServerSideEncryptionConfigurationNotFoundError" {
+			return NewBucketServerSideEncryptionNotEnabledError(bucketName, region, algorithm)
+		}
 		return err
 	}
 
 	if out.ServerSideEncryptionConfiguration == nil {
-		return NewBucketServerSideEncryptionNotEnabledError(bucketName, region, algorithm, "")
+		return NewBucketServerSideEncryptionNotEnabledError(bucketName, region, algorithm)
 	}
 
 	for _, rule := range out.ServerSideEncryptionConfiguration.Rules {
@@ -940,7 +951,7 @@ func AssertS3BucketServerSideEncryptionContextE(t testing.TestingT, ctx context.
 		}
 	}
 
-	return NewBucketServerSideEncryptionNotEnabledError(bucketName, region, algorithm, "")
+	return NewBucketServerSideEncryptionNotEnabledError(bucketName, region, algorithm)
 }
 
 // AssertS3BucketServerSideEncryptionContext checks if the given S3 bucket has server-side encryption configured with

--- a/modules/aws/s3.go
+++ b/modules/aws/s3.go
@@ -935,6 +935,7 @@ func AssertS3BucketServerSideEncryptionContextE(t testing.TestingT, ctx context.
 		if errors.As(err, &apiErr) && apiErr.ErrorCode() == "ServerSideEncryptionConfigurationNotFoundError" {
 			return NewBucketServerSideEncryptionNotEnabledError(bucketName, region, algorithm)
 		}
+
 		return err
 	}
 
@@ -946,6 +947,7 @@ func AssertS3BucketServerSideEncryptionContextE(t testing.TestingT, ctx context.
 		if rule.ApplyServerSideEncryptionByDefault == nil {
 			continue
 		}
+
 		if rule.ApplyServerSideEncryptionByDefault.SSEAlgorithm == algorithm {
 			return nil
 		}

--- a/modules/aws/s3_test.go
+++ b/modules/aws/s3_test.go
@@ -368,8 +368,10 @@ func TestAssertS3BucketServerSideEncryption(t *testing.T) {
 			if algorithm == types.ServerSideEncryptionAwsKms {
 				otherAlgorithm = types.ServerSideEncryptionAes256
 			}
-			err = terraaws.AssertS3BucketServerSideEncryptionE(t, region, s3BucketName, otherAlgorithm)
+
 			var notEnabled terraaws.BucketServerSideEncryptionNotEnabledError
+
+			err = terraaws.AssertS3BucketServerSideEncryptionE(t, region, s3BucketName, otherAlgorithm)
 			require.ErrorAs(t, err, &notEnabled)
 		})
 	}

--- a/modules/aws/s3_test.go
+++ b/modules/aws/s3_test.go
@@ -369,7 +369,8 @@ func TestAssertS3BucketServerSideEncryption(t *testing.T) {
 				otherAlgorithm = types.ServerSideEncryptionAes256
 			}
 			err = terraaws.AssertS3BucketServerSideEncryptionE(t, region, s3BucketName, otherAlgorithm)
-			assert.Error(t, err)
+			var notEnabled terraaws.BucketServerSideEncryptionNotEnabledError
+			require.ErrorAs(t, err, &notEnabled)
 		})
 	}
 }

--- a/modules/aws/s3_test.go
+++ b/modules/aws/s3_test.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	cryptorand "crypto/rand"
+	"fmt"
 	"math/rand"
 	"strconv"
 	"strings"
@@ -325,6 +326,52 @@ func TestGetS3BucketOwnershipControls(t *testing.T) {
 		_, err := terraaws.GetS3BucketOwnershipControlsE(t, region, s3BucketName)
 		assert.Error(t, err)
 	})
+}
+
+func TestAssertS3BucketServerSideEncryption(t *testing.T) {
+	t.Parallel()
+
+	region := terraaws.GetRandomStableRegion(t, nil, nil)
+	logger.Default.Logf(t, "Random values selected. Region = %s\n", region)
+
+	algorithms := []types.ServerSideEncryption{
+		types.ServerSideEncryptionAes256,
+		types.ServerSideEncryptionAwsKms,
+	}
+	for i, algorithm := range algorithms {
+		algorithm := algorithm
+		t.Run(string(algorithm), func(t *testing.T) {
+			t.Parallel()
+
+			s3BucketName := fmt.Sprintf("gruntwork-terratest-sse-%d-%s", i, strings.ToLower(random.UniqueID()))
+			terraaws.CreateS3Bucket(t, region, s3BucketName)
+			t.Cleanup(func() { terraaws.DeleteS3Bucket(t, region, s3BucketName) })
+
+			s3Client := terraaws.NewS3Client(t, region)
+			_, err := s3Client.PutBucketEncryption(context.Background(), &s3.PutBucketEncryptionInput{
+				Bucket: aws.String(s3BucketName),
+				ServerSideEncryptionConfiguration: &types.ServerSideEncryptionConfiguration{
+					Rules: []types.ServerSideEncryptionRule{
+						{
+							ApplyServerSideEncryptionByDefault: &types.ServerSideEncryptionByDefault{
+								SSEAlgorithm: algorithm,
+							},
+						},
+					},
+				},
+			})
+			require.NoError(t, err)
+
+			terraaws.AssertS3BucketServerSideEncryption(t, region, s3BucketName, algorithm)
+
+			otherAlgorithm := types.ServerSideEncryptionAwsKms
+			if algorithm == types.ServerSideEncryptionAwsKms {
+				otherAlgorithm = types.ServerSideEncryptionAes256
+			}
+			err = terraaws.AssertS3BucketServerSideEncryptionE(t, region, s3BucketName, otherAlgorithm)
+			assert.Error(t, err)
+		})
+	}
 }
 
 func TestS3ObjectContents(t *testing.T) {


### PR DESCRIPTION
## Summary
Restores the SSE assertion helpers (originally added in #1494, dropped in fb3ba0a) and brings them in line with the modern Context/ContextE pattern. Adds a typed `BucketServerSideEncryptionNotEnabledError`.

Public surface:
- `AssertS3BucketServerSideEncryptionContext` / `AssertS3BucketServerSideEncryptionContextE`
- Deprecated `AssertS3BucketServerSideEncryption` / `AssertS3BucketServerSideEncryptionE` (delegate to the Context variants)
- `BucketServerSideEncryptionNotEnabledError` + `NewBucketServerSideEncryptionNotEnabledError`

Closes [LIB-4875](https://linear.app/gruntwork/issue/LIB-4875). Upstream issue: gruntwork-io/terratest#1762.

## Test plan
- [ ] `go vet ./modules/aws/...`
- [ ] `go build ./modules/aws/...`
- [ ] CI: `TestAssertS3BucketServerSideEncryption` runs against AES256 and aws:kms; verifies positive match and negative-match error path