### PR TITLE
ci: allow manual dispatch of the stale workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -2,6 +2,7 @@ name: 'Close stale issues and PRs'
 on:
   schedule:
     - cron: '30 1 * * *'
+  workflow_dispatch:
 
 jobs:
   stale:


### PR DESCRIPTION
## What

Adds a `workflow_dispatch` trigger to the stale workflow so it can be run on demand from the Actions tab (or via `gh workflow run`), not only on the daily schedule.

## Why

Useful for sweeping the existing backlog immediately and for testing the workflow without waiting for the 01:30 UTC cron.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced repository maintenance workflow to support manual triggering alongside scheduled automated runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->