### PR TITLE
feat(aws): add ECR Public repository support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -70,7 +70,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azcertificates v1.4.0
 	github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azkeys v1.4.0
 	github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets v1.4.0
-	github.com/aws/aws-sdk-go-v2 v1.41.6
+	github.com/aws/aws-sdk-go-v2 v1.42.0
 	github.com/aws/aws-sdk-go-v2/config v1.32.16
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.15
 	github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager v0.1.17
@@ -80,6 +80,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.57.2
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.297.1
 	github.com/aws/aws-sdk-go-v2/service/ecr v1.57.1
+	github.com/aws/aws-sdk-go-v2/service/ecrpublic v1.39.6
 	github.com/aws/aws-sdk-go-v2/service/ecs v1.78.1
 	github.com/aws/aws-sdk-go-v2/service/iam v1.53.8
 	github.com/aws/aws-sdk-go-v2/service/kms v1.50.5
@@ -92,7 +93,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sqs v1.42.26
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.68.5
 	github.com/aws/aws-sdk-go-v2/service/sts v1.42.0
-	github.com/aws/smithy-go v1.25.0
+	github.com/aws/smithy-go v1.27.1
 	github.com/gonvenience/ytbx v1.4.4
 	github.com/hashicorp/go-getter/v2 v2.2.3
 	github.com/homeport/dyff v1.6.0
@@ -126,8 +127,8 @@ require (
 	github.com/apparentlymart/go-textseg/v15 v15.0.0 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.9 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.22 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.22 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.22 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.29 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.29 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.23 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.8 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.9.14 // indirect

--- a/go.sum
+++ b/go.sum
@@ -125,8 +125,8 @@ github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPd
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/aws/aws-lambda-go v1.54.0 h1:EGYpdyRGF88xszqlGcBewz811mJeRS+maNlLZXFheII=
 github.com/aws/aws-lambda-go v1.54.0/go.mod h1:dpMpZgvWx5vuQJfBt0zqBha60q7Dd7RfgJv23DymV8A=
-github.com/aws/aws-sdk-go-v2 v1.41.6 h1:1AX0AthnBQzMx1vbmir3Y4WsnJgiydmnJjiLu+LvXOg=
-github.com/aws/aws-sdk-go-v2 v1.41.6/go.mod h1:dy0UzBIfwSeot4grGvY1AqFWN5zgziMmWGzysDnHFcQ=
+github.com/aws/aws-sdk-go-v2 v1.42.0 h1:XvXMJTkFQtpBKIWZnmr9ZEOc2InWM2yldjXEJ/bymhA=
+github.com/aws/aws-sdk-go-v2 v1.42.0/go.mod h1:27+ACypSLljLAEKsCYOmrjKh83vuTRkuAe9Uv/3A4bg=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.9 h1:adBsCIIpLbLmYnkQU+nAChU5yhVTvu5PerROm+/Kq2A=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.9/go.mod h1:uOYhgfgThm/ZyAuJGNQ5YgNyOlYfqnGpTHXvk3cpykg=
 github.com/aws/aws-sdk-go-v2/config v1.32.16 h1:Q0iQ7quUgJP0F/SCRTieScnaMdXr9h/2+wze1u3cNeM=
@@ -137,10 +137,10 @@ github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.22 h1:IOGsJ1xVWhsi+ZO7/NW8Ou
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.22/go.mod h1:b+hYdbU+jGKfXE8kKM6g1+h+L/Go3vMvzlxBsiuGsxg=
 github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager v0.1.17 h1:95y7/EqethAhFwMKJ9cDutzBhsS1h8uBwkJ5rp8pNTU=
 github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager v0.1.17/go.mod h1:77baheqr62SkTw77HWH8qpdWTd2gXKN0xg0qLvDSkpk=
-github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.22 h1:GmLa5Kw1ESqtFpXsx5MmC84QWa/ZrLZvlJGa2y+4kcQ=
-github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.22/go.mod h1:6sW9iWm9DK9YRpRGga/qzrzNLgKpT2cIxb7Vo2eNOp0=
-github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.22 h1:dY4kWZiSaXIzxnKlj17nHnBcXXBfac6UlsAx2qL6XrU=
-github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.22/go.mod h1:KIpEUx0JuRZLO7U6cbV204cWAEco2iC3l061IxlwLtI=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.29 h1:f3vKqSo13fhTYb+JEcXwXefZQE26I1FB5eTSniU67ko=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.29/go.mod h1:MzoLFUArKGpGD+ukmPiTPG1X5x4o6M2kq4v2dr1FiEc=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.29 h1:RdwIf/CuUsvJX3RgJagbOyotl/cxoLY4xviKuE7p2GY=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.29/go.mod h1:71wt8W2EgswdZy9Mf9KNnzxZ3TiZlv4caKghPktDOkA=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.23 h1:FPXsW9+gMuIeKmz7j6ENWcWtBGTe1kH8r9thNt5Uxx4=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.23/go.mod h1:7J8iGMdRKk6lw2C+cMIphgAnT8uTwBwNOsGkyOCm80U=
 github.com/aws/aws-sdk-go-v2/service/acm v1.38.2 h1:ozcwethaFOi2ST9h6MKGq1GAIHP68tjiDqgkWVPwfR8=
@@ -155,6 +155,8 @@ github.com/aws/aws-sdk-go-v2/service/ec2 v1.297.1 h1:9nfacm+uWgbdPaOplvJjxN50qgt
 github.com/aws/aws-sdk-go-v2/service/ec2 v1.297.1/go.mod h1:E1pnYwWFZ8N3REmeN9Fe/Zipbpps4HJj8DQGNnLUMYc=
 github.com/aws/aws-sdk-go-v2/service/ecr v1.57.1 h1:G/O4muLF2pe1UJBKEyF7J+kdokEEqFJjm42cU68FqH4=
 github.com/aws/aws-sdk-go-v2/service/ecr v1.57.1/go.mod h1:KBzTxiBlQ2bB5XT367+t18i3Qe7NZDRyGKxdzN43aOw=
+github.com/aws/aws-sdk-go-v2/service/ecrpublic v1.39.6 h1:pI1S5+Z8cfN/fImioNCHCWKFgm49ZeBhnjffJfRWHYA=
+github.com/aws/aws-sdk-go-v2/service/ecrpublic v1.39.6/go.mod h1:VctLEHQ91HQAWosSGqbNykn4OoxuUVGbE+1SachaXa0=
 github.com/aws/aws-sdk-go-v2/service/ecs v1.78.1 h1:9zSVr4X6X8JNTxSMip2RORaBB+Mu0/IfzNu3iRWZE9c=
 github.com/aws/aws-sdk-go-v2/service/ecs v1.78.1/go.mod h1:1DlTqkp+8uc5At3UXyJAvJXFaWoMmxSHcp2Zdor0qGw=
 github.com/aws/aws-sdk-go-v2/service/iam v1.53.8 h1:p0oB4eZfBfBAOasnKvHJOlNcuHVE/ieuWs7uIZgQlyQ=
@@ -195,8 +197,8 @@ github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.20 h1:oK/njaL8GtyEihkWMD4k3Vg
 github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.20/go.mod h1:JHs8/y1f3zY7U5WcuzoJ/yAYGYtNIVPKLIbp61euvmg=
 github.com/aws/aws-sdk-go-v2/service/sts v1.42.0 h1:ks8KBcZPh3PYISr5dAiXCM5/Thcuxk8l+PG4+A0exds=
 github.com/aws/aws-sdk-go-v2/service/sts v1.42.0/go.mod h1:pFw33T0WLvXU3rw1WBkpMlkgIn54eCB5FYLhjDc9Foo=
-github.com/aws/smithy-go v1.25.0 h1:Sz/XJ64rwuiKtB6j98nDIPyYrV1nVNJ4YU74gttcl5U=
-github.com/aws/smithy-go v1.25.0/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
+github.com/aws/smithy-go v1.27.1 h1:4T340VFndXtADGF52gYa1POyL7s9E4Z1OeZ1hCscIw8=
+github.com/aws/smithy-go v1.27.1/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
 github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d h1:xDfNPAt8lFiC1UJrqV3uuy861HCTo708pDMbjHHdCas=
 github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d/go.mod h1:6QX/PXZ00z/TKoufEY6K/a0k6AhaJrQKdFe6OfVXsa4=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=

--- a/modules/aws/ecrpublic.go
+++ b/modules/aws/ecrpublic.go
@@ -1,0 +1,179 @@
+package aws
+
+import (
+	"context"
+	goerrors "errors"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ecrpublic"
+	"github.com/aws/aws-sdk-go-v2/service/ecrpublic/types"
+	"github.com/gruntwork-io/go-commons/errors"
+	"github.com/gruntwork-io/terratest/modules/testing"
+	"github.com/stretchr/testify/require"
+)
+
+// Note: the ECR Public API is only available in the us-east-1 region, so pass "us-east-1" as the region to these
+// functions regardless of where the rest of your infrastructure lives.
+
+// CreateECRPublicRepoContextE creates a new ECR Public Repository.
+// The ctx parameter supports cancellation and timeouts.
+func CreateECRPublicRepoContextE(t testing.TestingT, ctx context.Context, region string, name string) (*types.Repository, error) {
+	client, err := NewECRPublicClientContextE(t, ctx, region)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := client.CreateRepository(ctx, &ecrpublic.CreateRepositoryInput{RepositoryName: aws.String(name)})
+	if err != nil {
+		return nil, err
+	}
+
+	return resp.Repository, nil
+}
+
+// CreateECRPublicRepoContext creates a new ECR Public Repository.
+// This function will fail the test if there is an error.
+// The ctx parameter supports cancellation and timeouts.
+func CreateECRPublicRepoContext(t testing.TestingT, ctx context.Context, region string, name string) *types.Repository {
+	t.Helper()
+
+	repo, err := CreateECRPublicRepoContextE(t, ctx, region, name)
+	require.NoError(t, err)
+
+	return repo
+}
+
+// CreateECRPublicRepoE creates a new ECR Public Repository.
+func CreateECRPublicRepoE(t testing.TestingT, region string, name string) (*types.Repository, error) {
+	return CreateECRPublicRepoContextE(t, context.Background(), region, name)
+}
+
+// CreateECRPublicRepo creates a new ECR Public Repository. This will fail the test and stop execution if there is an error.
+func CreateECRPublicRepo(t testing.TestingT, region string, name string) *types.Repository {
+	t.Helper()
+
+	return CreateECRPublicRepoContext(t, context.Background(), region, name)
+}
+
+// GetECRPublicRepoContextE gets an ECR Public Repository by name.
+// An error occurs if a repository with the given name does not exist.
+// The ctx parameter supports cancellation and timeouts.
+func GetECRPublicRepoContextE(t testing.TestingT, ctx context.Context, region string, name string) (*types.Repository, error) {
+	client, err := NewECRPublicClientContextE(t, ctx, region)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := client.DescribeRepositories(ctx, &ecrpublic.DescribeRepositoriesInput{RepositoryNames: []string{name}})
+	if err != nil {
+		return nil, err
+	}
+
+	if len(resp.Repositories) != 1 {
+		return nil, errors.WithStackTrace(goerrors.New("an unexpected condition occurred. Please file an issue at github.com/gruntwork-io/terratest"))
+	}
+
+	return &resp.Repositories[0], nil
+}
+
+// GetECRPublicRepoContext gets an ECR Public Repository by name.
+// This function will fail the test if there is an error.
+// An error occurs if a repository with the given name does not exist.
+// The ctx parameter supports cancellation and timeouts.
+func GetECRPublicRepoContext(t testing.TestingT, ctx context.Context, region string, name string) *types.Repository {
+	t.Helper()
+
+	repo, err := GetECRPublicRepoContextE(t, ctx, region, name)
+	require.NoError(t, err)
+
+	return repo
+}
+
+// GetECRPublicRepoE gets an ECR Public Repository by name.
+// An error occurs if a repository with the given name does not exist.
+func GetECRPublicRepoE(t testing.TestingT, region string, name string) (*types.Repository, error) {
+	return GetECRPublicRepoContextE(t, context.Background(), region, name)
+}
+
+// GetECRPublicRepo gets an ECR Public Repository by name. This will fail the test and stop execution if there is an error.
+// An error occurs if a repository with the given name does not exist.
+func GetECRPublicRepo(t testing.TestingT, region string, name string) *types.Repository {
+	t.Helper()
+
+	return GetECRPublicRepoContext(t, context.Background(), region, name)
+}
+
+// DeleteECRPublicRepoContextE force deletes the ECR Public repository, including any images it contains.
+// The ctx parameter supports cancellation and timeouts.
+func DeleteECRPublicRepoContextE(t testing.TestingT, ctx context.Context, region string, repo *types.Repository) error {
+	client, err := NewECRPublicClientContextE(t, ctx, region)
+	if err != nil {
+		return err
+	}
+
+	_, err = client.DeleteRepository(ctx, &ecrpublic.DeleteRepositoryInput{
+		RepositoryName: repo.RepositoryName,
+		Force:          true,
+	})
+
+	return err
+}
+
+// DeleteECRPublicRepoContext force deletes the ECR Public repository, including any images it contains.
+// This function will fail the test if there is an error.
+// The ctx parameter supports cancellation and timeouts.
+func DeleteECRPublicRepoContext(t testing.TestingT, ctx context.Context, region string, repo *types.Repository) {
+	t.Helper()
+
+	err := DeleteECRPublicRepoContextE(t, ctx, region, repo)
+	require.NoError(t, err)
+}
+
+// DeleteECRPublicRepoE force deletes the ECR Public repository, including any images it contains.
+func DeleteECRPublicRepoE(t testing.TestingT, region string, repo *types.Repository) error {
+	return DeleteECRPublicRepoContextE(t, context.Background(), region, repo)
+}
+
+// DeleteECRPublicRepo force deletes the ECR Public repository, including any images it contains.
+// This will fail the test and stop execution if there is an error.
+func DeleteECRPublicRepo(t testing.TestingT, region string, repo *types.Repository) {
+	t.Helper()
+
+	DeleteECRPublicRepoContext(t, context.Background(), region, repo)
+}
+
+// NewECRPublicClientContextE returns a client for the Elastic Container Registry Public.
+// The ctx parameter supports cancellation and timeouts.
+func NewECRPublicClientContextE(t testing.TestingT, ctx context.Context, region string) (*ecrpublic.Client, error) {
+	sess, err := NewAuthenticatedSessionContext(ctx, region)
+	if err != nil {
+		return nil, err
+	}
+
+	return ecrpublic.NewFromConfig(*sess), nil
+}
+
+// NewECRPublicClientContext returns a client for the Elastic Container Registry Public.
+// This function will fail the test if there is an error.
+// The ctx parameter supports cancellation and timeouts.
+func NewECRPublicClientContext(t testing.TestingT, ctx context.Context, region string) *ecrpublic.Client {
+	t.Helper()
+
+	client, err := NewECRPublicClientContextE(t, ctx, region)
+	require.NoError(t, err)
+
+	return client
+}
+
+// NewECRPublicClientE returns a client for the Elastic Container Registry Public.
+func NewECRPublicClientE(t testing.TestingT, region string) (*ecrpublic.Client, error) {
+	return NewECRPublicClientContextE(t, context.Background(), region)
+}
+
+// NewECRPublicClient returns a client for the Elastic Container Registry Public. This will fail the test and
+// stop execution if there is an error.
+func NewECRPublicClient(t testing.TestingT, region string) *ecrpublic.Client {
+	t.Helper()
+
+	return NewECRPublicClientContext(t, context.Background(), region)
+}

--- a/modules/aws/ecrpublic_test.go
+++ b/modules/aws/ecrpublic_test.go
@@ -1,0 +1,40 @@
+package aws_test
+
+import (
+	"strings"
+	"testing"
+
+	awsSDK "github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	aws "github.com/gruntwork-io/terratest/modules/aws"
+	"github.com/gruntwork-io/terratest/modules/random"
+)
+
+// ecrPublicRegion is fixed because the ECR Public API is only available in us-east-1.
+const ecrPublicRegion = "us-east-1"
+
+func TestEcrPublicRepo(t *testing.T) {
+	t.Parallel()
+
+	ecrRepoName := "terratest" + strings.ToLower(random.UniqueID())
+
+	repo1, err := aws.CreateECRPublicRepoE(t, ecrPublicRegion, ecrRepoName)
+	defer aws.DeleteECRPublicRepo(t, ecrPublicRegion, repo1)
+
+	require.NoError(t, err)
+
+	assert.Equal(t, ecrRepoName, awsSDK.ToString(repo1.RepositoryName))
+
+	repo2, err := aws.GetECRPublicRepoE(t, ecrPublicRegion, ecrRepoName)
+	require.NoError(t, err)
+	assert.Equal(t, ecrRepoName, awsSDK.ToString(repo2.RepositoryName))
+}
+
+func TestGetEcrPublicRepoError(t *testing.T) {
+	t.Parallel()
+
+	_, err := aws.GetECRPublicRepoE(t, ecrPublicRegion, "terratest"+strings.ToLower(random.UniqueID()))
+	require.Error(t, err)
+}


### PR DESCRIPTION
Fixes #1288.

Adds an ecrpublic module to the AWS package, mirroring the existing ecr module: CreateECRPublicRepo, GetECRPublicRepo, DeleteECRPublicRepo, and a NewECRPublicClient constructor, each with the standard basic / E / Context / ContextE variants. It uses the aws-sdk-go-v2 ecrpublic service (a new dependency).

Notes:
- ECR Public is only available in the us-east-1 region, documented on the functions and pinned in the integration test.
- DeleteECRPublicRepo uses the API's Force option, so it removes the repository even if it still contains images (no separate image-deletion pass needed, unlike private ECR).

Tested:
- Integration test (ecrpublic_test.go) mirroring the ecr test, runs in the AWS Integration Tests job.
- Verified end to end against a real account in us-east-1: create, get (ARN matches), nonexistent-repo errors, and force delete cleans up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for AWS ECR Public repository workflows, including creating, fetching, and deleting repositories.
  * Added a new client setup path for working with ECR Public in supported AWS regions.
  * Updated AWS SDK dependencies to newer versions for broader compatibility and improvements.

* **Tests**
  * Added coverage for ECR Public repository creation, retrieval, and error handling when a repository is missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->