### PR TITLE
ci: build and publish release binaries on tag push

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -3,6 +3,7 @@ name: Build and Release
 on:
   push:
     branches: [main]
+    tags: ['v*.*.*']
   pull_request:
   release:
     types: [created]
@@ -71,7 +72,7 @@ jobs:
 
   release:
     name: Release
-    if: github.event_name == 'release'
+    if: github.event_name == 'release' || startsWith(github.ref, 'refs/tags/v')
     needs: build
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -95,6 +96,11 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          if ! gh release view "${{ github.ref_name }}" >/dev/null 2>&1; then
+            gh release create "${{ github.ref_name }}" \
+              --title "${{ github.ref_name }}" \
+              --generate-notes
+          fi
           for f in cmd/bin/*; do
             gh release upload "${{ github.ref_name }}" "$f" --clobber
           done


### PR DESCRIPTION
## Summary
- Adds `tags: ['v*.*.*']` to the `push` trigger so version tag pushes drive the build.
- Allows the `release` job to run on any `refs/tags/v*` ref, in addition to the `release` event.
- Makes the upload idempotent: if the release does not already exist, the workflow creates it with auto-generated notes before uploading binaries.

The `release: types: [created]` event has never fired a workflow run in this repo, which is why v1.0.0 was published without binaries. Triggering on tag push removes the dependency on that event and means a manual `gh workflow run --ref vX.Y.Z` can also be used to backfill missing assets on past tags.

Closes LIB-5106 (https://linear.app/gruntwork/issue/LIB-5106) / #1825.

## Test plan
- [ ] Merge, then run `gh workflow run build-and-release.yml --ref v1.0.0` and confirm v1.0.0 release gets the expected 14 binaries + SHA256SUMS.
- [ ] On the next legitimate version tag push, confirm the workflow attaches assets automatically.