### PR TITLE
Migrate internal callers off deprecated function wrappers

### DIFF
--- a/modules/aws/account.go
+++ b/modules/aws/account.go
@@ -65,7 +65,7 @@ func GetAccountIDE(t testing.TestingT) (string, error) {
 //
 //nolint:staticcheck,revive // preserving deprecated function name
 func GetAccountId(t testing.TestingT) string {
-	return GetAccountID(t)
+	return GetAccountIDContext(t, context.Background())
 }
 
 // GetAccountIdE gets the Account ID for the currently logged in IAM User.
@@ -74,7 +74,7 @@ func GetAccountId(t testing.TestingT) string {
 //
 //nolint:staticcheck,revive // preserving deprecated function name
 func GetAccountIdE(t testing.TestingT) (string, error) {
-	return GetAccountIDE(t)
+	return GetAccountIDContextE(t, context.Background())
 }
 
 // ExtractAccountIDFromARN extracts the AWS account ID from an IAM ARN.

--- a/modules/aws/account_test.go
+++ b/modules/aws/account_test.go
@@ -1,6 +1,7 @@
 package aws_test
 
 import (
+	"context"
 	"testing"
 
 	aws "github.com/gruntwork-io/terratest/modules/aws/v2"
@@ -10,7 +11,7 @@ import (
 func TestGetAccountId(t *testing.T) {
 	t.Parallel()
 
-	accountID := aws.GetAccountID(t)
+	accountID := aws.GetAccountIDContext(t, context.Background())
 	assert.Regexp(t, "^[0-9]{12}$", accountID)
 }
 

--- a/modules/aws/ami.go
+++ b/modules/aws/ami.go
@@ -216,7 +216,7 @@ func GetMostRecentAmiIDE(t testing.TestingT, region string, ownerID string, filt
 //
 //nolint:staticcheck,revive // preserving deprecated function name
 func GetMostRecentAmiId(t testing.TestingT, region string, ownerId string, filters map[string][]string) string {
-	return GetMostRecentAmiID(t, region, ownerId, filters)
+	return GetMostRecentAmiIDContext(t, context.Background(), region, ownerId, filters)
 }
 
 // GetMostRecentAmiIdE gets the ID of the most recent AMI in the given region that has the given owner and matches
@@ -226,7 +226,7 @@ func GetMostRecentAmiId(t testing.TestingT, region string, ownerId string, filte
 //
 //nolint:staticcheck,revive // preserving deprecated function name
 func GetMostRecentAmiIdE(t testing.TestingT, region string, ownerId string, filters map[string][]string) (string, error) {
-	return GetMostRecentAmiIDE(t, region, ownerId, filters)
+	return GetMostRecentAmiIDContextE(t, context.Background(), region, ownerId, filters)
 }
 
 // Image sorting code borrowed from: https://github.com/hashicorp/packer/blob/7f4112ba229309cfc0ebaa10ded2abdfaf1b22c8/builder/amazon/common/step_source_ami_info.go

--- a/modules/aws/ami_test.go
+++ b/modules/aws/ami_test.go
@@ -1,6 +1,7 @@
 package aws_test
 
 import (
+	"context"
 	"testing"
 
 	aws "github.com/gruntwork-io/terratest/modules/aws/v2"
@@ -10,48 +11,48 @@ import (
 func TestGetUbuntu1404AmiReturnsSomeAmi(t *testing.T) {
 	t.Parallel()
 
-	amiID := aws.GetUbuntu1404Ami(t, "us-east-1")
+	amiID := aws.GetUbuntu1404AmiContext(t, context.Background(), "us-east-1")
 	assert.Regexp(t, "^ami-[[:alnum:]]+$", amiID)
 }
 
 func TestGetUbuntu1604AmiReturnsSomeAmi(t *testing.T) {
 	t.Parallel()
 
-	amiID := aws.GetUbuntu1604Ami(t, "us-west-1")
+	amiID := aws.GetUbuntu1604AmiContext(t, context.Background(), "us-west-1")
 	assert.Regexp(t, "^ami-[[:alnum:]]+$", amiID)
 }
 
 func TestGetUbuntu2004AmiReturnsSomeAmi(t *testing.T) {
 	t.Parallel()
 
-	amiID := aws.GetUbuntu2004Ami(t, "us-west-1")
+	amiID := aws.GetUbuntu2004AmiContext(t, context.Background(), "us-west-1")
 	assert.Regexp(t, "^ami-[[:alnum:]]+$", amiID)
 }
 
 func TestGetUbuntu2204AmiReturnsSomeAmi(t *testing.T) {
 	t.Parallel()
 
-	amiID := aws.GetUbuntu2204Ami(t, "us-west-1")
+	amiID := aws.GetUbuntu2204AmiContext(t, context.Background(), "us-west-1")
 	assert.Regexp(t, "^ami-[[:alnum:]]+$", amiID)
 }
 
 func TestGetCentos7AmiReturnsSomeAmi(t *testing.T) {
 	t.Parallel()
 
-	amiID := aws.GetCentos7Ami(t, "eu-west-1")
+	amiID := aws.GetCentos7AmiContext(t, context.Background(), "eu-west-1")
 	assert.Regexp(t, "^ami-[[:alnum:]]+$", amiID)
 }
 
 func TestGetAmazonLinuxAmiReturnsSomeAmi(t *testing.T) {
 	t.Parallel()
 
-	amiID := aws.GetAmazonLinuxAmi(t, "ap-southeast-1")
+	amiID := aws.GetAmazonLinuxAmiContext(t, context.Background(), "ap-southeast-1")
 	assert.Regexp(t, "^ami-[[:alnum:]]+$", amiID)
 }
 
 func TestGetEcsOptimizedAmazonLinuxAmiEReturnsSomeAmi(t *testing.T) {
 	t.Parallel()
 
-	amiID := aws.GetEcsOptimizedAmazonLinuxAmi(t, "us-east-2")
+	amiID := aws.GetEcsOptimizedAmazonLinuxAmiContext(t, context.Background(), "us-east-2")
 	assert.Regexp(t, "^ami-[[:alnum:]]+$", amiID)
 }

--- a/modules/aws/asg_test.go
+++ b/modules/aws/asg_test.go
@@ -22,14 +22,14 @@ func TestGetCapacityInfoForAsg(t *testing.T) {
 
 	uniqueID := random.UniqueID()
 	asgName := t.Name() + "-" + uniqueID
-	region := aws.GetRandomStableRegion(t, []string{}, []string{})
+	region := aws.GetRandomStableRegionContext(t, context.Background(), []string{}, []string{})
 
 	defer deleteAutoScalingGroup(t, asgName, region)
 
 	createTestAutoScalingGroup(t, asgName, region, 2)
-	aws.WaitForCapacity(t, asgName, region, 40, 15*time.Second)
+	aws.WaitForCapacityContext(t, context.Background(), asgName, region, 40, 15*time.Second)
 
-	capacityInfo := aws.GetCapacityInfoForAsg(t, asgName, region)
+	capacityInfo := aws.GetCapacityInfoForAsgContext(t, context.Background(), asgName, region)
 	assert.Equal(t, int64(2), capacityInfo.DesiredCapacity)
 	assert.Equal(t, int64(2), capacityInfo.CurrentCapacity)
 	assert.Equal(t, int64(1), capacityInfo.MinCapacity)
@@ -41,33 +41,33 @@ func TestGetInstanceIdsForAsg(t *testing.T) {
 
 	uniqueID := random.UniqueID()
 	asgName := t.Name() + "-" + uniqueID
-	region := aws.GetRandomStableRegion(t, []string{}, []string{})
+	region := aws.GetRandomStableRegionContext(t, context.Background(), []string{}, []string{})
 
 	defer deleteAutoScalingGroup(t, asgName, region)
 
 	createTestAutoScalingGroup(t, asgName, region, 1)
-	aws.WaitForCapacity(t, asgName, region, 40, 15*time.Second)
+	aws.WaitForCapacityContext(t, context.Background(), asgName, region, 40, 15*time.Second)
 
-	instanceIDs := aws.GetInstanceIdsForAsg(t, asgName, region)
+	instanceIDs := aws.GetInstanceIdsForAsgContext(t, context.Background(), asgName, region)
 	assert.Len(t, instanceIDs, 1)
 }
 
 func createTestAutoScalingGroup(t *testing.T, name string, region string, desiredCount int32) {
 	t.Helper()
 
-	azs := aws.GetAvailabilityZones(t, region)
-	ec2Client := aws.NewEc2Client(t, region)
-	imageID := aws.GetAmazonLinuxAmi(t, region)
+	azs := aws.GetAvailabilityZonesContext(t, context.Background(), region)
+	ec2Client := aws.NewEc2ClientContext(t, context.Background(), region)
+	imageID := aws.GetAmazonLinuxAmiContext(t, context.Background(), region)
 	template, err := ec2Client.CreateLaunchTemplate(context.Background(), &ec2.CreateLaunchTemplateInput{
 		LaunchTemplateData: &types.RequestLaunchTemplateData{
 			ImageId:      awsSDK.String(imageID),
-			InstanceType: types.InstanceType(aws.GetRecommendedInstanceType(t, region, []string{"t2.micro, t3.micro", "t2.small", "t3.small"})),
+			InstanceType: types.InstanceType(aws.GetRecommendedInstanceTypeContext(t, context.Background(), region, []string{"t2.micro, t3.micro", "t2.small", "t3.small"})),
 		},
 		LaunchTemplateName: awsSDK.String(name),
 	})
 	require.NoError(t, err)
 
-	asgClient := aws.NewAsgClient(t, region)
+	asgClient := aws.NewAsgClientContext(t, context.Background(), region)
 	param := &autoscaling.CreateAutoScalingGroupInput{
 		AutoScalingGroupName: &name,
 		LaunchTemplate: &autoscalingTypes.LaunchTemplateSpecification{
@@ -95,7 +95,7 @@ func deleteAutoScalingGroup(t *testing.T, name string, region string) {
 	// We have to scale ASG down to 0 before we can delete it
 	scaleAsgToZero(t, name, region)
 
-	asgClient := aws.NewAsgClient(t, region)
+	asgClient := aws.NewAsgClientContext(t, context.Background(), region)
 	input := &autoscaling.DeleteAutoScalingGroupInput{AutoScalingGroupName: awsSDK.String(name)}
 	_, err := asgClient.DeleteAutoScalingGroup(context.Background(), input)
 	require.NoError(t, err)
@@ -106,7 +106,7 @@ func deleteAutoScalingGroup(t *testing.T, name string, region string) {
 	}, 40*time.Minute)
 	require.NoError(t, err)
 
-	ec2Client := aws.NewEc2Client(t, region)
+	ec2Client := aws.NewEc2ClientContext(t, context.Background(), region)
 	_, err = ec2Client.DeleteLaunchTemplate(context.Background(), &ec2.DeleteLaunchTemplateInput{
 		LaunchTemplateName: awsSDK.String(name),
 	})
@@ -116,7 +116,7 @@ func deleteAutoScalingGroup(t *testing.T, name string, region string) {
 func scaleAsgToZero(t *testing.T, name string, region string) {
 	t.Helper()
 
-	asgClient := aws.NewAsgClient(t, region)
+	asgClient := aws.NewAsgClientContext(t, context.Background(), region)
 	input := &autoscaling.UpdateAutoScalingGroupInput{
 		AutoScalingGroupName: awsSDK.String(name),
 		DesiredCapacity:      awsSDK.Int32(0),
@@ -125,7 +125,7 @@ func scaleAsgToZero(t *testing.T, name string, region string) {
 	}
 	_, err := asgClient.UpdateAutoScalingGroup(context.Background(), input)
 	require.NoError(t, err)
-	aws.WaitForCapacity(t, name, region, 40, 15*time.Second)
+	aws.WaitForCapacityContext(t, context.Background(), name, region, 40, 15*time.Second)
 
 	// There is an eventual consistency bug where even though the ASG is scaled down, AWS sometimes still views a
 	// scaling activity so we add a 5-second pause here to work around it.

--- a/modules/aws/ec2-files.go
+++ b/modules/aws/ec2-files.go
@@ -286,7 +286,7 @@ func FetchFilesFromInstanceContextE(t testing.TestingT, ctx context.Context, aws
 	}
 
 	//nolint:staticcheck,contextcheck // ScpDirFromE has no Context variant yet
-	return ssh.ScpDirFromE(t, scpOptions, useSudo)
+	return ssh.SCPDirFromContextE(t, context.Background(), &scpOptions, useSudo)
 }
 
 // FetchFilesFromInstanceContext looks up the EC2 Instances in the given ASG, looks up the public IPs of those EC2

--- a/modules/aws/ec2-files.go
+++ b/modules/aws/ec2-files.go
@@ -285,8 +285,7 @@ func FetchFilesFromInstanceContextE(t testing.TestingT, ctx context.Context, aws
 		FileNameFilters: filenameFilters,
 	}
 
-	//nolint:staticcheck,contextcheck // ScpDirFromE has no Context variant yet
-	return ssh.SCPDirFromContextE(t, context.Background(), &scpOptions, useSudo)
+	return ssh.SCPDirFromContextE(t, ctx, &scpOptions, useSudo)
 }
 
 // FetchFilesFromInstanceContext looks up the EC2 Instances in the given ASG, looks up the public IPs of those EC2

--- a/modules/aws/ec2.go
+++ b/modules/aws/ec2.go
@@ -62,7 +62,7 @@ func GetPrivateIPOfEc2InstanceE(t testing.TestingT, instanceID string, awsRegion
 //
 //nolint:staticcheck,revive // preserving deprecated function name
 func GetPrivateIpOfEc2Instance(t testing.TestingT, instanceID string, awsRegion string) string {
-	return GetPrivateIPOfEc2Instance(t, instanceID, awsRegion)
+	return GetPrivateIPOfEc2InstanceContext(t, context.Background(), instanceID, awsRegion)
 }
 
 // GetPrivateIpOfEc2InstanceE gets the private IP address of the given EC2 Instance in the given region.
@@ -71,7 +71,7 @@ func GetPrivateIpOfEc2Instance(t testing.TestingT, instanceID string, awsRegion 
 //
 //nolint:staticcheck,revive // preserving deprecated function name
 func GetPrivateIpOfEc2InstanceE(t testing.TestingT, instanceID string, awsRegion string) (string, error) {
-	return GetPrivateIPOfEc2InstanceE(t, instanceID, awsRegion)
+	return GetPrivateIPOfEc2InstanceContextE(t, context.Background(), instanceID, awsRegion)
 }
 
 // GetPrivateIpsOfEc2InstancesContextE gets the private IP address of the given EC2 Instance in the given region. Returns a map of instance ID to IP address.
@@ -236,7 +236,7 @@ func GetPublicIPOfEc2InstanceE(t testing.TestingT, instanceID string, awsRegion 
 //
 //nolint:staticcheck,revive // preserving deprecated function name
 func GetPublicIpOfEc2Instance(t testing.TestingT, instanceID string, awsRegion string) string {
-	return GetPublicIPOfEc2Instance(t, instanceID, awsRegion)
+	return GetPublicIPOfEc2InstanceContext(t, context.Background(), instanceID, awsRegion)
 }
 
 // GetPublicIpOfEc2InstanceE gets the public IP address of the given EC2 Instance in the given region.
@@ -245,7 +245,7 @@ func GetPublicIpOfEc2Instance(t testing.TestingT, instanceID string, awsRegion s
 //
 //nolint:staticcheck,revive // preserving deprecated function name
 func GetPublicIpOfEc2InstanceE(t testing.TestingT, instanceID string, awsRegion string) (string, error) {
-	return GetPublicIPOfEc2InstanceE(t, instanceID, awsRegion)
+	return GetPublicIPOfEc2InstanceContextE(t, context.Background(), instanceID, awsRegion)
 }
 
 // GetPublicIpsOfEc2InstancesContextE gets the public IP address of the given EC2 Instance in the given region. Returns a map of instance ID to IP address.

--- a/modules/aws/ec2_test.go
+++ b/modules/aws/ec2_test.go
@@ -1,6 +1,7 @@
 package aws_test
 
 import (
+	"context"
 	"strings"
 	"testing"
 
@@ -16,8 +17,8 @@ import (
 func TestGetEc2InstanceIdsByTag(t *testing.T) {
 	t.Parallel()
 
-	region := aws.GetRandomStableRegion(t, nil, nil)
-	ids, err := aws.GetEc2InstanceIdsByTagE(t, region, "Name", "nonexistent-"+random.UniqueID())
+	region := aws.GetRandomStableRegionContext(t, context.Background(), nil, nil)
+	ids, err := aws.GetEc2InstanceIdsByTagContextE(t, context.Background(), region, "Name", "nonexistent-"+random.UniqueID())
 	require.NoError(t, err)
 	assert.Empty(t, ids)
 }
@@ -25,13 +26,13 @@ func TestGetEc2InstanceIdsByTag(t *testing.T) {
 func TestGetEc2InstanceIdsByFilters(t *testing.T) {
 	t.Parallel()
 
-	region := aws.GetRandomStableRegion(t, nil, nil)
+	region := aws.GetRandomStableRegionContext(t, context.Background(), nil, nil)
 	filters := map[string][]string{
 		"instance-state-name": {"running", "shutting-down"},
 		"tag:Name":            {"nonexistent-" + random.UniqueID()},
 	}
 
-	ids, err := aws.GetEc2InstanceIdsByFiltersE(t, region, filters)
+	ids, err := aws.GetEc2InstanceIdsByFiltersContextE(t, context.Background(), region, filters)
 	require.NoError(t, err)
 	assert.Empty(t, ids)
 }
@@ -55,7 +56,7 @@ func TestGetRecommendedInstanceType(t *testing.T) {
 
 		t.Run(testCase.region+"-"+strings.Join(testCase.instanceTypeOptions, "-"), func(t *testing.T) {
 			t.Parallel()
-			instanceType := aws.GetRecommendedInstanceType(t, testCase.region, testCase.instanceTypeOptions)
+			instanceType := aws.GetRecommendedInstanceTypeContext(t, context.Background(), testCase.region, testCase.instanceTypeOptions)
 			// We could hard-code the expected result (e.g., as of July 2020, we expect eu-west-1 to return t2.micro
 			// and ap-northeast-2 to return t3.micro), but the result will likely change over time, so to avoid a
 			// brittle test, we simply check that we get _one_ result. Combined with the unit test below, this hopefully

--- a/modules/aws/ecr_test.go
+++ b/modules/aws/ecr_test.go
@@ -1,6 +1,7 @@
 package aws_test
 
 import (
+	"context"
 	"strings"
 	"testing"
 
@@ -15,17 +16,17 @@ import (
 func TestEcrRepo(t *testing.T) {
 	t.Parallel()
 
-	region := aws.GetRandomStableRegion(t, nil, nil)
+	region := aws.GetRandomStableRegionContext(t, context.Background(), nil, nil)
 	ecrRepoName := "terratest" + strings.ToLower(random.UniqueID())
 
-	repo1, err := aws.CreateECRRepoE(t, region, ecrRepoName)
-	defer aws.DeleteECRRepo(t, region, repo1)
+	repo1, err := aws.CreateECRRepoContextE(t, context.Background(), region, ecrRepoName)
+	defer aws.DeleteECRRepoContext(t, context.Background(), region, repo1)
 
 	require.NoError(t, err)
 
 	assert.Equal(t, ecrRepoName, awsSDK.ToString(repo1.RepositoryName))
 
-	repo2, err := aws.GetECRRepoE(t, region, ecrRepoName)
+	repo2, err := aws.GetECRRepoContextE(t, context.Background(), region, ecrRepoName)
 	require.NoError(t, err)
 	assert.Equal(t, ecrRepoName, awsSDK.ToString(repo2.RepositoryName))
 }
@@ -33,28 +34,28 @@ func TestEcrRepo(t *testing.T) {
 func TestGetEcrRepoLifecyclePolicyError(t *testing.T) {
 	t.Parallel()
 
-	region := aws.GetRandomStableRegion(t, nil, nil)
+	region := aws.GetRandomStableRegionContext(t, context.Background(), nil, nil)
 	ecrRepoName := "terratest" + strings.ToLower(random.UniqueID())
 
-	repo1, err := aws.CreateECRRepoE(t, region, ecrRepoName)
-	defer aws.DeleteECRRepo(t, region, repo1)
+	repo1, err := aws.CreateECRRepoContextE(t, context.Background(), region, ecrRepoName)
+	defer aws.DeleteECRRepoContext(t, context.Background(), region, repo1)
 
 	require.NoError(t, err)
 
 	assert.Equal(t, ecrRepoName, awsSDK.ToString(repo1.RepositoryName))
 
-	_, err = aws.GetECRRepoLifecyclePolicyE(t, region, repo1)
+	_, err = aws.GetECRRepoLifecyclePolicyContextE(t, context.Background(), region, repo1)
 	require.Error(t, err)
 }
 
 func TestCanSetECRRepoLifecyclePolicyWithSingleRule(t *testing.T) {
 	t.Parallel()
 
-	region := aws.GetRandomStableRegion(t, nil, nil)
+	region := aws.GetRandomStableRegionContext(t, context.Background(), nil, nil)
 	ecrRepoName := "terratest" + strings.ToLower(random.UniqueID())
 
-	repo1, err := aws.CreateECRRepoE(t, region, ecrRepoName)
-	defer aws.DeleteECRRepo(t, region, repo1)
+	repo1, err := aws.CreateECRRepoContextE(t, context.Background(), region, ecrRepoName)
+	defer aws.DeleteECRRepoContext(t, context.Background(), region, repo1)
 
 	require.NoError(t, err)
 
@@ -76,21 +77,21 @@ func TestCanSetECRRepoLifecyclePolicyWithSingleRule(t *testing.T) {
 		]
 	}`
 
-	err = aws.PutECRRepoLifecyclePolicyE(t, region, repo1, lifecyclePolicy)
+	err = aws.PutECRRepoLifecyclePolicyContextE(t, context.Background(), region, repo1, lifecyclePolicy)
 	require.NoError(t, err)
 
-	policy := aws.GetECRRepoLifecyclePolicy(t, region, repo1)
+	policy := aws.GetECRRepoLifecyclePolicyContext(t, context.Background(), region, repo1)
 	assert.JSONEq(t, lifecyclePolicy, policy)
 }
 
 func TestCanSetRepositoryPolicyWithSimplePolicy(t *testing.T) {
 	t.Parallel()
 
-	region := aws.GetRandomStableRegion(t, nil, nil)
+	region := aws.GetRandomStableRegionContext(t, context.Background(), nil, nil)
 	ecrRepoName := "terratest" + strings.ToLower(random.UniqueID())
 
-	repo, err := aws.CreateECRRepoE(t, region, ecrRepoName)
-	defer aws.DeleteECRRepo(t, region, repo)
+	repo, err := aws.CreateECRRepoContextE(t, context.Background(), region, ecrRepoName)
+	defer aws.DeleteECRRepoContext(t, context.Background(), region, repo)
 
 	require.NoError(t, err)
 
@@ -109,9 +110,9 @@ func TestCanSetRepositoryPolicyWithSimplePolicy(t *testing.T) {
 		]
 	}`
 
-	err = aws.PutECRRepoPolicyE(t, region, repo, repositoryPolicy)
+	err = aws.PutECRRepoPolicyContextE(t, context.Background(), region, repo, repositoryPolicy)
 	require.NoError(t, err)
 
-	policy := aws.GetECRRepoPolicy(t, region, repo)
+	policy := aws.GetECRRepoPolicyContext(t, context.Background(), region, repo)
 	assert.JSONEq(t, repositoryPolicy, policy)
 }

--- a/modules/aws/ecs_test.go
+++ b/modules/aws/ecs_test.go
@@ -17,15 +17,15 @@ import (
 func TestEcsCluster(t *testing.T) {
 	t.Parallel()
 
-	region := aws.GetRandomStableRegion(t, nil, nil)
+	region := aws.GetRandomStableRegionContext(t, context.Background(), nil, nil)
 
-	c1, err := aws.CreateEcsClusterE(t, region, "terratest")
-	defer aws.DeleteEcsCluster(t, region, c1)
+	c1, err := aws.CreateEcsClusterContextE(t, context.Background(), region, "terratest")
+	defer aws.DeleteEcsClusterContext(t, context.Background(), region, c1)
 
 	require.NoError(t, err)
 	assert.Equal(t, "terratest", *c1.ClusterName)
 
-	c2, err := aws.GetEcsClusterE(t, region, *c1.ClusterName)
+	c2, err := aws.GetEcsClusterContextE(t, context.Background(), region, *c1.ClusterName)
 
 	require.NoError(t, err)
 	assert.Equal(t, "terratest", *c2.ClusterName)
@@ -34,32 +34,32 @@ func TestEcsCluster(t *testing.T) {
 func TestEcsClusterWithInclude(t *testing.T) {
 	t.Parallel()
 
-	region := aws.GetRandomStableRegion(t, nil, nil)
+	region := aws.GetRandomStableRegionContext(t, context.Background(), nil, nil)
 	clusterName := "terratest-" + random.UniqueID()
 	tags := []types.Tag{{
 		Key:   awsSDK.String("test-tag"),
 		Value: awsSDK.String("hello-world"),
 	}}
 
-	client := aws.NewEcsClient(t, region)
+	client := aws.NewEcsClientContext(t, context.Background(), region)
 	c1, err := client.CreateCluster(context.Background(), &ecs.CreateClusterInput{
 		ClusterName: awsSDK.String(clusterName),
 		Tags:        tags,
 	})
 	require.NoError(t, err)
 
-	defer aws.DeleteEcsCluster(t, region, c1.Cluster)
+	defer aws.DeleteEcsClusterContext(t, context.Background(), region, c1.Cluster)
 
 	assert.Equal(t, clusterName, awsSDK.ToString(c1.Cluster.ClusterName))
 
-	c2, err := aws.GetEcsClusterWithIncludeE(t, region, clusterName, []types.ClusterField{types.ClusterFieldTags})
+	c2, err := aws.GetEcsClusterWithIncludeContextE(t, context.Background(), region, clusterName, []types.ClusterField{types.ClusterFieldTags})
 	require.NoError(t, err)
 
 	assert.Equal(t, clusterName, awsSDK.ToString(c2.ClusterName))
 	assert.Equal(t, tags, c2.Tags)
 	assert.Empty(t, c2.Statistics)
 
-	c3, err := aws.GetEcsClusterWithIncludeE(t, region, clusterName, []types.ClusterField{types.ClusterFieldStatistics})
+	c3, err := aws.GetEcsClusterWithIncludeContextE(t, context.Background(), region, clusterName, []types.ClusterField{types.ClusterFieldStatistics})
 	require.NoError(t, err)
 
 	assert.Equal(t, clusterName, awsSDK.ToString(c3.ClusterName))

--- a/modules/aws/iam_test.go
+++ b/modules/aws/iam_test.go
@@ -16,26 +16,26 @@ import (
 func TestGetIamCurrentUserName(t *testing.T) {
 	t.Parallel()
 
-	username := aws.GetIamCurrentUserName(t)
+	username := aws.GetIamCurrentUserNameContext(t, context.Background())
 	assert.NotEmpty(t, username)
 }
 
 func TestGetIamCurrentUserArn(t *testing.T) {
 	t.Parallel()
 
-	username := aws.GetIamCurrentUserArn(t)
+	username := aws.GetIamCurrentUserArnContext(t, context.Background())
 	assert.Regexp(t, "^arn:aws:iam::[0-9]{12}:user/.+$", username)
 }
 
 func TestGetIAMPolicyDocument(t *testing.T) {
 	t.Parallel()
 
-	region := aws.GetRandomRegion(t, nil, nil)
+	region := aws.GetRandomRegionContext(t, context.Background(), nil, nil)
 
 	t.Run("Exists", func(t *testing.T) {
 		t.Parallel()
 
-		iamClient, err := aws.NewIamClientE(t, region)
+		iamClient, err := aws.NewIamClientContextE(t, context.Background(), region)
 		require.NoError(t, err)
 
 		policyDocument := `{
@@ -66,7 +66,7 @@ func TestGetIAMPolicyDocument(t *testing.T) {
 			require.NoError(t, err)
 		})
 
-		p := aws.GetIamPolicyDocument(t, region, *policy.Policy.Arn)
+		p := aws.GetIamPolicyDocumentContext(t, context.Background(), region, *policy.Policy.Arn)
 		t.Log("Retrieved Policy Document:", p)
 		assert.JSONEq(t, policyDocument, p)
 	})
@@ -74,7 +74,7 @@ func TestGetIAMPolicyDocument(t *testing.T) {
 	t.Run("DoesNotExist", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := aws.GetIamPolicyDocumentE(t, region, "arn:aws:iam::1234567890:policy/does-not-exist")
+		_, err := aws.GetIamPolicyDocumentContextE(t, context.Background(), region, "arn:aws:iam::1234567890:policy/does-not-exist")
 		require.Error(t, err)
 	})
 }

--- a/modules/aws/keypair_test.go
+++ b/modules/aws/keypair_test.go
@@ -14,11 +14,11 @@ import (
 func TestCreateImportAndDeleteEC2KeyPair(t *testing.T) {
 	t.Parallel()
 
-	region := aws.GetRandomStableRegion(t, nil, nil)
+	region := aws.GetRandomStableRegionContext(t, context.Background(), nil, nil)
 	uniqueID := random.UniqueID()
 	name := "test-key-pair-" + uniqueID
 
-	keyPair := aws.CreateAndImportEC2KeyPair(t, region, name)
+	keyPair := aws.CreateAndImportEC2KeyPairContext(t, context.Background(), region, name)
 	defer deleteKeyPair(t, keyPair)
 
 	assert.True(t, keyPairExists(t, keyPair))
@@ -31,7 +31,7 @@ func TestCreateImportAndDeleteEC2KeyPair(t *testing.T) {
 func keyPairExists(t *testing.T, keyPair *aws.Ec2Keypair) bool {
 	t.Helper()
 
-	client := aws.NewEc2Client(t, keyPair.Region)
+	client := aws.NewEc2ClientContext(t, context.Background(), keyPair.Region)
 
 	input := ec2.DescribeKeyPairsInput{
 		KeyNames: []string{keyPair.Name},
@@ -52,6 +52,6 @@ func keyPairExists(t *testing.T, keyPair *aws.Ec2Keypair) bool {
 func deleteKeyPair(t *testing.T, keyPair *aws.Ec2Keypair) {
 	t.Helper()
 
-	aws.DeleteEC2KeyPair(t, keyPair)
+	aws.DeleteEC2KeyPairContext(t, context.Background(), keyPair)
 	assert.False(t, keyPairExists(t, keyPair))
 }

--- a/modules/aws/rds_test.go
+++ b/modules/aws/rds_test.go
@@ -1,6 +1,7 @@
 package aws_test
 
 import (
+	"context"
 	"testing"
 
 	aws "github.com/gruntwork-io/terratest/modules/aws/v2"
@@ -60,8 +61,8 @@ func TestGetRecommendedRdsInstanceTypeHappyPath(t *testing.T) {
 
 		t.Run(scenerio.name, func(t *testing.T) {
 			t.Parallel()
-			engineVersion := aws.GetValidEngineVersion(t, scenerio.region, scenerio.databaseEngine, scenerio.engineMajorVersion)
-			actual, err := aws.GetRecommendedRdsInstanceTypeE(t, scenerio.region, scenerio.databaseEngine, engineVersion, scenerio.instanceTypes)
+			engineVersion := aws.GetValidEngineVersionContext(t, context.Background(), scenerio.region, scenerio.databaseEngine, scenerio.engineMajorVersion)
+			actual, err := aws.GetRecommendedRdsInstanceTypeContextE(t, context.Background(), scenerio.region, scenerio.databaseEngine, engineVersion, scenerio.instanceTypes)
 			require.NoError(t, err)
 			assert.Equal(t, scenerio.expected, actual)
 		})
@@ -144,7 +145,7 @@ func TestGetRecommendedRdsInstanceTypeErrors(t *testing.T) {
 		t.Run(scenerio.name, func(t *testing.T) {
 			t.Parallel()
 
-			_, err := aws.GetRecommendedRdsInstanceTypeE(t, scenerio.region, scenerio.databaseEngine, scenerio.databaseEngineVersion, scenerio.instanceTypes)
+			_, err := aws.GetRecommendedRdsInstanceTypeContextE(t, context.Background(), scenerio.region, scenerio.databaseEngine, scenerio.databaseEngineVersion, scenerio.instanceTypes)
 			assert.EqualError(t, err, aws.NoRdsInstanceTypeError{InstanceTypeOptions: scenerio.instanceTypes, DatabaseEngine: scenerio.databaseEngine, DatabaseEngineVersion: scenerio.databaseEngineVersion}.Error())
 		})
 	}

--- a/modules/aws/region_test.go
+++ b/modules/aws/region_test.go
@@ -1,6 +1,7 @@
 package aws_test
 
 import (
+	"context"
 	"testing"
 
 	aws "github.com/gruntwork-io/terratest/modules/aws/v2"
@@ -10,7 +11,7 @@ import (
 func TestGetRandomRegion(t *testing.T) {
 	t.Parallel()
 
-	randomRegion := aws.GetRandomRegion(t, nil, nil)
+	randomRegion := aws.GetRandomRegionContext(t, context.Background(), nil, nil)
 	assertLooksLikeRegionName(t, randomRegion)
 }
 
@@ -21,7 +22,7 @@ func TestGetRandomRegionExcludesForbiddenRegions(t *testing.T) {
 	forbiddenRegions := []string{"us-west-2", "ap-northeast-2"}
 
 	for i := 0; i < 1000; i++ {
-		randomRegion := aws.GetRandomRegion(t, approvedRegions, forbiddenRegions)
+		randomRegion := aws.GetRandomRegionContext(t, context.Background(), approvedRegions, forbiddenRegions)
 		assert.NotContains(t, forbiddenRegions, randomRegion)
 	}
 }
@@ -29,7 +30,7 @@ func TestGetRandomRegionExcludesForbiddenRegions(t *testing.T) {
 func TestGetAllAwsRegions(t *testing.T) {
 	t.Parallel()
 
-	regions := aws.GetAllAwsRegions(t)
+	regions := aws.GetAllAwsRegionsContext(t, context.Background())
 
 	// The typical account had access to 15 regions as of April, 2018: https://aws.amazon.com/about-aws/global-infrastructure/
 	assert.GreaterOrEqual(t, len(regions), 15, "Number of regions: %d", len(regions))
@@ -48,8 +49,8 @@ func assertLooksLikeRegionName(t *testing.T, regionName string) {
 func TestGetAvailabilityZones(t *testing.T) {
 	t.Parallel()
 
-	randomRegion := aws.GetRandomStableRegion(t, nil, nil)
-	azs := aws.GetAvailabilityZones(t, randomRegion)
+	randomRegion := aws.GetRandomStableRegionContext(t, context.Background(), nil, nil)
+	azs := aws.GetAvailabilityZonesContext(t, context.Background(), randomRegion)
 
 	// Every AWS account has access to different AZs, so he best we can do is make sure we get at least one back
 	assert.Greater(t, len(azs), 1)
@@ -64,8 +65,8 @@ func TestGetRandomRegionForService(t *testing.T) {
 
 	serviceName := "apigatewayv2"
 
-	regionsForService, _ := aws.GetRegionsForServiceE(t, serviceName)
-	randomRegionForService := aws.GetRandomRegionForService(t, serviceName)
+	regionsForService, _ := aws.GetRegionsForServiceContextE(t, context.Background(), serviceName)
+	randomRegionForService := aws.GetRandomRegionForServiceContext(t, context.Background(), serviceName)
 
 	assert.Contains(t, regionsForService, randomRegionForService)
 }

--- a/modules/aws/route53_test.go
+++ b/modules/aws/route53_test.go
@@ -16,8 +16,8 @@ import (
 
 func TestRoute53Record(t *testing.T) {
 	t.Parallel()
-	region := aws.GetRandomStableRegion(t, nil, nil)
-	c, err := aws.NewRoute53ClientE(t, region)
+	region := aws.GetRandomStableRegionContext(t, context.Background(), nil, nil)
+	c, err := aws.NewRoute53ClientContextE(t, context.Background(), region)
 	require.NoError(t, err)
 
 	domain := "terratest" + strconv.FormatInt(time.Now().UnixNano(), 10) + "example.com"
@@ -74,7 +74,7 @@ func TestRoute53Record(t *testing.T) {
 	t.Run("ExistingRecord", func(t *testing.T) {
 		t.Parallel()
 
-		route53Record := aws.GetRoute53Record(t, *hostedZone.HostedZone.Id, recordName, string(resourceRecordSet.Type), region)
+		route53Record := aws.GetRoute53RecordContext(t, context.Background(), *hostedZone.HostedZone.Id, recordName, string(resourceRecordSet.Type), region)
 		require.NotNil(t, route53Record)
 		assert.Equal(t, recordName+".", *route53Record.Name)
 		assert.Equal(t, resourceRecordSet.Type, route53Record.Type)
@@ -84,7 +84,7 @@ func TestRoute53Record(t *testing.T) {
 	t.Run("NotExistRecord", func(t *testing.T) {
 		t.Parallel()
 
-		route53Record, err := aws.GetRoute53RecordE(t, *hostedZone.HostedZone.Id, "ne"+recordName, "A", region)
+		route53Record, err := aws.GetRoute53RecordContextE(t, context.Background(), *hostedZone.HostedZone.Id, "ne"+recordName, "A", region)
 		require.Error(t, err)
 		assert.Nil(t, route53Record)
 	})

--- a/modules/aws/s3_test.go
+++ b/modules/aws/s3_test.go
@@ -25,40 +25,40 @@ import (
 func TestCreateAndDestroyS3Bucket(t *testing.T) {
 	t.Parallel()
 
-	region := terraaws.GetRandomStableRegion(t, nil, nil)
+	region := terraaws.GetRandomStableRegionContext(t, context.Background(), nil, nil)
 	id := random.UniqueID()
 	logger.Default.Logf(t, "Random values selected. Region = %s, Id = %s\n", region, id)
 
 	s3BucketName := "gruntwork-terratest-" + strings.ToLower(id)
 
-	terraaws.CreateS3Bucket(t, region, s3BucketName)
-	terraaws.DeleteS3Bucket(t, region, s3BucketName)
+	terraaws.CreateS3BucketContext(t, context.Background(), region, s3BucketName)
+	terraaws.DeleteS3BucketContext(t, context.Background(), region, s3BucketName)
 }
 
 func TestAssertS3BucketExistsNoFalseNegative(t *testing.T) {
 	t.Parallel()
 
-	region := terraaws.GetRandomStableRegion(t, nil, nil)
+	region := terraaws.GetRandomStableRegionContext(t, context.Background(), nil, nil)
 	s3BucketName := "gruntwork-terratest-" + strings.ToLower(random.UniqueID())
 	logger.Default.Logf(t, "Random values selected. Region = %s, s3BucketName = %s\n", region, s3BucketName)
 
-	terraaws.CreateS3Bucket(t, region, s3BucketName)
-	defer terraaws.DeleteS3Bucket(t, region, s3BucketName)
+	terraaws.CreateS3BucketContext(t, context.Background(), region, s3BucketName)
+	defer terraaws.DeleteS3BucketContext(t, context.Background(), region, s3BucketName)
 
-	terraaws.AssertS3BucketExists(t, region, s3BucketName)
+	terraaws.AssertS3BucketExistsContext(t, context.Background(), region, s3BucketName)
 }
 
 func TestAssertS3BucketExistsNoFalsePositive(t *testing.T) {
 	t.Parallel()
 
-	region := terraaws.GetRandomStableRegion(t, nil, nil)
+	region := terraaws.GetRandomStableRegionContext(t, context.Background(), nil, nil)
 	s3BucketName := "gruntwork-terratest-" + strings.ToLower(random.UniqueID())
 	logger.Default.Logf(t, "Random values selected. Region = %s, s3BucketName = %s\n", region, s3BucketName)
 
 	// We elect not to create the S3 bucket to confirm that our function correctly reports it doesn't exist.
 	// aws.CreateS3Bucket(region, s3BucketName)
 
-	err := terraaws.AssertS3BucketExistsE(t, region, s3BucketName)
+	err := terraaws.AssertS3BucketExistsContextE(t, context.Background(), region, s3BucketName)
 	if err == nil {
 		t.Fatalf("Function claimed that S3 Bucket '%s' exists, but in fact it does not.", s3BucketName)
 	}
@@ -67,31 +67,31 @@ func TestAssertS3BucketExistsNoFalsePositive(t *testing.T) {
 func TestAssertS3BucketVersioningEnabled(t *testing.T) {
 	t.Parallel()
 
-	region := terraaws.GetRandomStableRegion(t, nil, nil)
+	region := terraaws.GetRandomStableRegionContext(t, context.Background(), nil, nil)
 	s3BucketName := "gruntwork-terratest-" + strings.ToLower(random.UniqueID())
 	logger.Default.Logf(t, "Random values selected. Region = %s, s3BucketName = %s\n", region, s3BucketName)
 
-	terraaws.CreateS3Bucket(t, region, s3BucketName)
-	defer terraaws.DeleteS3Bucket(t, region, s3BucketName)
+	terraaws.CreateS3BucketContext(t, context.Background(), region, s3BucketName)
+	defer terraaws.DeleteS3BucketContext(t, context.Background(), region, s3BucketName)
 
-	terraaws.PutS3BucketVersioning(t, region, s3BucketName)
+	terraaws.PutS3BucketVersioningContext(t, context.Background(), region, s3BucketName)
 
-	terraaws.AssertS3BucketVersioningExists(t, region, s3BucketName)
+	terraaws.AssertS3BucketVersioningExistsContext(t, context.Background(), region, s3BucketName)
 }
 
 func TestEmptyS3Bucket(t *testing.T) {
 	t.Parallel()
 
-	region := terraaws.GetRandomStableRegion(t, nil, nil)
+	region := terraaws.GetRandomStableRegionContext(t, context.Background(), nil, nil)
 	id := random.UniqueID()
 	logger.Default.Logf(t, "Random values selected. Region = %s, Id = %s\n", region, id)
 
 	s3BucketName := "gruntwork-terratest-" + strings.ToLower(id)
 
-	terraaws.CreateS3Bucket(t, region, s3BucketName)
-	defer terraaws.DeleteS3Bucket(t, region, s3BucketName)
+	terraaws.CreateS3BucketContext(t, context.Background(), region, s3BucketName)
+	defer terraaws.DeleteS3BucketContext(t, context.Background(), region, s3BucketName)
 
-	s3Client, err := terraaws.NewS3ClientE(t, region)
+	s3Client, err := terraaws.NewS3ClientContextE(t, context.Background(), region)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -102,17 +102,17 @@ func TestEmptyS3Bucket(t *testing.T) {
 func TestEmptyS3BucketVersioned(t *testing.T) {
 	t.Parallel()
 
-	region := terraaws.GetRandomStableRegion(t, nil, nil)
+	region := terraaws.GetRandomStableRegionContext(t, context.Background(), nil, nil)
 
 	id := random.UniqueID()
 	logger.Default.Logf(t, "Random values selected. Region = %s, Id = %s\n", region, id)
 
 	s3BucketName := "gruntwork-terratest-" + strings.ToLower(id)
 
-	terraaws.CreateS3Bucket(t, region, s3BucketName)
-	defer terraaws.DeleteS3Bucket(t, region, s3BucketName)
+	terraaws.CreateS3BucketContext(t, context.Background(), region, s3BucketName)
+	defer terraaws.DeleteS3BucketContext(t, context.Background(), region, s3BucketName)
 
-	s3Client, err := terraaws.NewS3ClientE(t, region)
+	s3Client, err := terraaws.NewS3ClientContextE(t, context.Background(), region)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -136,7 +136,7 @@ func TestEmptyS3BucketVersioned(t *testing.T) {
 func TestAssertS3BucketPolicyExists(t *testing.T) {
 	t.Parallel()
 
-	region := terraaws.GetRandomStableRegion(t, nil, nil)
+	region := terraaws.GetRandomStableRegionContext(t, context.Background(), nil, nil)
 
 	id := random.UniqueID()
 	logger.Default.Logf(t, "Random values selected. Region = %s, Id = %s\n", region, id)
@@ -144,26 +144,26 @@ func TestAssertS3BucketPolicyExists(t *testing.T) {
 	s3BucketName := "gruntwork-terratest-" + strings.ToLower(id)
 	exampleBucketPolicy := `{"Version":"2012-10-17","Statement":[{"Effect":"Deny","Principal":{"AWS":["*"]},"Action":"s3:Get*","Resource":"arn:aws:s3:::` + s3BucketName + `/*","Condition":{"Bool":{"aws:SecureTransport":"false"}}}]}`
 
-	terraaws.CreateS3Bucket(t, region, s3BucketName)
-	defer terraaws.DeleteS3Bucket(t, region, s3BucketName)
+	terraaws.CreateS3BucketContext(t, context.Background(), region, s3BucketName)
+	defer terraaws.DeleteS3BucketContext(t, context.Background(), region, s3BucketName)
 
-	terraaws.PutS3BucketPolicy(t, region, s3BucketName, exampleBucketPolicy)
+	terraaws.PutS3BucketPolicyContext(t, context.Background(), region, s3BucketName, exampleBucketPolicy)
 
-	terraaws.AssertS3BucketPolicyExists(t, region, s3BucketName)
+	terraaws.AssertS3BucketPolicyExistsContext(t, context.Background(), region, s3BucketName)
 }
 
 func TestGetS3BucketTags(t *testing.T) {
 	t.Parallel()
 
-	region := terraaws.GetRandomStableRegion(t, nil, nil)
+	region := terraaws.GetRandomStableRegionContext(t, context.Background(), nil, nil)
 	id := random.UniqueID()
 	logger.Default.Logf(t, "Random values selected. Region = %s, Id = %s\n", region, id)
 	s3BucketName := "gruntwork-terratest-" + strings.ToLower(id)
 
-	terraaws.CreateS3Bucket(t, region, s3BucketName)
-	defer terraaws.DeleteS3Bucket(t, region, s3BucketName)
+	terraaws.CreateS3BucketContext(t, context.Background(), region, s3BucketName)
+	defer terraaws.DeleteS3BucketContext(t, context.Background(), region, s3BucketName)
 
-	s3Client, err := terraaws.NewS3ClientE(t, region)
+	s3Client, err := terraaws.NewS3ClientContextE(t, context.Background(), region)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -187,7 +187,7 @@ func TestGetS3BucketTags(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	actualTags := terraaws.GetS3BucketTags(t, region, s3BucketName)
+	actualTags := terraaws.GetS3BucketTagsContext(t, context.Background(), region, s3BucketName)
 	assert.Equal(t, "Value1", actualTags["Key1"])
 	assert.Equal(t, "Value2", actualTags["Key2"])
 	assert.Empty(t, actualTags["NonExistentKey"])
@@ -212,7 +212,7 @@ func testEmptyBucket(t *testing.T, s3Client *s3.Client, region string, s3BucketN
 			Body:   body,
 		}
 
-		uploader := terraaws.NewS3Uploader(t, region)
+		uploader := terraaws.NewS3UploaderContext(t, context.Background(), region)
 
 		_, err := uploader.UploadObject(context.Background(), params)
 		if err != nil {
@@ -268,7 +268,7 @@ func testEmptyBucket(t *testing.T, s3Client *s3.Client, region string, s3BucketN
 
 	// empty bucket
 	logger.Default.Logf(t, "Emptying bucket %s", s3BucketName)
-	terraaws.EmptyS3Bucket(t, region, s3BucketName)
+	terraaws.EmptyS3BucketContext(t, context.Background(), region, s3BucketName)
 
 	// verify the bucket is empty
 	bucketObjects, err := s3Client.ListObjectsV2(context.Background(), listObjectsParams)
@@ -282,20 +282,20 @@ func testEmptyBucket(t *testing.T, s3Client *s3.Client, region string, s3BucketN
 func TestGetS3BucketOwnershipControls(t *testing.T) {
 	t.Parallel()
 
-	region := terraaws.GetRandomStableRegion(t, nil, nil)
+	region := terraaws.GetRandomStableRegionContext(t, context.Background(), nil, nil)
 	id := random.UniqueID()
 	logger.Default.Logf(t, "Random values selected. Region = %s, Id = %s\n", region, id)
 
 	s3BucketName := "gruntwork-terratest-" + strings.ToLower(id)
-	terraaws.CreateS3Bucket(t, region, s3BucketName)
+	terraaws.CreateS3BucketContext(t, context.Background(), region, s3BucketName)
 	t.Cleanup(func() {
-		terraaws.DeleteS3Bucket(t, region, s3BucketName)
+		terraaws.DeleteS3BucketContext(t, context.Background(), region, s3BucketName)
 	})
 
 	t.Run("Exist", func(t *testing.T) {
 		t.Parallel()
 
-		s3Client, err := terraaws.NewS3ClientE(t, region)
+		s3Client, err := terraaws.NewS3ClientContextE(t, context.Background(), region)
 		require.NoError(t, err)
 		_, err = s3Client.PutBucketOwnershipControls(context.Background(), &s3.PutBucketOwnershipControlsInput{
 			Bucket: &s3BucketName,
@@ -315,7 +315,7 @@ func TestGetS3BucketOwnershipControls(t *testing.T) {
 			require.NoError(t, err)
 		})
 
-		controls := terraaws.GetS3BucketOwnershipControls(t, region, s3BucketName)
+		controls := terraaws.GetS3BucketOwnershipControlsContext(t, context.Background(), region, s3BucketName)
 		assert.Len(t, controls, 1)
 		assert.Equal(t, string(types.ObjectOwnershipBucketOwnerEnforced), controls[0])
 	})
@@ -323,7 +323,7 @@ func TestGetS3BucketOwnershipControls(t *testing.T) {
 	t.Run("NotExist", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := terraaws.GetS3BucketOwnershipControlsE(t, region, s3BucketName)
+		_, err := terraaws.GetS3BucketOwnershipControlsContextE(t, context.Background(), region, s3BucketName)
 		assert.Error(t, err)
 	})
 }
@@ -331,7 +331,7 @@ func TestGetS3BucketOwnershipControls(t *testing.T) {
 func TestAssertS3BucketServerSideEncryption(t *testing.T) {
 	t.Parallel()
 
-	region := terraaws.GetRandomStableRegion(t, nil, nil)
+	region := terraaws.GetRandomStableRegionContext(t, context.Background(), nil, nil)
 	logger.Default.Logf(t, "Random values selected. Region = %s\n", region)
 
 	algorithms := []types.ServerSideEncryption{
@@ -344,10 +344,10 @@ func TestAssertS3BucketServerSideEncryption(t *testing.T) {
 			t.Parallel()
 
 			s3BucketName := fmt.Sprintf("gruntwork-terratest-sse-%d-%s", i, strings.ToLower(random.UniqueID()))
-			terraaws.CreateS3Bucket(t, region, s3BucketName)
-			t.Cleanup(func() { terraaws.DeleteS3Bucket(t, region, s3BucketName) })
+			terraaws.CreateS3BucketContext(t, context.Background(), region, s3BucketName)
+			t.Cleanup(func() { terraaws.DeleteS3BucketContext(t, context.Background(), region, s3BucketName) })
 
-			s3Client := terraaws.NewS3Client(t, region)
+			s3Client := terraaws.NewS3ClientContext(t, context.Background(), region)
 			_, err := s3Client.PutBucketEncryption(context.Background(), &s3.PutBucketEncryptionInput{
 				Bucket: aws.String(s3BucketName),
 				ServerSideEncryptionConfiguration: &types.ServerSideEncryptionConfiguration{
@@ -362,7 +362,7 @@ func TestAssertS3BucketServerSideEncryption(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			terraaws.AssertS3BucketServerSideEncryption(t, region, s3BucketName, algorithm)
+			terraaws.AssertS3BucketServerSideEncryptionContext(t, context.Background(), region, s3BucketName, algorithm)
 
 			otherAlgorithm := types.ServerSideEncryptionAwsKms
 			if algorithm == types.ServerSideEncryptionAwsKms {
@@ -371,7 +371,7 @@ func TestAssertS3BucketServerSideEncryption(t *testing.T) {
 
 			var notEnabled terraaws.BucketServerSideEncryptionNotEnabledError
 
-			err = terraaws.AssertS3BucketServerSideEncryptionE(t, region, s3BucketName, otherAlgorithm)
+			err = terraaws.AssertS3BucketServerSideEncryptionContextE(t, context.Background(), region, s3BucketName, otherAlgorithm)
 			require.ErrorAs(t, err, &notEnabled)
 		})
 	}
@@ -380,21 +380,21 @@ func TestAssertS3BucketServerSideEncryption(t *testing.T) {
 func TestS3ObjectContents(t *testing.T) {
 	t.Parallel()
 
-	region := terraaws.GetRandomStableRegion(t, nil, nil)
+	region := terraaws.GetRandomStableRegionContext(t, context.Background(), nil, nil)
 	id := random.UniqueID()
 	logger.Default.Logf(t, "Random values selected. Region = %s, Id = %s\n", region, id)
 	s3BucketName := "gruntwork-terratest-" + strings.ToLower(id)
 
-	terraaws.CreateS3Bucket(t, region, s3BucketName)
-	defer terraaws.DeleteS3Bucket(t, region, s3BucketName)
-	defer terraaws.EmptyS3BucketE(t, region, s3BucketName)
+	terraaws.CreateS3BucketContext(t, context.Background(), region, s3BucketName)
+	defer terraaws.DeleteS3BucketContext(t, context.Background(), region, s3BucketName)
+	defer terraaws.EmptyS3BucketContextE(t, context.Background(), region, s3BucketName)
 
 	key := "content-" + id
 	body := make([]byte, 1024)
 	_, _ = cryptorand.Read(body)
 
-	terraaws.PutS3ObjectContentsE(t, region, s3BucketName, key, bytes.NewReader(body))
-	storedBody := terraaws.GetS3ObjectContents(t, region, s3BucketName, key)
+	terraaws.PutS3ObjectContentsContextE(t, context.Background(), region, s3BucketName, key, bytes.NewReader(body))
+	storedBody := terraaws.GetS3ObjectContentsContext(t, context.Background(), region, s3BucketName, key)
 
 	assert.Equal(t, body, []byte(storedBody))
 }

--- a/modules/aws/secretsmanager_test.go
+++ b/modules/aws/secretsmanager_test.go
@@ -1,6 +1,7 @@
 package aws_test
 
 import (
+	"context"
 	"testing"
 
 	terraaws "github.com/gruntwork-io/terratest/modules/aws/v2"
@@ -12,29 +13,29 @@ import (
 func TestSecretsManagerMethods(t *testing.T) {
 	t.Parallel()
 
-	region := terraaws.GetRandomStableRegion(t, nil, nil)
+	region := terraaws.GetRandomStableRegionContext(t, context.Background(), nil, nil)
 	name := random.UniqueID()
 	description := "This is just a secrets manager test description."
 	secretOriginalValue := "This is the secret value."
 	secretUpdatedValue := "This is the NEW secret value."
 
-	secretARN := terraaws.CreateSecretStringWithDefaultKey(t, region, description, name, secretOriginalValue)
+	secretARN := terraaws.CreateSecretStringWithDefaultKeyContext(t, context.Background(), region, description, name, secretOriginalValue)
 	defer deleteSecret(t, region, secretARN)
 
-	storedValue := terraaws.GetSecretValue(t, region, secretARN)
+	storedValue := terraaws.GetSecretValueContext(t, context.Background(), region, secretARN)
 	assert.Equal(t, secretOriginalValue, storedValue)
 
-	terraaws.PutSecretString(t, region, secretARN, secretUpdatedValue)
+	terraaws.PutSecretStringContext(t, context.Background(), region, secretARN, secretUpdatedValue)
 
-	storedValueAfterUpdate := terraaws.GetSecretValue(t, region, secretARN)
+	storedValueAfterUpdate := terraaws.GetSecretValueContext(t, context.Background(), region, secretARN)
 	assert.Equal(t, secretUpdatedValue, storedValueAfterUpdate)
 }
 
 func deleteSecret(t *testing.T, region, id string) {
 	t.Helper()
 
-	terraaws.DeleteSecret(t, region, id, true)
+	terraaws.DeleteSecretContext(t, context.Background(), region, id, true)
 
-	_, err := terraaws.GetSecretValueE(t, region, id)
+	_, err := terraaws.GetSecretValueContextE(t, context.Background(), region, id)
 	require.Error(t, err)
 }

--- a/modules/aws/sns_test.go
+++ b/modules/aws/sns_test.go
@@ -15,11 +15,11 @@ import (
 func TestCreateAndDeleteSnsTopic(t *testing.T) {
 	t.Parallel()
 
-	region := terraaws.GetRandomStableRegion(t, nil, nil)
+	region := terraaws.GetRandomStableRegionContext(t, context.Background(), nil, nil)
 	uniqueID := random.UniqueID()
 	name := "test-sns-topic-" + uniqueID
 
-	arn := terraaws.CreateSnsTopic(t, region, name)
+	arn := terraaws.CreateSnsTopicContext(t, context.Background(), region, name)
 	defer deleteTopic(t, region, arn)
 
 	assert.True(t, snsTopicExists(t, region, arn))
@@ -28,7 +28,7 @@ func TestCreateAndDeleteSnsTopic(t *testing.T) {
 func snsTopicExists(t *testing.T, region string, arn string) bool {
 	t.Helper()
 
-	snsClient := terraaws.NewSnsClient(t, region)
+	snsClient := terraaws.NewSnsClientContext(t, context.Background(), region)
 
 	input := sns.GetTopicAttributesInput{TopicArn: aws.String(arn)}
 
@@ -46,6 +46,6 @@ func snsTopicExists(t *testing.T, region string, arn string) bool {
 func deleteTopic(t *testing.T, region string, arn string) {
 	t.Helper()
 
-	terraaws.DeleteSNSTopic(t, region, arn)
+	terraaws.DeleteSNSTopicContext(t, context.Background(), region, arn)
 	assert.False(t, snsTopicExists(t, region, arn))
 }

--- a/modules/aws/sqs_test.go
+++ b/modules/aws/sqs_test.go
@@ -16,11 +16,11 @@ import (
 func TestSqsQueueMethods(t *testing.T) {
 	t.Parallel()
 
-	region := terraaws.GetRandomStableRegion(t, nil, nil)
+	region := terraaws.GetRandomStableRegionContext(t, context.Background(), nil, nil)
 	uniqueID := random.UniqueID()
 	namePrefix := "sqs-queue-test-" + uniqueID
 
-	url := terraaws.CreateRandomQueue(t, region, namePrefix)
+	url := terraaws.CreateRandomQueueContext(t, context.Background(), region, namePrefix)
 	defer deleteQueue(t, region, url)
 
 	assert.True(t, queueExists(t, region, url))
@@ -28,27 +28,27 @@ func TestSqsQueueMethods(t *testing.T) {
 	message := "test-message-" + uniqueID
 	timeoutSec := 20
 
-	terraaws.SendMessageToQueue(t, region, url, message)
+	terraaws.SendMessageToQueueContext(t, context.Background(), region, url, message)
 
-	firstResponse := terraaws.WaitForQueueMessage(t, region, url, timeoutSec)
+	firstResponse := terraaws.WaitForQueueMessageContext(t, context.Background(), region, url, timeoutSec)
 	require.NoError(t, firstResponse.Error)
 	assert.Equal(t, message, firstResponse.MessageBody)
 
-	terraaws.DeleteMessageFromQueue(t, region, url, firstResponse.ReceiptHandle)
+	terraaws.DeleteMessageFromQueueContext(t, context.Background(), region, url, firstResponse.ReceiptHandle)
 
-	secondResponse := terraaws.WaitForQueueMessage(t, region, url, timeoutSec)
+	secondResponse := terraaws.WaitForQueueMessageContext(t, context.Background(), region, url, timeoutSec)
 	assert.Error(t, secondResponse.Error, terraaws.ReceiveMessageTimeout{QueueUrl: url, TimeoutSec: timeoutSec})
 }
 
 func TestFifoSqsQueueMethods(t *testing.T) {
 	t.Parallel()
 
-	region := terraaws.GetRandomStableRegion(t, nil, nil)
+	region := terraaws.GetRandomStableRegionContext(t, context.Background(), nil, nil)
 	uniqueID := random.UniqueID()
 	namePrefix := "sqs-queue-test-" + uniqueID
 	fifoMessageGroupID := "g1"
 
-	url := terraaws.CreateRandomFifoQueue(t, region, namePrefix)
+	url := terraaws.CreateRandomFifoQueueContext(t, context.Background(), region, namePrefix)
 	defer deleteQueue(t, region, url)
 
 	assert.True(t, queueExists(t, region, url))
@@ -56,22 +56,22 @@ func TestFifoSqsQueueMethods(t *testing.T) {
 	message := "test-message-" + uniqueID
 	timeoutSec := 20
 
-	terraaws.SendMessageFifoToQueue(t, region, url, message, fifoMessageGroupID)
+	terraaws.SendMessageFifoToQueueContext(t, context.Background(), region, url, message, fifoMessageGroupID)
 
-	firstResponse := terraaws.WaitForQueueMessage(t, region, url, timeoutSec)
+	firstResponse := terraaws.WaitForQueueMessageContext(t, context.Background(), region, url, timeoutSec)
 	require.NoError(t, firstResponse.Error)
 	assert.Equal(t, message, firstResponse.MessageBody)
 
-	terraaws.DeleteMessageFromQueue(t, region, url, firstResponse.ReceiptHandle)
+	terraaws.DeleteMessageFromQueueContext(t, context.Background(), region, url, firstResponse.ReceiptHandle)
 
-	secondResponse := terraaws.WaitForQueueMessage(t, region, url, timeoutSec)
+	secondResponse := terraaws.WaitForQueueMessageContext(t, context.Background(), region, url, timeoutSec)
 	assert.Error(t, secondResponse.Error, terraaws.ReceiveMessageTimeout{QueueUrl: url, TimeoutSec: timeoutSec})
 }
 
 func queueExists(t *testing.T, region string, url string) bool {
 	t.Helper()
 
-	sqsClient := terraaws.NewSqsClient(t, region)
+	sqsClient := terraaws.NewSqsClientContext(t, context.Background(), region)
 
 	input := sqs.GetQueueAttributesInput{QueueUrl: aws.String(url)}
 
@@ -89,6 +89,6 @@ func queueExists(t *testing.T, region string, url string) bool {
 func deleteQueue(t *testing.T, region string, url string) {
 	t.Helper()
 
-	terraaws.DeleteQueue(t, region, url)
+	terraaws.DeleteQueueContext(t, context.Background(), region, url)
 	assert.False(t, queueExists(t, region, url))
 }

--- a/modules/aws/ssm_test.go
+++ b/modules/aws/ssm_test.go
@@ -1,6 +1,7 @@
 package aws_test
 
 import (
+	"context"
 	"testing"
 
 	terraaws "github.com/gruntwork-io/terratest/modules/aws/v2"
@@ -13,12 +14,12 @@ func TestParameterIsFound(t *testing.T) {
 	t.Parallel()
 
 	expectedName := "test-name-" + random.UniqueID()
-	awsRegion := terraaws.GetRandomRegion(t, nil, nil)
+	awsRegion := terraaws.GetRandomRegionContext(t, context.Background(), nil, nil)
 	expectedValue := "test-value-" + random.UniqueID()
 	expectedDescription := "test-description-" + random.UniqueID()
-	version := terraaws.PutParameter(t, awsRegion, expectedName, expectedDescription, expectedValue)
+	version := terraaws.PutParameterContext(t, context.Background(), awsRegion, expectedName, expectedDescription, expectedValue)
 	logger.Default.Logf(t, "Created parameter with version %d", version)
-	keyValue := terraaws.GetParameter(t, awsRegion, expectedName)
+	keyValue := terraaws.GetParameterContext(t, context.Background(), awsRegion, expectedName)
 	logger.Default.Logf(t, "Found key with name %s", expectedName)
 	assert.Equal(t, expectedValue, keyValue)
 }
@@ -27,16 +28,16 @@ func TestParameterIsDeleted(t *testing.T) {
 	t.Parallel()
 
 	expectedName := "test-name-" + random.UniqueID()
-	awsRegion := terraaws.GetRandomRegion(t, nil, nil)
+	awsRegion := terraaws.GetRandomRegionContext(t, context.Background(), nil, nil)
 	expectedValue := "test-value-" + random.UniqueID()
 	expectedDescription := "test-description-" + random.UniqueID()
-	version := terraaws.PutParameter(t, awsRegion, expectedName, expectedDescription, expectedValue)
+	version := terraaws.PutParameterContext(t, context.Background(), awsRegion, expectedName, expectedDescription, expectedValue)
 	logger.Default.Logf(t, "Created parameter with version %d", version)
 
-	terraaws.DeleteParameter(t, awsRegion, expectedName)
+	terraaws.DeleteParameterContext(t, context.Background(), awsRegion, expectedName)
 	logger.Default.Logf(t, "Deleted parameter %s", expectedName)
 
-	actualValue, err := terraaws.GetParameterE(t, awsRegion, expectedName)
+	actualValue, err := terraaws.GetParameterContextE(t, context.Background(), awsRegion, expectedName)
 	assert.Empty(t, actualValue)
 	assert.Error(t, err)
 }

--- a/modules/aws/vpc.go
+++ b/modules/aws/vpc.go
@@ -132,14 +132,14 @@ func GetVpcByIDE(t testing.TestingT, vpcID string, region string) (*Vpc, error) 
 //
 // Deprecated: Use [GetVpcByID] instead.
 func GetVpcById(t testing.TestingT, vpcID string, region string) *Vpc { //nolint:staticcheck,revive // preserving deprecated function name
-	return GetVpcByID(t, vpcID, region)
+	return GetVpcByIDContext(t, context.Background(), vpcID, region)
 }
 
 // GetVpcByIdE fetches information about a VPC with given ID in the given region.
 //
 // Deprecated: Use [GetVpcByIDE] instead.
 func GetVpcByIdE(t testing.TestingT, vpcID string, region string) (*Vpc, error) { //nolint:staticcheck,revive // preserving deprecated function name
-	return GetVpcByIDE(t, vpcID, region)
+	return GetVpcByIDContextE(t, context.Background(), vpcID, region)
 }
 
 // GetVpcsContextE fetches information about VPCs from given regions limited by filters

--- a/modules/aws/vpc_test.go
+++ b/modules/aws/vpc_test.go
@@ -17,8 +17,8 @@ import (
 func TestGetDefaultVpc(t *testing.T) {
 	t.Parallel()
 
-	region := terraaws.GetRandomStableRegion(t, nil, nil)
-	vpc := terraaws.GetDefaultVpc(t, region)
+	region := terraaws.GetRandomStableRegionContext(t, context.Background(), nil, nil)
+	vpc := terraaws.GetDefaultVpcContext(t, context.Background(), region)
 
 	assert.NotEmpty(t, vpc.Name)
 	assert.NotEmpty(t, vpc.Subnets)
@@ -28,12 +28,12 @@ func TestGetDefaultVpc(t *testing.T) {
 func TestGetVpcById(t *testing.T) {
 	t.Parallel()
 
-	region := terraaws.GetRandomStableRegion(t, nil, nil)
+	region := terraaws.GetRandomStableRegionContext(t, context.Background(), nil, nil)
 
 	vpc := createVpc(t, region)
 	defer deleteVpc(t, *vpc.VpcId, region)
 
-	vpcTest := terraaws.GetVpcByID(t, *vpc.VpcId, region)
+	vpcTest := terraaws.GetVpcByIDContext(t, context.Background(), *vpc.VpcId, region)
 	assert.Equal(t, *vpc.VpcId, vpcTest.Id)
 	assert.NotEmpty(t, vpcTest.CidrAssociations)
 }
@@ -41,14 +41,14 @@ func TestGetVpcById(t *testing.T) {
 func TestGetVpcsE(t *testing.T) {
 	t.Parallel()
 
-	region := terraaws.GetRandomStableRegion(t, nil, nil)
-	azs := terraaws.GetAvailabilityZones(t, region)
+	region := terraaws.GetRandomStableRegionContext(t, context.Background(), nil, nil)
+	azs := terraaws.GetAvailabilityZonesContext(t, context.Background(), region)
 
 	isDefaultFilterName := "isDefault"
 	isDefaultFilterValue := "true"
 
 	defaultVpcFilter := types.Filter{Name: &isDefaultFilterName, Values: []string{isDefaultFilterValue}}
-	vpcs, _ := terraaws.GetVpcsE(t, []types.Filter{defaultVpcFilter}, region)
+	vpcs, _ := terraaws.GetVpcsContextE(t, context.Background(), []types.Filter{defaultVpcFilter}, region)
 
 	require.Len(t, vpcs, 1)
 	assert.NotEmpty(t, vpcs[0].Name)
@@ -70,26 +70,26 @@ func TestGetFirstTwoOctets(t *testing.T) {
 func TestIsPublicSubnet(t *testing.T) {
 	t.Parallel()
 
-	region := terraaws.GetRandomStableRegion(t, nil, nil)
+	region := terraaws.GetRandomStableRegionContext(t, context.Background(), nil, nil)
 
 	vpc := createVpc(t, region)
 	defer deleteVpc(t, *vpc.VpcId, region)
 
 	routeTable := createRouteTable(t, *vpc.VpcId, region)
 	subnet := createSubnet(t, *vpc.VpcId, *routeTable.RouteTableId, region)
-	assert.False(t, terraaws.IsPublicSubnet(t, *subnet.SubnetId, region))
+	assert.False(t, terraaws.IsPublicSubnetContext(t, context.Background(), *subnet.SubnetId, region))
 
 	createPublicRoute(t, *vpc.VpcId, *routeTable.RouteTableId, region)
-	assert.True(t, terraaws.IsPublicSubnet(t, *subnet.SubnetId, region))
+	assert.True(t, terraaws.IsPublicSubnetContext(t, context.Background(), *subnet.SubnetId, region))
 }
 
 func TestGetDefaultSubnetIDsForVpc(t *testing.T) {
 	t.Parallel()
 
-	region := terraaws.GetRandomStableRegion(t, nil, nil)
-	defaultVpc := terraaws.GetDefaultVpc(t, region)
+	region := terraaws.GetRandomStableRegionContext(t, context.Background(), nil, nil)
+	defaultVpc := terraaws.GetDefaultVpcContext(t, context.Background(), region)
 
-	defaultSubnetIDs := terraaws.GetDefaultSubnetIDsForVpc(t, *defaultVpc)
+	defaultSubnetIDs := terraaws.GetDefaultSubnetIDsForVpcPContext(t, context.Background(), defaultVpc)
 	assert.NotEmpty(t, defaultSubnetIDs)
 
 	availabilityZones := []string{}
@@ -97,7 +97,7 @@ func TestGetDefaultSubnetIDsForVpc(t *testing.T) {
 	for _, id := range defaultSubnetIDs {
 		// default subnets are by default public
 		// https://docs.aws.amazon.com/vpc/latest/userguide/default-vpc.html
-		assert.True(t, terraaws.IsPublicSubnet(t, id, region))
+		assert.True(t, terraaws.IsPublicSubnetContext(t, context.Background(), id, region))
 
 		for _, subnet := range defaultVpc.Subnets {
 			if id == subnet.Id {
@@ -117,12 +117,12 @@ func TestGetDefaultSubnetIDsForVpc(t *testing.T) {
 func TestGetTagsForVpc(t *testing.T) {
 	t.Parallel()
 
-	region := terraaws.GetRandomStableRegion(t, nil, nil)
+	region := terraaws.GetRandomStableRegionContext(t, context.Background(), nil, nil)
 
 	vpc := createVpc(t, region)
 	defer deleteVpc(t, *vpc.VpcId, region)
 
-	noTags := terraaws.GetTagsForVpc(t, *vpc.VpcId, region)
+	noTags := terraaws.GetTagsForVpcContext(t, context.Background(), *vpc.VpcId, region)
 	assert.Empty(t, vpc.Tags)
 	assert.Empty(t, noTags)
 
@@ -130,9 +130,9 @@ func TestGetTagsForVpc(t *testing.T) {
 	testTags["TagKey1"] = "TagValue1"
 	testTags["TagKey2"] = "TagValue2"
 
-	terraaws.AddTagsToResource(t, region, *vpc.VpcId, testTags)
-	vpcWithTags := terraaws.GetVpcByID(t, *vpc.VpcId, region)
-	tags := terraaws.GetTagsForVpc(t, *vpc.VpcId, region)
+	terraaws.AddTagsToResourceContext(t, context.Background(), region, *vpc.VpcId, testTags)
+	vpcWithTags := terraaws.GetVpcByIDContext(t, context.Background(), *vpc.VpcId, region)
+	tags := terraaws.GetTagsForVpcContext(t, context.Background(), *vpc.VpcId, region)
 
 	assert.Len(t, vpcWithTags.Tags, len(testTags))
 	assert.Len(t, tags, len(testTags))
@@ -141,7 +141,7 @@ func TestGetTagsForVpc(t *testing.T) {
 func TestGetTagsForSubnet(t *testing.T) {
 	t.Parallel()
 
-	region := terraaws.GetRandomStableRegion(t, nil, nil)
+	region := terraaws.GetRandomStableRegionContext(t, context.Background(), nil, nil)
 
 	vpc := createVpc(t, region)
 	defer deleteVpc(t, *vpc.VpcId, region)
@@ -149,7 +149,7 @@ func TestGetTagsForSubnet(t *testing.T) {
 	routeTable := createRouteTable(t, *vpc.VpcId, region)
 	subnet := createSubnet(t, *vpc.VpcId, *routeTable.RouteTableId, region)
 
-	noTags := terraaws.GetTagsForSubnet(t, *subnet.SubnetId, region)
+	noTags := terraaws.GetTagsForSubnetContext(t, context.Background(), *subnet.SubnetId, region)
 	assert.Empty(t, subnet.Tags)
 	assert.Empty(t, noTags)
 
@@ -157,10 +157,10 @@ func TestGetTagsForSubnet(t *testing.T) {
 	testTags["TagKey1"] = "TagValue1"
 	testTags["TagKey2"] = "TagValue2"
 
-	terraaws.AddTagsToResource(t, region, *subnet.SubnetId, testTags)
+	terraaws.AddTagsToResourceContext(t, context.Background(), region, *subnet.SubnetId, testTags)
 
-	subnetWithTags := terraaws.GetSubnetsForVpc(t, *vpc.VpcId, region)[0]
-	tags := terraaws.GetTagsForSubnet(t, *subnet.SubnetId, region)
+	subnetWithTags := terraaws.GetSubnetsForVpcContext(t, context.Background(), *vpc.VpcId, region)[0]
+	tags := terraaws.GetTagsForSubnetContext(t, context.Background(), *subnet.SubnetId, region)
 
 	assert.Len(t, subnetWithTags.Tags, len(testTags))
 	assert.Len(t, tags, len(testTags))
@@ -171,19 +171,19 @@ func TestGetTagsForSubnet(t *testing.T) {
 func TestGetDefaultAzSubnets(t *testing.T) {
 	t.Parallel()
 
-	region := terraaws.GetRandomStableRegion(t, nil, nil)
-	vpc := terraaws.GetDefaultVpc(t, region)
+	region := terraaws.GetRandomStableRegionContext(t, context.Background(), nil, nil)
+	vpc := terraaws.GetDefaultVpcContext(t, context.Background(), region)
 
 	// Note: cannot know exact list of default azs aheard of time, but we know that
 	// it must be greater than 0 for default vpc.
-	subnets := terraaws.GetAzDefaultSubnetsForVpc(t, vpc.Id, region)
+	subnets := terraaws.GetAzDefaultSubnetsForVpcContext(t, context.Background(), vpc.Id, region)
 	assert.NotEmpty(t, subnets)
 }
 
 func createPublicRoute(t *testing.T, vpcID string, routeTableID string, region string) {
 	t.Helper()
 
-	ec2Client := terraaws.NewEc2Client(t, region)
+	ec2Client := terraaws.NewEc2ClientContext(t, context.Background(), region)
 
 	createIGWOut, igerr := ec2Client.CreateInternetGateway(context.Background(), &ec2.CreateInternetGatewayInput{})
 	require.NoError(t, igerr)
@@ -206,7 +206,7 @@ func createPublicRoute(t *testing.T, vpcID string, routeTableID string, region s
 func createRouteTable(t *testing.T, vpcID string, region string) types.RouteTable {
 	t.Helper()
 
-	ec2Client := terraaws.NewEc2Client(t, region)
+	ec2Client := terraaws.NewEc2ClientContext(t, context.Background(), region)
 
 	createRouteTableOutput, err := ec2Client.CreateRouteTable(context.Background(), &ec2.CreateRouteTableInput{
 		VpcId: aws.String(vpcID),
@@ -220,7 +220,7 @@ func createRouteTable(t *testing.T, vpcID string, region string) types.RouteTabl
 func createSubnet(t *testing.T, vpcID string, routeTableID string, region string) types.Subnet {
 	t.Helper()
 
-	ec2Client := terraaws.NewEc2Client(t, region)
+	ec2Client := terraaws.NewEc2ClientContext(t, context.Background(), region)
 
 	createSubnetOutput, err := ec2Client.CreateSubnet(context.Background(), &ec2.CreateSubnetInput{
 		CidrBlock: aws.String("10.10.1.0/24"),
@@ -240,7 +240,7 @@ func createSubnet(t *testing.T, vpcID string, routeTableID string, region string
 func createVpc(t *testing.T, region string) types.Vpc {
 	t.Helper()
 
-	ec2Client := terraaws.NewEc2Client(t, region)
+	ec2Client := terraaws.NewEc2ClientContext(t, context.Background(), region)
 
 	createVpcOutput, err := ec2Client.CreateVpc(context.Background(), &ec2.CreateVpcInput{
 		CidrBlock: aws.String("10.10.0.0/16"),
@@ -254,7 +254,7 @@ func createVpc(t *testing.T, region string) types.Vpc {
 func deleteRouteTables(t *testing.T, vpcID string, region string) {
 	t.Helper()
 
-	ec2Client := terraaws.NewEc2Client(t, region)
+	ec2Client := terraaws.NewEc2ClientContext(t, context.Background(), region)
 
 	vpcIDFilterName := "vpc-id"
 	vpcIDFilter := types.Filter{Name: &vpcIDFilterName, Values: []string{vpcID}}
@@ -290,7 +290,7 @@ func deleteRouteTables(t *testing.T, vpcID string, region string) {
 func deleteSubnets(t *testing.T, vpcID string, region string) {
 	t.Helper()
 
-	ec2Client := terraaws.NewEc2Client(t, region)
+	ec2Client := terraaws.NewEc2ClientContext(t, context.Background(), region)
 	vpcIDFilterName := "vpc-id"
 	vpcIDFilter := types.Filter{Name: &vpcIDFilterName, Values: []string{vpcID}}
 
@@ -308,7 +308,7 @@ func deleteSubnets(t *testing.T, vpcID string, region string) {
 func deleteInternetGateways(t *testing.T, vpcID string, region string) {
 	t.Helper()
 
-	ec2Client := terraaws.NewEc2Client(t, region)
+	ec2Client := terraaws.NewEc2ClientContext(t, context.Background(), region)
 	vpcIDFilterName := "attachment.vpc-id"
 	vpcIDFilter := types.Filter{Name: &vpcIDFilterName, Values: []string{vpcID}}
 
@@ -332,7 +332,7 @@ func deleteInternetGateways(t *testing.T, vpcID string, region string) {
 func deleteVpc(t *testing.T, vpcID string, region string) {
 	t.Helper()
 
-	ec2Client := terraaws.NewEc2Client(t, region)
+	ec2Client := terraaws.NewEc2ClientContext(t, context.Background(), region)
 
 	deleteRouteTables(t, vpcID, region)
 	deleteSubnets(t, vpcID, region)

--- a/modules/azure/client_factory.go
+++ b/modules/azure/client_factory.go
@@ -514,7 +514,7 @@ func CreateSQLMangedInstanceClientContext(ctx context.Context, subscriptionID st
 
 // Deprecated: Use [CreateSQLManagedInstanceClient] instead.
 func CreateSQLMangedInstanceClient(subscriptionID string) (*armsql.ManagedInstancesClient, error) { //nolint:revive,staticcheck // preserving deprecated function name
-	return CreateSQLManagedInstanceClient(subscriptionID)
+	return CreateSQLManagedInstanceClientContext(context.Background(), subscriptionID)
 }
 
 // CreateSQLManagedDatabasesClientContext is a helper function that will create and setup a sql managed databases client.
@@ -542,7 +542,7 @@ func CreateSQLMangedDatabasesClientContext(ctx context.Context, subscriptionID s
 
 // Deprecated: Use [CreateSQLManagedDatabasesClient] instead.
 func CreateSQLMangedDatabasesClient(subscriptionID string) (*armsql.ManagedDatabasesClient, error) { //nolint:revive,staticcheck // preserving deprecated function name
-	return CreateSQLManagedDatabasesClient(subscriptionID)
+	return CreateSQLManagedDatabasesClientContext(context.Background(), subscriptionID)
 }
 
 // getArmSQLClientFactory gets an arm sql client factory

--- a/modules/azure/keyvault.go
+++ b/modules/azure/keyvault.go
@@ -186,7 +186,7 @@ func KeyVaultSecretExistsE(keyVaultName, secretName string) (bool, error) {
 // GetKeyVaultSecretsClientContextE creates a KeyVault secrets client.
 // The ctx parameter supports cancellation and timeouts.
 func GetKeyVaultSecretsClientContextE(_ context.Context, keyVaultName string) (*azsecrets.Client, error) {
-	keyVaultSuffix, err := GetKeyVaultURISuffixE() //nolint:contextcheck
+	keyVaultSuffix, err := GetKeyVaultURISuffixContextE(context.Background()) //nolint:contextcheck
 	if err != nil {
 		return nil, err
 	}
@@ -211,7 +211,7 @@ func GetKeyVaultSecretsClientE(keyVaultName string) (*azsecrets.Client, error) {
 // GetKeyVaultKeysClientContextE creates a KeyVault keys client.
 // The ctx parameter supports cancellation and timeouts.
 func GetKeyVaultKeysClientContextE(_ context.Context, keyVaultName string) (*azkeys.Client, error) {
-	keyVaultSuffix, err := GetKeyVaultURISuffixE() //nolint:contextcheck
+	keyVaultSuffix, err := GetKeyVaultURISuffixContextE(context.Background()) //nolint:contextcheck
 	if err != nil {
 		return nil, err
 	}
@@ -236,7 +236,7 @@ func GetKeyVaultKeysClientE(keyVaultName string) (*azkeys.Client, error) {
 // GetKeyVaultCertificatesClientContextE creates a KeyVault certificates client.
 // The ctx parameter supports cancellation and timeouts.
 func GetKeyVaultCertificatesClientContextE(_ context.Context, keyVaultName string) (*azcertificates.Client, error) {
-	keyVaultSuffix, err := GetKeyVaultURISuffixE() //nolint:contextcheck
+	keyVaultSuffix, err := GetKeyVaultURISuffixContextE(context.Background()) //nolint:contextcheck
 	if err != nil {
 		return nil, err
 	}

--- a/modules/azure/servicebus.go
+++ b/modules/azure/servicebus.go
@@ -9,15 +9,15 @@ import (
 )
 
 func serviceBusNamespaceClientE(subscriptionID string) (*armservicebus.NamespacesClient, error) {
-	return CreateServiceBusNamespacesClientE(subscriptionID) //nolint:contextcheck
+	return CreateServiceBusNamespacesClientContextE(context.Background(), subscriptionID) //nolint:contextcheck
 }
 
 func serviceBusTopicClientE(subscriptionID string) (*armservicebus.TopicsClient, error) {
-	return CreateServiceBusTopicsClientE(subscriptionID) //nolint:contextcheck
+	return CreateServiceBusTopicsClientContextE(context.Background(), subscriptionID) //nolint:contextcheck
 }
 
 func serviceBusSubscriptionsClientE(subscriptionID string) (*armservicebus.SubscriptionsClient, error) {
-	return CreateServiceBusSubscriptionsClientE(subscriptionID) //nolint:contextcheck
+	return CreateServiceBusSubscriptionsClientContextE(context.Background(), subscriptionID) //nolint:contextcheck
 }
 
 // ListServiceBusNamespaceContextE lists all SB namespaces in all resource groups in the given subscription ID.

--- a/modules/azure/storage.go
+++ b/modules/azure/storage.go
@@ -518,7 +518,7 @@ func GetStorageDNSStringContextE(ctx context.Context, storageAccountName, resour
 	}
 
 	if retval {
-		storageSuffix, err2 := GetStorageURISuffixE() //nolint:contextcheck
+		storageSuffix, err2 := GetStorageURISuffixContextE(context.Background()) //nolint:contextcheck
 		if err2 != nil {
 			return "", err2
 		}

--- a/modules/azure/storage.go
+++ b/modules/azure/storage.go
@@ -518,7 +518,7 @@ func GetStorageDNSStringContextE(ctx context.Context, storageAccountName, resour
 	}
 
 	if retval {
-		storageSuffix, err2 := GetStorageURISuffixContextE(context.Background()) //nolint:contextcheck
+		storageSuffix, err2 := GetStorageURISuffixContextE(ctx)
 		if err2 != nil {
 			return "", err2
 		}

--- a/modules/azure/synapse.go
+++ b/modules/azure/synapse.go
@@ -73,7 +73,7 @@ func GetSynapseSQLPoolContext(t testing.TestingT, ctx context.Context, subscript
 // GetSynapseSQLPoolContextE retrieves the synapse SQL pool for the given subscription.
 // The ctx parameter supports cancellation and timeouts.
 func GetSynapseSQLPoolContextE(ctx context.Context, subscriptionID string, resGroupName string, workspaceName string, sqlPoolName string) (*armsynapse.SQLPool, error) {
-	synapseSQLPoolClient, err := CreateSynapseSqlPoolClientContextE(ctx, subscriptionID)
+	synapseSQLPoolClient, err := CreateSynapseSQLPoolClientContextE(ctx, subscriptionID)
 	if err != nil {
 		return nil, err
 	}

--- a/modules/core/logger/logger_test.go
+++ b/modules/core/logger/logger_test.go
@@ -36,7 +36,7 @@ func (c *customLogger) Logf(_ tftesting.TestingT, format string, args ...any) {
 
 //nolint:paralleltest // test verifies nil Logger behavior and uses subtests that interact with shared state
 func TestCustomLogger(t *testing.T) {
-	logger.Logf(t, "this should be logged with the default logger")
+	logger.Default.Logf(t, "this should be logged with the default logger")
 
 	var l *logger.Logger
 	l.Logf(t, "this should be logged with the default logger too")
@@ -81,7 +81,7 @@ func TestLockedLog(t *testing.T) {
 		},
 		{
 			fn: func(s string) {
-				logger.Logf(t, "%s", s)
+				logger.Default.Logf(t, "%s", s)
 			},
 			name: "Logf",
 		},

--- a/modules/core/retry/retry_test.go
+++ b/modules/core/retry/retry_test.go
@@ -1,6 +1,7 @@
 package retry_test
 
 import (
+	"context"
 	"errors"
 	"strconv"
 	"testing"
@@ -53,7 +54,7 @@ func TestDoWithRetry(t *testing.T) {
 		t.Run(testCase.description, func(t *testing.T) {
 			t.Parallel()
 
-			actualOutput, err := retry.DoWithRetryE(t, testCase.description, testCase.maxRetries, 1*time.Millisecond, testCase.action)
+			actualOutput, err := retry.DoWithRetryContextE(t, context.Background(), testCase.description, testCase.maxRetries, 1*time.Millisecond, testCase.action)
 			assert.Equal(t, expectedOutput, actualOutput)
 
 			if testCase.expectedError != nil {
@@ -111,7 +112,7 @@ func TestDoWithTimeout(t *testing.T) {
 		t.Run(testCase.description, func(t *testing.T) {
 			t.Parallel()
 
-			actualOutput, err := retry.DoWithTimeoutE(t, testCase.description, testCase.timeout, testCase.action)
+			actualOutput, err := retry.DoWithTimeoutContextE(t, context.Background(), testCase.description, testCase.timeout, testCase.action)
 			if testCase.expectedError != nil {
 				assert.Equal(t, testCase.expectedError, err)
 			} else {
@@ -129,7 +130,7 @@ func TestDoInBackgroundUntilStopped(t *testing.T) {
 	waitStop := sleepBetweenRetries*2 + sleepBetweenRetries/2
 	counter := 0
 
-	stop := retry.DoInBackgroundUntilStopped(t, t.Name(), sleepBetweenRetries, func() {
+	stop := retry.DoInBackgroundUntilStoppedContext(t, context.Background(), t.Name(), sleepBetweenRetries, func() {
 		counter++
 		t.Log(time.Now(), counter)
 	})
@@ -264,7 +265,7 @@ func TestDoWithRetryableErrors(t *testing.T) {
 		t.Run(testCase.description, func(t *testing.T) {
 			t.Parallel()
 
-			actualOutput, err := retry.DoWithRetryableErrorsE(t, testCase.description, testCase.retryableErrors, testCase.maxRetries, 1*time.Millisecond, testCase.action)
+			actualOutput, err := retry.DoWithRetryableErrorsContextE(t, context.Background(), testCase.description, testCase.retryableErrors, testCase.maxRetries, 1*time.Millisecond, testCase.action)
 			assert.Equal(t, expectedOutput, actualOutput)
 
 			if testCase.expectedError != nil {

--- a/modules/database/database.go
+++ b/modules/database/database.go
@@ -44,7 +44,7 @@ type DBConfig struct {
 func DBConnection(t testing.TestingT, dbType string, dbConfig DBConfig) *sql.DB { //nolint:gocritic // Preserving original signature for backward compatibility.
 	t.Helper()
 
-	db, err := DBConnectionE(t, dbType, dbConfig)
+	db, err := DBConnectionWithContextE(t, context.Background(), dbType, &dbConfig)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -99,7 +99,7 @@ func DBConnectionWithContextE(t testing.TestingT, ctx context.Context, dbType st
 func DBExecution(t testing.TestingT, db *sql.DB, command string) {
 	t.Helper()
 
-	_, err := DBExecutionE(t, db, command)
+	_, err := DBExecutionWithContextE(t, context.Background(), db, command)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -132,7 +132,7 @@ func DBExecutionWithContextE(t testing.TestingT, ctx context.Context, db *sql.DB
 func DBQuery(t testing.TestingT, db *sql.DB, command string) *sql.Rows {
 	t.Helper()
 
-	rows, err := DBQueryE(t, db, command)
+	rows, err := DBQueryWithContextE(t, context.Background(), db, command)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -181,7 +181,7 @@ func DBQueryWithValidation(t testing.TestingT, db *sql.DB, command string, expec
 func DBQueryWithValidationE(t testing.TestingT, db *sql.DB, command string, expected string) error {
 	t.Helper()
 
-	return DBQueryWithCustomValidationE(t, db, command, func(rows *sql.Rows) bool {
+	return DBQueryWithCustomValidationWithContextE(t, context.Background(), db, command, func(rows *sql.Rows) bool {
 		var name string
 		for rows.Next() {
 			err := rows.Scan(&name)
@@ -205,7 +205,7 @@ func DBQueryWithValidationE(t testing.TestingT, db *sql.DB, command string, expe
 func DBQueryWithCustomValidation(t testing.TestingT, db *sql.DB, command string, validateResponse func(*sql.Rows) bool) {
 	t.Helper()
 
-	err := DBQueryWithCustomValidationE(t, db, command, validateResponse)
+	err := DBQueryWithCustomValidationWithContextE(t, context.Background(), db, command, validateResponse)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/modules/gcp/compute.go
+++ b/modules/gcp/compute.go
@@ -308,14 +308,14 @@ func (i *Instance) GetPublicIPE(t testing.TestingT) (string, error) {
 //
 // Deprecated: Use [Instance.GetPublicIP] instead.
 func (i *Instance) GetPublicIp(t testing.TestingT) string { //nolint:staticcheck,revive // preserving deprecated method name
-	return i.GetPublicIP(t)
+	return i.GetPublicIPContext(t, context.Background())
 }
 
 // GetPublicIpE gets the public IP address of the given Compute Instance.
 //
 // Deprecated: Use [Instance.GetPublicIPE] instead.
 func (i *Instance) GetPublicIpE(t testing.TestingT) (string, error) { //nolint:staticcheck,revive // preserving deprecated method name
-	return i.GetPublicIPE(t)
+	return i.GetPublicIPContextE(t, context.Background())
 }
 
 // GetPublicIPContextE gets the public IP address of the given Compute Instance.
@@ -591,14 +591,14 @@ func (i *Instance) AddSSHKeyE(t testing.TestingT, username string, publicKey str
 //
 // Deprecated: Use [Instance.AddSSHKey] instead.
 func (i *Instance) AddSshKey(t testing.TestingT, username string, publicKey string) { //nolint:staticcheck,revive // preserving deprecated method name
-	i.AddSSHKey(t, username, publicKey)
+	i.AddSSHKeyContext(t, context.Background(), username, publicKey)
 }
 
 // AddSshKeyE adds the given public SSH key to the Compute Instance. Users can SSH in with the given username.
 //
 // Deprecated: Use [Instance.AddSSHKeyE] instead.
 func (i *Instance) AddSshKeyE(t testing.TestingT, username string, publicKey string) error { //nolint:staticcheck,revive // preserving deprecated method name
-	return i.AddSSHKeyE(t, username, publicKey)
+	return i.AddSSHKeyContextE(t, context.Background(), username, publicKey)
 }
 
 // AddSSHKeyContextE adds the given public SSH key to the Compute Instance. Users can SSH in with the given username.
@@ -712,14 +712,14 @@ func (ig *ZonalInstanceGroup) GetInstanceIDsE(t testing.TestingT) ([]string, err
 //
 // Deprecated: Use [ZonalInstanceGroup.GetInstanceIDs] instead.
 func (ig *ZonalInstanceGroup) GetInstanceIds(t testing.TestingT) []string { //nolint:staticcheck,revive // preserving deprecated method name
-	return ig.GetInstanceIDs(t)
+	return ig.GetInstanceIDsContext(t, context.Background())
 }
 
 // GetInstanceIdsE gets the IDs of Instances in the given Zonal Instance Group.
 //
 // Deprecated: Use [ZonalInstanceGroup.GetInstanceIDsE] instead.
 func (ig *ZonalInstanceGroup) GetInstanceIdsE(t testing.TestingT) ([]string, error) { //nolint:staticcheck,revive // preserving deprecated method name
-	return ig.GetInstanceIDsE(t)
+	return ig.GetInstanceIDsContextE(t, context.Background())
 }
 
 // GetInstanceIDsContextE gets the IDs of Instances in the given Zonal Instance Group.
@@ -796,14 +796,14 @@ func (ig *RegionalInstanceGroup) GetInstanceIDsE(t testing.TestingT) ([]string, 
 //
 // Deprecated: Use [RegionalInstanceGroup.GetInstanceIDs] instead.
 func (ig *RegionalInstanceGroup) GetInstanceIds(t testing.TestingT) []string { //nolint:staticcheck,revive // preserving deprecated method name
-	return ig.GetInstanceIDs(t)
+	return ig.GetInstanceIDsContext(t, context.Background())
 }
 
 // GetInstanceIdsE gets the IDs of Instances in the given Regional Instance Group.
 //
 // Deprecated: Use [RegionalInstanceGroup.GetInstanceIDsE] instead.
 func (ig *RegionalInstanceGroup) GetInstanceIdsE(t testing.TestingT) ([]string, error) { //nolint:staticcheck,revive // preserving deprecated method name
-	return ig.GetInstanceIDsE(t)
+	return ig.GetInstanceIDsContextE(t, context.Background())
 }
 
 // GetInstanceIDsContextE gets the IDs of Instances in the given Regional Instance Group.
@@ -963,14 +963,14 @@ func (ig *ZonalInstanceGroup) GetPublicIPsE(t testing.TestingT, projectID string
 //
 // Deprecated: Use [ZonalInstanceGroup.GetPublicIPs] instead.
 func (ig *ZonalInstanceGroup) GetPublicIps(t testing.TestingT, projectID string) []string { //nolint:staticcheck,revive // preserving deprecated method name
-	return ig.GetPublicIPs(t, projectID)
+	return ig.GetPublicIPsContext(t, context.Background(), projectID)
 }
 
 // GetPublicIpsE returns a slice of the public IPs from the given Zonal Instance Group.
 //
 // Deprecated: Use [ZonalInstanceGroup.GetPublicIPsE] instead.
 func (ig *ZonalInstanceGroup) GetPublicIpsE(t testing.TestingT, projectID string) ([]string, error) { //nolint:staticcheck,revive // preserving deprecated method name
-	return ig.GetPublicIPsE(t, projectID)
+	return ig.GetPublicIPsContextE(t, context.Background(), projectID)
 }
 
 // GetPublicIPsContextE returns a slice of the public IPs from the given Zonal Instance Group.
@@ -1009,14 +1009,14 @@ func (ig *RegionalInstanceGroup) GetPublicIPsE(t testing.TestingT, projectID str
 //
 // Deprecated: Use [RegionalInstanceGroup.GetPublicIPs] instead.
 func (ig *RegionalInstanceGroup) GetPublicIps(t testing.TestingT, projectID string) []string { //nolint:staticcheck,revive // preserving deprecated method name
-	return ig.GetPublicIPs(t, projectID)
+	return ig.GetPublicIPsContext(t, context.Background(), projectID)
 }
 
 // GetPublicIpsE returns a slice of the public IPs from the given Regional Instance Group.
 //
 // Deprecated: Use [RegionalInstanceGroup.GetPublicIPsE] instead.
 func (ig *RegionalInstanceGroup) GetPublicIpsE(t testing.TestingT, projectID string) ([]string, error) { //nolint:staticcheck,revive // preserving deprecated method name
-	return ig.GetPublicIPsE(t, projectID)
+	return ig.GetPublicIPsContextE(t, context.Background(), projectID)
 }
 
 // GetPublicIPsContextE returns a slice of the public IPs from the given Regional Instance Group.

--- a/modules/gcp/static_token_test.go
+++ b/modules/gcp/static_token_test.go
@@ -1,6 +1,7 @@
 package gcp_test
 
 import (
+	"context"
 	"os"
 	"testing"
 
@@ -18,16 +19,16 @@ func TestStaticTokenShortCircuitsCredentialLookup(t *testing.T) {
 	t.Setenv("GOOGLE_APPLICATION_CREDENTIALS", "/nonexistent/credentials.json")
 	t.Setenv("GOOGLE_OAUTH_ACCESS_TOKEN", "fake-access-token")
 
-	svc, err := gcp.NewComputeServiceE(t)
+	svc, err := gcp.NewComputeServiceContextE(t, context.Background())
 	require.NoError(t, err)
 	assert.NotNil(t, svc)
 
-	cb, err := gcp.NewCloudBuildServiceE(t)
+	cb, err := gcp.NewCloudBuildServiceContextE(t, context.Background())
 	require.NoError(t, err)
 	require.NotNil(t, cb)
 	require.NoError(t, cb.Close())
 
-	osl, err := gcp.NewOSLoginServiceE(t)
+	osl, err := gcp.NewOSLoginServiceContextE(t, context.Background())
 	require.NoError(t, err)
 	assert.NotNil(t, osl)
 }
@@ -42,6 +43,6 @@ func TestMissingStaticTokenFallsBackToADC(t *testing.T) {
 
 	t.Setenv("GOOGLE_APPLICATION_CREDENTIALS", "/nonexistent/credentials.json")
 
-	_, err := gcp.NewCloudBuildServiceE(t)
+	_, err := gcp.NewCloudBuildServiceContextE(t, context.Background())
 	assert.Error(t, err)
 }

--- a/modules/helm/cmd.go
+++ b/modules/helm/cmd.go
@@ -68,14 +68,14 @@ func getValuesArgsE(options *Options, args ...string) ([]string, error) {
 	args = append(args, FormatSetValuesAsArgs(options.SetStrValues, "--set-string")...)
 	args = append(args, FormatSetValuesAsArgs(mergeSetJSONValues(options), "--set-json")...)
 
-	valuesFilesArgs, err := FormatValuesFilesAsArgsE(options.ValuesFiles)
+	valuesFilesArgs, err := FormatValuesFilesAsArgsContextE(context.Background(), options.ValuesFiles)
 	if err != nil {
 		return args, err
 	}
 
 	args = append(args, valuesFilesArgs...)
 
-	setFilesArgs, err := FormatSetFilesAsArgsE(options.SetFiles)
+	setFilesArgs, err := FormatSetFilesAsArgsContextE(context.Background(), options.SetFiles)
 	if err != nil {
 		return args, err
 	}

--- a/modules/helm/format_test.go
+++ b/modules/helm/format_test.go
@@ -1,6 +1,7 @@
 package helm_test
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -122,7 +123,7 @@ func TestFormatSetFilesAsArgs(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 
-			assert.Equal(t, testCase.expected, helm.FormatSetFilesAsArgs(t, testCase.setFiles))
+			assert.Equal(t, testCase.expected, helm.FormatSetFilesAsArgsContext(t, context.Background(), testCase.setFiles))
 		})
 	}
 }
@@ -166,7 +167,7 @@ func TestFormatValuesFilesAsArgs(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 
-			assert.Equal(t, testCase.expected, helm.FormatValuesFilesAsArgs(t, testCase.valuesFiles))
+			assert.Equal(t, testCase.expected, helm.FormatValuesFilesAsArgsContext(t, context.Background(), testCase.valuesFiles))
 		})
 	}
 }

--- a/modules/helm/install_test.go
+++ b/modules/helm/install_test.go
@@ -9,6 +9,7 @@
 package helm_test
 
 import (
+	"context"
 	"crypto/tls"
 	"fmt"
 	"path/filepath"
@@ -63,9 +64,9 @@ func TestRemoteChartInstall(t *testing.T) {
 
 	// Add the stable repo under a random name so as not to touch existing repo configs
 	uniqueName := strings.ToLower("terratest-" + random.UniqueID())
-	defer helm.RemoveRepo(t, options, uniqueName)
+	defer helm.RemoveRepoContext(t, context.Background(), options, uniqueName)
 
-	helm.AddRepo(t, options, uniqueName, remoteChartSource)
+	helm.AddRepoContext(t, context.Background(), options, uniqueName, remoteChartSource)
 	helmChart := fmt.Sprintf("%s/%s", uniqueName, remoteChartName)
 
 	// Generate a unique release name so we can defer the delete before installing
@@ -73,18 +74,18 @@ func TestRemoteChartInstall(t *testing.T) {
 		"%s-%s",
 		remoteChartName, strings.ToLower(random.UniqueID()),
 	)
-	defer helm.Delete(t, options, releaseName, true)
+	defer helm.DeleteContext(t, context.Background(), options, releaseName, true)
 
 	// Test if helm.install will return an error if the chart version is incorrect
 	options.Version = "notValidVersion.0.0.0"
-	require.Error(t, helm.InstallE(t, options, helmChart, releaseName))
+	require.Error(t, helm.InstallContextE(t, context.Background(), options, helmChart, releaseName))
 
 	// Fix chart version and retry install
 	options.Version = remoteChartVersion
 	// Test that passing extra arguments doesn't error, by changing default timeout
 	options.ExtraArgs = map[string][]string{"install": {"--timeout", "5m1s"}}
 	options.ExtraArgs["delete"] = []string{"--timeout", "5m1s"}
-	require.NoError(t, helm.InstallE(t, options, helmChart, releaseName))
+	require.NoError(t, helm.InstallContextE(t, context.Background(), options, helmChart, releaseName))
 	waitForRemoteChartPods(t, kubectlOptions, releaseName, 1)
 
 	// Verify service is accessible. Wait for it to become available and then hit the endpoint.
@@ -143,10 +144,10 @@ func TestHelmDependencyInstall(t *testing.T) {
 	// By doing so, we can schedule the delete call here so that at the end of the test, we run
 	// `helm delete RELEASE_NAME` to clean up any resources that were created.
 	releaseName := "helm-dependency-example-" + strings.ToLower(random.UniqueID())
-	defer helm.Delete(t, options, releaseName, true)
+	defer helm.DeleteContext(t, context.Background(), options, releaseName, true)
 
 	// Deploy the chart using `helm install`.
-	err = helm.InstallE(t, options, helmChartPath, releaseName)
+	err = helm.InstallContextE(t, context.Background(), options, helmChartPath, releaseName)
 	assert.NoError(t, err) //nolint:testifylint // assert not require: deferred Delete must run even if install fails
 
 	// Verify that Kubernetes service is available after helm chart deployment.

--- a/modules/helm/template_test.go
+++ b/modules/helm/template_test.go
@@ -9,6 +9,7 @@
 package helm_test
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -59,7 +60,7 @@ func TestRemoteChartRender(t *testing.T) {
 
 	// Run RenderTemplate to render the template and capture the output. Note that we use the version without `E`, since
 	// we want to assert that the template renders without any errors.
-	output := helm.RenderRemoteTemplate(t, options, remoteChartSource, releaseName, []string{"templates/deployment.yaml"})
+	output := helm.RenderRemoteTemplateContext(t, context.Background(), options, remoteChartSource, releaseName, []string{"templates/deployment.yaml"})
 
 	// Now we use kubernetes/client-go library to render the template output into the Deployment struct. This will
 	// ensure the Deployment resource is rendered correctly.
@@ -97,7 +98,7 @@ func TestRemoteChartRenderDiff(t *testing.T) {
 		SnapshotPath: initialSnapshot,
 	}
 	// diff in: spec.initContainers.preserve-logs-symlinks.imag, spec.containers.nginx.image, tls certificates
-	require.Equal(t, 4, helm.DiffAgainstSnapshot(t, options, output, "nginx"))
+	require.Equal(t, 4, helm.DiffAgainstSnapshotContext(t, context.Background(), options, output, "nginx"))
 }
 
 // render chart dump and return the rendered output
@@ -126,7 +127,7 @@ func renderChartDump(t *testing.T, remoteChartVersion, snapshotDir string) strin
 
 	// Run RenderTemplate to render the template and capture the output. Note that we use the version without `E`, since
 	// we want to assert that the template renders without any errors.
-	output := helm.RenderRemoteTemplate(t, options, remoteChartSource, releaseName, []string{})
+	output := helm.RenderRemoteTemplateContext(t, context.Background(), options, remoteChartSource, releaseName, []string{})
 
 	// Now we use kubernetes/client-go library to render the template output into the Deployment struct. This will
 	// ensure the Deployment resource is rendered correctly.
@@ -141,7 +142,7 @@ func renderChartDump(t *testing.T, remoteChartVersion, snapshotDir string) strin
 		Logger:       logger.Default,
 		SnapshotPath: snapshotDir,
 	}
-	helm.UpdateSnapshot(t, options, output, releaseName)
+	helm.UpdateSnapshotContext(t, context.Background(), options, output, releaseName)
 
 	return output
 }
@@ -211,7 +212,7 @@ func TestRenderWarning(t *testing.T) {
 	chart, err := filepath.Abs("testdata/deprecated-chart")
 	require.NoError(t, err)
 
-	stdout, stderr, err := helm.RenderTemplateAndGetStdOutErrE(t, &helm.Options{}, chart, "test", nil)
+	stdout, stderr, err := helm.RenderTemplateAndGetStdOutErrContextE(t, context.Background(), &helm.Options{}, chart, "test", nil)
 	require.NoError(t, err)
 
 	assert.Contains(t, stderr, "WARNING:")
@@ -227,7 +228,7 @@ func TestRenderMultipleManifests(t *testing.T) {
 	chart, err := filepath.Abs("testdata/multiple-manifests")
 	require.NoError(t, err)
 
-	out := helm.RenderTemplate(t, &helm.Options{}, chart, "test", []string{})
+	out := helm.RenderTemplateContext(t, context.Background(), &helm.Options{}, chart, "test", []string{})
 
 	var configs []corev1.ConfigMap
 	helm.UnmarshalK8SYamlsE(t, out, &configs, func(v corev1.ConfigMap) bool {

--- a/modules/helm/upgrade_test.go
+++ b/modules/helm/upgrade_test.go
@@ -9,6 +9,7 @@
 package helm_test
 
 import (
+	"context"
 	"crypto/tls"
 	"fmt"
 	"path/filepath"
@@ -55,9 +56,9 @@ func TestRemoteChartInstallUpgradeRollback(t *testing.T) {
 
 	// Add the stable repo under a random name so as not to touch existing repo configs
 	uniqueName := strings.ToLower("terratest-" + random.UniqueID())
-	defer helm.RemoveRepo(t, options, uniqueName)
+	defer helm.RemoveRepoContext(t, context.Background(), options, uniqueName)
 
-	helm.AddRepo(t, options, uniqueName, remoteChartSource)
+	helm.AddRepoContext(t, context.Background(), options, uniqueName, remoteChartSource)
 	helmChart := fmt.Sprintf("%s/%s", uniqueName, remoteChartName)
 
 	// Generate a unique release name so we can defer the delete before installing
@@ -65,9 +66,9 @@ func TestRemoteChartInstallUpgradeRollback(t *testing.T) {
 		"%s-%s",
 		remoteChartName, strings.ToLower(random.UniqueID()),
 	)
-	defer helm.Delete(t, options, releaseName, true)
+	defer helm.DeleteContext(t, context.Background(), options, releaseName, true)
 
-	helm.Install(t, options, helmChart, releaseName)
+	helm.InstallContext(t, context.Background(), options, helmChart, releaseName)
 	waitForRemoteChartPods(t, kubectlOptions, releaseName, 1)
 
 	// Setting replica count to 2 to check the upgrade functionality.
@@ -80,7 +81,7 @@ func TestRemoteChartInstallUpgradeRollback(t *testing.T) {
 	// Test that passing extra arguments doesn't error, by changing default timeout
 	options.ExtraArgs = map[string][]string{"upgrade": {"--timeout", "5m1s"}}
 	options.ExtraArgs["rollback"] = []string{"--timeout", "5m1s"}
-	helm.Upgrade(t, options, helmChart, releaseName)
+	helm.UpgradeContext(t, context.Background(), options, helmChart, releaseName)
 	waitForRemoteChartPods(t, kubectlOptions, releaseName, 2)
 
 	// Verify service is accessible. Wait for it to become available and then hit the endpoint.
@@ -105,7 +106,7 @@ func TestRemoteChartInstallUpgradeRollback(t *testing.T) {
 	)
 
 	// Finally, test rollback functionality. When rolling back, we should see the pods go back down to 1.
-	helm.Rollback(t, options, releaseName, "")
+	helm.RollbackContext(t, context.Background(), options, releaseName, "")
 	waitForRemoteChartPods(t, kubectlOptions, releaseName, 1)
 }
 
@@ -143,13 +144,13 @@ func TestHelmDependencyUpgrade(t *testing.T) {
 	// By doing so, we can schedule the delete call here so that at the end of the test, we run
 	// `helm delete RELEASE_NAME` to clean up any resources that were created.
 	releaseName := "helm-dependency-example-" + strings.ToLower(random.UniqueID())
-	defer helm.Delete(t, options, releaseName, true)
+	defer helm.DeleteContext(t, context.Background(), options, releaseName, true)
 
 	// Deploy the chart using `helm install`.
-	err = helm.InstallE(t, options, helmChartPath, releaseName)
+	err = helm.InstallContextE(t, context.Background(), options, helmChartPath, releaseName)
 	require.NoError(t, err)
 
 	// Verify that upgrade is working as expected.
-	err = helm.UpgradeE(t, options, helmChartPath, releaseName)
+	err = helm.UpgradeContextE(t, context.Background(), options, helmChartPath, releaseName)
 	assert.NoError(t, err)
 }

--- a/modules/httphelper/dummy_server_test.go
+++ b/modules/httphelper/dummy_server_test.go
@@ -1,6 +1,7 @@
 package httphelper_test
 
 import (
+	"context"
 	"crypto/tls"
 	"fmt"
 	"io"
@@ -19,11 +20,11 @@ func TestRunDummyServer(t *testing.T) {
 	uniqueID := random.UniqueID()
 	text := "dummy-server-" + uniqueID
 
-	listener, port := httphelper.RunDummyServer(t, text)
+	listener, port := httphelper.RunDummyServerContext(t, context.Background(), text)
 	defer shutDownServer(t, listener)
 
 	url := fmt.Sprintf("http://localhost:%d", port)
-	httphelper.HttpGetWithValidation(t, url, &tls.Config{}, 200, text)
+	httphelper.HTTPGetWithValidationContext(t, context.Background(), url, &tls.Config{}, 200, text)
 }
 
 func TestContinuouslyCheck(t *testing.T) {
@@ -33,10 +34,10 @@ func TestContinuouslyCheck(t *testing.T) {
 	text := "dummy-server-" + uniqueID
 	stopChecking := make(chan bool, 1)
 
-	listener, port := httphelper.RunDummyServer(t, text)
+	listener, port := httphelper.RunDummyServerContext(t, context.Background(), text)
 
 	url := fmt.Sprintf("http://localhost:%d", port)
-	wg, responses := httphelper.ContinuouslyCheckUrl(t, url, stopChecking, 1*time.Second)
+	wg, responses := httphelper.ContinuouslyCheckURLContext(t, context.Background(), url, stopChecking, 1*time.Second)
 
 	defer func() {
 		stopChecking <- true
@@ -90,7 +91,7 @@ func TestRunDummyServersWithHandlers(t *testing.T) {
 			"/v1/endpoint": handler,
 		}
 
-		listener, port := httphelper.RunDummyServerWithHandlers(t, handlerMap)
+		listener, port := httphelper.RunDummyServerWithHandlersContext(t, context.Background(), handlerMap)
 		defer shutDownServer(t, listener)
 
 		data[idx] = testData{text: text, port: port}
@@ -98,7 +99,7 @@ func TestRunDummyServersWithHandlers(t *testing.T) {
 
 	for _, testInstance := range data {
 		url := fmt.Sprintf("http://localhost:%d/v1/endpoint", testInstance.port)
-		httphelper.HttpGetWithValidation(t, url, &tls.Config{}, 200, testInstance.text)
+		httphelper.HTTPGetWithValidationContext(t, context.Background(), url, &tls.Config{}, 200, testInstance.text)
 	}
 }
 

--- a/modules/httphelper/httphelper.go
+++ b/modules/httphelper/httphelper.go
@@ -302,7 +302,7 @@ func HttpGetWithRetryE(t testing.TestingT, url string, tlsConfig *tls.Config, ex
 //
 //nolint:staticcheck,revive // preserving existing function name
 func HttpGetWithRetryWithOptionsE(t testing.TestingT, options HttpGetOptions, expectedStatus int, expectedBody string, retries int, sleepBetweenRetries time.Duration) error {
-	_, err := retry.DoWithRetryE(t, "HTTP GET to URL "+options.Url, retries, sleepBetweenRetries, func() (string, error) {
+	_, err := retry.DoWithRetryContextE(t, context.Background(), "HTTP GET to URL "+options.Url, retries, sleepBetweenRetries, func() (string, error) {
 		return "", HttpGetWithValidationWithOptionsE(t, options, expectedStatus, expectedBody)
 	})
 
@@ -363,7 +363,7 @@ func HttpGetWithRetryWithCustomValidationE(t testing.TestingT, url string, tlsCo
 //
 //nolint:staticcheck,revive // preserving existing function name
 func HttpGetWithRetryWithCustomValidationWithOptionsE(t testing.TestingT, options HttpGetOptions, retries int, sleepBetweenRetries time.Duration, validateResponse func(int, string) bool) error {
-	_, err := retry.DoWithRetryE(t, "HTTP GET to URL "+options.Url, retries, sleepBetweenRetries, func() (string, error) {
+	_, err := retry.DoWithRetryContextE(t, context.Background(), "HTTP GET to URL "+options.Url, retries, sleepBetweenRetries, func() (string, error) {
 		return "", HttpGetWithCustomValidationWithOptionsE(t, options, validateResponse)
 	})
 
@@ -625,8 +625,8 @@ func HTTPDoWithRetryWithOptionsE(
 
 	options.Body = nil
 
-	out, err := retry.DoWithRetryE( //nolint:staticcheck // deprecated wrapper; use HTTPDoWithRetryContext for context support
-		t, "HTTP "+options.Method+" to URL "+options.Url, retries,
+	out, err := retry.DoWithRetryContextE( //nolint:staticcheck // deprecated wrapper; use HTTPDoWithRetryContext for context support
+		t, context.Background(), "HTTP "+options.Method+" to URL "+options.Url, retries,
 		sleepBetweenRetries, func() (string, error) {
 			options.Body = bytes.NewReader(data)
 
@@ -751,7 +751,7 @@ func HTTPDoWithValidationRetryWithOptionsE(
 	t testing.TestingT, options HttpDoOptions, expectedStatus int,
 	expectedBody string, retries int, sleepBetweenRetries time.Duration,
 ) error {
-	_, err := retry.DoWithRetryE(t, "HTTP "+options.Method+" to URL "+options.Url, retries, //nolint:staticcheck // deprecated wrapper; use HTTPDoWithValidationRetryContext for context support
+	_, err := retry.DoWithRetryContextE(t, context.Background(), "HTTP "+options.Method+" to URL "+options.Url, retries, //nolint:staticcheck // deprecated wrapper; use HTTPDoWithValidationRetryContext for context support
 		sleepBetweenRetries, func() (string, error) {
 			return "", HTTPDoWithValidationWithOptionsE(t, options, expectedStatus, expectedBody)
 		})

--- a/modules/httphelper/httphelper_test.go
+++ b/modules/httphelper/httphelper_test.go
@@ -2,6 +2,7 @@ package httphelper_test
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -30,7 +31,7 @@ func TestOkBody(t *testing.T) {
 	url := ts.URL
 	expectedBody := "Hello, Terratest!"
 	body := bytes.NewReader([]byte(expectedBody))
-	statusCode, respBody := httphelper.HTTPDo(t, "POST", url, body, nil, nil)
+	statusCode, respBody := httphelper.HTTPDoContext(t, context.Background(), "POST", url, body, nil, nil)
 
 	expectedCode := 200
 
@@ -52,7 +53,7 @@ func TestHTTPDoWithValidation(t *testing.T) {
 	url := ts.URL
 	expectedBody := "Hello, Terratest!"
 	body := bytes.NewReader([]byte(expectedBody))
-	httphelper.HTTPDoWithValidation(t, "POST", url, body, nil, 200, expectedBody, nil)
+	httphelper.HTTPDoWithValidationContext(t, context.Background(), "POST", url, body, nil, 200, expectedBody, nil)
 }
 
 func TestHTTPDoWithCustomValidation(t *testing.T) {
@@ -69,7 +70,7 @@ func TestHTTPDoWithCustomValidation(t *testing.T) {
 		return statusCode == 200 && response == expectedBody
 	}
 
-	httphelper.HTTPDoWithCustomValidation(t, "POST", url, body, nil, customValidation, nil)
+	httphelper.HTTPDoWithCustomValidationContext(t, context.Background(), "POST", url, body, nil, customValidation, nil)
 }
 
 func TestOkHeaders(t *testing.T) {
@@ -80,7 +81,7 @@ func TestOkHeaders(t *testing.T) {
 
 	url := ts.URL
 	headers := map[string]string{"Authorization": "Bearer 1a2b3c99ff"}
-	statusCode, respBody := httphelper.HTTPDo(t, "POST", url, nil, headers, nil)
+	statusCode, respBody := httphelper.HTTPDoContext(t, context.Background(), "POST", url, nil, headers, nil)
 
 	expectedCode := 200
 
@@ -102,7 +103,7 @@ func TestWrongStatus(t *testing.T) {
 	defer ts.Close()
 
 	url := ts.URL
-	statusCode, _ := httphelper.HTTPDo(t, "POST", url, nil, nil, nil)
+	statusCode, _ := httphelper.HTTPDoContext(t, context.Background(), "POST", url, nil, nil, nil)
 
 	expectedCode := 500
 
@@ -119,7 +120,7 @@ func TestRequestTimeout(t *testing.T) {
 
 	url := ts.URL
 
-	_, _, err := httphelper.HTTPDoE(t, "DELETE", url, nil, nil, nil)
+	_, _, err := httphelper.HTTPDoContextE(t, context.Background(), "DELETE", url, nil, nil, nil)
 	if err == nil {
 		t.Error("handler didn't return a timeout error")
 	}
@@ -140,7 +141,7 @@ func TestOkWithRetry(t *testing.T) {
 
 	url := ts.URL
 	counter = 3
-	response := httphelper.HTTPDoWithRetry(t, "POST", url, bodyBytes, nil, 200, 10, time.Second, nil)
+	response := httphelper.HTTPDoWithRetryContext(t, context.Background(), "POST", url, bodyBytes, nil, 200, 10, time.Second, nil)
 	require.Equal(t, body, response)
 }
 
@@ -154,7 +155,7 @@ func TestErrorWithRetry(t *testing.T) {
 
 	url := ts.URL
 
-	_, err := httphelper.HTTPDoWithRetryE(t, "POST", url, nil, nil, 200, 2, time.Second, nil)
+	_, err := httphelper.HTTPDoWithRetryContextE(t, context.Background(), "POST", url, nil, nil, 200, 2, time.Second, nil)
 	if err == nil {
 		t.Error("handler didn't return a retry error")
 	}

--- a/modules/k8s/cluster_role_test.go
+++ b/modules/k8s/cluster_role_test.go
@@ -10,6 +10,7 @@
 package k8s_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/gruntwork-io/terratest/modules/k8s/v2"
@@ -21,7 +22,7 @@ func TestGetClusterRoleEReturnsErrorForNonExistantClusterRole(t *testing.T) {
 	t.Parallel()
 
 	options := k8s.NewKubectlOptions("", "", "default")
-	_, err := k8s.GetClusterRoleE(t, options, "non-existing-role")
+	_, err := k8s.GetClusterRoleContextE(t, context.Background(), options, "non-existing-role")
 	require.Error(t, err)
 }
 
@@ -29,11 +30,11 @@ func TestGetClusterRoleEReturnsCorrectClusterRoleInCorrectNamespace(t *testing.T
 	t.Parallel()
 
 	options := k8s.NewKubectlOptions("", "", "default")
-	defer k8s.KubectlDeleteFromString(t, options, exampleClusterRoleYAMLTemplate)
+	defer k8s.KubectlDeleteFromStringContext(t, context.Background(), options, exampleClusterRoleYAMLTemplate)
 
-	k8s.KubectlApplyFromString(t, options, exampleClusterRoleYAMLTemplate)
+	k8s.KubectlApplyFromStringContext(t, context.Background(), options, exampleClusterRoleYAMLTemplate)
 
-	role := k8s.GetClusterRole(t, options, "terratest-cluster-role")
+	role := k8s.GetClusterRoleContext(t, context.Background(), options, "terratest-cluster-role")
 	require.Equal(t, "terratest-cluster-role", role.Name)
 }
 

--- a/modules/k8s/config.go
+++ b/modules/k8s/config.go
@@ -54,7 +54,7 @@ func LoadApiClientConfigE(configPath string, contextName string) (*restclient.Co
 // that are orphaned as a result of it. The config path is either specified in the environment variable KUBECONFIG or at
 // the user's home directory under `.kube/config`.
 func DeleteConfigContextE(t testing.TestingT, contextName string) error {
-	kubeConfigPath, err := GetKubeConfigPathE(t)
+	kubeConfigPath, err := GetKubeConfigPathContextE(t, context.Background())
 	if err != nil {
 		return err
 	}

--- a/modules/k8s/configmap_test.go
+++ b/modules/k8s/configmap_test.go
@@ -10,6 +10,7 @@
 package k8s_test
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"testing"
@@ -26,7 +27,7 @@ func TestGetConfigMapEReturnsErrorForNonExistantConfigMap(t *testing.T) {
 	t.Parallel()
 
 	options := k8s.NewKubectlOptions("", "", "default")
-	_, err := k8s.GetConfigMapE(t, options, "test-config-map")
+	_, err := k8s.GetConfigMapContextE(t, context.Background(), options, "test-config-map")
 	require.Error(t, err)
 }
 
@@ -37,11 +38,11 @@ func TestGetConfigMapEReturnsCorrectConfigMapInCorrectNamespace(t *testing.T) {
 	options := k8s.NewKubectlOptions("", "", uniqueID)
 
 	configData := fmt.Sprintf(exampleConfigMapYAMLTemplate, uniqueID, uniqueID)
-	defer k8s.KubectlDeleteFromString(t, options, configData)
+	defer k8s.KubectlDeleteFromStringContext(t, context.Background(), options, configData)
 
-	k8s.KubectlApplyFromString(t, options, configData)
+	k8s.KubectlApplyFromStringContext(t, context.Background(), options, configData)
 
-	configMap := k8s.GetConfigMap(t, options, "test-config-map")
+	configMap := k8s.GetConfigMapContext(t, context.Background(), options, "test-config-map")
 	require.Equal(t, "test-config-map", configMap.Name)
 	require.Equal(t, configMap.Namespace, uniqueID)
 }
@@ -53,10 +54,10 @@ func TestWaitUntilConfigMapAvailableReturnsSuccessfully(t *testing.T) {
 	options := k8s.NewKubectlOptions("", "", uniqueID)
 
 	configData := fmt.Sprintf(exampleConfigMapYAMLTemplate, uniqueID, uniqueID)
-	defer k8s.KubectlDeleteFromString(t, options, configData)
+	defer k8s.KubectlDeleteFromStringContext(t, context.Background(), options, configData)
 
-	k8s.KubectlApplyFromString(t, options, configData)
-	k8s.WaitUntilConfigMapAvailable(t, options, "test-config-map", 10, 1*time.Second)
+	k8s.KubectlApplyFromStringContext(t, context.Background(), options, configData)
+	k8s.WaitUntilConfigMapAvailableContext(t, context.Background(), options, "test-config-map", 10, 1*time.Second)
 }
 
 const exampleConfigMapYAMLTemplate = `---

--- a/modules/k8s/cronjob_test.go
+++ b/modules/k8s/cronjob_test.go
@@ -4,6 +4,7 @@
 package k8s_test
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"testing"
@@ -26,11 +27,11 @@ func TestListCronJobsReturnsCronJobsInNamespace(t *testing.T) {
 	options := k8s.NewKubectlOptions("", "", uniqueID)
 
 	configData := fmt.Sprintf(ExampleCronjobYamlTemplate, uniqueID, uniqueID)
-	defer k8s.KubectlDeleteFromString(t, options, configData)
+	defer k8s.KubectlDeleteFromStringContext(t, context.Background(), options, configData)
 
-	k8s.KubectlApplyFromString(t, options, configData)
+	k8s.KubectlApplyFromStringContext(t, context.Background(), options, configData)
 
-	jobs := k8s.ListCronJobs(t, options, metav1.ListOptions{})
+	jobs := k8s.ListCronJobsContext(t, context.Background(), options, metav1.ListOptions{})
 	require.Len(t, jobs, 1)
 	job := jobs[0]
 	require.Equal(t, "cron-job", job.Name)
@@ -41,7 +42,7 @@ func TestGetCronJobEReturnErrorForNotExistingCronJob(t *testing.T) {
 	t.Parallel()
 
 	options := k8s.NewKubectlOptions("", "", "default")
-	_, err := k8s.GetJobE(t, options, random.UniqueID())
+	_, err := k8s.GetJobContextE(t, context.Background(), options, random.UniqueID())
 	require.Error(t, err)
 }
 
@@ -52,11 +53,11 @@ func TestGetCronJobEReturnsCorrectJobInNamespace(t *testing.T) {
 	options := k8s.NewKubectlOptions("", "", uniqueID)
 
 	configData := fmt.Sprintf(ExampleCronjobYamlTemplate, uniqueID, uniqueID)
-	defer k8s.KubectlDeleteFromString(t, options, configData)
+	defer k8s.KubectlDeleteFromStringContext(t, context.Background(), options, configData)
 
-	k8s.KubectlApplyFromString(t, options, configData)
+	k8s.KubectlApplyFromStringContext(t, context.Background(), options, configData)
 
-	job := k8s.GetCronJob(t, options, "cron-job")
+	job := k8s.GetCronJobContext(t, context.Background(), options, "cron-job")
 	require.Equal(t, "cron-job", job.Name)
 	require.Equal(t, job.Namespace, uniqueID)
 }
@@ -68,11 +69,11 @@ func TestWaitUntilCronJobScheduleSuccessfullyContainer(t *testing.T) {
 	options := k8s.NewKubectlOptions("", "", uniqueID)
 
 	configData := fmt.Sprintf(ExampleCronjobYamlTemplate, uniqueID, uniqueID)
-	defer k8s.KubectlDeleteFromString(t, options, configData)
+	defer k8s.KubectlDeleteFromStringContext(t, context.Background(), options, configData)
 
-	k8s.KubectlApplyFromString(t, options, configData)
+	k8s.KubectlApplyFromStringContext(t, context.Background(), options, configData)
 
-	k8s.WaitUntilCronJobSucceed(t, options, "cron-job", 60, 5*time.Second)
+	k8s.WaitUntilCronJobSucceedContext(t, context.Background(), options, "cron-job", 60, 5*time.Second)
 }
 
 func TestIsCronJobSucceeded(t *testing.T) {

--- a/modules/k8s/daemonset_test.go
+++ b/modules/k8s/daemonset_test.go
@@ -9,6 +9,7 @@
 package k8s_test
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -28,7 +29,7 @@ func TestGetDaemonSetEReturnsErrorForNonExistantDaemonSet(t *testing.T) {
 	t.Parallel()
 
 	options := k8s.NewKubectlOptions("", "", "")
-	_, err := k8s.GetDaemonSetE(t, options, "sample-ds")
+	_, err := k8s.GetDaemonSetContextE(t, context.Background(), options, "sample-ds")
 	require.Error(t, err)
 }
 
@@ -39,10 +40,10 @@ func TestGetDaemonSetEReturnsCorrectServiceInCorrectNamespace(t *testing.T) {
 	options := k8s.NewKubectlOptions("", "", uniqueID)
 	configData := fmt.Sprintf(exampleDaemonSetYAMLTemplate, uniqueID, uniqueID)
 
-	k8s.KubectlApplyFromString(t, options, configData)
-	defer k8s.KubectlDeleteFromString(t, options, configData)
+	k8s.KubectlApplyFromStringContext(t, context.Background(), options, configData)
+	defer k8s.KubectlDeleteFromStringContext(t, context.Background(), options, configData)
 
-	daemonSet := k8s.GetDaemonSet(t, options, "sample-ds")
+	daemonSet := k8s.GetDaemonSetContext(t, context.Background(), options, "sample-ds")
 	require.Equal(t, "sample-ds", daemonSet.Name)
 	require.Equal(t, daemonSet.Namespace, uniqueID)
 }
@@ -54,10 +55,10 @@ func TestListDaemonSetsReturnsCorrectServiceInCorrectNamespace(t *testing.T) {
 	options := k8s.NewKubectlOptions("", "", uniqueID)
 	configData := fmt.Sprintf(exampleDaemonSetYAMLTemplate, uniqueID, uniqueID)
 
-	k8s.KubectlApplyFromString(t, options, configData)
-	defer k8s.KubectlDeleteFromString(t, options, configData)
+	k8s.KubectlApplyFromStringContext(t, context.Background(), options, configData)
+	defer k8s.KubectlDeleteFromStringContext(t, context.Background(), options, configData)
 
-	daemonSets := k8s.ListDaemonSets(t, options, metav1.ListOptions{})
+	daemonSets := k8s.ListDaemonSetsContext(t, context.Background(), options, metav1.ListOptions{})
 	require.Len(t, daemonSets, 1)
 
 	daemonSet := daemonSets[0]
@@ -72,10 +73,10 @@ func TestWaitUntilDaemonSetAvailable(t *testing.T) {
 	options := k8s.NewKubectlOptions("", "", uniqueID)
 	configData := fmt.Sprintf(exampleDaemonSetYAMLTemplate, uniqueID, uniqueID)
 
-	k8s.KubectlApplyFromString(t, options, configData)
-	defer k8s.KubectlDeleteFromString(t, options, configData)
+	k8s.KubectlApplyFromStringContext(t, context.Background(), options, configData)
+	defer k8s.KubectlDeleteFromStringContext(t, context.Background(), options, configData)
 
-	k8s.WaitUntilDaemonSetAvailable(t, options, "sample-ds", 60, 1*time.Second)
+	k8s.WaitUntilDaemonSetAvailableContext(t, context.Background(), options, "sample-ds", 60, 1*time.Second)
 }
 
 func TestIsDaemonSetAvailable(t *testing.T) {

--- a/modules/k8s/deployment_test.go
+++ b/modules/k8s/deployment_test.go
@@ -10,6 +10,7 @@
 package k8s_test
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -29,7 +30,7 @@ func TestGetDeploymentEReturnsError(t *testing.T) {
 	t.Parallel()
 
 	options := k8s.NewKubectlOptions("", "", "")
-	_, err := k8s.GetDeploymentE(t, options, "nginx-deployment")
+	_, err := k8s.GetDeploymentContextE(t, context.Background(), options, "nginx-deployment")
 	require.Error(t, err)
 }
 
@@ -40,10 +41,10 @@ func TestGetDeployments(t *testing.T) {
 	options := k8s.NewKubectlOptions("", "", uniqueID)
 	configData := fmt.Sprintf(ExampleDeploymentYAMLTemplate, uniqueID)
 
-	k8s.KubectlApplyFromString(t, options, configData)
-	defer k8s.KubectlDeleteFromString(t, options, configData)
+	k8s.KubectlApplyFromStringContext(t, context.Background(), options, configData)
+	defer k8s.KubectlDeleteFromStringContext(t, context.Background(), options, configData)
 
-	deployment := k8s.GetDeployment(t, options, "nginx-deployment")
+	deployment := k8s.GetDeploymentContext(t, context.Background(), options, "nginx-deployment")
 	require.Equal(t, "nginx-deployment", deployment.Name)
 	require.Equal(t, deployment.Namespace, uniqueID)
 }
@@ -55,10 +56,10 @@ func TestListDeployments(t *testing.T) {
 	options := k8s.NewKubectlOptions("", "", uniqueID)
 	configData := fmt.Sprintf(ExampleDeploymentYAMLTemplate, uniqueID)
 
-	k8s.KubectlApplyFromString(t, options, configData)
-	defer k8s.KubectlDeleteFromString(t, options, configData)
+	k8s.KubectlApplyFromStringContext(t, context.Background(), options, configData)
+	defer k8s.KubectlDeleteFromStringContext(t, context.Background(), options, configData)
 
-	deployments := k8s.ListDeployments(t, options, metav1.ListOptions{})
+	deployments := k8s.ListDeploymentsContext(t, context.Background(), options, metav1.ListOptions{})
 	require.Len(t, deployments, 1)
 
 	deployment := deployments[0]
@@ -73,10 +74,10 @@ func TestWaitUntilDeploymentAvailable(t *testing.T) {
 	options := k8s.NewKubectlOptions("", "", uniqueID)
 	configData := fmt.Sprintf(ExampleDeploymentYAMLTemplate, uniqueID)
 
-	k8s.KubectlApplyFromString(t, options, configData)
-	defer k8s.KubectlDeleteFromString(t, options, configData)
+	k8s.KubectlApplyFromStringContext(t, context.Background(), options, configData)
+	defer k8s.KubectlDeleteFromStringContext(t, context.Background(), options, configData)
 
-	k8s.WaitUntilDeploymentAvailable(t, options, "nginx-deployment", 60, 1*time.Second)
+	k8s.WaitUntilDeploymentAvailableContext(t, context.Background(), options, "nginx-deployment", 60, 1*time.Second)
 }
 
 func TestTestIsDeploymentAvailable(t *testing.T) {

--- a/modules/k8s/event_test.go
+++ b/modules/k8s/event_test.go
@@ -10,6 +10,7 @@
 package k8s_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/gruntwork-io/terratest/modules/k8s/v2"
@@ -24,7 +25,7 @@ func TestListEventsEReturnsNilErrorWhenListingEvents(t *testing.T) {
 	t.Parallel()
 
 	options := k8s.NewKubectlOptions("", "", "kube-system")
-	events, err := k8s.ListEventsE(t, options, v1.ListOptions{})
+	events, err := k8s.ListEventsContextE(t, context.Background(), options, v1.ListOptions{})
 	require.NoError(t, err)
 	require.NotEmpty(t, events)
 }
@@ -33,7 +34,7 @@ func TestListEventsInNamespace(t *testing.T) {
 	t.Parallel()
 
 	options := k8s.NewKubectlOptions("", "", "kube-system")
-	events := k8s.ListEvents(t, options, v1.ListOptions{})
+	events := k8s.ListEventsContext(t, context.Background(), options, v1.ListOptions{})
 	require.NotEmpty(t, events)
 }
 
@@ -44,11 +45,11 @@ func TestListEventsReturnsZeroEventsIfNoneCreated(t *testing.T) {
 
 	options := k8s.NewKubectlOptions("", "", "")
 
-	defer k8s.DeleteNamespace(t, options, ns)
+	defer k8s.DeleteNamespaceContext(t, context.Background(), options, ns)
 
-	k8s.CreateNamespace(t, options, ns)
+	k8s.CreateNamespaceContext(t, context.Background(), options, ns)
 
 	options.Namespace = ns
-	events := k8s.ListEvents(t, options, v1.ListOptions{})
+	events := k8s.ListEventsContext(t, context.Background(), options, v1.ListOptions{})
 	require.Empty(t, events)
 }

--- a/modules/k8s/ingress_test.go
+++ b/modules/k8s/ingress_test.go
@@ -10,6 +10,7 @@
 package k8s_test
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"testing"
@@ -29,7 +30,7 @@ func TestGetIngressEReturnsErrorForNonExistantIngress(t *testing.T) {
 	t.Parallel()
 
 	options := k8s.NewKubectlOptions("", "", "default")
-	_, err := k8s.GetIngressE(t, options, "i-dont-exist")
+	_, err := k8s.GetIngressContextE(t, context.Background(), options, "i-dont-exist")
 	require.Error(t, err)
 }
 
@@ -40,10 +41,10 @@ func TestGetIngressEReturnsCorrectIngressInCorrectNamespace(t *testing.T) {
 	options := k8s.NewKubectlOptions("", "", uniqueID)
 	configData := fmt.Sprintf(exampleIngressDeploymentYamlTemplate, uniqueID, uniqueID, uniqueID, uniqueID, uniqueID)
 
-	k8s.KubectlApplyFromString(t, options, configData)
-	defer k8s.KubectlDeleteFromString(t, options, configData)
+	k8s.KubectlApplyFromStringContext(t, context.Background(), options, configData)
+	defer k8s.KubectlDeleteFromStringContext(t, context.Background(), options, configData)
 
-	service := k8s.GetIngress(t, options, "nginx-service-ingress")
+	service := k8s.GetIngressContext(t, context.Background(), options, "nginx-service-ingress")
 	require.Equal(t, "nginx-service-ingress", service.Name)
 	require.Equal(t, service.Namespace, uniqueID)
 }
@@ -55,10 +56,10 @@ func TestListIngressesReturnsCorrectIngressInCorrectNamespace(t *testing.T) {
 	options := k8s.NewKubectlOptions("", "", uniqueID)
 	configData := fmt.Sprintf(exampleIngressDeploymentYamlTemplate, uniqueID, uniqueID, uniqueID, uniqueID, uniqueID)
 
-	k8s.KubectlApplyFromString(t, options, configData)
-	defer k8s.KubectlDeleteFromString(t, options, configData)
+	k8s.KubectlApplyFromStringContext(t, context.Background(), options, configData)
+	defer k8s.KubectlDeleteFromStringContext(t, context.Background(), options, configData)
 
-	ingresses := k8s.ListIngresses(t, options, metav1.ListOptions{})
+	ingresses := k8s.ListIngressesContext(t, context.Background(), options, metav1.ListOptions{})
 	require.Len(t, ingresses, 1)
 
 	ingress := ingresses[0]
@@ -73,10 +74,10 @@ func TestWaitUntilIngressAvailableReturnsSuccessfully(t *testing.T) {
 	options := k8s.NewKubectlOptions("", "", uniqueID)
 	configData := fmt.Sprintf(exampleIngressDeploymentYamlTemplate, uniqueID, uniqueID, uniqueID, uniqueID, uniqueID)
 
-	k8s.KubectlApplyFromString(t, options, configData)
-	defer k8s.KubectlDeleteFromString(t, options, configData)
+	k8s.KubectlApplyFromStringContext(t, context.Background(), options, configData)
+	defer k8s.KubectlDeleteFromStringContext(t, context.Background(), options, configData)
 
-	k8s.WaitUntilIngressAvailable(t, options, ExampleIngressName, 60, 5*time.Second)
+	k8s.WaitUntilIngressAvailableContext(t, context.Background(), options, ExampleIngressName, 60, 5*time.Second)
 }
 
 const exampleIngressDeploymentYamlTemplate = `---

--- a/modules/k8s/job_test.go
+++ b/modules/k8s/job_test.go
@@ -10,6 +10,7 @@
 package k8s_test
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"testing"
@@ -33,11 +34,11 @@ func TestListJobsReturnsJobsInNamespace(t *testing.T) {
 	options := k8s.NewKubectlOptions("", "", uniqueID)
 
 	configData := fmt.Sprintf(exampleJobYAMLTemplate, uniqueID, uniqueID)
-	defer k8s.KubectlDeleteFromString(t, options, configData)
+	defer k8s.KubectlDeleteFromStringContext(t, context.Background(), options, configData)
 
-	k8s.KubectlApplyFromString(t, options, configData)
+	k8s.KubectlApplyFromStringContext(t, context.Background(), options, configData)
 
-	jobs := k8s.ListJobs(t, options, metav1.ListOptions{})
+	jobs := k8s.ListJobsContext(t, context.Background(), options, metav1.ListOptions{})
 	require.Len(t, jobs, 1)
 	job := jobs[0]
 	require.Equal(t, "pi-job", job.Name)
@@ -48,7 +49,7 @@ func TestGetJobEReturnsErrorForNonExistantJob(t *testing.T) {
 	t.Parallel()
 
 	options := k8s.NewKubectlOptions("", "", "default")
-	_, err := k8s.GetJobE(t, options, "pi-job")
+	_, err := k8s.GetJobContextE(t, context.Background(), options, "pi-job")
 	require.Error(t, err)
 }
 
@@ -59,11 +60,11 @@ func TestGetJobEReturnsCorrectJobInCorrectNamespace(t *testing.T) {
 	options := k8s.NewKubectlOptions("", "", uniqueID)
 
 	configData := fmt.Sprintf(exampleJobYAMLTemplate, uniqueID, uniqueID)
-	defer k8s.KubectlDeleteFromString(t, options, configData)
+	defer k8s.KubectlDeleteFromStringContext(t, context.Background(), options, configData)
 
-	k8s.KubectlApplyFromString(t, options, configData)
+	k8s.KubectlApplyFromStringContext(t, context.Background(), options, configData)
 
-	job := k8s.GetJob(t, options, "pi-job")
+	job := k8s.GetJobContext(t, context.Background(), options, "pi-job")
 	require.Equal(t, "pi-job", job.Name)
 	require.Equal(t, job.Namespace, uniqueID)
 }
@@ -75,11 +76,11 @@ func TestWaitUntilJobSucceedReturnsSuccessfully(t *testing.T) {
 	options := k8s.NewKubectlOptions("", "", uniqueID)
 
 	configData := fmt.Sprintf(exampleJobYAMLTemplate, uniqueID, uniqueID)
-	defer k8s.KubectlDeleteFromString(t, options, configData)
+	defer k8s.KubectlDeleteFromStringContext(t, context.Background(), options, configData)
 
-	k8s.KubectlApplyFromString(t, options, configData)
+	k8s.KubectlApplyFromStringContext(t, context.Background(), options, configData)
 
-	k8s.WaitUntilJobSucceed(t, options, "pi-job", 60, 1*time.Second)
+	k8s.WaitUntilJobSucceedContext(t, context.Background(), options, "pi-job", 60, 1*time.Second)
 }
 
 func TestIsJobSucceeded(t *testing.T) {
@@ -146,12 +147,12 @@ func TestCreateJobFromCronJobReturnsCreatedJob(t *testing.T) {
 	options := k8s.NewKubectlOptions("", "", uniqueID)
 
 	configData := fmt.Sprintf(exampleCronJobYAMLTemplate, uniqueID, uniqueID)
-	defer k8s.KubectlDeleteFromString(t, options, configData)
+	defer k8s.KubectlDeleteFromStringContext(t, context.Background(), options, configData)
 
-	k8s.KubectlApplyFromString(t, options, configData)
+	k8s.KubectlApplyFromStringContext(t, context.Background(), options, configData)
 
 	newJobName := "pi-copied-job"
-	job := k8s.CreateJobFromCronJob(t, options, "pi-cronjob", newJobName)
+	job := k8s.CreateJobFromCronJobContext(t, context.Background(), options, "pi-cronjob", newJobName)
 	require.NotNil(t, job)
 	assert.Equal(t, job.Namespace, uniqueID)
 	assert.Equal(t, job.Name, newJobName)
@@ -161,7 +162,7 @@ func TestCreateJobFromCronJobEReturnsErrorForNonExistentCronJob(t *testing.T) {
 	t.Parallel()
 
 	options := k8s.NewKubectlOptions("", "", "default")
-	_, err := k8s.CreateJobFromCronJobE(t, options, "non-existent-cronjob", "new-job-name")
+	_, err := k8s.CreateJobFromCronJobContextE(t, context.Background(), options, "non-existent-cronjob", "new-job-name")
 	require.Error(t, err)
 }
 

--- a/modules/k8s/kubectl_options.go
+++ b/modules/k8s/kubectl_options.go
@@ -1,6 +1,7 @@
 package k8s
 
 import (
+	"context"
 	"time"
 
 	"github.com/gruntwork-io/terratest/modules/core/v2/logger"
@@ -53,7 +54,7 @@ func (kubectlOptions *KubectlOptions) GetConfigPath(t testing.TestingT) (string,
 
 	kubeConfigPath := kubectlOptions.ConfigPath
 	if kubeConfigPath == "" {
-		kubeConfigPath, err = GetKubeConfigPathE(t)
+		kubeConfigPath, err = GetKubeConfigPathContextE(t, context.Background())
 		if err != nil {
 			return "", err
 		}

--- a/modules/k8s/kubectl_test.go
+++ b/modules/k8s/kubectl_test.go
@@ -10,6 +10,7 @@
 package k8s_test
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -30,7 +31,7 @@ func TestRunKubectlAndGetOutputReturnsOutput(t *testing.T) {
 
 	namespaceName := "kubectl-test-" + strings.ToLower(random.UniqueID())
 	options := k8s.NewKubectlOptions("", "", namespaceName)
-	output, err := k8s.RunKubectlAndGetOutputE(t, options, "auth", "can-i", "get", "pods")
+	output, err := k8s.RunKubectlAndGetOutputContextE(t, context.Background(), options, "auth", "can-i", "get", "pods")
 	require.NoError(t, err)
 	require.Equal(t, "yes", output)
 }
@@ -76,7 +77,7 @@ current-context: dummy-context
 			ContextName: "dummy-context",
 			ConfigPath:  k8s.StoreConfigToTempFile(t, config),
 		}
-		_, err := k8s.RunKubectlAndGetOutputE(t, options, "get", "pods")
+		_, err := k8s.RunKubectlAndGetOutputContextE(t, context.Background(), options, "get", "pods")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "dummy-error")
 		assert.NotContains(t, err.Error(), "Client.Timeout exceeded while awaiting headers")
@@ -88,7 +89,7 @@ current-context: dummy-context
 			ConfigPath:     k8s.StoreConfigToTempFile(t, config),
 			RequestTimeout: time.Second,
 		}
-		_, err := k8s.RunKubectlAndGetOutputE(t, options, "get", "pods")
+		_, err := k8s.RunKubectlAndGetOutputContextE(t, context.Background(), options, "get", "pods")
 		require.Error(t, err)
 		assert.Equal(t, options.RequestTimeout, parsedTimeout)
 		assert.NotContains(t, err.Error(), "dummy-error")

--- a/modules/k8s/minikube.go
+++ b/modules/k8s/minikube.go
@@ -1,6 +1,7 @@
 package k8s
 
 import (
+	"context"
 	"strings"
 
 	"github.com/gruntwork-io/terratest/modules/core/v2/testing"
@@ -10,7 +11,7 @@ import (
 // IsMinikubeE returns true if the underlying kubernetes cluster is Minikube. This is determined by getting the
 // associated nodes and checking if all nodes has at least one label namespaced with "minikube.k8s.io".
 func IsMinikubeE(t testing.TestingT, options *KubectlOptions) (bool, error) {
-	nodes, err := GetNodesE(t, options)
+	nodes, err := GetNodesContextE(t, context.Background(), options)
 	if err != nil {
 		return false, err
 	}

--- a/modules/k8s/namespace_test.go
+++ b/modules/k8s/namespace_test.go
@@ -10,6 +10,7 @@
 package k8s_test
 
 import (
+	"context"
 	"strings"
 	"testing"
 
@@ -28,15 +29,15 @@ func TestNamespaces(t *testing.T) {
 	uniqueID := random.UniqueID()
 	namespaceName := strings.ToLower(uniqueID)
 	options := k8s.NewKubectlOptions("", "", namespaceName)
-	k8s.CreateNamespace(t, options, namespaceName)
+	k8s.CreateNamespaceContext(t, context.Background(), options, namespaceName)
 
 	defer func() {
-		k8s.DeleteNamespace(t, options, namespaceName)
-		namespace := k8s.GetNamespace(t, options, namespaceName)
+		k8s.DeleteNamespaceContext(t, context.Background(), options, namespaceName)
+		namespace := k8s.GetNamespaceContext(t, context.Background(), options, namespaceName)
 		require.Equal(t, corev1.NamespaceTerminating, namespace.Status.Phase)
 	}()
 
-	namespace := k8s.GetNamespace(t, options, namespaceName)
+	namespace := k8s.GetNamespaceContext(t, context.Background(), options, namespaceName)
 	require.Equal(t, namespace.Name, namespaceName)
 }
 
@@ -51,15 +52,15 @@ func TestNamespaceWithMetadata(t *testing.T) {
 		Name:   namespaceName,
 		Labels: namespaceLabels,
 	}
-	k8s.CreateNamespaceWithMetadata(t, options, namespaceObjectMetaWithLabels)
+	k8s.CreateNamespaceWithMetadataContext(t, context.Background(), options, namespaceObjectMetaWithLabels)
 
 	defer func() {
-		k8s.DeleteNamespace(t, options, namespaceName)
-		namespace := k8s.GetNamespace(t, options, namespaceName)
+		k8s.DeleteNamespaceContext(t, context.Background(), options, namespaceName)
+		namespace := k8s.GetNamespaceContext(t, context.Background(), options, namespaceName)
 		require.Equal(t, corev1.NamespaceTerminating, namespace.Status.Phase)
 	}()
 
-	namespace := k8s.GetNamespace(t, options, namespaceName)
+	namespace := k8s.GetNamespaceContext(t, context.Background(), options, namespaceName)
 	require.Equal(t, namespace.Name, namespaceName)
 
 	for k, v := range namespaceLabels {
@@ -74,12 +75,12 @@ func TestListNamespaces(t *testing.T) {
 	namespaceName := strings.ToLower(uniqueID)
 	options := k8s.NewKubectlOptions("", "", namespaceName)
 
-	k8s.CreateNamespace(t, options, namespaceName)
-	t.Cleanup(func() { k8s.DeleteNamespace(t, options, namespaceName) })
+	k8s.CreateNamespaceContext(t, context.Background(), options, namespaceName)
+	t.Cleanup(func() { k8s.DeleteNamespaceContext(t, context.Background(), options, namespaceName) })
 
 	t.Run("List all namespaces and find the created one", func(t *testing.T) {
 		t.Parallel()
-		namespaces := k8s.ListNamespaces(t, options, metav1.ListOptions{})
+		namespaces := k8s.ListNamespacesContext(t, context.Background(), options, metav1.ListOptions{})
 		require.NotEmpty(t, namespaces, "Should find at least some namespaces")
 
 		found := false

--- a/modules/k8s/networkpolicy_test.go
+++ b/modules/k8s/networkpolicy_test.go
@@ -10,6 +10,7 @@
 package k8s_test
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"testing"
@@ -26,7 +27,7 @@ func TestGetNetworkPolicyEReturnsErrorForNonExistantNetworkPolicy(t *testing.T) 
 	t.Parallel()
 
 	options := k8s.NewKubectlOptions("", "", "default")
-	_, err := k8s.GetNetworkPolicyE(t, options, "test-network-policy")
+	_, err := k8s.GetNetworkPolicyContextE(t, context.Background(), options, "test-network-policy")
 	require.Error(t, err)
 }
 
@@ -37,11 +38,11 @@ func TestGetNetworkPolicyEReturnsCorrectNetworkPolicyInCorrectNamespace(t *testi
 	options := k8s.NewKubectlOptions("", "", uniqueID)
 
 	configData := fmt.Sprintf(exampleNetworkPolicyYAMLTemplate, uniqueID, uniqueID)
-	defer k8s.KubectlDeleteFromString(t, options, configData)
+	defer k8s.KubectlDeleteFromStringContext(t, context.Background(), options, configData)
 
-	k8s.KubectlApplyFromString(t, options, configData)
+	k8s.KubectlApplyFromStringContext(t, context.Background(), options, configData)
 
-	networkPolicy := k8s.GetNetworkPolicy(t, options, "test-network-policy")
+	networkPolicy := k8s.GetNetworkPolicyContext(t, context.Background(), options, "test-network-policy")
 	require.Equal(t, "test-network-policy", networkPolicy.Name)
 	require.Equal(t, networkPolicy.Namespace, uniqueID)
 }
@@ -53,10 +54,10 @@ func TestWaitUntilNetworkPolicyAvailableReturnsSuccessfully(t *testing.T) {
 	options := k8s.NewKubectlOptions("", "", uniqueID)
 
 	configData := fmt.Sprintf(exampleNetworkPolicyYAMLTemplate, uniqueID, uniqueID)
-	defer k8s.KubectlDeleteFromString(t, options, configData)
+	defer k8s.KubectlDeleteFromStringContext(t, context.Background(), options, configData)
 
-	k8s.KubectlApplyFromString(t, options, configData)
-	k8s.WaitUntilNetworkPolicyAvailable(t, options, "test-network-policy", 10, 1*time.Second)
+	k8s.KubectlApplyFromStringContext(t, context.Background(), options, configData)
+	k8s.WaitUntilNetworkPolicyAvailableContext(t, context.Background(), options, "test-network-policy", 10, 1*time.Second)
 }
 
 const exampleNetworkPolicyYAMLTemplate = `---

--- a/modules/k8s/node.go
+++ b/modules/k8s/node.go
@@ -233,7 +233,7 @@ func AreAllNodesReadyContextE(t testing.TestingT, ctx context.Context, options *
 //
 // Deprecated: Use [AreAllNodesReadyContextE] instead.
 func AreAllNodesReady(t testing.TestingT, options *KubectlOptions) bool {
-	nodesReady, _ := AreAllNodesReadyE(t, options)
+	nodesReady, _ := AreAllNodesReadyContextE(t, context.Background(), options)
 	return nodesReady
 }
 

--- a/modules/k8s/node_test.go
+++ b/modules/k8s/node_test.go
@@ -10,6 +10,7 @@
 package k8s_test
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -27,7 +28,7 @@ func TestGetNodes(t *testing.T) {
 
 	// Assumes local kubernetes (minikube or docker-for-desktop kube), where there is only one node
 	options := k8s.NewKubectlOptions("", "", "default")
-	nodes := k8s.GetNodes(t, options)
+	nodes := k8s.GetNodesContext(t, context.Background(), options)
 	require.Len(t, nodes, 1)
 
 	node := nodes[0]
@@ -43,7 +44,7 @@ func TestGetReadyNodes(t *testing.T) {
 
 	// Assumes local kubernetes (minikube or docker-for-desktop kube), where there is only one node
 	options := k8s.NewKubectlOptions("", "", "default")
-	nodes := k8s.GetReadyNodes(t, options)
+	nodes := k8s.GetReadyNodesContext(t, context.Background(), options)
 	require.Len(t, nodes, 1)
 
 	node := nodes[0]
@@ -59,16 +60,16 @@ func TestWaitUntilAllNodesReady(t *testing.T) {
 
 	options := k8s.NewKubectlOptions("", "", "default")
 
-	k8s.WaitUntilAllNodesReady(t, options, 12, 5*time.Second)
+	k8s.WaitUntilAllNodesReadyContext(t, context.Background(), options, 12, 5*time.Second)
 
-	nodes := k8s.GetNodes(t, options)
+	nodes := k8s.GetNodesContext(t, context.Background(), options)
 
 	nodeNames := map[string]bool{}
 	for _, node := range nodes {
 		nodeNames[node.Name] = true
 	}
 
-	readyNodes := k8s.GetReadyNodes(t, options)
+	readyNodes := k8s.GetReadyNodesContext(t, context.Background(), options)
 
 	readyNodeNames := map[string]bool{}
 	for _, node := range readyNodes {

--- a/modules/k8s/persistent_volume_claim_test.go
+++ b/modules/k8s/persistent_volume_claim_test.go
@@ -10,6 +10,7 @@
 package k8s_test
 
 import (
+	"context"
 	"strings"
 	"testing"
 	"time"
@@ -33,11 +34,11 @@ func TestListPersistentVolumeClaimsReturnsPersistentVolumeClaimsInNamespace(t *t
 	options := k8s.NewKubectlOptions("", "", namespace)
 
 	configData := renderFixtureYamlTemplate(namespace, pvcName)
-	defer k8s.KubectlDeleteFromString(t, options, configData)
+	defer k8s.KubectlDeleteFromStringContext(t, context.Background(), options, configData)
 
-	k8s.KubectlApplyFromString(t, options, configData)
+	k8s.KubectlApplyFromStringContext(t, context.Background(), options, configData)
 
-	pvcs := k8s.ListPersistentVolumeClaims(t, options, metav1.ListOptions{})
+	pvcs := k8s.ListPersistentVolumeClaimsContext(t, context.Background(), options, metav1.ListOptions{})
 	require.Len(t, pvcs, 1)
 	pvc := pvcs[0]
 	require.Equal(t, pvc.Name, pvcName)
@@ -50,10 +51,10 @@ func TestListPersistentVolumeClaimsReturnsZeroPersistentVolumeClaimsIfNoneCreate
 	namespace := strings.ToLower(random.UniqueID())
 	options := k8s.NewKubectlOptions("", "", namespace)
 
-	k8s.CreateNamespace(t, options, namespace)
-	defer k8s.DeleteNamespace(t, options, namespace)
+	k8s.CreateNamespaceContext(t, context.Background(), options, namespace)
+	defer k8s.DeleteNamespaceContext(t, context.Background(), options, namespace)
 
-	pvcs := k8s.ListPersistentVolumeClaims(t, options, metav1.ListOptions{})
+	pvcs := k8s.ListPersistentVolumeClaimsContext(t, context.Background(), options, metav1.ListOptions{})
 	require.Empty(t, pvcs)
 }
 
@@ -61,7 +62,7 @@ func TestGetPersistentVolumeClaimEReturnsErrorForNonExistantPersistentVolumeClai
 	t.Parallel()
 
 	options := k8s.NewKubectlOptions("", "", "default")
-	_, err := k8s.GetPersistentVolumeClaimE(t, options, "non-existent")
+	_, err := k8s.GetPersistentVolumeClaimContextE(t, context.Background(), options, "non-existent")
 	require.Error(t, err)
 }
 
@@ -73,11 +74,11 @@ func TestGetPersistentVolumeClaimReturnsCorrectPersistentVolumeClaimInCorrectNam
 	options := k8s.NewKubectlOptions("", "", namespace)
 
 	configData := renderFixtureYamlTemplate(namespace, pvcName)
-	defer k8s.KubectlDeleteFromString(t, options, configData)
+	defer k8s.KubectlDeleteFromStringContext(t, context.Background(), options, configData)
 
-	k8s.KubectlApplyFromString(t, options, configData)
+	k8s.KubectlApplyFromStringContext(t, context.Background(), options, configData)
 
-	pvc := k8s.GetPersistentVolumeClaim(t, options, pvcName)
+	pvc := k8s.GetPersistentVolumeClaimContext(t, context.Background(), options, pvcName)
 	require.Equal(t, pvc.Name, pvcName)
 	require.Equal(t, pvc.Namespace, namespace)
 }
@@ -91,11 +92,11 @@ func TestWaitUntilPersistentVolumeClaimInGivenStatusPhase(t *testing.T) {
 	options := k8s.NewKubectlOptions("", "", namespace)
 
 	configData := renderFixtureYamlTemplate(namespace, pvcName)
-	defer k8s.KubectlDeleteFromString(t, options, configData)
+	defer k8s.KubectlDeleteFromStringContext(t, context.Background(), options, configData)
 
-	k8s.KubectlApplyFromString(t, options, configData)
+	k8s.KubectlApplyFromStringContext(t, context.Background(), options, configData)
 
-	k8s.WaitUntilPersistentVolumeClaimInStatus(t, options, pvcName, &pvcBoundStatusPhase, 60, 1*time.Second)
+	k8s.WaitUntilPersistentVolumeClaimInStatusContext(t, context.Background(), options, pvcName, &pvcBoundStatusPhase, 60, 1*time.Second)
 }
 
 func TestWaitUntilPersistentVolumeClaimInStatusEReturnsErrorWhenWaitingForAnUnexistentPvc(t *testing.T) {
@@ -103,7 +104,7 @@ func TestWaitUntilPersistentVolumeClaimInStatusEReturnsErrorWhenWaitingForAnUnex
 
 	pvcBoundStatusPhase := corev1.ClaimBound
 	options := k8s.NewKubectlOptions("", "", "default")
-	err := k8s.WaitUntilPersistentVolumeClaimInStatusE(t, options, "non-existent", &pvcBoundStatusPhase, 3, 1*time.Second)
+	err := k8s.WaitUntilPersistentVolumeClaimInStatusContextE(t, context.Background(), options, "non-existent", &pvcBoundStatusPhase, 3, 1*time.Second)
 	require.Error(t, err)
 }
 
@@ -116,11 +117,11 @@ func TestWaitUntilPersistentVolumeClaimInStatusEReturnsErrorWhenTimesOut(t *test
 	options := k8s.NewKubectlOptions("", "", namespace)
 
 	configData := renderFixtureYamlTemplate(namespace, pvcName)
-	defer k8s.KubectlDeleteFromString(t, options, configData)
+	defer k8s.KubectlDeleteFromStringContext(t, context.Background(), options, configData)
 
-	k8s.KubectlApplyFromString(t, options, configData)
+	k8s.KubectlApplyFromStringContext(t, context.Background(), options, configData)
 
-	err := k8s.WaitUntilPersistentVolumeClaimInStatusE(t, options, pvcName, &pvcLostStatusPhase, 5, 1*time.Second)
+	err := k8s.WaitUntilPersistentVolumeClaimInStatusContextE(t, context.Background(), options, pvcName, &pvcLostStatusPhase, 5, 1*time.Second)
 	require.Error(t, err)
 }
 

--- a/modules/k8s/persistent_volume_test.go
+++ b/modules/k8s/persistent_volume_test.go
@@ -10,6 +10,7 @@
 package k8s_test
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"testing"
@@ -40,12 +41,12 @@ func TestListPersistentVolumesReturnsAllPersistentVolumes(t *testing.T) {
 
 	for pvName := range pvNames {
 		pv := fmt.Sprintf(PvFixtureYamlTemplate, pvName, pvName)
-		defer k8s.KubectlDeleteFromString(t, options, pv)
+		defer k8s.KubectlDeleteFromStringContext(t, context.Background(), options, pv)
 
-		k8s.KubectlApplyFromString(t, options, pv)
+		k8s.KubectlApplyFromStringContext(t, context.Background(), options, pv)
 	}
 
-	pvs := k8s.ListPersistentVolumes(t, options, metav1.ListOptions{})
+	pvs := k8s.ListPersistentVolumesContext(t, context.Background(), options, metav1.ListOptions{})
 	for _, pv := range pvs {
 		if _, ok := pvNames[pv.Name]; ok {
 			numPvFound++
@@ -59,7 +60,7 @@ func TestListPersistentVolumesReturnsZeroPersistentVolumesIfNoneCreated(t *testi
 	t.Parallel()
 
 	options := k8s.NewKubectlOptions("", "", "")
-	pvs := k8s.ListPersistentVolumes(t, options, metav1.ListOptions{})
+	pvs := k8s.ListPersistentVolumesContext(t, context.Background(), options, metav1.ListOptions{})
 	require.Empty(t, pvs)
 }
 
@@ -67,7 +68,7 @@ func TestGetPersistentVolumeEReturnsErrorForNonExistentPersistentVolumes(t *test
 	t.Parallel()
 
 	options := k8s.NewKubectlOptions("", "", "")
-	_, err := k8s.GetPersistentVolumeE(t, options, "non-existent")
+	_, err := k8s.GetPersistentVolumeContextE(t, context.Background(), options, "non-existent")
 	require.Error(t, err)
 }
 
@@ -78,11 +79,11 @@ func TestGetPersistentVolumeReturnsCorrectPersistentVolume(t *testing.T) {
 	options := k8s.NewKubectlOptions("", "", "")
 
 	configData := fmt.Sprintf(PvFixtureYamlTemplate, pvName, pvName)
-	defer k8s.KubectlDeleteFromString(t, options, configData)
+	defer k8s.KubectlDeleteFromStringContext(t, context.Background(), options, configData)
 
-	k8s.KubectlApplyFromString(t, options, configData)
+	k8s.KubectlApplyFromStringContext(t, context.Background(), options, configData)
 
-	pv := k8s.GetPersistentVolume(t, options, pvName)
+	pv := k8s.GetPersistentVolumeContext(t, context.Background(), options, pvName)
 	require.Equal(t, pv.Name, pvName)
 }
 
@@ -95,10 +96,10 @@ func TestWaitUntilPersistentVolumeInTheGivenStatusPhase(t *testing.T) {
 	options := k8s.NewKubectlOptions("", "", pvName)
 	configData := fmt.Sprintf(PvFixtureYamlTemplate, pvName, pvName)
 
-	k8s.KubectlApplyFromString(t, options, configData)
-	defer k8s.KubectlDeleteFromString(t, options, configData)
+	k8s.KubectlApplyFromStringContext(t, context.Background(), options, configData)
+	defer k8s.KubectlDeleteFromStringContext(t, context.Background(), options, configData)
 
-	k8s.WaitUntilPersistentVolumeInStatus(t, options, pvName, &pvAvailableStatusPhase, 60, 1*time.Second)
+	k8s.WaitUntilPersistentVolumeInStatusContext(t, context.Background(), options, pvName, &pvAvailableStatusPhase, 60, 1*time.Second)
 }
 
 const PvFixtureYamlTemplate = `---

--- a/modules/k8s/pod_test.go
+++ b/modules/k8s/pod_test.go
@@ -10,6 +10,7 @@
 package k8s_test
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"testing"
@@ -31,11 +32,11 @@ func TestListPodsReturnsPodsInNamespace(t *testing.T) {
 	options := k8s.NewKubectlOptions("", "", uniqueID)
 
 	configData := fmt.Sprintf(examplePodYAMLTemplate, uniqueID, uniqueID)
-	defer k8s.KubectlDeleteFromString(t, options, configData)
+	defer k8s.KubectlDeleteFromStringContext(t, context.Background(), options, configData)
 
-	k8s.KubectlApplyFromString(t, options, configData)
+	k8s.KubectlApplyFromStringContext(t, context.Background(), options, configData)
 
-	pods := k8s.ListPods(t, options, metav1.ListOptions{})
+	pods := k8s.ListPodsContext(t, context.Background(), options, metav1.ListOptions{})
 	require.Len(t, pods, 1)
 	pod := pods[0]
 	require.Equal(t, "nginx-pod", pod.Name)
@@ -46,7 +47,7 @@ func TestGetPodEReturnsErrorForNonExistantPod(t *testing.T) {
 	t.Parallel()
 
 	options := k8s.NewKubectlOptions("", "", "default")
-	_, err := k8s.GetPodE(t, options, "nginx-pod")
+	_, err := k8s.GetPodContextE(t, context.Background(), options, "nginx-pod")
 	require.Error(t, err)
 }
 
@@ -57,11 +58,11 @@ func TestGetPodEReturnsCorrectPodInCorrectNamespace(t *testing.T) {
 	options := k8s.NewKubectlOptions("", "", uniqueID)
 
 	configData := fmt.Sprintf(examplePodYAMLTemplate, uniqueID, uniqueID)
-	defer k8s.KubectlDeleteFromString(t, options, configData)
+	defer k8s.KubectlDeleteFromStringContext(t, context.Background(), options, configData)
 
-	k8s.KubectlApplyFromString(t, options, configData)
+	k8s.KubectlApplyFromStringContext(t, context.Background(), options, configData)
 
-	pod := k8s.GetPod(t, options, "nginx-pod")
+	pod := k8s.GetPodContext(t, context.Background(), options, "nginx-pod")
 	require.Equal(t, "nginx-pod", pod.Name)
 	require.Equal(t, pod.Namespace, uniqueID)
 }
@@ -73,11 +74,11 @@ func TestWaitUntilNumPodsCreatedReturnsSuccessfully(t *testing.T) {
 	options := k8s.NewKubectlOptions("", "", uniqueID)
 
 	configData := fmt.Sprintf(examplePodYAMLTemplate, uniqueID, uniqueID)
-	defer k8s.KubectlDeleteFromString(t, options, configData)
+	defer k8s.KubectlDeleteFromStringContext(t, context.Background(), options, configData)
 
-	k8s.KubectlApplyFromString(t, options, configData)
+	k8s.KubectlApplyFromStringContext(t, context.Background(), options, configData)
 
-	k8s.WaitUntilNumPodsCreated(t, options, metav1.ListOptions{}, 1, 60, 1*time.Second)
+	k8s.WaitUntilNumPodsCreatedContext(t, context.Background(), options, metav1.ListOptions{}, 1, 60, 1*time.Second)
 }
 
 func TestWaitUntilPodAvailableReturnsSuccessfully(t *testing.T) {
@@ -87,11 +88,11 @@ func TestWaitUntilPodAvailableReturnsSuccessfully(t *testing.T) {
 	options := k8s.NewKubectlOptions("", "", uniqueID)
 
 	configData := fmt.Sprintf(examplePodYAMLTemplate, uniqueID, uniqueID)
-	defer k8s.KubectlDeleteFromString(t, options, configData)
+	defer k8s.KubectlDeleteFromStringContext(t, context.Background(), options, configData)
 
-	k8s.KubectlApplyFromString(t, options, configData)
+	k8s.KubectlApplyFromStringContext(t, context.Background(), options, configData)
 
-	k8s.WaitUntilPodAvailable(t, options, "nginx-pod", 60, 1*time.Second)
+	k8s.WaitUntilPodAvailableContext(t, context.Background(), options, "nginx-pod", 60, 1*time.Second)
 }
 
 func TestWaitUntilPodWithMultipleContainersAvailableReturnsSuccessfully(t *testing.T) {
@@ -101,11 +102,11 @@ func TestWaitUntilPodWithMultipleContainersAvailableReturnsSuccessfully(t *testi
 	options := k8s.NewKubectlOptions("", "", uniqueID)
 
 	configData := fmt.Sprintf(examplePodWithMultipleContainersYAMLTemplate, uniqueID, uniqueID)
-	defer k8s.KubectlDeleteFromString(t, options, configData)
+	defer k8s.KubectlDeleteFromStringContext(t, context.Background(), options, configData)
 
-	k8s.KubectlApplyFromString(t, options, configData)
+	k8s.KubectlApplyFromStringContext(t, context.Background(), options, configData)
 
-	k8s.WaitUntilPodAvailable(t, options, "nginx-pod", 60, 1*time.Second)
+	k8s.WaitUntilPodAvailableContext(t, context.Background(), options, "nginx-pod", 60, 1*time.Second)
 }
 
 func TestWaitUntilPodAvailableWithReadinessProbe(t *testing.T) {
@@ -115,11 +116,11 @@ func TestWaitUntilPodAvailableWithReadinessProbe(t *testing.T) {
 	options := k8s.NewKubectlOptions("", "", uniqueID)
 
 	configData := fmt.Sprintf(examplePodWithReadinessProbe, uniqueID, uniqueID)
-	defer k8s.KubectlDeleteFromString(t, options, configData)
+	defer k8s.KubectlDeleteFromStringContext(t, context.Background(), options, configData)
 
-	k8s.KubectlApplyFromString(t, options, configData)
+	k8s.KubectlApplyFromStringContext(t, context.Background(), options, configData)
 
-	k8s.WaitUntilPodAvailable(t, options, "nginx-pod", 60, 1*time.Second)
+	k8s.WaitUntilPodAvailableContext(t, context.Background(), options, "nginx-pod", 60, 1*time.Second)
 }
 
 func TestWaitUntilPodAvailableWithFailingReadinessProbe(t *testing.T) {
@@ -129,11 +130,11 @@ func TestWaitUntilPodAvailableWithFailingReadinessProbe(t *testing.T) {
 	options := k8s.NewKubectlOptions("", "", uniqueID)
 
 	configData := fmt.Sprintf(examplePodWithFailingReadinessProbe, uniqueID, uniqueID)
-	defer k8s.KubectlDeleteFromString(t, options, configData)
+	defer k8s.KubectlDeleteFromStringContext(t, context.Background(), options, configData)
 
-	k8s.KubectlApplyFromString(t, options, configData)
+	k8s.KubectlApplyFromStringContext(t, context.Background(), options, configData)
 
-	err := k8s.WaitUntilPodAvailableE(t, options, "nginx-pod", 60, 1*time.Second)
+	err := k8s.WaitUntilPodAvailableContextE(t, context.Background(), options, "nginx-pod", 60, 1*time.Second)
 	require.Error(t, err)
 }
 
@@ -289,16 +290,16 @@ func TestExecPod(t *testing.T) {
 
 	configData := fmt.Sprintf(examplePodWithMultipleContainersYAMLTemplate, uniqueID, uniqueID)
 
-	t.Cleanup(func() { k8s.KubectlDeleteFromString(t, options, configData) })
+	t.Cleanup(func() { k8s.KubectlDeleteFromStringContext(t, context.Background(), options, configData) })
 
-	k8s.KubectlApplyFromString(t, options, configData)
+	k8s.KubectlApplyFromStringContext(t, context.Background(), options, configData)
 
-	k8s.WaitUntilPodAvailable(t, options, "nginx-pod", 60, 1*time.Second)
+	k8s.WaitUntilPodAvailableContext(t, context.Background(), options, "nginx-pod", 60, 1*time.Second)
 
 	t.Run("TestExecPodWithoutContainer", func(t *testing.T) {
 		t.Parallel()
 
-		stdout, err := k8s.ExecPodE(t, options, "nginx-pod", "", "env")
+		stdout, err := k8s.ExecPodContextE(t, context.Background(), options, "nginx-pod", "", "env")
 		require.NoError(t, err)
 		require.Contains(t, stdout, "NAME=nginx\n")
 	})
@@ -306,7 +307,7 @@ func TestExecPod(t *testing.T) {
 	t.Run("TestExecPodWithContainer", func(t *testing.T) {
 		t.Parallel()
 
-		stdout, err := k8s.ExecPodE(t, options, "nginx-pod", "nginx-two", "env")
+		stdout, err := k8s.ExecPodContextE(t, context.Background(), options, "nginx-pod", "nginx-two", "env")
 		require.NoError(t, err)
 		require.Contains(t, stdout, "NAME=nginx-two\n")
 	})

--- a/modules/k8s/replicaset_test.go
+++ b/modules/k8s/replicaset_test.go
@@ -10,6 +10,7 @@
 package k8s_test
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/gruntwork-io/terratest/modules/k8s/v2"
@@ -26,7 +27,7 @@ func TestGetReplicaSetEReturnsError(t *testing.T) {
 	t.Parallel()
 
 	options := k8s.NewKubectlOptions("", "", "")
-	_, err := k8s.GetReplicaSetE(t, options, "sample-rs")
+	_, err := k8s.GetReplicaSetContextE(t, context.Background(), options, "sample-rs")
 	require.Error(t, err)
 }
 
@@ -37,11 +38,11 @@ func TestGetReplicaSets(t *testing.T) {
 	options := k8s.NewKubectlOptions("", "", uniqueID)
 
 	configData := fmt.Sprintf(exampleReplicaSetYAMLTemplate, uniqueID, uniqueID)
-	defer k8s.KubectlDeleteFromString(t, options, configData)
+	defer k8s.KubectlDeleteFromStringContext(t, context.Background(), options, configData)
 
-	k8s.KubectlApplyFromString(t, options, configData)
+	k8s.KubectlApplyFromStringContext(t, context.Background(), options, configData)
 
-	replicaSet := k8s.GetReplicaSet(t, options, "sample-rs")
+	replicaSet := k8s.GetReplicaSetContext(t, context.Background(), options, "sample-rs")
 	require.Equal(t, "sample-rs", replicaSet.Name)
 	require.Equal(t, replicaSet.Namespace, uniqueID)
 }
@@ -53,11 +54,11 @@ func TestListReplicaSets(t *testing.T) {
 	options := k8s.NewKubectlOptions("", "", uniqueID)
 
 	configData := fmt.Sprintf(exampleReplicaSetYAMLTemplate, uniqueID, uniqueID)
-	defer k8s.KubectlDeleteFromString(t, options, configData)
+	defer k8s.KubectlDeleteFromStringContext(t, context.Background(), options, configData)
 
-	k8s.KubectlApplyFromString(t, options, configData)
+	k8s.KubectlApplyFromStringContext(t, context.Background(), options, configData)
 
-	replicaSets := k8s.ListReplicaSets(t, options, metav1.ListOptions{})
+	replicaSets := k8s.ListReplicaSetsContext(t, context.Background(), options, metav1.ListOptions{})
 	require.Len(t, replicaSets, 1)
 
 	replicaSet := replicaSets[0]

--- a/modules/k8s/role_test.go
+++ b/modules/k8s/role_test.go
@@ -10,6 +10,7 @@
 package k8s_test
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"testing"
@@ -25,7 +26,7 @@ func TestGetRoleEReturnsErrorForNonExistantRole(t *testing.T) {
 	t.Parallel()
 
 	options := k8s.NewKubectlOptions("", "", "default")
-	_, err := k8s.GetRoleE(t, options, "non-existing-role")
+	_, err := k8s.GetRoleContextE(t, context.Background(), options, "non-existing-role")
 	require.Error(t, err)
 }
 
@@ -36,11 +37,11 @@ func TestGetRoleEReturnsCorrectRoleInCorrectNamespace(t *testing.T) {
 	options := k8s.NewKubectlOptions("", "", uniqueID)
 
 	configData := fmt.Sprintf(exampleRoleYAMLTemplate, uniqueID, uniqueID)
-	defer k8s.KubectlDeleteFromString(t, options, configData)
+	defer k8s.KubectlDeleteFromStringContext(t, context.Background(), options, configData)
 
-	k8s.KubectlApplyFromString(t, options, configData)
+	k8s.KubectlApplyFromStringContext(t, context.Background(), options, configData)
 
-	role := k8s.GetRole(t, options, "terratest-role")
+	role := k8s.GetRoleContext(t, context.Background(), options, "terratest-role")
 	require.Equal(t, "terratest-role", role.Name)
 	require.Equal(t, role.Namespace, uniqueID)
 }

--- a/modules/k8s/secret_test.go
+++ b/modules/k8s/secret_test.go
@@ -10,6 +10,7 @@
 package k8s_test
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"testing"
@@ -26,7 +27,7 @@ func TestGetSecretEReturnsErrorForNonExistantSecret(t *testing.T) {
 	t.Parallel()
 
 	options := k8s.NewKubectlOptions("", "", "default")
-	_, err := k8s.GetSecretE(t, options, "master-password")
+	_, err := k8s.GetSecretContextE(t, context.Background(), options, "master-password")
 	require.Error(t, err)
 }
 
@@ -37,11 +38,11 @@ func TestGetSecretEReturnsCorrectSecretInCorrectNamespace(t *testing.T) {
 	options := k8s.NewKubectlOptions("", "", uniqueID)
 
 	configData := fmt.Sprintf(exampleSecretYAMLTemplate, uniqueID, uniqueID)
-	defer k8s.KubectlDeleteFromString(t, options, configData)
+	defer k8s.KubectlDeleteFromStringContext(t, context.Background(), options, configData)
 
-	k8s.KubectlApplyFromString(t, options, configData)
+	k8s.KubectlApplyFromStringContext(t, context.Background(), options, configData)
 
-	secret := k8s.GetSecret(t, options, "master-password")
+	secret := k8s.GetSecretContext(t, context.Background(), options, "master-password")
 	require.Equal(t, "master-password", secret.Name)
 	require.Equal(t, secret.Namespace, uniqueID)
 }
@@ -53,10 +54,10 @@ func TestWaitUntilSecretAvailableReturnsSuccessfully(t *testing.T) {
 	options := k8s.NewKubectlOptions("", "", uniqueID)
 
 	configData := fmt.Sprintf(exampleSecretYAMLTemplate, uniqueID, uniqueID)
-	defer k8s.KubectlDeleteFromString(t, options, configData)
+	defer k8s.KubectlDeleteFromStringContext(t, context.Background(), options, configData)
 
-	k8s.KubectlApplyFromString(t, options, configData)
-	k8s.WaitUntilSecretAvailable(t, options, "master-password", 10, 1*time.Second)
+	k8s.KubectlApplyFromStringContext(t, context.Background(), options, configData)
+	k8s.WaitUntilSecretAvailableContext(t, context.Background(), options, "master-password", 10, 1*time.Second)
 }
 
 const exampleSecretYAMLTemplate = `---

--- a/modules/k8s/self_subject_access_review_test.go
+++ b/modules/k8s/self_subject_access_review_test.go
@@ -10,6 +10,7 @@
 package k8s_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/gruntwork-io/terratest/modules/k8s/v2"
@@ -30,5 +31,5 @@ func TestCanIDoReturnsTrueForAllowedAction(t *testing.T) {
 		Resource:  "pod",
 	}
 	options := k8s.NewKubectlOptions("", "", "kube-system")
-	assert.True(t, k8s.CanIDo(t, options, action))
+	assert.True(t, k8s.CanIDoContext(t, context.Background(), options, action))
 }

--- a/modules/k8s/service.go
+++ b/modules/k8s/service.go
@@ -317,7 +317,7 @@ func FindNodePortE(service *corev1.Service, servicePort int32) (int32, error) {
 
 // pickRandomNode will pick a random node in the kubernetes cluster
 func pickRandomNodeE(t testing.TestingT, options *KubectlOptions) (corev1.Node, error) {
-	nodes, err := GetNodesE(t, options)
+	nodes, err := GetNodesContextE(t, context.Background(), options)
 	if err != nil {
 		return corev1.Node{}, err
 	}

--- a/modules/k8s/service_account_test.go
+++ b/modules/k8s/service_account_test.go
@@ -10,6 +10,7 @@
 package k8s_test
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"testing"
@@ -33,13 +34,13 @@ func TestGetServiceAccountWithAuthTokenGetsTokenThatCanBeUsedForAuth(t *testing.
 
 	options := k8s.NewKubectlOptions("", tmpConfigPath, namespaceName)
 
-	k8s.CreateNamespace(t, options, namespaceName)
-	defer k8s.DeleteNamespace(t, options, namespaceName)
+	k8s.CreateNamespaceContext(t, context.Background(), options, namespaceName)
+	defer k8s.DeleteNamespaceContext(t, context.Background(), options, namespaceName)
 
 	// Create service account
 	serviceAccountName := strings.ToLower(random.UniqueID())
-	k8s.CreateServiceAccount(t, options, serviceAccountName)
-	token := k8s.GetServiceAccountAuthToken(t, options, serviceAccountName)
+	k8s.CreateServiceAccountContext(t, context.Background(), options, serviceAccountName)
+	token := k8s.GetServiceAccountAuthTokenContext(t, context.Background(), options, serviceAccountName)
 	require.NoError(t, k8s.AddConfigContextForServiceAccountE(t, options, serviceAccountName, serviceAccountName, token))
 
 	// Now validate auth as service account. This is a bit tricky because we don't have an API endpoint in k8s that
@@ -51,14 +52,14 @@ func TestGetServiceAccountWithAuthTokenGetsTokenThatCanBeUsedForAuth(t *testing.
 		Verb:      "list",
 		Resource:  "pod",
 	}
-	require.False(t, k8s.CanIDo(t, serviceAccountOptions, action))
+	require.False(t, k8s.CanIDoContext(t, context.Background(), serviceAccountOptions, action))
 }
 
 func TestGetServiceAccountEReturnsErrorForNonExistantServiceAccount(t *testing.T) {
 	t.Parallel()
 
 	options := k8s.NewKubectlOptions("", "", "default")
-	_, err := k8s.GetServiceAccountE(t, options, "terratest")
+	_, err := k8s.GetServiceAccountContextE(t, context.Background(), options, "terratest")
 	require.Error(t, err)
 }
 
@@ -69,11 +70,11 @@ func TestGetServiceAccountEReturnsCorrectServiceAccountInCorrectNamespace(t *tes
 	options := k8s.NewKubectlOptions("", "", uniqueID)
 
 	configData := fmt.Sprintf(exampleServiceAccountYAMLTemplate, uniqueID, uniqueID)
-	defer k8s.KubectlDeleteFromString(t, options, configData)
+	defer k8s.KubectlDeleteFromStringContext(t, context.Background(), options, configData)
 
-	k8s.KubectlApplyFromString(t, options, configData)
+	k8s.KubectlApplyFromStringContext(t, context.Background(), options, configData)
 
-	serviceAccount := k8s.GetServiceAccount(t, options, "terratest")
+	serviceAccount := k8s.GetServiceAccountContext(t, context.Background(), options, "terratest")
 	require.Equal(t, "terratest", serviceAccount.Name)
 	require.Equal(t, serviceAccount.Namespace, uniqueID)
 }
@@ -84,14 +85,14 @@ func TestCreateServiceAccountECreatesServiceAccountInNamespaceWithGivenName(t *t
 	uniqueID := strings.ToLower(random.UniqueID())
 
 	options := k8s.NewKubectlOptions("", "", uniqueID)
-	defer k8s.DeleteNamespace(t, options, options.Namespace)
+	defer k8s.DeleteNamespaceContext(t, context.Background(), options, options.Namespace)
 
-	k8s.CreateNamespace(t, options, options.Namespace)
+	k8s.CreateNamespaceContext(t, context.Background(), options, options.Namespace)
 
 	// Note: We don't need to delete this at the end of test, because deleting the namespace automatically deletes
 	// everything created in the namespace.
-	k8s.CreateServiceAccount(t, options, "terratest")
-	serviceAccount := k8s.GetServiceAccount(t, options, "terratest")
+	k8s.CreateServiceAccountContext(t, context.Background(), options, "terratest")
+	serviceAccount := k8s.GetServiceAccountContext(t, context.Background(), options, "terratest")
 	require.Equal(t, "terratest", serviceAccount.Name)
 	require.Equal(t, serviceAccount.Namespace, uniqueID)
 }

--- a/modules/k8s/service_test.go
+++ b/modules/k8s/service_test.go
@@ -10,6 +10,7 @@
 package k8s_test
 
 import (
+	"context"
 	"crypto/tls"
 	"fmt"
 	"strings"
@@ -29,7 +30,7 @@ func TestGetServiceEReturnsErrorForNonExistantService(t *testing.T) {
 	t.Parallel()
 
 	options := k8s.NewKubectlOptions("", "", "default")
-	_, err := k8s.GetServiceE(t, options, "nginx-service")
+	_, err := k8s.GetServiceContextE(t, context.Background(), options, "nginx-service")
 	require.Error(t, err)
 }
 
@@ -40,10 +41,10 @@ func TestGetServiceEReturnsCorrectServiceInCorrectNamespace(t *testing.T) {
 	options := k8s.NewKubectlOptions("", "", uniqueID)
 	configData := fmt.Sprintf(exampleDeploymentYAMLTemplate, uniqueID, uniqueID, uniqueID)
 
-	k8s.KubectlApplyFromString(t, options, configData)
-	defer k8s.KubectlDeleteFromString(t, options, configData)
+	k8s.KubectlApplyFromStringContext(t, context.Background(), options, configData)
+	defer k8s.KubectlDeleteFromStringContext(t, context.Background(), options, configData)
 
-	service := k8s.GetService(t, options, "nginx-service")
+	service := k8s.GetServiceContext(t, context.Background(), options, "nginx-service")
 	require.Equal(t, "nginx-service", service.Name)
 	require.Equal(t, service.Namespace, uniqueID)
 }
@@ -55,10 +56,10 @@ func TestListServicesReturnsCorrectServiceInCorrectNamespace(t *testing.T) {
 	options := k8s.NewKubectlOptions("", "", uniqueID)
 	configData := fmt.Sprintf(exampleDeploymentYAMLTemplate, uniqueID, uniqueID, uniqueID)
 
-	k8s.KubectlApplyFromString(t, options, configData)
-	defer k8s.KubectlDeleteFromString(t, options, configData)
+	k8s.KubectlApplyFromStringContext(t, context.Background(), options, configData)
+	defer k8s.KubectlDeleteFromStringContext(t, context.Background(), options, configData)
 
-	services := k8s.ListServices(t, options, metav1.ListOptions{})
+	services := k8s.ListServicesContext(t, context.Background(), options, metav1.ListOptions{})
 	require.Len(t, services, 1)
 
 	service := services[0]
@@ -73,10 +74,10 @@ func TestWaitUntilServiceAvailableReturnsSuccessfullyOnNodePortType(t *testing.T
 	options := k8s.NewKubectlOptions("", "", uniqueID)
 	configData := fmt.Sprintf(exampleDeploymentYAMLTemplate, uniqueID, uniqueID, uniqueID)
 
-	k8s.KubectlApplyFromString(t, options, configData)
-	defer k8s.KubectlDeleteFromString(t, options, configData)
+	k8s.KubectlApplyFromStringContext(t, context.Background(), options, configData)
+	defer k8s.KubectlDeleteFromStringContext(t, context.Background(), options, configData)
 
-	k8s.WaitUntilServiceAvailable(t, options, "nginx-service", 10, 1*time.Second)
+	k8s.WaitUntilServiceAvailableContext(t, context.Background(), options, "nginx-service", 10, 1*time.Second)
 }
 
 func TestGetServiceEndpointEReturnsAccessibleEndpointForNodePort(t *testing.T) {
@@ -86,11 +87,11 @@ func TestGetServiceEndpointEReturnsAccessibleEndpointForNodePort(t *testing.T) {
 	options := k8s.NewKubectlOptions("", "", uniqueID)
 	configData := fmt.Sprintf(exampleDeploymentYAMLTemplate, uniqueID, uniqueID, uniqueID)
 
-	k8s.KubectlApplyFromString(t, options, configData)
-	defer k8s.KubectlDeleteFromString(t, options, configData)
+	k8s.KubectlApplyFromStringContext(t, context.Background(), options, configData)
+	defer k8s.KubectlDeleteFromStringContext(t, context.Background(), options, configData)
 
-	service := k8s.GetService(t, options, "nginx-service")
-	endpoint := k8s.GetServiceEndpoint(t, options, service, 80)
+	service := k8s.GetServiceContext(t, context.Background(), options, "nginx-service")
+	endpoint := k8s.GetServiceEndpointContext(t, context.Background(), options, service, 80)
 
 	// Setup a TLS configuration to submit with the helper, a blank struct is acceptable
 	tlsConfig := tls.Config{}

--- a/modules/k8s/tunnel.go
+++ b/modules/k8s/tunnel.go
@@ -134,14 +134,14 @@ func (tunnel *Tunnel) getAttachablePodForResourceE(t testing.TestingT) (string, 
 
 // getAttachablePodForDeploymentE will find an active pod associated with the Deployment and return the pod name.
 func (tunnel *Tunnel) getAttachablePodForDeploymentE(t testing.TestingT) (string, error) {
-	deploy, err := GetDeploymentE(t, tunnel.kubectlOptions, tunnel.resourceName)
+	deploy, err := GetDeploymentContextE(t, context.Background(), tunnel.kubectlOptions, tunnel.resourceName)
 	if err != nil {
 		return "", err
 	}
 
 	selectorLabelsOfPods := makeLabels(deploy.Spec.Selector.MatchLabels)
 
-	deploymentPods, err := ListPodsE(t, tunnel.kubectlOptions, metav1.ListOptions{LabelSelector: selectorLabelsOfPods})
+	deploymentPods, err := ListPodsContextE(t, context.Background(), tunnel.kubectlOptions, metav1.ListOptions{LabelSelector: selectorLabelsOfPods})
 	if err != nil {
 		return "", err
 	}
@@ -157,14 +157,14 @@ func (tunnel *Tunnel) getAttachablePodForDeploymentE(t testing.TestingT) (string
 
 // getAttachablePodForServiceE will find an active pod associated with the Service and return the pod name.
 func (tunnel *Tunnel) getAttachablePodForServiceE(t testing.TestingT) (string, error) {
-	service, err := GetServiceE(t, tunnel.kubectlOptions, tunnel.resourceName)
+	service, err := GetServiceContextE(t, context.Background(), tunnel.kubectlOptions, tunnel.resourceName)
 	if err != nil {
 		return "", err
 	}
 
 	selectorLabelsOfPods := makeLabels(service.Spec.Selector)
 
-	servicePods, err := ListPodsE(t, tunnel.kubectlOptions, metav1.ListOptions{LabelSelector: selectorLabelsOfPods})
+	servicePods, err := ListPodsContextE(t, context.Background(), tunnel.kubectlOptions, metav1.ListOptions{LabelSelector: selectorLabelsOfPods})
 	if err != nil {
 		return "", err
 	}
@@ -196,7 +196,7 @@ func (tunnel *Tunnel) ForwardPortE(t testing.TestingT) error {
 	)
 
 	// Prepare a kubernetes client for the client-go library
-	clientset, err := GetKubernetesClientFromOptionsE(t, tunnel.kubectlOptions)
+	clientset, err := GetKubernetesClientFromOptionsContextE(t, context.Background(), tunnel.kubectlOptions)
 	if err != nil {
 		tunnel.logger.Logf(t, "Error creating a new Kubernetes client: %s", err)
 		return err
@@ -230,14 +230,14 @@ func (tunnel *Tunnel) ForwardPortE(t testing.TestingT) error {
 
 	// in case of services, find target port on pod based on service definition
 	if tunnel.resourceType == ResourceTypeService {
-		service := GetService(t, tunnel.kubectlOptions, tunnel.resourceName)
+		service := GetServiceContext(t, context.Background(), tunnel.kubectlOptions, tunnel.resourceName)
 
 		var portFound = false
 
 		for _, portSpec := range service.Spec.Ports {
 			if portSpec.Port == int32(targetPort) {
 				if portSpec.TargetPort.Type == intstr.String {
-					pod, err := GetPodE(t, tunnel.kubectlOptions, podName)
+					pod, err := GetPodContextE(t, context.Background(), tunnel.kubectlOptions, podName)
 					if err != nil {
 						return err
 					}
@@ -296,7 +296,7 @@ func (tunnel *Tunnel) ForwardPortE(t testing.TestingT) error {
 	if tunnel.localPort == 0 {
 		tunnel.logger.Logf(t, "Requested local port is 0. Selecting an open port on host system")
 
-		tunnel.localPort, err = GetAvailablePortE(t)
+		tunnel.localPort, err = GetAvailablePortContextE(t, context.Background())
 		if err != nil {
 			tunnel.logger.Logf(t, "Error getting available port: %s", err)
 			return err

--- a/modules/k8s/tunnel_test.go
+++ b/modules/k8s/tunnel_test.go
@@ -10,6 +10,7 @@
 package k8s_test
 
 import (
+	"context"
 	"crypto/tls"
 	"fmt"
 	"strings"
@@ -29,10 +30,10 @@ func TestTunnelOpensAPortForwardTunnelToPod(t *testing.T) {
 	options := k8s.NewKubectlOptions("", "", uniqueID)
 
 	configData := fmt.Sprintf(examplePodYAMLTemplate, uniqueID, uniqueID)
-	defer k8s.KubectlDeleteFromString(t, options, configData)
+	defer k8s.KubectlDeleteFromStringContext(t, context.Background(), options, configData)
 
-	k8s.KubectlApplyFromString(t, options, configData)
-	k8s.WaitUntilPodAvailable(t, options, "nginx-pod", 60, 1*time.Second)
+	k8s.KubectlApplyFromStringContext(t, context.Background(), options, configData)
+	k8s.WaitUntilPodAvailableContext(t, context.Background(), options, "nginx-pod", 60, 1*time.Second)
 
 	// Open a tunnel to pod from any available port locally
 	tunnel := k8s.NewTunnel(options, k8s.ResourceTypePod, "nginx-pod", 0, 80)
@@ -62,10 +63,10 @@ func TestTunnelOpensAPortForwardTunnelToDeployment(t *testing.T) {
 	options := k8s.NewKubectlOptions("", "", uniqueID)
 	configData := fmt.Sprintf(ExampleDeploymentYAMLTemplate, uniqueID)
 
-	k8s.KubectlApplyFromString(t, options, configData)
-	defer k8s.KubectlDeleteFromString(t, options, configData)
+	k8s.KubectlApplyFromStringContext(t, context.Background(), options, configData)
+	defer k8s.KubectlDeleteFromStringContext(t, context.Background(), options, configData)
 
-	k8s.WaitUntilDeploymentAvailable(t, options, "nginx-deployment", 60, 1*time.Second)
+	k8s.WaitUntilDeploymentAvailableContext(t, context.Background(), options, "nginx-deployment", 60, 1*time.Second)
 
 	// Open a tunnel to pod from any available port locally
 	tunnel := k8s.NewTunnel(options, k8s.ResourceTypeDeployment, "nginx-deployment", 0, 80)
@@ -96,11 +97,11 @@ func TestTunnelOpensAPortForwardTunnelToService(t *testing.T) {
 	configData := fmt.Sprintf(ExamplePodWithServiceYAMLTemplate, uniqueID, uniqueID, uniqueID, uniqueID)
 
 	t.Cleanup(func() {
-		k8s.KubectlDeleteFromString(t, options, configData)
+		k8s.KubectlDeleteFromStringContext(t, context.Background(), options, configData)
 	})
-	k8s.KubectlApplyFromString(t, options, configData)
+	k8s.KubectlApplyFromStringContext(t, context.Background(), options, configData)
 	// t.FailNow()
-	k8s.WaitUntilPodAvailable(t, options, "nginx-pod", 60, 1*time.Second)
+	k8s.WaitUntilPodAvailableContext(t, context.Background(), options, "nginx-pod", 60, 1*time.Second)
 
 	testCases := []struct {
 		name        string
@@ -120,7 +121,7 @@ func TestTunnelOpensAPortForwardTunnelToService(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 
-			k8s.WaitUntilServiceAvailable(t, options, testCase.serviceName, 60, 1*time.Second)
+			k8s.WaitUntilServiceAvailableContext(t, context.Background(), options, testCase.serviceName, 60, 1*time.Second)
 
 			// Open a tunnel from any available port locally
 			tunnel := k8s.NewTunnel(options, k8s.ResourceTypeService, testCase.serviceName, 0, 8080)

--- a/modules/k8s/version_test.go
+++ b/modules/k8s/version_test.go
@@ -10,6 +10,7 @@
 package k8s_test
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 
@@ -28,11 +29,11 @@ type KubectlVersion struct {
 func TestGetKubernetesClusterVersionE(t *testing.T) {
 	t.Parallel()
 
-	kubernetesClusterVersion, err := k8s.GetKubernetesClusterVersionE(t)
+	kubernetesClusterVersion, err := k8s.GetKubernetesClusterVersionContextE(t, context.Background())
 	require.NoError(t, err)
 
 	options := k8s.NewKubectlOptions("", "", "")
-	kubernetesClusterVersionFromKubectl, err := k8s.RunKubectlAndGetOutputE(t, options, "version", "-o", "json")
+	kubernetesClusterVersionFromKubectl, err := k8s.RunKubectlAndGetOutputContextE(t, context.Background(), options, "version", "-o", "json")
 	require.NoError(t, err)
 
 	var kctlClusterVersion KubectlVersion
@@ -48,10 +49,10 @@ func TestGetKubernetesClusterVersionWithOptionsE(t *testing.T) {
 	t.Parallel()
 
 	options := k8s.NewKubectlOptions("", "", "")
-	kubernetesClusterVersion, err := k8s.GetKubernetesClusterVersionWithOptionsE(t, options)
+	kubernetesClusterVersion, err := k8s.GetKubernetesClusterVersionWithOptionsContextE(t, context.Background(), options)
 	require.NoError(t, err)
 
-	kubernetesClusterVersionFromKubectl, err := k8s.RunKubectlAndGetOutputE(t, options, "version", "-o", "json")
+	kubernetesClusterVersionFromKubectl, err := k8s.RunKubectlAndGetOutputContextE(t, context.Background(), options, "version", "-o", "json")
 	require.NoError(t, err)
 
 	var kctlClusterVersion KubectlVersion

--- a/modules/packer/packer_test.go
+++ b/modules/packer/packer_test.go
@@ -1,6 +1,7 @@
 package packer_test
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -241,18 +242,18 @@ func TestGetArtifactIDFromManifestBuildNameE(t *testing.T) {
 	t.Run("Found", func(t *testing.T) {
 		t.Parallel()
 
-		artifactID, err := packer.GetArtifactIDFromManifestBuildNameE(t, manifestPath, "docker")
+		artifactID, err := packer.GetArtifactIDFromManifestBuildNameContextE(t, context.Background(), manifestPath, "docker")
 		require.NoError(t, err)
 		assert.Equal(t, "Container", artifactID)
 
-		artifactID2 := packer.GetArtifactIDFromManifestBuildName(t, manifestPath, "docker")
+		artifactID2 := packer.GetArtifactIDFromManifestBuildNameContext(t, context.Background(), manifestPath, "docker")
 		assert.Equal(t, "Container", artifactID2)
 	})
 
 	t.Run("Not Found", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := packer.GetArtifactIDFromManifestBuildNameE(t, manifestPath, "notfound")
+		_, err := packer.GetArtifactIDFromManifestBuildNameContextE(t, context.Background(), manifestPath, "notfound")
 		require.Error(t, err)
 	})
 }

--- a/modules/ssh/ssh_test.go
+++ b/modules/ssh/ssh_test.go
@@ -1,6 +1,7 @@
 package ssh_test
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -32,7 +33,7 @@ func TestCheckSshConnectionWithRetryE(t *testing.T) {
 
 	timesCalled := 0
 
-	handler := func(_ grunttest.TestingT, _ ssh.Host) error {
+	handler := func(_ grunttest.TestingT, _ context.Context, _ *ssh.Host) error {
 		timesCalled++
 
 		if timesCalled >= 5 {
@@ -45,7 +46,7 @@ func TestCheckSshConnectionWithRetryE(t *testing.T) {
 	host := ssh.Host{Hostname: "Host"}
 	retries := 10
 
-	assert.NoError(t, ssh.CheckSshConnectionWithRetryE(t, host, retries, 3*time.Millisecond, handler))
+	assert.NoError(t, ssh.CheckSSHConnectionWithRetryContextE(t, context.Background(), &host, retries, 3*time.Millisecond, handler))
 }
 
 func TestCheckSshConnectionWithRetryEExceedsMaxRetries(t *testing.T) {
@@ -53,7 +54,7 @@ func TestCheckSshConnectionWithRetryEExceedsMaxRetries(t *testing.T) {
 
 	timesCalled := 0
 
-	handler := func(_ grunttest.TestingT, _ ssh.Host) error {
+	handler := func(_ grunttest.TestingT, _ context.Context, _ *ssh.Host) error {
 		timesCalled++
 
 		if timesCalled >= 5 {
@@ -68,7 +69,7 @@ func TestCheckSshConnectionWithRetryEExceedsMaxRetries(t *testing.T) {
 	// Not enough retries.
 	retries := 3
 
-	assert.Error(t, ssh.CheckSshConnectionWithRetryE(t, host, retries, 3*time.Millisecond, handler))
+	assert.Error(t, ssh.CheckSSHConnectionWithRetryContextE(t, context.Background(), &host, retries, 3*time.Millisecond, handler))
 }
 
 func TestCheckSshConnectionWithRetry(t *testing.T) {
@@ -76,7 +77,7 @@ func TestCheckSshConnectionWithRetry(t *testing.T) {
 
 	timesCalled := 0
 
-	handler := func(_ grunttest.TestingT, _ ssh.Host) error {
+	handler := func(_ grunttest.TestingT, _ context.Context, _ *ssh.Host) error {
 		timesCalled++
 
 		if timesCalled >= 5 {
@@ -89,7 +90,7 @@ func TestCheckSshConnectionWithRetry(t *testing.T) {
 	host := ssh.Host{Hostname: "Host"}
 	retries := 10
 
-	ssh.CheckSshConnectionWithRetry(t, host, retries, 3*time.Millisecond, handler)
+	ssh.CheckSSHConnectionWithRetryContext(t, context.Background(), &host, retries, 3*time.Millisecond, handler)
 }
 
 func TestCheckSshCommandWithRetryE(t *testing.T) {
@@ -97,7 +98,7 @@ func TestCheckSshCommandWithRetryE(t *testing.T) {
 
 	timesCalled := 0
 
-	handler := func(_ grunttest.TestingT, _ ssh.Host, _ string) (string, error) {
+	handler := func(_ grunttest.TestingT, _ context.Context, _ *ssh.Host, _ string) (string, error) {
 		timesCalled++
 
 		if timesCalled >= 5 {
@@ -111,7 +112,7 @@ func TestCheckSshCommandWithRetryE(t *testing.T) {
 	command := "echo -n hello world"
 	retries := 10
 
-	_, err := ssh.CheckSshCommandWithRetryE(t, host, command, retries, 3*time.Millisecond, handler)
+	_, err := ssh.CheckSSHCommandWithRetryContextE(t, context.Background(), &host, command, retries, 3*time.Millisecond, handler)
 	assert.NoError(t, err)
 }
 
@@ -120,7 +121,7 @@ func TestCheckSshCommandWithRetryEExceedsRetries(t *testing.T) {
 
 	timesCalled := 0
 
-	handler := func(_ grunttest.TestingT, _ ssh.Host, _ string) (string, error) {
+	handler := func(_ grunttest.TestingT, _ context.Context, _ *ssh.Host, _ string) (string, error) {
 		timesCalled++
 
 		if timesCalled >= 5 {
@@ -136,7 +137,7 @@ func TestCheckSshCommandWithRetryEExceedsRetries(t *testing.T) {
 	// Not enough retries.
 	retries := 3
 
-	_, err := ssh.CheckSshCommandWithRetryE(t, host, command, retries, 3*time.Millisecond, handler)
+	_, err := ssh.CheckSSHCommandWithRetryContextE(t, context.Background(), &host, command, retries, 3*time.Millisecond, handler)
 	assert.Error(t, err)
 }
 
@@ -145,7 +146,7 @@ func TestCheckSshCommandWithRetry(t *testing.T) {
 
 	timesCalled := 0
 
-	handler := func(_ grunttest.TestingT, _ ssh.Host, _ string) (string, error) {
+	handler := func(_ grunttest.TestingT, _ context.Context, _ *ssh.Host, _ string) (string, error) {
 		timesCalled++
 
 		if timesCalled >= 5 {
@@ -159,5 +160,5 @@ func TestCheckSshCommandWithRetry(t *testing.T) {
 	command := "echo -n hello world"
 	retries := 10
 
-	ssh.CheckSshCommandWithRetry(t, host, command, retries, 3*time.Millisecond, handler)
+	ssh.CheckSSHCommandWithRetryContext(t, context.Background(), &host, command, retries, 3*time.Millisecond, handler)
 }

--- a/modules/terraform/apply_test.go
+++ b/modules/terraform/apply_test.go
@@ -1,6 +1,7 @@
 package terraform_test
 
 import (
+	"context"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -22,7 +23,7 @@ func TestApplyNoError(t *testing.T) {
 		NoColor:      true,
 	})
 
-	out := terraform.InitAndApply(t, options)
+	out := terraform.InitAndApplyContext(t, context.Background(), options)
 
 	require.Contains(t, out, "Hello, World")
 
@@ -40,7 +41,7 @@ func TestApplyWithErrorNoRetry(t *testing.T) {
 		TerraformDir: testFolder,
 	})
 
-	out, err := terraform.InitAndApplyE(t, options)
+	out, err := terraform.InitAndApplyContextE(t, context.Background(), options)
 
 	require.Error(t, err)
 	require.Contains(t, out, "This is the first run, exiting with an error")
@@ -60,7 +61,7 @@ func TestApplyWithErrorWithRetry(t *testing.T) {
 		},
 	})
 
-	out := terraform.InitAndApply(t, options)
+	out := terraform.InitAndApplyContext(t, context.Background(), options)
 
 	require.Contains(t, out, "This is the first run, exiting with an error")
 }
@@ -122,7 +123,7 @@ func TestApplyWithWarning(t *testing.T) {
 				WarningsAsErrors: scenario.warnings,
 			})
 
-			out, err := terraform.InitAndApplyE(t, options)
+			out, err := terraform.InitAndApplyContextE(t, context.Background(), options)
 			if scenario.isError {
 				require.Error(t, err)
 			} else {
@@ -145,7 +146,7 @@ func TestIdempotentNoChanges(t *testing.T) {
 		NoColor:      true,
 	})
 
-	terraform.InitAndApplyAndIdempotentE(t, options)
+	terraform.InitAndApplyAndIdempotentContextE(t, context.Background(), options)
 }
 
 func TestIdempotentWithChanges(t *testing.T) {
@@ -159,7 +160,7 @@ func TestIdempotentWithChanges(t *testing.T) {
 		NoColor:      true,
 	})
 
-	out, err := terraform.InitAndApplyAndIdempotentE(t, options)
+	out, err := terraform.InitAndApplyAndIdempotentContextE(t, context.Background(), options)
 
 	require.NotEmpty(t, out)
 	require.Error(t, err)
@@ -177,14 +178,14 @@ func TestParallelism(t *testing.T) { //nolint:paralleltest // test depends on pr
 		NoColor:      true,
 	})
 
-	terraform.Init(t, options)
+	terraform.InitContext(t, context.Background(), options)
 
 	// Run the first time with parallelism set to 5 and it should take about 5 seconds (plus or minus 10 seconds to
 	// account for other CPU hogging stuff)
 	options.Parallelism = 5
 	start := time.Now()
 
-	terraform.Apply(t, options)
+	terraform.ApplyContext(t, context.Background(), options)
 
 	end := time.Now()
 	require.WithinDuration(t, end, start, 15*time.Second)
@@ -193,7 +194,7 @@ func TestParallelism(t *testing.T) { //nolint:paralleltest // test depends on pr
 	options.Parallelism = 1
 	start = time.Now()
 
-	terraform.Apply(t, options)
+	terraform.ApplyContext(t, context.Background(), options)
 
 	end = time.Now()
 	duration := end.Sub(start)
@@ -217,11 +218,11 @@ func TestApplyWithPlanFile(t *testing.T) {
 		PlanFilePath: planFilePath,
 	}
 
-	_, err = terraform.InitAndPlanE(t, options)
+	_, err = terraform.InitAndPlanContextE(t, context.Background(), options)
 	require.NoError(t, err)
 	require.FileExists(t, planFilePath, "Plan file was not saved to expected location:", planFilePath)
 
-	out, err := terraform.ApplyE(t, options)
+	out, err := terraform.ApplyContextE(t, context.Background(), options)
 	require.NoError(t, err)
 	require.Contains(t, out, "1 added, 0 changed, 0 destroyed.")
 	require.NotRegexp(t, `\[\d*m`, out, "Output should not contain color escape codes")

--- a/modules/terraform/cmd_test.go
+++ b/modules/terraform/cmd_test.go
@@ -1,6 +1,7 @@
 package terraform_test
 
 import (
+	"context"
 	"strings"
 	"testing"
 
@@ -22,9 +23,9 @@ func TestTerraformCommand(t *testing.T) {
 		options := &terraform.Options{
 			TerraformDir: testFolder,
 		}
-		terraform.Init(t, options)
+		terraform.InitContext(t, context.Background(), options)
 
-		stdout, stderr, code, err := terraform.RunTerraformCommandAndGetStdOutErrCodeE(t, options, "apply", "-input=false", "-auto-approve")
+		stdout, stderr, code, err := terraform.RunTerraformCommandAndGetStdOutErrCodeContextE(t, context.Background(), options, "apply", "-input=false", "-auto-approve")
 		require.Error(t, err)
 		assert.Contains(t, stdout, "Creating...", "should capture stdout")
 		assert.Contains(t, stderr, "Error: ", "should capture stderr")
@@ -43,9 +44,9 @@ func TestTerraformCommand(t *testing.T) {
 				".*lorem ipsum.*": "this warning message should shown.",
 			},
 		}
-		terraform.Init(t, options)
+		terraform.InitContext(t, context.Background(), options)
 
-		stdout, stderr, code, err := terraform.RunTerraformCommandAndGetStdOutErrCodeE(t, options, "apply", "-input=false", "-auto-approve")
+		stdout, stderr, code, err := terraform.RunTerraformCommandAndGetStdOutErrCodeContextE(t, context.Background(), options, "apply", "-input=false", "-auto-approve")
 		require.Error(t, err)
 		assert.Contains(t, stdout, "Creating...", "should capture stdout")
 		assert.Contains(t, stderr, "", "should capture stderr")
@@ -63,14 +64,14 @@ func TestTerraformCommand(t *testing.T) {
 		}
 
 		{
-			stdout, stderr, code := terraform.RunTerraformCommandAndGetStdOutErrCode(t, options, "apply", "-input=false", "-auto-approve")
+			stdout, stderr, code := terraform.RunTerraformCommandAndGetStdOutErrCodeContext(t, context.Background(), options, "apply", "-input=false", "-auto-approve")
 			assert.Contains(t, stdout, `test = "Hello, World"`, "should capture stdout")
 			assert.Equal(t, 0, code)
 			assert.Empty(t, stderr)
 		}
 
 		{
-			stdout := terraform.RunTerraformCommandAndGetStdout(t, options, "apply", "-input=false", "-auto-approve")
+			stdout := terraform.RunTerraformCommandAndGetStdoutContext(t, context.Background(), options, "apply", "-input=false", "-auto-approve")
 			assert.Contains(t, stdout, `test = "Hello, World"`, "should capture stdout")
 		}
 	})

--- a/modules/terraform/count_test.go
+++ b/modules/terraform/count_test.go
@@ -44,23 +44,23 @@ func TestGetResourceCountENoColor(t *testing.T) { //nolint:tparallel // subtests
 func runTestGetResourceCountE(t *testing.T, noColor bool) { //nolint:tparallel // subtests share mutable terraform options
 	t.Helper()
 	testCases := []struct {
-		tfFuncToRun     func(t ttesting.TestingT, options *terraform.Options) string
+		tfFuncToRun     func(t ttesting.TestingT, ctx context.Context, options *terraform.Options) string
 		name            string
 		cntValue        int
 		expectedAdd     int
 		expectedChange  int
 		expectedDestroy int
 	}{
-		{name: "PlanZero", tfFuncToRun: terraform.InitAndPlan, cntValue: 0, expectedAdd: 0, expectedChange: 0, expectedDestroy: 0},
-		{name: "ApplyZero", tfFuncToRun: terraform.InitAndApply, cntValue: 0, expectedAdd: 0, expectedChange: 0, expectedDestroy: 0},
-		{name: "PlanAddResouce", tfFuncToRun: terraform.InitAndPlan, cntValue: 2, expectedAdd: 2, expectedChange: 0, expectedDestroy: 0},
-		{name: "ApplyAddResouce", tfFuncToRun: terraform.InitAndApply, cntValue: 2, expectedAdd: 2, expectedChange: 0, expectedDestroy: 0},
-		{name: "PlanNoOp", tfFuncToRun: terraform.InitAndApply, cntValue: 2, expectedAdd: 0, expectedChange: 0, expectedDestroy: 0},
-		{name: "ApplyNoOp", tfFuncToRun: terraform.InitAndApply, cntValue: 2, expectedAdd: 0, expectedChange: 0, expectedDestroy: 0},
-		{name: "PlanDestroyResource", tfFuncToRun: terraform.InitAndPlan, cntValue: 1, expectedAdd: 0, expectedChange: 0, expectedDestroy: 1},
-		{name: "ApplyDestroyResource", tfFuncToRun: terraform.InitAndApply, cntValue: 1, expectedAdd: 0, expectedChange: 0, expectedDestroy: 1},
-		{name: "Destroy", tfFuncToRun: terraform.Destroy, cntValue: 1, expectedAdd: 0, expectedChange: 0, expectedDestroy: 1},
-		{name: "DestroyNoOp", tfFuncToRun: terraform.Destroy, cntValue: 1, expectedAdd: 0, expectedChange: 0, expectedDestroy: 0},
+		{name: "PlanZero", tfFuncToRun: terraform.InitAndPlanContext, cntValue: 0, expectedAdd: 0, expectedChange: 0, expectedDestroy: 0},
+		{name: "ApplyZero", tfFuncToRun: terraform.InitAndApplyContext, cntValue: 0, expectedAdd: 0, expectedChange: 0, expectedDestroy: 0},
+		{name: "PlanAddResouce", tfFuncToRun: terraform.InitAndPlanContext, cntValue: 2, expectedAdd: 2, expectedChange: 0, expectedDestroy: 0},
+		{name: "ApplyAddResouce", tfFuncToRun: terraform.InitAndApplyContext, cntValue: 2, expectedAdd: 2, expectedChange: 0, expectedDestroy: 0},
+		{name: "PlanNoOp", tfFuncToRun: terraform.InitAndApplyContext, cntValue: 2, expectedAdd: 0, expectedChange: 0, expectedDestroy: 0},
+		{name: "ApplyNoOp", tfFuncToRun: terraform.InitAndApplyContext, cntValue: 2, expectedAdd: 0, expectedChange: 0, expectedDestroy: 0},
+		{name: "PlanDestroyResource", tfFuncToRun: terraform.InitAndPlanContext, cntValue: 1, expectedAdd: 0, expectedChange: 0, expectedDestroy: 1},
+		{name: "ApplyDestroyResource", tfFuncToRun: terraform.InitAndApplyContext, cntValue: 1, expectedAdd: 0, expectedChange: 0, expectedDestroy: 1},
+		{name: "Destroy", tfFuncToRun: terraform.DestroyContext, cntValue: 1, expectedAdd: 0, expectedChange: 0, expectedDestroy: 1},
+		{name: "DestroyNoOp", tfFuncToRun: terraform.DestroyContext, cntValue: 1, expectedAdd: 0, expectedChange: 0, expectedDestroy: 0},
 	}
 
 	testFolder, err := files.CopyTerraformFolderToTemp("../../test/fixtures/terraform-basic-configuration", t.Name())
@@ -78,7 +78,7 @@ func runTestGetResourceCountE(t *testing.T, noColor bool) { //nolint:tparallel /
 		t.Run(tc.name,
 			func(t *testing.T) {
 				terraformOptions.Vars["cnt"] = tc.cntValue
-				cnt, err := terraform.GetResourceCountE(t, tc.tfFuncToRun(t, terraformOptions))
+				cnt, err := terraform.GetResourceCountE(t, tc.tfFuncToRun(t, context.Background(), terraformOptions))
 				require.NoError(t, err)
 				assert.Equal(t, tc.expectedAdd, cnt.Add)
 				assert.Equal(t, tc.expectedChange, cnt.Change)

--- a/modules/terraform/count_test.go
+++ b/modules/terraform/count_test.go
@@ -1,6 +1,7 @@
 package terraform_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/gruntwork-io/terratest/modules/core/v2/files"
@@ -22,7 +23,7 @@ func TestGetResourceCount(t *testing.T) {
 		},
 	}
 
-	cnt := terraform.GetResourceCount(t, terraform.InitAndPlan(t, terraformOptions))
+	cnt := terraform.GetResourceCount(t, terraform.InitAndPlanContext(t, context.Background(), terraformOptions))
 	assert.Equal(t, 1, cnt.Add)
 	assert.Equal(t, 0, cnt.Change)
 	assert.Equal(t, 0, cnt.Destroy)
@@ -88,7 +89,7 @@ func runTestGetResourceCountE(t *testing.T, noColor bool) { //nolint:tparallel /
 	t.Run("InvalidInput",
 		func(t *testing.T) {
 			terraformOptions.Vars["cnt"] = "abc"
-			cmdout, _ := terraform.PlanE(t, terraformOptions)
+			cmdout, _ := terraform.PlanContextE(t, context.Background(), terraformOptions)
 			cnt, err := terraform.GetResourceCountE(t, cmdout)
 			require.EqualError(t, err, terraform.GetResourceCountErrMessage)
 			assert.Nil(t, cnt)

--- a/modules/terraform/init_test.go
+++ b/modules/terraform/init_test.go
@@ -1,6 +1,7 @@
 package terraform_test
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -58,7 +59,7 @@ func TestInitBackendConfig(t *testing.T) {
 			require.NoError(t, err)
 
 			options, expectedPath := tt.setup(t, testFolder)
-			terraform.InitAndApply(t, options)
+			terraform.InitAndApplyContext(t, context.Background(), options)
 			assert.FileExists(t, expectedPath)
 		})
 	}
@@ -90,9 +91,9 @@ func TestInitPluginDir(t *testing.T) {
 		PluginDir:    testingDir,
 	}
 
-	terraform.Init(t, terraformOptions)
+	terraform.InitContext(t, context.Background(), terraformOptions)
 
-	_, err = terraform.InitE(t, terraformOptionsPluginDir)
+	_, err = terraform.InitContextE(t, context.Background(), terraformOptionsPluginDir)
 	require.Error(t, err)
 
 	// In Terraform 0.13, the directory is "plugins"
@@ -104,7 +105,7 @@ func TestInitPluginDir(t *testing.T) {
 	files.CopyFolderContents(initializedPluginDir, testingDir)
 	files.CopyFolderContents(initializedProviderDir, testingDir)
 
-	initOutput := terraform.Init(t, terraformOptionsPluginDir)
+	initOutput := terraform.InitContext(t, context.Background(), terraformOptionsPluginDir)
 
 	assert.Contains(t, initOutput, "(unauthenticated)")
 }
@@ -127,14 +128,14 @@ func TestInitReconfigureBackend(t *testing.T) {
 		},
 	}
 
-	terraform.Init(t, options)
+	terraform.InitContext(t, context.Background(), options)
 
 	options.BackendConfig["workspace_dir"] = "new"
-	_, err = terraform.InitE(t, options)
+	_, err = terraform.InitContextE(t, context.Background(), options)
 	require.Error(t, err, "Backend initialization with changed configuration should fail without -reconfigure option")
 
 	options.Reconfigure = true
-	_, err = terraform.InitE(t, options)
+	_, err = terraform.InitContextE(t, context.Background(), options)
 	require.NoError(t, err, "Backend initialization with changed configuration should success with -reconfigure option")
 }
 
@@ -156,14 +157,14 @@ func TestInitBackendMigration(t *testing.T) {
 		},
 	}
 
-	terraform.Init(t, options)
+	terraform.InitContext(t, context.Background(), options)
 
 	options.BackendConfig["workspace_dir"] = "new"
-	_, err = terraform.InitE(t, options)
+	_, err = terraform.InitContextE(t, context.Background(), options)
 	require.Error(t, err, "Backend initialization with changed configuration should fail without -migrate-state option")
 
 	options.MigrateState = true
-	_, err = terraform.InitE(t, options)
+	_, err = terraform.InitContextE(t, context.Background(), options)
 	require.NoError(t, err, "Backend initialization with changed configuration should success with -migrate-state option")
 }
 
@@ -178,7 +179,7 @@ func TestInitNoColorOption(t *testing.T) {
 		NoColor:      true,
 	})
 
-	out := terraform.InitAndApply(t, options)
+	out := terraform.InitAndApplyContext(t, context.Background(), options)
 
 	require.Contains(t, out, "Hello, World")
 

--- a/modules/terraform/options_test.go
+++ b/modules/terraform/options_test.go
@@ -1,6 +1,7 @@
 package terraform_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/gruntwork-io/terratest/modules/core/v2/random"
@@ -55,37 +56,37 @@ func TestExtraArgsHelp(t *testing.T) {
 		{
 			name: "apply",
 			fn: func() (string, error) {
-				return terraform.ApplyE(t, &terraform.Options{ExtraArgs: terraform.ExtraArgs{Apply: []string{"-help"}}})
+				return terraform.ApplyContextE(t, context.Background(), &terraform.Options{ExtraArgs: terraform.ExtraArgs{Apply: []string{"-help"}}})
 			},
 		},
 		{
 			name: "destroy",
 			fn: func() (string, error) {
-				return terraform.DestroyE(t, &terraform.Options{ExtraArgs: terraform.ExtraArgs{Destroy: []string{"-help"}}})
+				return terraform.DestroyContextE(t, context.Background(), &terraform.Options{ExtraArgs: terraform.ExtraArgs{Destroy: []string{"-help"}}})
 			},
 		},
 		{
 			name: "get",
 			fn: func() (string, error) {
-				return terraform.GetE(t, &terraform.Options{ExtraArgs: terraform.ExtraArgs{Get: []string{"-help"}}})
+				return terraform.GetContextE(t, context.Background(), &terraform.Options{ExtraArgs: terraform.ExtraArgs{Get: []string{"-help"}}})
 			},
 		},
 		{
 			name: "init",
 			fn: func() (string, error) {
-				return terraform.InitE(t, &terraform.Options{ExtraArgs: terraform.ExtraArgs{Init: []string{"-help"}}})
+				return terraform.InitContextE(t, context.Background(), &terraform.Options{ExtraArgs: terraform.ExtraArgs{Init: []string{"-help"}}})
 			},
 		},
 		{
 			name: "plan",
 			fn: func() (string, error) {
-				return terraform.PlanE(t, &terraform.Options{ExtraArgs: terraform.ExtraArgs{Plan: []string{"-help"}}})
+				return terraform.PlanContextE(t, context.Background(), &terraform.Options{ExtraArgs: terraform.ExtraArgs{Plan: []string{"-help"}}})
 			},
 		},
 		{
 			name: "validate",
 			fn: func() (string, error) {
-				return terraform.ValidateE(t, &terraform.Options{ExtraArgs: terraform.ExtraArgs{Validate: []string{"-help"}}})
+				return terraform.ValidateContextE(t, context.Background(), &terraform.Options{ExtraArgs: terraform.ExtraArgs{Validate: []string{"-help"}}})
 			},
 		},
 	}
@@ -106,17 +107,17 @@ func TestExtraArgsWorkspace(t *testing.T) {
 		t.Parallel()
 
 		// set to default
-		terraform.WorkspaceSelectOrNew(t, &terraform.Options{}, "default")
+		terraform.WorkspaceSelectOrNewContext(t, context.Background(), &terraform.Options{}, "default")
 
 		// after adding -help, the function did not create the workspace
-		out, err := terraform.WorkspaceSelectOrNewE(t, &terraform.Options{ExtraArgs: terraform.ExtraArgs{
+		out, err := terraform.WorkspaceSelectOrNewContextE(t, context.Background(), &terraform.Options{ExtraArgs: terraform.ExtraArgs{
 			WorkspaceNew: []string{"-help"},
 		}}, random.UniqueID())
 		require.NoError(t, err)
 		require.Equal(t, "default", out)
 	})
 
-	out, err := terraform.WorkspaceSelectOrNewE(t, &terraform.Options{}, name)
+	out, err := terraform.WorkspaceSelectOrNewContextE(t, context.Background(), &terraform.Options{}, name)
 	require.NoError(t, err)
 	require.Equal(t, name, out)
 
@@ -124,10 +125,10 @@ func TestExtraArgsWorkspace(t *testing.T) {
 		t.Parallel()
 
 		// set to default
-		terraform.WorkspaceSelectOrNew(t, &terraform.Options{}, "default")
+		terraform.WorkspaceSelectOrNewContext(t, context.Background(), &terraform.Options{}, "default")
 
 		// after adding -help to select, the function did not select the workspace
-		out, err := terraform.WorkspaceSelectOrNewE(t, &terraform.Options{ExtraArgs: terraform.ExtraArgs{
+		out, err := terraform.WorkspaceSelectOrNewContextE(t, context.Background(), &terraform.Options{ExtraArgs: terraform.ExtraArgs{
 			WorkspaceSelect: []string{"-help"},
 		}}, name)
 		require.NoError(t, err)
@@ -138,13 +139,13 @@ func TestExtraArgsWorkspace(t *testing.T) {
 		t.Parallel()
 
 		// after adding -help to select, the function did not delete the workspace
-		_, err := terraform.WorkspaceDeleteE(t, &terraform.Options{ExtraArgs: terraform.ExtraArgs{
+		_, err := terraform.WorkspaceDeleteContextE(t, context.Background(), &terraform.Options{ExtraArgs: terraform.ExtraArgs{
 			WorkspaceDelete: []string{"-help"},
 		}}, name)
 		require.NoError(t, err)
 
 		// the workspace should still exist
-		out, err := terraform.RunTerraformCommandE(t, &terraform.Options{}, "workspace", "list")
+		out, err := terraform.RunTerraformCommandContextE(t, context.Background(), &terraform.Options{}, "workspace", "list")
 		require.NoError(t, err)
 		assert.Contains(t, out, name)
 	})

--- a/modules/terraform/output_test.go
+++ b/modules/terraform/output_test.go
@@ -1,6 +1,7 @@
 package terraform_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -20,21 +21,21 @@ func TestOutputString(t *testing.T) {
 		TerraformDir: testFolder,
 	}
 
-	terraform.InitAndApply(t, options)
+	terraform.InitAndApplyContext(t, context.Background(), options)
 
-	b := terraform.Output(t, options, "bool")
+	b := terraform.OutputContext(t, context.Background(), options, "bool")
 	require.Equal(t, "true", b, "Bool %q should match %q", "true", b)
 
-	str := terraform.Output(t, options, "string")
+	str := terraform.OutputContext(t, context.Background(), options, "string")
 	require.Equal(t, "This is a string.", str, "String %q should match %q", "This is a string.", str)
 
-	num := terraform.Output(t, options, "number")
+	num := terraform.OutputContext(t, context.Background(), options, "number")
 	require.Equal(t, "3.14", num, "Number %q should match %q", "3.14", num)
 
-	num1 := terraform.Output(t, options, "number1")
+	num1 := terraform.OutputContext(t, context.Background(), options, "number1")
 	require.Equal(t, "3", num1, "Number %q should match %q", "3", num1)
 
-	unicodeString := terraform.Output(t, options, "unicode_string")
+	unicodeString := terraform.OutputContext(t, context.Background(), options, "unicode_string")
 	require.Equal(t, "söme chäräcter", unicodeString)
 }
 
@@ -48,8 +49,8 @@ func TestOutputList(t *testing.T) {
 		TerraformDir: testFolder,
 	}
 
-	terraform.InitAndApply(t, options)
-	out := terraform.OutputList(t, options, "giant_steps")
+	terraform.InitAndApplyContext(t, context.Background(), options)
+	out := terraform.OutputListContext(t, context.Background(), options, "giant_steps")
 
 	expectedLen := 4
 	expectedItem := "John Coltrane"
@@ -73,9 +74,9 @@ func TestOutputNotListError(t *testing.T) {
 		TerraformDir: testFolder,
 	}
 
-	terraform.InitAndApply(t, options)
+	terraform.InitAndApplyContext(t, context.Background(), options)
 
-	_, err = terraform.OutputListE(t, options, "not_a_list")
+	_, err = terraform.OutputListContextE(t, context.Background(), options, "not_a_list")
 	require.Error(t, err)
 }
 
@@ -89,8 +90,8 @@ func TestOutputMap(t *testing.T) {
 		TerraformDir: testFolder,
 	}
 
-	terraform.InitAndApply(t, options)
-	out := terraform.OutputMap(t, options, "mogwai")
+	terraform.InitAndApplyContext(t, context.Background(), options)
+	out := terraform.OutputMapContext(t, context.Background(), options, "mogwai")
 
 	t.Log(out)
 
@@ -116,9 +117,9 @@ func TestOutputNotMapError(t *testing.T) {
 		TerraformDir: testFolder,
 	}
 
-	terraform.InitAndApply(t, options)
+	terraform.InitAndApplyContext(t, context.Background(), options)
 
-	_, err = terraform.OutputMapE(t, options, "not_a_map")
+	_, err = terraform.OutputMapContextE(t, context.Background(), options, "not_a_map")
 	require.Error(t, err)
 }
 
@@ -132,8 +133,8 @@ func TestOutputMapOfObjects(t *testing.T) {
 		TerraformDir: testFolder,
 	}
 
-	terraform.InitAndApply(t, options)
-	out := terraform.OutputMapOfObjects(t, options, "map_of_objects")
+	terraform.InitAndApplyContext(t, context.Background(), options)
+	out := terraform.OutputMapOfObjectsContext(t, context.Background(), options, "map_of_objects")
 
 	nestedMap1 := map[string]any{
 		"four": 4,
@@ -170,9 +171,9 @@ func TestOutputNotMapOfObjectsError(t *testing.T) {
 		TerraformDir: testFolder,
 	}
 
-	terraform.InitAndApply(t, options)
+	terraform.InitAndApplyContext(t, context.Background(), options)
 
-	_, err = terraform.OutputMapOfObjectsE(t, options, "not_map_of_objects")
+	_, err = terraform.OutputMapOfObjectsContextE(t, context.Background(), options, "not_map_of_objects")
 	require.Error(t, err)
 }
 
@@ -186,8 +187,8 @@ func TestOutputListOfObjects(t *testing.T) {
 		TerraformDir: testFolder,
 	}
 
-	terraform.InitAndApply(t, options)
-	out := terraform.OutputListOfObjects(t, options, "list_of_maps")
+	terraform.InitAndApplyContext(t, context.Background(), options)
+	out := terraform.OutputListOfObjectsContext(t, context.Background(), options, "list_of_maps")
 
 	expectedLen := 3
 	nestedMap1 := map[string]any{
@@ -243,9 +244,9 @@ func TestOutputNotListOfObjectsError(t *testing.T) {
 		TerraformDir: testFolder,
 	}
 
-	terraform.InitAndApply(t, options)
+	terraform.InitAndApplyContext(t, context.Background(), options)
 
-	_, err = terraform.OutputListOfObjectsE(t, options, "not_list_of_maps")
+	_, err = terraform.OutputListOfObjectsContextE(t, context.Background(), options, "not_list_of_maps")
 	require.Error(t, err)
 }
 
@@ -261,8 +262,8 @@ func TestOutputsForKeys(t *testing.T) {
 
 	keys := []string{"our_star", "stars", "magnitudes"}
 
-	terraform.InitAndApply(t, options)
-	out := terraform.OutputForKeys(t, options, keys)
+	terraform.InitAndApplyContext(t, context.Background(), options)
+	out := terraform.OutputForKeysContext(t, context.Background(), options, keys)
 
 	expectedLen := 3
 	require.Len(t, out, expectedLen, "Output should contain %d items", expectedLen)
@@ -311,7 +312,7 @@ func TestOutputJson(t *testing.T) {
 		TerraformDir: testFolder,
 	}
 
-	terraform.InitAndApply(t, options)
+	terraform.InitAndApplyContext(t, context.Background(), options)
 
 	expected := `{
   "bool": {
@@ -341,7 +342,7 @@ func TestOutputJson(t *testing.T) {
   }
 }`
 
-	str := terraform.OutputJSON(t, options, "")
+	str := terraform.OutputJSONContext(t, context.Background(), options, "")
 	require.Equal(t, expected, str, "JSON %q should match %q", expected, str)
 }
 
@@ -371,7 +372,7 @@ func TestOutputStruct(t *testing.T) {
 		},
 	}
 
-	terraform.InitAndApply(t, options)
+	terraform.InitAndApplyContext(t, context.Background(), options)
 
 	expectedObject := TestStruct{
 		Somebool:    true,
@@ -384,7 +385,7 @@ func TestOutputStruct(t *testing.T) {
 	}
 	actualObject := TestStruct{}
 
-	terraform.OutputStruct(t, options, "object", &actualObject)
+	terraform.OutputStructContext(t, context.Background(), options, "object", &actualObject)
 
 	expectedList := []TestStruct{
 		{
@@ -402,7 +403,7 @@ func TestOutputStruct(t *testing.T) {
 	}
 	actualList := []TestStruct{}
 
-	terraform.OutputStruct(t, options, "list_of_objects", &actualList)
+	terraform.OutputStructContext(t, context.Background(), options, "list_of_objects", &actualList)
 
 	require.Equal(t, expectedObject, actualObject, "Object should be %q, got %q", expectedObject, actualObject)
 	require.Equal(t, expectedList, actualList, "List should be %q, got %q", expectedList, actualList)
@@ -420,8 +421,8 @@ func TestOutputsAll(t *testing.T) {
 		TerraformDir: testFolder,
 	}
 
-	terraform.InitAndApply(t, options)
-	out := terraform.OutputAll(t, options)
+	terraform.InitAndApplyContext(t, context.Background(), options)
+	out := terraform.OutputAllContext(t, context.Background(), options)
 
 	expectedLen := 4
 	require.Len(t, out, expectedLen, "Output should contain %d items", expectedLen)
@@ -465,9 +466,9 @@ func TestOutputsForKeysError(t *testing.T) {
 		TerraformDir: testFolder,
 	}
 
-	terraform.InitAndApply(t, options)
+	terraform.InitAndApplyContext(t, context.Background(), options)
 
-	_, err = terraform.OutputForKeysE(t, options, []string{"random_key"})
+	_, err = terraform.OutputForKeysContextE(t, context.Background(), options, []string{"random_key"})
 	require.Error(t, err)
 }
 
@@ -481,9 +482,9 @@ func TestOutputWithDebugLogLevel(t *testing.T) {
 		TerraformDir: testFolder,
 	}
 
-	terraform.InitAndApply(t, options)
+	terraform.InitAndApplyContext(t, context.Background(), options)
 
-	_, err = terraform.OutputMapOfObjectsE(t, &terraform.Options{
+	_, err = terraform.OutputMapOfObjectsContextE(t, context.Background(), &terraform.Options{
 		TerraformDir: options.TerraformDir,
 		EnvVars:      map[string]string{"TF_LOG": "DEBUG"},
 	}, "map_of_objects")

--- a/modules/terraform/plan_test.go
+++ b/modules/terraform/plan_test.go
@@ -1,6 +1,7 @@
 package terraform_test
 
 import (
+	"context"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -21,7 +22,7 @@ func TestInitAndPlanWithError(t *testing.T) {
 		TerraformDir: testFolder,
 	}
 
-	_, err = terraform.InitAndPlanE(t, options)
+	_, err = terraform.InitAndPlanContextE(t, context.Background(), options)
 	require.Error(t, err)
 }
 
@@ -39,9 +40,9 @@ func TestInitAndPlanWithNoError(t *testing.T) {
 	// report "No changes. Infrastructure is up-to-date." However, with 0.13 and above, if the Terraform configuration
 	// has never been applied at all, 'plan' always shows changes. So we have to run 'apply' first, and can then
 	// check that 'plan' returns the message we expect.
-	terraform.InitAndApply(t, options)
+	terraform.InitAndApplyContext(t, context.Background(), options)
 
-	out, err := terraform.PlanE(t, options)
+	out, err := terraform.PlanContextE(t, context.Background(), options)
 	require.NoError(t, err)
 	require.Contains(t, out, "No changes.")
 }
@@ -59,7 +60,7 @@ func TestInitAndPlanWithOutput(t *testing.T) {
 		},
 	}
 
-	out, err := terraform.InitAndPlanE(t, options)
+	out, err := terraform.InitAndPlanContextE(t, context.Background(), options)
 	require.NoError(t, err)
 	require.Contains(t, out, "1 to add, 0 to change, 0 to destroy.")
 }
@@ -80,7 +81,7 @@ func TestInitAndPlanWithPlanFile(t *testing.T) {
 		PlanFilePath: planFilePath,
 	}
 
-	out, err := terraform.InitAndPlanE(t, options)
+	out, err := terraform.InitAndPlanContextE(t, context.Background(), options)
 	require.NoError(t, err)
 
 	// clean output to be consistent in checks
@@ -103,7 +104,7 @@ func TestInitAndPlanAndShowWithStructNoLogTempPlanFile(t *testing.T) {
 		},
 	}
 
-	planStruct := terraform.InitAndPlanAndShowWithStructNoLogTempPlanFile(t, options)
+	planStruct := terraform.InitAndPlanAndShowWithStructNoLogTempPlanFileContext(t, context.Background(), options)
 	assert.Len(t, planStruct.ResourceChangesMap, 1)
 }
 
@@ -121,9 +122,9 @@ func TestPlanWithExitCodeWithNoChanges(t *testing.T) {
 	// would return a code of 0. However, with 0.13 and above, if the Terraform configuration has never been applied
 	// at all, -detailed-exitcode always returns an exit code of 2. So we have to run 'apply' first, and can then
 	// check that 'plan' returns the exit code we expect.
-	terraform.InitAndApply(t, options)
+	terraform.InitAndApplyContext(t, context.Background(), options)
 
-	exitCode := terraform.PlanExitCode(t, options)
+	exitCode := terraform.PlanExitCodeContext(t, context.Background(), options)
 	require.Equal(t, terraform.DefaultSuccessExitCode, exitCode)
 }
 
@@ -140,7 +141,7 @@ func TestPlanWithExitCodeWithChanges(t *testing.T) {
 		},
 	}
 
-	exitCode := terraform.InitAndPlanWithExitCode(t, options)
+	exitCode := terraform.InitAndPlanWithExitCodeContext(t, context.Background(), options)
 	require.Equal(t, terraform.TerraformPlanChangesPresentExitCode, exitCode)
 }
 
@@ -154,7 +155,7 @@ func TestPlanWithExitCodeWithFailure(t *testing.T) {
 		TerraformDir: testFolder,
 	}
 
-	exitCode, getExitCodeErr := terraform.InitAndPlanWithExitCodeE(t, options)
+	exitCode, getExitCodeErr := terraform.InitAndPlanWithExitCodeContextE(t, context.Background(), options)
 	require.NoError(t, getExitCodeErr)
 	require.Equal(t, 1, exitCode)
 }

--- a/modules/terraform/show_test.go
+++ b/modules/terraform/show_test.go
@@ -1,6 +1,7 @@
 package terraform_test
 
 import (
+	"context"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -26,7 +27,7 @@ func TestShowWithInlinePlan(t *testing.T) {
 		},
 	}
 
-	out := terraform.InitAndPlan(t, options)
+	out := terraform.InitAndPlanContext(t, context.Background(), options)
 	out = strings.ReplaceAll(out, "\n", "")
 	require.Contains(t, out, "Saved the plan to:"+planFilePath)
 	require.FileExists(t, planFilePath, "Plan file was not saved to expected location:", planFilePath)
@@ -38,7 +39,7 @@ func TestShowWithInlinePlan(t *testing.T) {
 	}
 
 	// Test the JSON string
-	planJSON := terraform.Show(t, showOptions)
+	planJSON := terraform.ShowContext(t, context.Background(), showOptions)
 	require.Contains(t, planJSON, "null_resource.test[0]")
 }
 
@@ -58,7 +59,7 @@ func TestShowWithStructInlinePlan(t *testing.T) {
 		},
 	}
 
-	out := terraform.InitAndPlan(t, options)
+	out := terraform.InitAndPlanContext(t, context.Background(), options)
 	out = strings.ReplaceAll(out, "\n", "")
 	require.Contains(t, out, "Saved the plan to:"+planFilePath)
 	require.FileExists(t, planFilePath, "Plan file was not saved to expected location:", planFilePath)
@@ -70,6 +71,6 @@ func TestShowWithStructInlinePlan(t *testing.T) {
 	}
 
 	// Test the JSON string
-	plan := terraform.ShowWithStruct(t, showOptions)
+	plan := terraform.ShowWithStructContext(t, context.Background(), showOptions)
 	require.Contains(t, plan.ResourcePlannedValuesMap, "null_resource.test[0]")
 }

--- a/modules/terraform/validate_test.go
+++ b/modules/terraform/validate_test.go
@@ -1,6 +1,7 @@
 package terraform_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/gruntwork-io/terratest/modules/core/v2/files"
@@ -18,7 +19,7 @@ func TestInitAndValidateWithNoError(t *testing.T) {
 		TerraformDir: testFolder,
 	}
 
-	out := terraform.InitAndValidate(t, options)
+	out := terraform.InitAndValidateContext(t, context.Background(), options)
 	require.Contains(t, out, "The configuration is valid")
 }
 
@@ -32,7 +33,7 @@ func TestInitAndValidateWithError(t *testing.T) {
 		TerraformDir: testFolder,
 	}
 
-	out, err := terraform.InitAndValidateE(t, options)
+	out, err := terraform.InitAndValidateContextE(t, context.Background(), options)
 	require.Error(t, err)
 	require.Contains(t, out, "Reference to undeclared input variable")
 }

--- a/modules/terraform/workspace_test.go
+++ b/modules/terraform/workspace_test.go
@@ -1,6 +1,7 @@
 package terraform_test
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -22,7 +23,7 @@ func TestWorkspaceNew(t *testing.T) {
 		TerraformDir: testFolder,
 	}
 
-	out := terraform.WorkspaceSelectOrNew(t, options, "terratest")
+	out := terraform.WorkspaceSelectOrNewContext(t, context.Background(), options, "terratest")
 
 	assert.Equal(t, "terratest", out)
 }
@@ -39,7 +40,7 @@ func TestWorkspaceIllegalName(t *testing.T) {
 		TerraformDir: testFolder,
 	}
 
-	out, err := terraform.WorkspaceSelectOrNewE(t, options, "###@@@&&&")
+	out, err := terraform.WorkspaceSelectOrNewContextE(t, context.Background(), options, "###@@@&&&")
 
 	require.Error(t, err)
 	assert.Empty(t, out, "%q should be an empty string", out)
@@ -57,10 +58,10 @@ func TestWorkspaceSelect(t *testing.T) {
 		TerraformDir: testFolder,
 	}
 
-	out := terraform.WorkspaceSelectOrNew(t, options, "terratest")
+	out := terraform.WorkspaceSelectOrNewContext(t, context.Background(), options, "terratest")
 	assert.Equal(t, "terratest", out)
 
-	out = terraform.WorkspaceSelectOrNew(t, options, "default")
+	out = terraform.WorkspaceSelectOrNewContext(t, context.Background(), options, "default")
 	assert.Equal(t, "default", out)
 }
 
@@ -76,8 +77,8 @@ func TestWorkspaceApply(t *testing.T) {
 		TerraformDir: testFolder,
 	}
 
-	terraform.WorkspaceSelectOrNew(t, options, "Terratest")
-	out := terraform.InitAndApply(t, options)
+	terraform.WorkspaceSelectOrNewContext(t, context.Background(), options, "Terratest")
+	out := terraform.InitAndApplyContext(t, context.Background(), options)
 
 	assert.Contains(t, out, "Hello, Terratest")
 }
@@ -184,16 +185,16 @@ func TestWorkspaceDeleteE(t *testing.T) {
 
 			// Set up pre-existing environment based on test case description
 			for _, existingWorkspace := range testCase.initialState.workspaces {
-				_, err = terraform.RunTerraformCommandE(t, options, "workspace", "new", existingWorkspace)
+				_, err = terraform.RunTerraformCommandContextE(t, context.Background(), options, "workspace", "new", existingWorkspace)
 				require.NoError(t, err)
 			}
 
 			// Switch to the specified workspace
-			_, err = terraform.RunTerraformCommandE(t, options, "workspace", "select", testCase.initialState.current)
+			_, err = terraform.RunTerraformCommandContextE(t, context.Background(), options, "workspace", "select", testCase.initialState.current)
 			require.NoError(t, err)
 
 			// Testing time, wooohoooo
-			gotResult, gotErr := terraform.WorkspaceDeleteE(t, options, testCase.toDeleteWorkspace)
+			gotResult, gotErr := terraform.WorkspaceDeleteContextE(t, context.Background(), options, testCase.toDeleteWorkspace)
 
 			// Check for errors
 			if testCase.expectedError != nil {
@@ -204,7 +205,7 @@ func TestWorkspaceDeleteE(t *testing.T) {
 				require.NoError(t, gotErr)
 				// Check for results
 				assert.Equal(t, testCase.expectedCurrent, gotResult)
-				assert.False(t, terraform.IsExistingWorkspace(terraform.RunTerraformCommand(t, options, "workspace", "list"), testCase.toDeleteWorkspace))
+				assert.False(t, terraform.IsExistingWorkspace(terraform.RunTerraformCommandContext(t, context.Background(), options, "workspace", "list"), testCase.toDeleteWorkspace))
 			}
 		})
 	}

--- a/modules/terragrunt/apply_test.go
+++ b/modules/terragrunt/apply_test.go
@@ -1,6 +1,7 @@
 package terragrunt_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/gruntwork-io/terratest/modules/core/v2/files"
@@ -19,9 +20,9 @@ func TestApplyAll(t *testing.T) {
 		TerragruntBinary: "terragrunt",
 	}
 
-	defer terragrunt.DestroyAll(t, options)
+	defer terragrunt.DestroyAllContext(t, context.Background(), options)
 
-	out := terragrunt.ApplyAll(t, options)
+	out := terragrunt.ApplyAllContext(t, context.Background(), options)
 	require.Contains(t, out, "Hello, World")
 }
 
@@ -36,9 +37,9 @@ func TestApply(t *testing.T) {
 		TerragruntBinary: "terragrunt",
 	}
 
-	defer terragrunt.Destroy(t, options)
+	defer terragrunt.DestroyContext(t, context.Background(), options)
 
-	out := terragrunt.Apply(t, options)
+	out := terragrunt.ApplyContext(t, context.Background(), options)
 	require.Contains(t, out, "Hello, World")
 }
 
@@ -53,9 +54,9 @@ func TestInitAndApply(t *testing.T) {
 		TerragruntBinary: "terragrunt",
 	}
 
-	defer terragrunt.Destroy(t, options)
+	defer terragrunt.DestroyContext(t, context.Background(), options)
 
-	out := terragrunt.InitAndApply(t, options)
+	out := terragrunt.InitAndApplyContext(t, context.Background(), options)
 	require.Contains(t, out, "Hello, World")
 }
 
@@ -73,7 +74,7 @@ func TestInitAndApplyE_InitFailure(t *testing.T) {
 		TerragruntBinary: "terragrunt",
 	}
 
-	out, err := terragrunt.InitAndApplyE(t, options)
+	out, err := terragrunt.InitAndApplyContextE(t, context.Background(), options)
 	require.Error(t, err, "InitAndApplyE should propagate init failure")
 	require.Empty(t, out, "Output should be empty when init fails")
 	require.Contains(t, err.Error(), "Missing expression",

--- a/modules/terragrunt/cmd_args_test.go
+++ b/modules/terragrunt/cmd_args_test.go
@@ -1,6 +1,7 @@
 package terragrunt_test
 
 import (
+	"context"
 	"os/exec"
 	"path/filepath"
 	"testing"
@@ -27,7 +28,7 @@ func TestTerragruntArgsIncluded(t *testing.T) {
 	}
 
 	// Run init - if TerragruntArgs work, we should only see error-level logs
-	output, err := terragrunt.InitE(t, options)
+	output, err := terragrunt.InitContextE(t, context.Background(), options)
 	require.NoError(t, err)
 
 	// With --log-level error, we shouldn't see info-level messages
@@ -53,7 +54,7 @@ func TestTerraformArgsIncluded(t *testing.T) {
 	}
 
 	// Run init with -backend=false flag
-	output, err := terragrunt.InitE(t, options)
+	output, err := terragrunt.InitContextE(t, context.Background(), options)
 	require.NoError(t, err)
 
 	// With -backend=false, we should NOT see backend initialization messages
@@ -75,9 +76,9 @@ func TestPlanExitCodeIncludesArgs(t *testing.T) {
 		TerragruntDir:    testFolder,
 		TerragruntBinary: "terragrunt",
 	}
-	defer terragrunt.DestroyAll(t, baseOptions)
+	defer terragrunt.DestroyAllContext(t, context.Background(), baseOptions)
 
-	terragrunt.ApplyAll(t, baseOptions)
+	terragrunt.ApplyAllContext(t, context.Background(), baseOptions)
 
 	// Now run plan with exit code AND TerragruntArgs
 	options := &terragrunt.Options{
@@ -88,7 +89,7 @@ func TestPlanExitCodeIncludesArgs(t *testing.T) {
 	}
 
 	// This should return exit code 0 (no changes) and should respect the log level
-	exitCode, err := terragrunt.PlanAllExitCodeE(t, options)
+	exitCode, err := terragrunt.PlanAllExitCodeContextE(t, context.Background(), options)
 	require.NoError(t, err)
 	require.Equal(t, 0, exitCode)
 
@@ -117,7 +118,7 @@ func TestCombinedArgsOrdering(t *testing.T) {
 	}
 
 	// Run init - both args should be passed in the correct order
-	output, err := terragrunt.InitE(t, options)
+	output, err := terragrunt.InitContextE(t, context.Background(), options)
 	require.NoError(t, err)
 
 	// Verify TerragruntArgs effect: should not see info-level logs
@@ -351,7 +352,7 @@ func TestEnvVarsPropagation(t *testing.T) {
 	}
 
 	// Run init - should succeed with env vars set
-	output, err := terragrunt.InitE(t, options)
+	output, err := terragrunt.InitContextE(t, context.Background(), options)
 	require.NoError(t, err)
 	require.NotEmpty(t, output)
 	// With TG_LOG_LEVEL=error, should not see info logs

--- a/modules/terragrunt/destroy_test.go
+++ b/modules/terragrunt/destroy_test.go
@@ -1,6 +1,7 @@
 package terragrunt_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/gruntwork-io/terratest/modules/core/v2/files"
@@ -19,8 +20,8 @@ func TestDestroyAll(t *testing.T) {
 		TerragruntBinary: "terragrunt",
 	}
 
-	terragrunt.ApplyAll(t, options)
-	destroyOut := terragrunt.DestroyAll(t, options)
+	terragrunt.ApplyAllContext(t, context.Background(), options)
+	destroyOut := terragrunt.DestroyAllContext(t, context.Background(), options)
 	require.NotEmpty(t, destroyOut)
 }
 
@@ -35,8 +36,8 @@ func TestDestroy(t *testing.T) {
 		TerragruntBinary: "terragrunt",
 	}
 
-	terragrunt.Apply(t, options)
-	destroyOut := terragrunt.Destroy(t, options)
+	terragrunt.ApplyContext(t, context.Background(), options)
+	destroyOut := terragrunt.DestroyContext(t, context.Background(), options)
 	require.NotEmpty(t, destroyOut)
 }
 
@@ -48,7 +49,7 @@ func TestDestroyAllWithArgs(t *testing.T) {
 	require.NoError(t, err)
 
 	// Apply first
-	terragrunt.ApplyAll(t, &terragrunt.Options{
+	terragrunt.ApplyAllContext(t, context.Background(), &terragrunt.Options{
 		TerragruntDir:    testFolder,
 		TerragruntBinary: "terragrunt",
 	})
@@ -60,7 +61,7 @@ func TestDestroyAllWithArgs(t *testing.T) {
 		TerragruntArgs:   []string{"--log-level", "error"},
 	}
 
-	destroyOut := terragrunt.DestroyAll(t, options)
+	destroyOut := terragrunt.DestroyAllContext(t, context.Background(), options)
 	require.NotEmpty(t, destroyOut)
 	// With --log-level error, should not see info logs
 	require.NotContains(t, destroyOut, "level=info")

--- a/modules/terragrunt/format_test.go
+++ b/modules/terragrunt/format_test.go
@@ -1,6 +1,7 @@
 package terragrunt_test
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -33,7 +34,7 @@ foo="bar"
 	}
 
 	// Run format command
-	terragrunt.FormatAll(t, options)
+	terragrunt.FormatAllContext(t, context.Background(), options)
 
 	// Read the formatted file to verify it was actually formatted
 	formattedContent, err := os.ReadFile(tgFile)
@@ -71,7 +72,7 @@ foo="bar"
 	}
 
 	// Run format command - should succeed
-	_, err = terragrunt.FormatAllE(t, options)
+	_, err = terragrunt.FormatAllContextE(t, context.Background(), options)
 	require.NoError(t, err)
 
 	// Verify the file was actually formatted by reading it

--- a/modules/terragrunt/graph_test.go
+++ b/modules/terragrunt/graph_test.go
@@ -1,6 +1,7 @@
 package terragrunt_test
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -16,7 +17,7 @@ func TestGraph(t *testing.T) {
 	testFolder, err := files.CopyTerragruntFolderToTemp("testdata/terragrunt-multi-plan", t.Name())
 	require.NoError(t, err)
 
-	output := terragrunt.Graph(t, &terragrunt.Options{
+	output := terragrunt.GraphContext(t, context.Background(), &terragrunt.Options{
 		TerragruntDir:    testFolder,
 		TerragruntBinary: "terragrunt",
 	})
@@ -32,7 +33,7 @@ func TestGraphE_InvalidConfig(t *testing.T) {
 	tmpDir := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "terragrunt.hcl"), []byte("not_valid!!!"), 0644))
 
-	output, err := terragrunt.GraphE(t, &terragrunt.Options{TerragruntDir: tmpDir})
+	output, err := terragrunt.GraphContextE(t, context.Background(), &terragrunt.Options{TerragruntDir: tmpDir})
 	require.NoError(t, err)
 	require.Contains(t, output, "digraph")
 	// Invalid config produces a minimal graph with just the current unit

--- a/modules/terragrunt/hcl_validate_test.go
+++ b/modules/terragrunt/hcl_validate_test.go
@@ -1,6 +1,7 @@
 package terragrunt_test
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -16,7 +17,7 @@ func TestHclValidate(t *testing.T) {
 	testFolder, err := files.CopyTerragruntFolderToTemp("testdata/terragrunt-multi-plan", t.Name())
 	require.NoError(t, err)
 
-	terragrunt.HclValidate(t, &terragrunt.Options{
+	terragrunt.HclValidateContext(t, context.Background(), &terragrunt.Options{
 		TerragruntDir:    testFolder,
 		TerragruntBinary: "terragrunt",
 	})
@@ -28,6 +29,6 @@ func TestHclValidateE_InvalidConfig(t *testing.T) {
 	tmpDir := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "terragrunt.hcl"), []byte("not_valid!!!"), 0644))
 
-	_, err := terragrunt.HclValidateE(t, &terragrunt.Options{TerragruntDir: tmpDir})
+	_, err := terragrunt.HclValidateContextE(t, context.Background(), &terragrunt.Options{TerragruntDir: tmpDir})
 	require.Error(t, err)
 }

--- a/modules/terragrunt/init_test.go
+++ b/modules/terragrunt/init_test.go
@@ -1,6 +1,7 @@
 package terragrunt_test
 
 import (
+	"context"
 	"path/filepath"
 	"testing"
 
@@ -16,7 +17,7 @@ func TestInit(t *testing.T) {
 		"testdata/terragrunt-no-error", t.Name())
 	require.NoError(t, err)
 
-	out := terragrunt.Init(t, &terragrunt.Options{
+	out := terragrunt.InitContext(t, context.Background(), &terragrunt.Options{
 		TerragruntDir:    testFolder,
 		TerragruntBinary: "terragrunt",
 		TerraformArgs:    []string{"-upgrade=true"},
@@ -32,7 +33,7 @@ func TestInitE(t *testing.T) {
 		"testdata/terragrunt-no-error", t.Name())
 	require.NoError(t, err)
 
-	out, err := terragrunt.InitE(t, &terragrunt.Options{
+	out, err := terragrunt.InitContextE(t, context.Background(), &terragrunt.Options{
 		TerragruntDir:    testFolder,
 		TerragruntBinary: "terragrunt",
 		TerraformArgs:    []string{"-upgrade=true"}, // Common terraform init flag
@@ -50,7 +51,7 @@ func TestInitWithInvalidConfig(t *testing.T) {
 	require.NoError(t, err)
 
 	// This should fail due to invalid HCL syntax in tg.hcl
-	_, err = terragrunt.InitE(t, &terragrunt.Options{
+	_, err = terragrunt.InitContextE(t, context.Background(), &terragrunt.Options{
 		TerragruntDir:    testFolder,
 		TerragruntBinary: "terragrunt",
 		TerraformArgs:    []string{"-upgrade=true"}, // Common terraform init flag
@@ -75,7 +76,7 @@ func TestInitWithBothArgTypes(t *testing.T) {
 		TerraformArgs:    []string{"-upgrade"},
 	}
 
-	output, err := terragrunt.InitE(t, options)
+	output, err := terragrunt.InitContextE(t, context.Background(), options)
 	require.NoError(t, err)
 	// Verify TerragruntArgs: no info logs
 	require.NotContains(t, output, "level=info")

--- a/modules/terragrunt/output_test.go
+++ b/modules/terragrunt/output_test.go
@@ -1,6 +1,7 @@
 package terragrunt_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/gruntwork-io/terratest/modules/core/v2/files"
@@ -20,10 +21,10 @@ func TestOutputJSON(t *testing.T) {
 		TerragruntBinary: "terragrunt",
 	}
 
-	terragrunt.Apply(t, options)
-	defer terragrunt.Destroy(t, options)
+	terragrunt.ApplyContext(t, context.Background(), options)
+	defer terragrunt.DestroyContext(t, context.Background(), options)
 
-	json := terragrunt.OutputJSON(t, options, "str")
+	json := terragrunt.OutputJSONContext(t, context.Background(), options, "str")
 	assert.Contains(t, json, "str")
 }
 
@@ -38,10 +39,10 @@ func TestOutputJSONAllKeys(t *testing.T) {
 		TerragruntBinary: "terragrunt",
 	}
 
-	terragrunt.Apply(t, options)
-	defer terragrunt.Destroy(t, options)
+	terragrunt.ApplyContext(t, context.Background(), options)
+	defer terragrunt.DestroyContext(t, context.Background(), options)
 
-	json := terragrunt.OutputJSON(t, options, "")
+	json := terragrunt.OutputJSONContext(t, context.Background(), options, "")
 	assert.Contains(t, json, "str")
 	assert.Contains(t, json, "list")
 	assert.Contains(t, json, "map")
@@ -55,6 +56,6 @@ func TestOutputJSONE_Error(t *testing.T) {
 		TerragruntBinary: "terragrunt",
 	}
 
-	_, err := terragrunt.OutputJSONE(t, options, "")
+	_, err := terragrunt.OutputJSONContextE(t, context.Background(), options, "")
 	require.Error(t, err)
 }

--- a/modules/terragrunt/plan_test.go
+++ b/modules/terragrunt/plan_test.go
@@ -1,6 +1,7 @@
 package terragrunt_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/gruntwork-io/terratest/modules/core/v2/files"
@@ -20,10 +21,10 @@ func TestPlanAllExitCode(t *testing.T) {
 		TerragruntBinary: "terragrunt",
 	}
 
-	defer terragrunt.DestroyAll(t, options)
+	defer terragrunt.DestroyAllContext(t, context.Background(), options)
 
-	terragrunt.ApplyAll(t, options)
-	exitCode := terragrunt.PlanAllExitCode(t, options)
+	terragrunt.ApplyAllContext(t, context.Background(), options)
+	exitCode := terragrunt.PlanAllExitCodeContext(t, context.Background(), options)
 	require.Equal(t, 0, exitCode)
 }
 
@@ -38,7 +39,7 @@ func TestPlan(t *testing.T) {
 		TerragruntBinary: "terragrunt",
 	}
 
-	out := terragrunt.Plan(t, options)
+	out := terragrunt.PlanContext(t, context.Background(), options)
 	require.NotEmpty(t, out)
 }
 
@@ -54,10 +55,10 @@ func TestPlanExitCode(t *testing.T) {
 	}
 
 	// Apply first so plan shows no changes (exit code 0)
-	terragrunt.Apply(t, options)
-	defer terragrunt.Destroy(t, options)
+	terragrunt.ApplyContext(t, context.Background(), options)
+	defer terragrunt.DestroyContext(t, context.Background(), options)
 
-	exitCode := terragrunt.PlanExitCode(t, options)
+	exitCode := terragrunt.PlanExitCodeContext(t, context.Background(), options)
 	assert.Equal(t, 0, exitCode)
 }
 
@@ -72,7 +73,7 @@ func TestInitAndPlan(t *testing.T) {
 		TerragruntBinary: "terragrunt",
 	}
 
-	out := terragrunt.InitAndPlan(t, options)
+	out := terragrunt.InitAndPlanContext(t, context.Background(), options)
 	require.NotEmpty(t, out)
 }
 
@@ -87,7 +88,7 @@ func TestPlanAllWithError(t *testing.T) {
 		TerragruntBinary: "terragrunt",
 	}
 
-	getExitCode, errExitCode := terragrunt.PlanAllExitCodeE(t, options)
+	getExitCode, errExitCode := terragrunt.PlanAllExitCodeContextE(t, context.Background(), options)
 	// GetExitCodeForRunCommandError was unable to determine the exit code correctly
 	require.NoError(t, errExitCode)
 
@@ -105,9 +106,9 @@ func TestAssertPlanAllExitCodeNoError(t *testing.T) {
 		TerragruntBinary: "terragrunt",
 	}
 
-	defer terragrunt.DestroyAll(t, options)
+	defer terragrunt.DestroyAllContext(t, context.Background(), options)
 
-	getExitCode, errExitCode := terragrunt.PlanAllExitCodeE(t, options)
+	getExitCode, errExitCode := terragrunt.PlanAllExitCodeContextE(t, context.Background(), options)
 	if errExitCode != nil {
 		t.Fatal(errExitCode)
 	}
@@ -116,9 +117,9 @@ func TestAssertPlanAllExitCodeNoError(t *testing.T) {
 	assert.Equal(t, 2, getExitCode)
 	assertPlanAllExitCode(t, getExitCode, true)
 
-	terragrunt.ApplyAll(t, options)
+	terragrunt.ApplyAllContext(t, context.Background(), options)
 
-	getExitCode, errExitCode = terragrunt.PlanAllExitCodeE(t, options)
+	getExitCode, errExitCode = terragrunt.PlanAllExitCodeContextE(t, context.Background(), options)
 	if errExitCode != nil {
 		t.Fatal(errExitCode)
 	}
@@ -139,7 +140,7 @@ func TestAssertPlanAllExitCodeWithError(t *testing.T) {
 		TerragruntBinary: "terragrunt",
 	}
 
-	getExitCode, errExitCode := terragrunt.PlanAllExitCodeE(t, options)
+	getExitCode, errExitCode := terragrunt.PlanAllExitCodeContextE(t, context.Background(), options)
 	require.NoError(t, errExitCode)
 
 	assertPlanAllExitCode(t, getExitCode, false)

--- a/modules/terragrunt/render_test.go
+++ b/modules/terragrunt/render_test.go
@@ -1,6 +1,7 @@
 package terragrunt_test
 
 import (
+	"context"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -17,7 +18,7 @@ func TestRender(t *testing.T) {
 	testFolder, err := files.CopyTerragruntFolderToTemp("testdata/terragrunt-no-error", t.Name())
 	require.NoError(t, err)
 
-	output := terragrunt.Render(t, &terragrunt.Options{
+	output := terragrunt.RenderContext(t, context.Background(), &terragrunt.Options{
 		TerragruntDir:    testFolder,
 		TerragruntBinary: "terragrunt",
 	})
@@ -35,7 +36,7 @@ func TestRenderJSON(t *testing.T) {
 	testFolder, err := files.CopyTerragruntFolderToTemp("testdata/terragrunt-no-error", t.Name())
 	require.NoError(t, err)
 
-	output := terragrunt.RenderJSON(t, &terragrunt.Options{
+	output := terragrunt.RenderJSONContext(t, context.Background(), &terragrunt.Options{
 		TerragruntDir:    testFolder,
 		TerragruntBinary: "terragrunt",
 	})
@@ -68,6 +69,6 @@ func TestRenderE_InvalidConfig(t *testing.T) {
 	tmpDir := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "terragrunt.hcl"), []byte("not_valid!!!"), 0644))
 
-	_, err := terragrunt.RenderE(t, &terragrunt.Options{TerragruntDir: tmpDir})
+	_, err := terragrunt.RenderContextE(t, context.Background(), &terragrunt.Options{TerragruntDir: tmpDir})
 	require.Error(t, err)
 }

--- a/modules/terragrunt/run_all.go
+++ b/modules/terragrunt/run_all.go
@@ -28,12 +28,12 @@ func RunAllContextE(t testing.TestingT, ctx context.Context, options *Options, c
 //
 // Deprecated: Use [RunContext] with the --all flag in tgArgs instead.
 func RunAll(t testing.TestingT, options *Options, command string) string {
-	return RunAllContext(t, context.Background(), options, command)
+	return RunContext(t, context.Background(), options, []string{"--all"}, []string{command})
 }
 
 // RunAllE runs terragrunt run --all -- <command> with the given options and returns stdout/stderr.
 //
 // Deprecated: Use [RunContextE] with the --all flag in tgArgs instead.
 func RunAllE(t testing.TestingT, options *Options, command string) (string, error) {
-	return RunAllContextE(t, context.Background(), options, command)
+	return RunContextE(t, context.Background(), options, []string{"--all"}, []string{command})
 }

--- a/modules/terragrunt/run_all_test.go
+++ b/modules/terragrunt/run_all_test.go
@@ -1,6 +1,7 @@
 package terragrunt_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/gruntwork-io/terratest/modules/core/v2/files"
@@ -20,7 +21,7 @@ func TestRunAll(t *testing.T) {
 	}
 
 	// Test with validate command
-	out := terragrunt.RunAll(t, options, "validate")
+	out := terragrunt.RunContext(t, context.Background(), options, []string{"--all"}, []string{"validate"})
 	require.NotEmpty(t, out)
 }
 
@@ -36,7 +37,7 @@ func TestRunAllE(t *testing.T) {
 	}
 
 	// Test with validate command
-	out, err := terragrunt.RunAllE(t, options, "validate")
+	out, err := terragrunt.RunContextE(t, context.Background(), options, []string{"--all"}, []string{"validate"})
 	require.NoError(t, err)
 	require.NotEmpty(t, out)
 }
@@ -53,7 +54,7 @@ func TestRunAllWithPlan(t *testing.T) {
 	}
 
 	// Test with plan command - verify output contains expected terraform plan text
-	out, err := terragrunt.RunAllE(t, options, "plan")
+	out, err := terragrunt.RunContextE(t, context.Background(), options, []string{"--all"}, []string{"plan"})
 	require.NoError(t, err)
 	require.Contains(t, out, "Changes to Outputs")
 }

--- a/modules/terragrunt/run_test.go
+++ b/modules/terragrunt/run_test.go
@@ -1,6 +1,7 @@
 package terragrunt_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/gruntwork-io/terratest/modules/core/v2/files"
@@ -62,11 +63,11 @@ func TestRunE_EmptyTfArgs(t *testing.T) {
 		TerragruntDir: "/some/path",
 	}
 
-	_, err := terragrunt.RunE(t, options, []string{}, []string{})
+	_, err := terragrunt.RunContextE(t, context.Background(), options, []string{}, []string{})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "tfArgs cannot be empty")
 
-	_, err = terragrunt.RunE(t, options, []string{"--all"}, nil)
+	_, err = terragrunt.RunContextE(t, context.Background(), options, []string{"--all"}, nil)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "tfArgs cannot be empty")
 }
@@ -83,9 +84,9 @@ func TestRun(t *testing.T) {
 		TerragruntBinary: "terragrunt",
 	}
 
-	defer terragrunt.Run(t, options, []string{}, []string{"destroy", "-auto-approve"})
+	defer terragrunt.RunContext(t, context.Background(), options, []string{}, []string{"destroy", "-auto-approve"})
 
-	out := terragrunt.Run(t, options, []string{}, []string{"apply", "-input=false", "-auto-approve"})
+	out := terragrunt.RunContext(t, context.Background(), options, []string{}, []string{"apply", "-input=false", "-auto-approve"})
 	require.Contains(t, out, "Hello, World")
 }
 
@@ -102,7 +103,7 @@ func TestRunE(t *testing.T) {
 	}
 
 	// Run an invalid tf command to trigger an error
-	_, err = terragrunt.RunE(t, options, []string{}, []string{"not-a-real-command"})
+	_, err = terragrunt.RunContextE(t, context.Background(), options, []string{}, []string{"not-a-real-command"})
 	require.Error(t, err)
 }
 
@@ -118,10 +119,10 @@ func TestRunWithTgArgs(t *testing.T) {
 		TerragruntBinary: "terragrunt",
 	}
 
-	defer terragrunt.Run(t, options, []string{}, []string{"destroy", "-auto-approve"})
+	defer terragrunt.RunContext(t, context.Background(), options, []string{}, []string{"destroy", "-auto-approve"})
 
 	// Use --log-level error as a tg arg to verify it's respected
-	out := terragrunt.Run(t, options, []string{"--log-level", "error"}, []string{"apply", "-input=false", "-auto-approve"})
+	out := terragrunt.RunContext(t, context.Background(), options, []string{"--log-level", "error"}, []string{"apply", "-input=false", "-auto-approve"})
 	require.Contains(t, out, "Hello, World")
 	require.NotContains(t, out, "level=info",
 		"With --log-level error, info logs should not appear")
@@ -133,7 +134,7 @@ func TestRunE_ValidationError(t *testing.T) {
 
 	// Missing TerragruntDir
 	options := &terragrunt.Options{}
-	_, err := terragrunt.RunE(t, options, []string{}, []string{"apply"})
+	_, err := terragrunt.RunContextE(t, context.Background(), options, []string{}, []string{"apply"})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "TerragruntDir is required")
 }

--- a/modules/terragrunt/stack_clean_test.go
+++ b/modules/terragrunt/stack_clean_test.go
@@ -1,6 +1,7 @@
 package terragrunt_test
 
 import (
+	"context"
 	"path"
 	"testing"
 
@@ -18,14 +19,14 @@ func TestStackClean(t *testing.T) {
 
 	stackDir := path.Join(testFolder, "live", ".terragrunt-stack")
 
-	terragrunt.StackGenerate(t, &terragrunt.Options{
+	terragrunt.StackGenerateContext(t, context.Background(), &terragrunt.Options{
 		TerragruntDir:    path.Join(testFolder, "live"),
 		TerragruntBinary: "terragrunt",
 	})
 
 	require.DirExists(t, stackDir)
 
-	out := terragrunt.StackClean(t, &terragrunt.Options{
+	out := terragrunt.StackCleanContext(t, context.Background(), &terragrunt.Options{
 		TerragruntDir:    path.Join(testFolder, "live"),
 		TerragruntBinary: "terragrunt",
 	})
@@ -44,7 +45,7 @@ func TestStackCleanE(t *testing.T) {
 	stackDir := path.Join(testFolder, "live", ".terragrunt-stack")
 
 	// First generate the stack to create .terragrunt-stack directory
-	_, err = terragrunt.StackGenerateE(t, &terragrunt.Options{
+	_, err = terragrunt.StackGenerateContextE(t, context.Background(), &terragrunt.Options{
 		TerragruntDir:    path.Join(testFolder, "live"),
 		TerragruntBinary: "terragrunt",
 	})
@@ -54,7 +55,7 @@ func TestStackCleanE(t *testing.T) {
 	require.DirExists(t, stackDir)
 
 	// Clean the stack
-	out, err := terragrunt.StackCleanE(t, &terragrunt.Options{
+	out, err := terragrunt.StackCleanContextE(t, context.Background(), &terragrunt.Options{
 		TerragruntDir:    path.Join(testFolder, "live"),
 		TerragruntBinary: "terragrunt",
 	})
@@ -80,7 +81,7 @@ func TestStackCleanNonExistentStack(t *testing.T) {
 	require.NoDirExists(t, stackDir)
 
 	// Clean should succeed even if .terragrunt-stack doesn't exist
-	_, err = terragrunt.StackCleanE(t, &terragrunt.Options{
+	_, err = terragrunt.StackCleanContextE(t, context.Background(), &terragrunt.Options{
 		TerragruntDir:    path.Join(testFolder, "live"),
 		TerragruntBinary: "terragrunt",
 	})
@@ -97,7 +98,7 @@ func TestStackCleanAfterRun(t *testing.T) {
 	stackDir := path.Join(testFolder, "live", ".terragrunt-stack")
 
 	// Initialize the stack
-	_, err = terragrunt.InitE(t, &terragrunt.Options{
+	_, err = terragrunt.InitContextE(t, context.Background(), &terragrunt.Options{
 		TerragruntDir:    path.Join(testFolder, "live"),
 		TerragruntBinary: "terragrunt",
 		TerraformArgs:    []string{"-upgrade=true"},
@@ -105,7 +106,7 @@ func TestStackCleanAfterRun(t *testing.T) {
 	require.NoError(t, err)
 
 	// Run plan to generate the stack
-	_, err = terragrunt.StackRunE(t, &terragrunt.Options{
+	_, err = terragrunt.StackRunContextE(t, context.Background(), &terragrunt.Options{
 		TerragruntDir:    path.Join(testFolder, "live"),
 		TerragruntBinary: "terragrunt",
 		TerraformArgs:    []string{"plan"},
@@ -116,7 +117,7 @@ func TestStackCleanAfterRun(t *testing.T) {
 	require.DirExists(t, stackDir)
 
 	// Clean the stack
-	out, err := terragrunt.StackCleanE(t, &terragrunt.Options{
+	out, err := terragrunt.StackCleanContextE(t, context.Background(), &terragrunt.Options{
 		TerragruntDir:    path.Join(testFolder, "live"),
 		TerragruntBinary: "terragrunt",
 	})

--- a/modules/terragrunt/stack_generate_test.go
+++ b/modules/terragrunt/stack_generate_test.go
@@ -1,6 +1,7 @@
 package terragrunt_test
 
 import (
+	"context"
 	"path"
 	"strings"
 	"testing"
@@ -17,13 +18,13 @@ func TestStackGenerate(t *testing.T) {
 		"testdata/terragrunt-stack-init", t.Name())
 	require.NoError(t, err)
 
-	terragrunt.Init(t, &terragrunt.Options{
+	terragrunt.InitContext(t, context.Background(), &terragrunt.Options{
 		TerragruntDir:    path.Join(testFolder, "live"),
 		TerragruntBinary: "terragrunt",
 		TerraformArgs:    []string{"-upgrade=true"},
 	})
 
-	out := terragrunt.StackGenerate(t, &terragrunt.Options{
+	out := terragrunt.StackGenerateContext(t, context.Background(), &terragrunt.Options{
 		TerragruntDir:    path.Join(testFolder, "live"),
 		TerragruntBinary: "terragrunt",
 	})
@@ -40,7 +41,7 @@ func TestStackGenerateE(t *testing.T) {
 	require.NoError(t, err)
 
 	// First initialize the stack
-	_, err = terragrunt.InitE(t, &terragrunt.Options{
+	_, err = terragrunt.InitContextE(t, context.Background(), &terragrunt.Options{
 		TerragruntDir:    path.Join(testFolder, "live"),
 		TerragruntBinary: "terragrunt",
 		TerraformArgs:    []string{"-upgrade=true"},
@@ -48,7 +49,7 @@ func TestStackGenerateE(t *testing.T) {
 	require.NoError(t, err)
 
 	// Then generate the stack
-	out, err := terragrunt.StackGenerateE(t, &terragrunt.Options{
+	out, err := terragrunt.StackGenerateContextE(t, context.Background(), &terragrunt.Options{
 		TerragruntDir:    path.Join(testFolder, "live"),
 		TerragruntBinary: "terragrunt",
 	})
@@ -74,7 +75,7 @@ func TestStackGenerateNonExistentDir(t *testing.T) {
 	t.Parallel()
 
 	// Test with non-existent directory
-	_, err := terragrunt.StackGenerateE(t, &terragrunt.Options{
+	_, err := terragrunt.StackGenerateContextE(t, context.Background(), &terragrunt.Options{
 		TerragruntDir:    "/non/existent/path",
 		TerragruntBinary: "terragrunt",
 	})
@@ -95,14 +96,14 @@ func TestStackGenerateWithArgs(t *testing.T) {
 	require.NoError(t, err)
 
 	// Initialize first
-	_, err = terragrunt.InitE(t, &terragrunt.Options{
+	_, err = terragrunt.InitContextE(t, context.Background(), &terragrunt.Options{
 		TerragruntDir:    path.Join(testFolder, "live"),
 		TerragruntBinary: "terragrunt",
 	})
 	require.NoError(t, err)
 
 	// Generate with TerragruntArgs
-	out, err := terragrunt.StackGenerateE(t, &terragrunt.Options{
+	out, err := terragrunt.StackGenerateContextE(t, context.Background(), &terragrunt.Options{
 		TerragruntDir:    path.Join(testFolder, "live"),
 		TerragruntBinary: "terragrunt",
 		TerragruntArgs:   []string{"--log-level", "error"},

--- a/modules/terragrunt/stack_output_test.go
+++ b/modules/terragrunt/stack_output_test.go
@@ -1,6 +1,7 @@
 package terragrunt_test
 
 import (
+	"context"
 	"encoding/json"
 	"strings"
 	"testing"
@@ -28,7 +29,7 @@ func TestStackOutputIntegration(t *testing.T) {
 	}
 
 	// Initialize and apply tg using stack commands
-	_, err = terragrunt.InitE(t, options)
+	_, err = terragrunt.InitContextE(t, context.Background(), options)
 	require.NoError(t, err)
 
 	applyOptions := &terragrunt.Options{
@@ -37,7 +38,7 @@ func TestStackOutputIntegration(t *testing.T) {
 		Logger:           logger.Discard,
 		TerraformArgs:    []string{"apply"}, // stack run auto-approves by default
 	}
-	_, err = terragrunt.StackRunE(t, applyOptions)
+	_, err = terragrunt.StackRunContextE(t, context.Background(), applyOptions)
 	require.NoError(t, err)
 
 	// Clean up after test
@@ -48,11 +49,11 @@ func TestStackOutputIntegration(t *testing.T) {
 			Logger:           logger.Discard,
 			TerraformArgs:    []string{"destroy"}, // stack run auto-approves by default
 		}
-		_, _ = terragrunt.StackRunE(t, destroyOptions)
+		_, _ = terragrunt.StackRunContextE(t, context.Background(), destroyOptions)
 	}()
 
 	// Test string stack output - get output from mother unit
-	strOutput := terragrunt.StackOutput(t, options, "mother")
+	strOutput := terragrunt.StackOutputContext(t, context.Background(), options, "mother")
 	assert.Contains(t, strOutput, "./test.txt")
 
 	// Test getting stack output as JSON using the StackOutputJSON function
@@ -62,12 +63,12 @@ func TestStackOutputIntegration(t *testing.T) {
 		Logger:           logger.Discard,
 	}
 
-	strOutputJSON := terragrunt.StackOutputJSON(t, jsonOptions, "mother")
+	strOutputJSON := terragrunt.StackOutputJSONContext(t, context.Background(), jsonOptions, "mother")
 	// The JSON output for a single value should still be cleaned to just show the value
 	assert.Contains(t, strOutputJSON, "./test.txt")
 
 	// Test getting all stack outputs as JSON
-	allOutputsJSON := terragrunt.StackOutputJSON(t, jsonOptions, "")
+	allOutputsJSON := terragrunt.StackOutputJSONContext(t, context.Background(), jsonOptions, "")
 	require.NotEmpty(t, allOutputsJSON)
 
 	// For JSON output of all outputs, we should get valid JSON
@@ -114,7 +115,7 @@ func TestStackOutputErrorHandling(t *testing.T) {
 	}
 
 	// Initialize and apply tg using stack commands
-	_, err = terragrunt.InitE(t, options)
+	_, err = terragrunt.InitContextE(t, context.Background(), options)
 	require.NoError(t, err)
 
 	applyOptions := &terragrunt.Options{
@@ -123,7 +124,7 @@ func TestStackOutputErrorHandling(t *testing.T) {
 		Logger:           logger.Discard,
 		TerraformArgs:    []string{"apply"}, // stack run auto-approves by default
 	}
-	_, err = terragrunt.StackRunE(t, applyOptions)
+	_, err = terragrunt.StackRunContextE(t, context.Background(), applyOptions)
 	require.NoError(t, err)
 
 	// Clean up after test
@@ -134,11 +135,11 @@ func TestStackOutputErrorHandling(t *testing.T) {
 			Logger:           logger.Discard,
 			TerraformArgs:    []string{"destroy"}, // stack run auto-approves by default
 		}
-		_, _ = terragrunt.StackRunE(t, destroyOptions)
+		_, _ = terragrunt.StackRunContextE(t, context.Background(), destroyOptions)
 	}()
 
 	// Test that non-existent stack output returns error or empty string
-	output, err := terragrunt.StackOutputE(t, options, "non_existent_output")
+	output, err := terragrunt.StackOutputContextE(t, context.Background(), options, "non_existent_output")
 	// Tg stack output might return empty string for non-existent outputs
 	// rather than an error, so we need to handle both cases
 	if err != nil {
@@ -164,7 +165,7 @@ func TestStackOutputAll(t *testing.T) {
 	}
 
 	// Initialize and apply tg using stack commands
-	_, err = terragrunt.InitE(t, options)
+	_, err = terragrunt.InitContextE(t, context.Background(), options)
 	require.NoError(t, err)
 
 	applyOptions := &terragrunt.Options{
@@ -173,7 +174,7 @@ func TestStackOutputAll(t *testing.T) {
 		Logger:           logger.Discard,
 		TerraformArgs:    []string{"apply"}, // stack run auto-approves by default
 	}
-	_, err = terragrunt.StackRunE(t, applyOptions)
+	_, err = terragrunt.StackRunContextE(t, context.Background(), applyOptions)
 	require.NoError(t, err)
 
 	// Clean up after test
@@ -184,11 +185,11 @@ func TestStackOutputAll(t *testing.T) {
 			Logger:           logger.Discard,
 			TerraformArgs:    []string{"destroy"}, // stack run auto-approves by default
 		}
-		_, _ = terragrunt.StackRunE(t, destroyOptions)
+		_, _ = terragrunt.StackRunContextE(t, context.Background(), destroyOptions)
 	}()
 
 	// Test StackOutputAll - get all outputs as a map
-	allOutputs := terragrunt.StackOutputAll(t, options)
+	allOutputs := terragrunt.StackOutputAllContext(t, context.Background(), options)
 	require.NotEmpty(t, allOutputs)
 
 	// Verify expected outputs are present
@@ -218,7 +219,7 @@ func TestStackOutputListAll(t *testing.T) {
 	}
 
 	// Initialize and apply using stack commands
-	_, err = terragrunt.InitE(t, options)
+	_, err = terragrunt.InitContextE(t, context.Background(), options)
 	require.NoError(t, err)
 
 	applyOptions := &terragrunt.Options{
@@ -227,7 +228,7 @@ func TestStackOutputListAll(t *testing.T) {
 		Logger:           logger.Discard,
 		TerraformArgs:    []string{"apply"},
 	}
-	_, err = terragrunt.StackRunE(t, applyOptions)
+	_, err = terragrunt.StackRunContextE(t, context.Background(), applyOptions)
 	require.NoError(t, err)
 
 	// Clean up after test
@@ -238,11 +239,11 @@ func TestStackOutputListAll(t *testing.T) {
 			Logger:           logger.Discard,
 			TerraformArgs:    []string{"destroy"},
 		}
-		_, _ = terragrunt.StackRunE(t, destroyOptions)
+		_, _ = terragrunt.StackRunContextE(t, context.Background(), destroyOptions)
 	}()
 
 	// Test StackOutputListAll - get all output keys
-	keys := terragrunt.StackOutputListAll(t, options)
+	keys := terragrunt.StackOutputListAllContext(t, context.Background(), options)
 	require.NotEmpty(t, keys)
 
 	// Verify expected keys are present
@@ -269,7 +270,7 @@ func TestStackOutputListAllE(t *testing.T) {
 		Logger:           logger.Discard,
 	}
 
-	_, err = terragrunt.InitE(t, options)
+	_, err = terragrunt.InitContextE(t, context.Background(), options)
 	require.NoError(t, err)
 
 	applyOptions := &terragrunt.Options{
@@ -278,7 +279,7 @@ func TestStackOutputListAllE(t *testing.T) {
 		Logger:           logger.Discard,
 		TerraformArgs:    []string{"apply"},
 	}
-	_, err = terragrunt.StackRunE(t, applyOptions)
+	_, err = terragrunt.StackRunContextE(t, context.Background(), applyOptions)
 	require.NoError(t, err)
 
 	defer func() {
@@ -288,10 +289,10 @@ func TestStackOutputListAllE(t *testing.T) {
 			Logger:           logger.Discard,
 			TerraformArgs:    []string{"destroy"},
 		}
-		_, _ = terragrunt.StackRunE(t, destroyOptions)
+		_, _ = terragrunt.StackRunContextE(t, context.Background(), destroyOptions)
 	}()
 
-	keys, err := terragrunt.StackOutputListAllE(t, options)
+	keys, err := terragrunt.StackOutputListAllContextE(t, context.Background(), options)
 	require.NoError(t, err)
 	require.NotEmpty(t, keys)
 	require.Contains(t, keys, "mother")

--- a/modules/terragrunt/stack_run_test.go
+++ b/modules/terragrunt/stack_run_test.go
@@ -1,6 +1,7 @@
 package terragrunt_test
 
 import (
+	"context"
 	"path"
 	"testing"
 
@@ -16,13 +17,13 @@ func TestStackRun(t *testing.T) {
 		"testdata/terragrunt-stack-init", t.Name())
 	require.NoError(t, err)
 
-	terragrunt.Init(t, &terragrunt.Options{
+	terragrunt.InitContext(t, context.Background(), &terragrunt.Options{
 		TerragruntDir:    path.Join(testFolder, "live"),
 		TerragruntBinary: "terragrunt",
 		TerraformArgs:    []string{"-upgrade=true"},
 	})
 
-	out := terragrunt.StackRun(t, &terragrunt.Options{
+	out := terragrunt.StackRunContext(t, context.Background(), &terragrunt.Options{
 		TerragruntDir:    path.Join(testFolder, "live"),
 		TerragruntBinary: "terragrunt",
 		TerraformArgs:    []string{"plan"},
@@ -40,7 +41,7 @@ func TestStackRunE(t *testing.T) {
 	require.NoError(t, err)
 
 	// First initialize the stack
-	_, err = terragrunt.InitE(t, &terragrunt.Options{
+	_, err = terragrunt.InitContextE(t, context.Background(), &terragrunt.Options{
 		TerragruntDir:    path.Join(testFolder, "live"),
 		TerragruntBinary: "terragrunt",
 		TerraformArgs:    []string{"-upgrade=true"},
@@ -48,7 +49,7 @@ func TestStackRunE(t *testing.T) {
 	require.NoError(t, err)
 
 	// Then run plan on the stack
-	out, err := terragrunt.StackRunE(t, &terragrunt.Options{
+	out, err := terragrunt.StackRunContextE(t, context.Background(), &terragrunt.Options{
 		TerragruntDir:    path.Join(testFolder, "live"),
 		TerragruntBinary: "terragrunt",
 		TerraformArgs:    []string{"plan"},
@@ -79,7 +80,7 @@ func TestStackRunPlanWithNoColor(t *testing.T) {
 	require.NoError(t, err)
 
 	// First initialize the stack
-	_, err = terragrunt.InitE(t, &terragrunt.Options{
+	_, err = terragrunt.InitContextE(t, context.Background(), &terragrunt.Options{
 		TerragruntDir:    path.Join(testFolder, "live"),
 		TerragruntBinary: "terragrunt",
 		TerraformArgs:    []string{"-upgrade=true"},
@@ -87,7 +88,7 @@ func TestStackRunPlanWithNoColor(t *testing.T) {
 	require.NoError(t, err)
 
 	// Run plan with no-color option
-	out, err := terragrunt.StackRunE(t, &terragrunt.Options{
+	out, err := terragrunt.StackRunContextE(t, context.Background(), &terragrunt.Options{
 		TerragruntDir:    path.Join(testFolder, "live"),
 		TerragruntBinary: "terragrunt",
 		TerragruntArgs:   []string{"--no-color"},
@@ -108,7 +109,7 @@ func TestStackRunNonExistentDir(t *testing.T) {
 	t.Parallel()
 
 	// Test with non-existent directory
-	_, err := terragrunt.StackRunE(t, &terragrunt.Options{
+	_, err := terragrunt.StackRunContextE(t, context.Background(), &terragrunt.Options{
 		TerragruntDir:    "/non/existent/path",
 		TerragruntBinary: "terragrunt",
 	})
@@ -119,7 +120,7 @@ func TestStackRunEmptyOptions(t *testing.T) {
 	t.Parallel()
 
 	// Test with minimal options to verify default behavior
-	_, err := terragrunt.StackRunE(t, &terragrunt.Options{})
+	_, err := terragrunt.StackRunContextE(t, context.Background(), &terragrunt.Options{})
 	require.Error(t, err)
 	// Should fail due to missing TerragruntDir
 }

--- a/modules/terragrunt/terragrunt_e2e_test.go
+++ b/modules/terragrunt/terragrunt_e2e_test.go
@@ -1,6 +1,7 @@
 package terragrunt_test
 
 import (
+	"context"
 	"encoding/json"
 	"path/filepath"
 	"strings"
@@ -31,27 +32,27 @@ func TestTerragruntEndToEndIntegration(t *testing.T) {
 	// Step 1: Plan with exit code (original bug scenario from issue #1609)
 	// This is the exact scenario from the bug report
 	t.Log("Step 1: Testing PlanAllExitCode with TerragruntArgs (original bug scenario)")
-	exitCode, err := terragrunt.PlanAllExitCodeE(t, options)
+	exitCode, err := terragrunt.PlanAllExitCodeContextE(t, context.Background(), options)
 	require.NoError(t, err)
 	// Should show changes (exit code 2) since nothing has been applied yet
 	require.Equal(t, 2, exitCode, "Plan should detect changes")
 
 	// Step 2: Apply all modules
 	t.Log("Step 2: Testing ApplyAll with TerragruntArgs")
-	applyOutput := terragrunt.ApplyAll(t, options)
+	applyOutput := terragrunt.ApplyAllContext(t, context.Background(), options)
 	require.NotEmpty(t, applyOutput)
 	// Verify TerragruntArgs: should not see info-level logs
 	require.NotContains(t, applyOutput, "level=info", "TerragruntArgs should suppress info logs")
 
 	// Step 3: Plan again - should show no changes (exit code 0)
 	t.Log("Step 3: Verifying infrastructure is up-to-date")
-	exitCode, err = terragrunt.PlanAllExitCodeE(t, options)
+	exitCode, err = terragrunt.PlanAllExitCodeContextE(t, context.Background(), options)
 	require.NoError(t, err)
 	require.Equal(t, 0, exitCode, "Plan should show no changes after apply")
 
 	// Step 4: Clean up - Destroy all
 	t.Log("Step 4: Testing DestroyAll with TerragruntArgs")
-	destroyOutput := terragrunt.DestroyAll(t, options)
+	destroyOutput := terragrunt.DestroyAllContext(t, context.Background(), options)
 	require.NotEmpty(t, destroyOutput)
 	// Verify TerragruntArgs: should not see info-level logs
 	require.NotContains(t, destroyOutput, "level=info", "TerragruntArgs should suppress info logs")
@@ -75,13 +76,13 @@ func TestStackEndToEndIntegration(t *testing.T) {
 
 	// Step 1: Initialize stack
 	t.Log("Step 1: Initializing stack with TerragruntArgs")
-	output, err := terragrunt.InitE(t, options)
+	output, err := terragrunt.InitContextE(t, context.Background(), options)
 	require.NoError(t, err)
 	require.NotContains(t, output, "level=info", "TerragruntArgs should suppress info logs")
 
 	// Step 2: Generate stack
 	t.Log("Step 2: Generating stack with TerragruntArgs")
-	genOutput, err := terragrunt.StackGenerateE(t, options)
+	genOutput, err := terragrunt.StackGenerateContextE(t, context.Background(), options)
 	require.NoError(t, err)
 	require.NotContains(t, genOutput, "level=info", "TerragruntArgs should suppress info logs")
 
@@ -90,14 +91,14 @@ func TestStackEndToEndIntegration(t *testing.T) {
 
 	runOptions := *options
 	runOptions.TerraformArgs = []string{"plan"}
-	planOutput, err := terragrunt.StackRunE(t, &runOptions)
+	planOutput, err := terragrunt.StackRunContextE(t, context.Background(), &runOptions)
 	require.NoError(t, err)
 	// Check for common plan indicator (works with both Terraform and OpenTofu)
 	require.Contains(t, planOutput, "will perform")
 
 	// Step 4: Clean stack
 	t.Log("Step 4: Cleaning stack")
-	_, err = terragrunt.StackCleanE(t, options)
+	_, err = terragrunt.StackCleanContextE(t, context.Background(), options)
 	require.NoError(t, err)
 
 	t.Log("Stack integration test completed successfully")
@@ -113,10 +114,10 @@ func TestOutputAllJSONEndToEnd(t *testing.T) {
 
 	options := &terragrunt.Options{TerragruntDir: testFolder}
 
-	terragrunt.ApplyAll(t, options)
-	defer terragrunt.DestroyAll(t, options)
+	terragrunt.ApplyAllContext(t, context.Background(), options)
+	defer terragrunt.DestroyAllContext(t, context.Background(), options)
 
-	output := terragrunt.OutputAllJSON(t, options)
+	output := terragrunt.OutputAllJSONContext(t, context.Background(), options)
 
 	// Contains module outputs, no log noise
 	require.Contains(t, output, `"value": "foo"`)

--- a/modules/terragrunt/validate_test.go
+++ b/modules/terragrunt/validate_test.go
@@ -1,6 +1,7 @@
 package terragrunt_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/gruntwork-io/terratest/modules/core/v2/files"
@@ -14,7 +15,7 @@ func TestValidateAll(t *testing.T) {
 	testFolder, err := files.CopyTerragruntFolderToTemp("testdata/terragrunt-multi-plan", t.Name())
 	require.NoError(t, err)
 
-	terragrunt.ValidateAll(t, &terragrunt.Options{
+	terragrunt.ValidateAllContext(t, context.Background(), &terragrunt.Options{
 		TerragruntDir:    testFolder,
 		TerragruntBinary: "terragrunt",
 	})
@@ -26,7 +27,7 @@ func TestValidate(t *testing.T) {
 	testFolder, err := files.CopyTerragruntFolderToTemp("testdata/terragrunt-no-error", t.Name())
 	require.NoError(t, err)
 
-	terragrunt.Validate(t, &terragrunt.Options{
+	terragrunt.ValidateContext(t, context.Background(), &terragrunt.Options{
 		TerragruntDir:    testFolder,
 		TerragruntBinary: "terragrunt",
 	})
@@ -38,7 +39,7 @@ func TestInitAndValidate(t *testing.T) {
 	testFolder, err := files.CopyTerragruntFolderToTemp("testdata/terragrunt-no-error", t.Name())
 	require.NoError(t, err)
 
-	out := terragrunt.InitAndValidate(t, &terragrunt.Options{
+	out := terragrunt.InitAndValidateContext(t, context.Background(), &terragrunt.Options{
 		TerragruntDir:    testFolder,
 		TerragruntBinary: "terragrunt",
 	})


### PR DESCRIPTION
Part 1 of removing the v1 deprecated API in v2 (staged migrate-then-delete).

This PR moves every in-repo call site off the deprecated non-context function wrappers to their Context variants, inserting context.Background() to preserve behavior. The deprecated wrappers are intentionally left in place, so this change builds green on its own. The wrappers are deleted in the follow-up PR (#1870), which is then a pure removal with no callers to chase.

Scope:
- 766 call sites across 100 files (production, tests, examples). Done with an AST codemod that derives each transform from the wrapper body and applies it as a surgical text splice of the call span only, so comments and formatting are preserved exactly.
- Verified: all 16 submodules plus root build and test-compile green; modularization gates pass; zero comment lines and zero blank lines changed.

Two intentional behavior fixes (called out, not behavior-preserving):
- FetchFilesFromInstanceContextE (modules/aws/ec2-files.go) and GetStorageDNSStringContextE (modules/azure/storage.go) both accept a ctx but were dropping it in favor of a background context. The old deprecated wrappers hid this; the migration made it explicit. They now propagate ctx, so cancellation and timeouts work as documented.

Not in this PR:
- Deleting the deprecated symbols (#1870).
- The 3 aws deprecated error types and the gcp interface methods (handled in #1870, they need alias promotion).
- core/v2/collections removal (separate: its usage is Intersection/Subtract/Keys, which stdlib slices does not cover).

Stacked on #1868 (now merged).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed deprecated non-context/E wrappers that could incorrectly recurse, ensuring they now delegate to the intended context-aware implementations (with `context.Background()` for non-context calls).
  - Improved client/suffix construction paths in several modules to use context-aware lookups where applicable.

- **Tests**
  - Updated unit and integration tests across AWS, Azure, GCP, Kubernetes, Helm, Terraform, Terragrunt, HTTP, SSH, and storage to use `*Context*` APIs consistently.
  - Kept existing assertions and error expectations, with explicit context propagation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->