### PR TITLE
fix: correct typos in docs, comments, and examples

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -208,7 +208,7 @@ collections:
 5. Add `index.html` file to newly create folder:
 ```
 ---
-layout: collection-browser # DO NOT CAHNGE THIS
+layout: collection-browser # DO NOT CHANGE THIS
 title: Use cases
 subtitle: Learn how to work with Terratest.
 excerpt: Learn how to work with Terratest.

--- a/docs/_docs/01_getting-started/quick-start.md
+++ b/docs/_docs/01_getting-started/quick-start.md
@@ -307,7 +307,7 @@ Here's how you automate this process with Terratest:
 
 {% include examples/explorer.html example_id='kubernetes-hello-world' file_id='test_code' class='wide quick-start-examples' skip_learn_more=true skip_view_on_github=true skip_tags=true %}
 
-The test code above uses Kuberenetes helpers built into Terratest to run `kubectl apply`, wait for the service to come
+The test code above uses Kubernetes helpers built into Terratest to run `kubectl apply`, wait for the service to come
 up, get the service endpoint, make HTTP requests to the service (with plenty of retries), check the response is what
 we expect, and runs `kubectl delete` at the end. You run this test with `go test` as well! 
 

--- a/docs/assets/js/collection-browser_search.js
+++ b/docs/assets/js/collection-browser_search.js
@@ -4,7 +4,7 @@
  * TOC:
  *  - FILTER FUNCTIONS - functions to extract the terms from DOM element(s) and use them in search engine to show/hide elements.
  *  - MAIN - INITIALIZE - initializes Browser Search and registers actions (click etc.) on filter components.
- *  - SEARCH ENGINE - here is the logic to show & hide elements accoriding to filters terms.
+ *  - SEARCH ENGINE - here is the logic to show & hide elements according to filters terms.
  *  - OTHER
  */
 (function () {

--- a/docs/assets/js/collection-browser_toc.js
+++ b/docs/assets/js/collection-browser_toc.js
@@ -26,7 +26,7 @@ $(document).ready(function () {
     }
   })
 
-  // Expand / collpase on click
+  // Expand / collapse on click
   $('#toc .nav-collapse-handler').on('click', function() {
     toggleNav($(this))
   })
@@ -34,7 +34,7 @@ $(document).ready(function () {
   $(docSidebarInitialExpand)
 })
 
-// Expand / collpase on click
+// Expand / collapse on click
 function toggleNav(el) {
   if (el.hasClass('collapsed')) {
     if (!el.hasClass('no-children')) {

--- a/docs/assets/js/examples.js
+++ b/docs/assets/js/examples.js
@@ -33,7 +33,7 @@ $(document).ready(function () {
   // Open example and scroll to examples section when user clicks on
   // tech in the header
   $('.link-to-test-with-terratest').on('click', function() {
-    // Find any containting the keyword from data-target
+    // Find any containing the keyword from data-target
     const found = $('.navs .examples__nav-item[data-id*="'+$(this).data('target')+'"]')
     if (found && found.length > 0) {
       openExample('index_page', $(found[0]).data('id'))

--- a/examples/azure/terraform-azure-aks-example/README.md
+++ b/examples/azure/terraform-azure-aks-example/README.md
@@ -2,7 +2,7 @@
 
 This folder contains a Terraform module that deploys a basic AKS cluster in [Azure](https://azure.microsoft.com/) to demonstrate how you can use Terratest to write automated tests for your Azure Terraform code. 
 
-This module deploys [Azure Kubenetes Service](https://azure.microsoft.com/en-us/services/kubernetes-service/), then deploys nginx by a kubernetes yaml file with a Public IP Address using the `Service` resource.
+This module deploys [Azure Kubernetes Service](https://azure.microsoft.com/en-us/services/kubernetes-service/), then deploys nginx by a kubernetes yaml file with a Public IP Address using the `Service` resource.
 
 Check out [test/azure/terraform_azure_aks_example_test.go](/test/azure/terraform_azure_aks_example_test.go) to see how you can write automated tests for this module and validate the configuration of the parameters and options. 
 

--- a/examples/azure/terraform-azure-aks-example/variables.tf
+++ b/examples/azure/terraform-azure-aks-example/variables.tf
@@ -26,7 +26,7 @@ variable "ssh_public_key" {
 }
 
 variable "dns_prefix" {
-  description = "The prefix to set for the AKS cluster resoureces names."
+  description = "The prefix to set for the AKS cluster resources names."
   default     = "k8stest"
 }
 

--- a/examples/azure/terraform-azure-availabilityset-example/README.md
+++ b/examples/azure/terraform-azure-availabilityset-example/README.md
@@ -1,7 +1,7 @@
 # Terraform Azure Availability Set Example
 
 This folder contains a simple Terraform module that deploys resources in [Azure](https://azure.microsoft.com/) to demonstrate
-how you can use Terratest to write automated tests for your Azure Terraform code. This module deploys an Availability Set with one attched Virtual Machine.
+how you can use Terratest to write automated tests for your Azure Terraform code. This module deploys an Availability Set with one attached Virtual Machine.
 
 - An [Availability Set](https://docs.microsoft.com/en-us/azure/virtual-machines/availability) that gives the module the following:
   - `Availability Set` with the name specified in the `availability_set_name` output variable.

--- a/modules/aws/s3.go
+++ b/modules/aws/s3.go
@@ -730,7 +730,7 @@ func NewS3UploaderContext(t testing.TestingT, ctx context.Context, region string
 	return uploader
 }
 
-// S3AccessLoggingNotEnabledErr is a custom error that occurs when acess logging hasn't been enabled on the S3 Bucket
+// S3AccessLoggingNotEnabledErr is a custom error that occurs when access logging hasn't been enabled on the S3 Bucket
 type S3AccessLoggingNotEnabledErr struct {
 	OriginBucket string
 	Region       string

--- a/modules/core/logger/parser/parser.go
+++ b/modules/core/logger/parser/parser.go
@@ -169,7 +169,7 @@ func parseAndStoreTestOutput(
 
 			case strings.HasPrefix(data, "Test"):
 				// Heuristic: `go test` will only execute test functions named `Test.*`, so we assume any line prefixed
-				// with `Test` is a test output for a named test. Also assume that test output will be space delimeted and
+				// with `Test` is a test output for a named test. Also assume that test output will be space delimited and
 				// test names can't contain spaces (because they are function names).
 				// This must be modified when `logger.DoLog` changes.
 				vals := strings.Split(data, " ")

--- a/modules/core/shell/output.go
+++ b/modules/core/shell/output.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 )
 
-// output contains the output after runnig a command.
+// output contains the output after running a command.
 type output struct {
 	stdout *outputStream
 	stderr *outputStream

--- a/modules/k8s/tunnel.go
+++ b/modules/k8s/tunnel.go
@@ -60,7 +60,7 @@ func makeLabels(labels map[string]string) string {
 	return strings.Join(out, ",")
 }
 
-// Tunnel is the main struct that configures and manages port forwading tunnels to Kubernetes resources.
+// Tunnel is the main struct that configures and manages port forwarding tunnels to Kubernetes resources.
 type Tunnel struct {
 	out            io.Writer
 	logger         logger.TestLogger

--- a/modules/terraform/options.go
+++ b/modules/terraform/options.go
@@ -48,7 +48,7 @@ type Options struct {
 	Stdin            io.Reader         // Optional stdin to pass to Terraform commands
 	WarningsAsErrors map[string]string // Terraform warning messages that should be treated as errors. The keys are a regexp to match against the warning and the value is what to display to a user if that warning is matched.
 	Logger           *logger.Logger    // Set a non-default logger that should be used. See the logger package for more info.
-	BackendConfig    map[string]any    // The vars to pass to the terraform init command for extra configuration for the backend. If a var is nil, it will be formated as `--backend-config=var` instead of `--backend-config=var=null`
+	BackendConfig    map[string]any    // The vars to pass to the terraform init command for extra configuration for the backend. If a var is nil, it will be formatted as `--backend-config=var` instead of `--backend-config=var=null`
 	EnvVars          map[string]string // Environment variables to set when running Terraform
 
 	// The vars to pass to Terraform commands using the -var option. Note that terraform does not support passing `null`
@@ -69,7 +69,7 @@ type Options struct {
 	LockTimeout              string            // The lock timeout option to pass to the terraform command with -lock-timeout
 	ExtraArgs                ExtraArgs         // Extra arguments passed to Terraform commands
 	Targets                  []string          // The target resources to pass to the terraform command with -target
-	MixedVars                []Var             // Mix of `-var` and `-var-file` in arbritrary order, use `VarInline()` `VarFile()` to set the value.
+	MixedVars                []Var             // Mix of `-var` and `-var-file` in arbitrary order, use `VarInline()` `VarFile()` to set the value.
 	VarFiles                 []string          // The var file paths to pass to Terraform commands using -var-file option.
 	TimeBetweenRetries       time.Duration     // The amount of time to wait between retries
 	Parallelism              int               // Set the parallelism setting for Terraform

--- a/modules/teststructure/save_test_data.go
+++ b/modules/teststructure/save_test_data.go
@@ -24,7 +24,7 @@ func SaveTerraformOptions(t testing.TestingT, testFolder string, terraformOption
 
 // SaveTerraformOptionsIfNotPresent serializes and saves TerraformOptions into the given folder if the file does not exist or the json is
 // empty. This allows you to create TerraformOptions during setup and to reuse that TerraformOptions later during validation and teardown,
-// but will prevent overwritting the contents and potentially duplicating resources.
+// but will prevent overwriting the contents and potentially duplicating resources.
 func SaveTerraformOptionsIfNotPresent(t testing.TestingT, testFolder string, terraformOptions *terraform.Options) {
 	SaveTestData(t, formatTerraformOptionsPath(testFolder), false, terraformOptions)
 }

--- a/test-docker-images/gruntwork-amazon-linux-test/Dockerfile
+++ b/test-docker-images/gruntwork-amazon-linux-test/Dockerfile
@@ -28,6 +28,6 @@ RUN pip install awscli --upgrade
 
 # Ideally, we'd install the latest version of Docker to avoid a conflict between the Docker client in this container
 # and the Docker API on your local host, but installing the latest version of Docker yields the error "Requires:
-# container-selinux >= 2.9", whch indicates that a newer Linux kernel version is required than what comes with Amazon Linux.
+# container-selinux >= 2.9", which indicates that a newer Linux kernel version is required than what comes with Amazon Linux.
 # So we settle for the Amazon Linux supported version for now.
 RUN yum install -y docker

--- a/test-docker-images/moto/README.md
+++ b/test-docker-images/moto/README.md
@@ -39,7 +39,7 @@ upload it:
 docker run -p 5000:5000 gruntwork/moto moto_server ec2 --host 0.0.0.0
 ```
 
-This runs the `moto` service as a RESTful API, specially for the AWS EC2 API with support for acceping connections from
+This runs the `moto` service as a RESTful API, specially for the AWS EC2 API with support for accepting connections from
 any IP address (versus just from localhost). For additional information:
 - See the [moto stand-alone server usage docs](https://github.com/spulec/moto#stand-alone-server-mode)
 - See [which AWS services are supported](https://github.com/spulec/moto#in-a-nutshell)


### PR DESCRIPTION
Fix 17 misspellings found via codespell scan across Go source comments, documentation, and example files.

**Changes:**

- `modules/core/shell/output.go`: `runnig` → `running`
- `modules/terraform/options.go`: `formated` → `formatted`, `arbritrary` → `arbitrary`
- `modules/core/logger/parser/parser.go`: `delimeted` → `delimited`
- `modules/teststructure/save_test_data.go`: `overwritting` → `overwriting`
- `modules/aws/s3.go`: `acess` → `access`
- `modules/k8s/tunnel.go`: `forwading` → `forwarding`
- `test-docker-images/gruntwork-amazon-linux-test/Dockerfile`: `whch` → `which`
- `test-docker-images/moto/README.md`: `acceping` → `accepting`
- `docs/_docs/01_getting-started/quick-start.md`: `Kuberenetes` → `Kubernetes`
- `docs/README.md`: `CAHNGE` → `CHANGE`
- `examples/azure/terraform-azure-availabilityset-example/README.md`: `attched` → `attached`
- `examples/azure/terraform-azure-aks-example/variables.tf`: `resoureces` → `resources`
- `examples/azure/terraform-azure-aks-example/README.md`: `Kubenetes` → `Kubernetes`
- `docs/assets/js/collection-browser_toc.js`: `collpase` → `collapse` (2 occurrences)
- `docs/assets/js/collection-browser_search.js`: `accoriding` → `according`
- `docs/assets/js/examples.js`: `containting` → `containing`

All fixes were manually verified to be genuine English word misspellings (not identifiers, acronyms, or non-English text).

Signed-off-by: maxtaran2010 <ocotifuzo727@gmail.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Corrected multiple typos across getting-started guides, example READMEs, and documentation text (including Kubernetes/Azure/AWS/Terraform wording).
  * Updated typos in collection browser-related documentation/comment text to improve readability and accuracy.
  * Refreshed small comment phrasing in infrastructure module and test output descriptions without changing any behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->