### PR TITLE
feat(test-structure): add opt-in parallel mode to ValidateAllTerraformModules

### DIFF
--- a/modules/test-structure/test_structure.go
+++ b/modules/test-structure/test_structure.go
@@ -278,6 +278,10 @@ func runValidateOnAllTerraformModulesContext(
 
 	for _, dir := range dirsToValidate {
 		t.Run(strings.TrimLeft(dir, "/"), func(t *go_test.T) {
+			if clonedOpts.Parallel {
+				t.Parallel()
+			}
+
 			// Run the validation function on the test folder that was copied to /tmp to avoid any potential conflicts
 			// with tests that may not use the same copy to /tmp behavior
 			tfOpts := &terraform.Options{TerraformDir: dir}

--- a/modules/test-structure/test_structure_test.go
+++ b/modules/test-structure/test_structure_test.go
@@ -46,6 +46,39 @@ func TestValidateAllTerraformModulesSucceedsOnValidTerraform(t *testing.T) {
 	teststructure.ValidateAllTerraformModulesContext(t, t.Context(), opts)
 }
 
+// TestValidateAllTerraformModulesParallelSucceedsOnValidTerraform runs the same valid fixture with Parallel enabled,
+// exercising the t.Parallel path.
+func TestValidateAllTerraformModulesParallelSucceedsOnValidTerraform(t *testing.T) {
+	t.Parallel()
+
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+
+	projectRootDir := filepath.Join(cwd, "../../test/fixtures")
+
+	opts, optsErr := teststructure.NewValidationOptions(projectRootDir, []string{"terraform-validation-valid"}, []string{})
+	require.NoError(t, optsErr)
+
+	opts.Parallel = true
+
+	teststructure.ValidateAllTerraformModulesContext(t, t.Context(), opts)
+}
+
+// TestCloneWithNewRootDirPreservesParallel ensures the Parallel flag survives the clone that ValidateAllTerraformModules
+// performs internally; otherwise the parallel mode would never take effect.
+func TestCloneWithNewRootDirPreservesParallel(t *testing.T) {
+	t.Parallel()
+
+	opts, err := teststructure.NewValidationOptions(t.TempDir(), []string{}, []string{})
+	require.NoError(t, err)
+
+	opts.Parallel = true
+
+	cloned, err := teststructure.CloneWithNewRootDir(opts, t.TempDir())
+	require.NoError(t, err)
+	assert.True(t, cloned.Parallel)
+}
+
 func TestNewValidationOptionsRejectsEmptyRootDir(t *testing.T) {
 	t.Parallel()
 

--- a/modules/test-structure/validate_struct.go
+++ b/modules/test-structure/validate_struct.go
@@ -37,6 +37,9 @@ type ValidationOptions struct {
 	// Note that while the struct requires full paths, you can pass relative paths to the NewValidationOptions function
 	// which will build the full paths based on the supplied RootDir
 	ExcludeDirs []string
+	// If true, each discovered module is validated in a parallel subtest (via t.Parallel) rather than sequentially.
+	// Go caps the number of concurrent subtests at the -parallel flag (GOMAXPROCS by default).
+	Parallel bool
 }
 
 // CloneWithNewRootDir clones the given opts with a new root dir. Updates all include and exclude dirs to be relative
@@ -58,6 +61,7 @@ func CloneWithNewRootDir(opts *ValidationOptions, newRootDir string) (*Validatio
 	}
 
 	out.FileType = opts.FileType
+	out.Parallel = opts.Parallel
 
 	return out, nil
 }


### PR DESCRIPTION
Fixes #1236.

ValidateAllTerraformModules validates each discovered module sequentially. This adds a ValidationOptions.Parallel flag: when set, each module runs in its own parallel subtest via t.Parallel, so validation of many modules can run concurrently. Go caps the concurrency at the -parallel flag (GOMAXPROCS by default), so it is bounded.

The flag defaults to false, so existing callers are unaffected. The flag is carried through CloneWithNewRootDir (the internal clone the function performs), otherwise it would never take effect.

Tests:
- A unit test that the Parallel flag survives the internal clone.
- An integration test that runs the existing valid fixture with Parallel enabled, exercising the t.Parallel path against real terraform.