### PR TITLE
ci: iterate over submodules in tidy, lint, build-and-release

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -52,15 +52,26 @@ jobs:
 
       - name: Build binaries
         run: |
+          set -e
           mkdir -p cmd/bin
           EXT=""
           if [ "${{ matrix.os }}" = "windows" ]; then EXT=".exe"; fi
-          CGO_ENABLED=0 GOOS=${{ matrix.os }} GOARCH=${{ matrix.arch }} \
-            go build -o "cmd/bin/terratest_log_parser_${{ matrix.os }}_${{ matrix.arch }}${EXT}" \
-            ./cmd/terratest_log_parser
-          CGO_ENABLED=0 GOOS=${{ matrix.os }} GOARCH=${{ matrix.arch }} \
-            go build -o "cmd/bin/pick-instance-type_${{ matrix.os }}_${{ matrix.arch }}${EXT}" \
-            ./cmd/pick-instance-type
+          OUT_DIR="$(pwd)/cmd/bin"
+          for cmd_dir in cmd/*/; do
+            cmd_name=$(basename "$cmd_dir")
+            # Skip the output dir itself
+            if [ "$cmd_name" = "bin" ]; then continue; fi
+            echo "Building $cmd_name for ${{ matrix.os }}/${{ matrix.arch }}"
+            if [ -f "$cmd_dir/go.mod" ]; then
+              (cd "$cmd_dir" && \
+                CGO_ENABLED=0 GOOS=${{ matrix.os }} GOARCH=${{ matrix.arch }} \
+                go build -o "$OUT_DIR/${cmd_name}_${{ matrix.os }}_${{ matrix.arch }}${EXT}" .)
+            else
+              CGO_ENABLED=0 GOOS=${{ matrix.os }} GOARCH=${{ matrix.arch }} \
+                go build -o "$OUT_DIR/${cmd_name}_${{ matrix.os }}_${{ matrix.arch }}${EXT}" \
+                "./$cmd_dir"
+            fi
+          done
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/go-mod-tidy-check.yml
+++ b/.github/workflows/go-mod-tidy-check.yml
@@ -19,13 +19,20 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Run go mod tidy
-      run: go mod tidy
+    - name: Run go mod tidy in each module
+      run: |
+        set -e
+        find . -name go.mod -not -path '*/vendor/*' -print0 \
+          | xargs -0 -n1 dirname \
+          | while read -r dir; do
+              echo "Tidying $dir"
+              (cd "$dir" && go mod tidy)
+            done
 
     - name: Check for changes
       run: |
-        if ! git diff --exit-code go.mod go.sum; then
-          echo "::error::go.mod or go.sum are not tidy. Please run 'go mod tidy' locally and commit the changes."
+        if ! git diff --exit-code -- '**/go.mod' '**/go.sum'; then
+          echo "::error::A go.mod or go.sum is not tidy. Run 'go mod tidy' in the affected module(s) and commit."
           exit 1
         fi
-        echo "go.mod and go.sum are tidy"
+        echo "All go.mod and go.sum files are tidy"

--- a/Makefile
+++ b/Makefile
@@ -9,15 +9,26 @@ update-lint-config:
 	  echo '# It is automatically updated weekly via the update-lint-config workflow. Do not edit manually.' ;\
 	  cat .golangci.yml; } > $${tmpfile} && mv $${tmpfile} .golangci.yml
 
+MODULE_DIRS := $(shell find . -name go.mod -not -path '*/vendor/*' -exec dirname {} \;)
+
 lint:
-	GOFLAGS="-tags=$(LINT_TAGS)" mise x golangci-lint -- golangci-lint run -v --timeout=30m ./...
+	@for dir in $(MODULE_DIRS); do \
+		echo "Linting $$dir"; \
+		(cd $$dir && GOFLAGS="-tags=$(LINT_TAGS)" mise x golangci-lint -- golangci-lint run -v --timeout=30m ./...) || exit 1; \
+	done
 
 lint-incremental:
 	@echo "Incremental lint (new issues only)"
-	GOFLAGS="-tags=$(LINT_TAGS)" mise x golangci-lint -- golangci-lint run -v --timeout=30m --new-from-merge-base=main ./...
+	@for dir in $(MODULE_DIRS); do \
+		echo "Linting $$dir"; \
+		(cd $$dir && GOFLAGS="-tags=$(LINT_TAGS)" mise x golangci-lint -- golangci-lint run -v --timeout=30m --new-from-merge-base=main ./...) || exit 1; \
+	done
 
 lint-fix:
 	@echo "Linting with auto-fix"
-	GOFLAGS="-tags=$(LINT_TAGS)" mise x golangci-lint -- golangci-lint run -v --timeout=30m --fix ./...
+	@for dir in $(MODULE_DIRS); do \
+		echo "Linting $$dir"; \
+		(cd $$dir && GOFLAGS="-tags=$(LINT_TAGS)" mise x golangci-lint -- golangci-lint run -v --timeout=30m --fix ./...) || exit 1; \
+	done
 
 .PHONY: lint lint-incremental lint-fix update-lint-config


### PR DESCRIPTION
Prereq for OSS-3526. Three workflows iterate over `find . -name go.mod` so they handle per-submodule `go.mod` once they appear. No-op on the current single-module state.

- `go-mod-tidy-check.yml`: tidy each module, diff all `go.mod`/`go.sum`.
- `Makefile` lint targets: loop `golangci-lint` per module via `MODULE_DIRS`.
- `build-and-release.yml`: iterate `cmd/*/`, cd per-cmd when a `go.mod` exists, else root build.

Integration test workflows handled in OSS-3526 via `go.work`.

## Test plan
- [ ] CI green on this PR (no-op iteration).
- [ ] Re-verify after OSS-3526 lands with `modules/core/` present.