### PR TITLE
ci(azure): run live integration tests weekly instead of per PR

### DIFF
--- a/.github/workflows/azure-integration-tests.yml
+++ b/.github/workflows/azure-integration-tests.yml
@@ -1,25 +1,13 @@
 name: Azure Integration Tests
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - 'modules/azure/**'
-      - 'test/azure/**'
-      - 'examples/azure/**'
-      - 'go.mod'
-      - 'go.sum'
-      - 'mise.toml'
-      - '.github/workflows/azure-integration-tests.yml'
-  pull_request:
-    paths:
-      - 'modules/azure/**'
-      - 'test/azure/**'
-      - 'examples/azure/**'
-      - 'go.mod'
-      - 'go.sum'
-      - 'mise.toml'
-      - '.github/workflows/azure-integration-tests.yml'
+  # Live Azure integration tests provision real infrastructure and take 45+ minutes, and they
+  # are brittle to upstream Azure platform retirements. Rather than block every PR, they run on
+  # a weekly schedule and on demand. Per-PR Azure coverage is provided by azure-tests.yml (build,
+  # compile-check of test/azure, and modules/azure unit tests with SDK fakes), which needs no
+  # Azure credentials. See OSS-3436.
+  schedule:
+    - cron: '0 6 * * 1' # Mondays at 06:00 UTC
   workflow_dispatch:
 
 concurrency:
@@ -29,9 +17,6 @@ concurrency:
 jobs:
   azure-integration-tests:
     name: Azure Integration Tests
-    if: >-
-      github.event_name != 'pull_request' ||
-      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:


### PR DESCRIPTION
Moves the Azure live integration suite off per PR onto a weekly schedule plus workflow_dispatch, per OSS-3436.

Why: the suite provisions real Azure infrastructure, takes 45+ minutes, and breaks on upstream Azure platform retirements (Frontdoor classic, MySQL/PostgreSQL Single Server, Basic SKU public IPs, B-family VM capacity), so running it on every PR that touches Azure paths blocks unrelated work and burns CI time.

Per PR Azure coverage is unchanged and stays in azure-tests.yml: build, compile check of test/azure, and the modules/azure unit tests, which use Azure SDK fakes and need no credentials. The live suite still runs weekly and on demand to catch real deployment drift.

Also removed the now dead fork PR guard on the job, since pull_request no longer triggers this workflow.

Refs OSS-3436.