### PR TITLE
ci: add stale bot to auto-close inactive issues and PRs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,27 @@
+name: 'Close stale issues and PRs'
+on:
+  schedule:
+    - cron: '30 1 * * *'
+
+jobs:
+  stale:
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+    runs-on: ubuntu-slim
+    steps:
+      - uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899 # v10
+        with:
+          stale-issue-message: 'This issue has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs. Thank you for raising this issue.'
+          stale-pr-message: |
+            Thanks for this contribution, and apologies it sat open so long. This pull request has been automatically marked as stale because it has not had recent activity, and the codebase has since undergone significant refactoring that may make these changes substantially out of date. It will be closed in 7 days if no further activity occurs.
+
+            This is not a reflection on the quality of the work. You are always welcome to reopen this pull request (or open a fresh one) if you would like to rebase and continue. We genuinely appreciate the time you put in.
+          days-before-stale: 90
+          days-before-close: 7
+          stale-issue-label: 'stale'
+          stale-pr-label: 'stale'
+          exempt-issue-labels: 'rfc,preserved'
+          exempt-pr-labels: 'preserved'
+          exempt-draft-pr: true


### PR DESCRIPTION
## What

Adds `.github/workflows/stale.yml`, mirroring the workflow already in use in Terragrunt. A scheduled job (daily) uses `actions/stale` to:

- Mark issues and PRs **stale after 90 days** of inactivity
- **Close them 7 days later** if there is still no activity
- Exempt draft PRs, and anything labeled `preserved` (plus `rfc` for issues)

## Why

We have a large backlog of open PRs that have been inactive for a long time, many predating significant refactoring of the codebase, so the changes are now substantially out of date. Rather than closing them manually, the bot handles it on a schedule and posts a friendly note inviting contributors to reopen and rebase if they want to continue. This also keeps maintainers from being @-ed individually.

The stale PR message thanks the contributor, explains the closure, and makes clear they are welcome to reopen.

## Notes

- On first run the bot will sweep the existing backlog (anything inactive 90+ days), not just PRs older than a year.
- To keep a specific issue/PR open indefinitely, add the `preserved` label.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated workflow to identify and close stale issues and pull requests. Items will be marked stale after 90 days without activity and closed 7 days later. Draft pull requests and certain labels are exempt from this process, ensuring important work is preserved while maintaining repository organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->