### PR TITLE
ci: drop Terragrunt-specific no-direct-go-getter depguard rule

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,7 +18,6 @@ linters:
     - bidichk
     - bodyclose
     - contextcheck
-    - depguard
     - dupl
     - durationcheck
     - errchkjson
@@ -60,30 +59,6 @@ linters:
     - wsl_v5
     - zerologlint
   settings:
-    depguard:
-      rules:
-        no-direct-go-getter:
-          # Direct hashicorp/go-getter imports are confined to the internal/getter
-          # package (which owns the integration) plus two carve-out files that
-          # would otherwise create import cycles. Everything else must go through
-          # internal/getter.
-          list-mode: lax
-          files:
-            - $all
-            - "!**/internal/getter/**"
-            - "!**/internal/util/file.go"
-            - "!**/internal/cas/stacks.go"
-          deny:
-            - pkg: github.com/hashicorp/go-getter
-              desc: use github.com/gruntwork-io/terragrunt/internal/getter instead
-            - pkg: github.com/hashicorp/go-getter/v2
-              desc: use github.com/gruntwork-io/terragrunt/internal/getter instead
-            - pkg: github.com/hashicorp/go-getter/v2/helper/url
-              desc: use github.com/gruntwork-io/terragrunt/internal/getter URLParse instead
-            - pkg: github.com/hashicorp/go-getter/s3/v2
-              desc: use github.com/gruntwork-io/terragrunt/internal/getter instead
-            - pkg: github.com/hashicorp/go-getter/gcs/v2
-              desc: use github.com/gruntwork-io/terragrunt/internal/getter instead
     dupl:
       threshold: 120
     errcheck:


### PR DESCRIPTION
## What

Removes the `no-direct-go-getter` depguard rule from `.golangci.yml` (and `depguard` itself, since this was its only rule).

## Why

The rule was copied over from Terragrunt's golangci config and cannot be satisfied in Terratest:

- It denies direct `hashicorp/go-getter` imports and points to `github.com/gruntwork-io/terragrunt/internal/getter` as the replacement. Terratest is a separate Go module and **cannot import another module's `internal/` package**, so the prescribed fix doesn't compile here.
- Its carve-out paths (`internal/getter/`, `internal/util/file.go`, `internal/cas/stacks.go`) are Terragrunt paths that don't exist in Terratest.
- Terratest uses `go-getter` directly and legitimately (e.g. `modules/opa/download_policy.go`).

The result: the rule fails Lint on every PR with no valid way to fix it in code. Removing it restores green lint without touching any Go.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development tooling configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->