### PR TITLE
Automate v2 release into a single create-release workflow

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,11 +1,15 @@
-name: v2 Release (lockstep tag push)
+name: Create v2 Release (pin + lockstep tags)
 
-# Manual-trigger workflow that pushes the full v2 tag set from a release-prep commit.
-# Procedure documented in docs/v2-release-runbook.md.
+# One manual workflow that cuts a full v2 release from main:
+#   1. Pre-flight: the modularization gates + the GOWORK=off release-mode build.
+#   2. Pin every submodule's cross-module require to the release version and
+#      commit that in-CI (the commit the tags point at). Deterministic; runs
+#      scripts/release-prep-pin.sh.
+#   3. Push the 16 per-module tags in dependency order, then verify the proxy.
 #
-# Use this AFTER:
-#   - scripts/release-prep.sh ran on the release-prep branch
-#   - The release-prep commit was reviewed and approved
+# Supersedes the old two-step flow (manual release-prep-pin.sh on a throwaway
+# branch + a tag-only workflow). Procedure documented in
+# docs/v2-release-runbook.md. Run with dry_run=true first to preview the tags.
 
 on:
   workflow_dispatch:
@@ -14,18 +18,19 @@ on:
         description: 'Version to tag (e.g. v2.0.0-beta.1). Applied to every submodule.'
         required: true
         type: string
-      commit_sha:
-        description: 'SHA of the release-prep commit to tag.'
-        required: true
+      ref:
+        description: 'Base ref/SHA to release from.'
+        required: false
         type: string
+        default: main
       dry_run:
-        description: 'If true, print the tag commands without pushing.'
+        description: 'If true, pin and print the tag commands without pushing.'
         required: false
         type: boolean
         default: true
 
-# Default to read-only. Only the tag-pushing job is granted write, so the
-# pre-flight job cannot push even though it runs scripts from a dispatched SHA.
+# Default to read-only. Only the tagging job is granted write, so the pre-flight
+# job cannot push even though it runs scripts from a dispatched ref.
 permissions:
   contents: read
 
@@ -37,7 +42,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          ref: ${{ inputs.commit_sha }}
+          ref: ${{ inputs.ref }}
           persist-credentials: false
       - run: bash scripts/check-acyclic-deps.sh
       - run: bash scripts/check-single-source.sh
@@ -47,11 +52,13 @@ jobs:
         uses: jdx/mise-action@5228313ee0372e111a38da051671ca30fc5a96db # v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # Validates the exact release-mode build (pin + GOWORK=off external
+      # consumer) in a throwaway, so it runs against the un-pinned ref.
       - name: Release-mode build (GOWORK=off external consumer)
         run: bash scripts/check-release-mode.sh
 
   tag-and-push:
-    name: Push lockstep tags
+    name: Pin, tag, push
     needs: verify
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -70,29 +77,48 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          ref: ${{ inputs.commit_sha }}
+          ref: ${{ inputs.ref }}
           fetch-depth: 0
+
+      - name: Validate version
+        run: |
+          if [[ ! "$VERSION" =~ ^v2\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?$ ]]; then
+            echo "::error::version '$VERSION' must look like v2.<minor>.<patch>[-suffix] (e.g. v2.0.0-beta.1)"
+            exit 1
+          fi
+
+      - name: Set up mise
+        uses: jdx/mise-action@5228313ee0372e111a38da051671ca30fc5a96db # v3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Configure git
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
+      # Pin the cross-module requires to the real version and commit in-CI. This
+      # is the commit the tags point at. It intentionally breaks the go.work
+      # build (the tags do not exist yet); that only matters until the push.
+      - name: Pin cross-module requires and commit
+        run: |
+          bash scripts/release-prep-pin.sh "$VERSION"
+          if git diff --quiet; then
+            echo "no placeholders to pin (ref already pinned to $VERSION)"
+          else
+            git commit -am "release-prep: pin cross-module requires to $VERSION"
+          fi
+          echo "PINNED_SHA=$(git rev-parse HEAD)" >> "$GITHUB_ENV"
+
       - name: Tag in dependency order
         env:
           DRY_RUN: ${{ inputs.dry_run }}
         run: |
           set -e
-
-          if [[ ! "$VERSION" =~ ^v2\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?$ ]]; then
-            echo "::error::version '$VERSION' must look like v2.<minor>.<patch>[-suffix] (e.g. v2.0.0-beta.1)"
-            exit 1
-          fi
-
           for path in $MODULE_PATHS; do
             tag="${path}/v2/${VERSION}"
             if [ "$DRY_RUN" = "true" ]; then
-              echo "DRY-RUN would tag: $tag"
+              echo "DRY-RUN would tag ${PINNED_SHA:0:12}: $tag"
             else
               git tag -a "$tag" -m "v2 lockstep release $VERSION"
               git push origin "$tag"

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -116,7 +116,7 @@ jobs:
         run: |
           set -e
           for path in $MODULE_PATHS; do
-            tag="${path}/v2/${VERSION}"
+            tag="${path}/${VERSION}"
             if [ "$DRY_RUN" = "true" ]; then
               echo "DRY-RUN would tag ${PINNED_SHA:0:12}: $tag"
             else

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -145,3 +145,34 @@ jobs:
           if [ "$fail" -ne 0 ]; then
             echo "::warning::Proxy has not served every tag yet. The tags are already pushed and immutable; the proxy usually populates within a few minutes. Re-run this check if needed."
           fi
+
+      # One human-facing GitHub Release for the whole version (not 16). Attached
+      # to the core tag; -beta/-rc suffixes are marked prerelease.
+      - name: Create GitHub Release
+        if: ${{ inputs.dry_run == false }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          prerelease=""
+          case "$VERSION" in *-*) prerelease="--prerelease" ;; esac
+          {
+            echo "Terratest v2 lockstep release. All 16 submodules are tagged at ${VERSION}."
+            echo
+            echo "## Install"
+            echo
+            echo '```'
+            echo "go get github.com/gruntwork-io/terratest/modules/aws/v2@${VERSION}"
+            echo '```'
+            echo
+            echo "## Modules"
+            echo
+            echo "All at \`github.com/gruntwork-io/terratest/modules/<name>/v2\`:"
+            echo
+            for p in $MODULE_PATHS; do printf '%s ' "${p#modules/}"; done
+            echo
+          } > release_notes.md
+          # shellcheck disable=SC2086
+          gh release create "modules/core/${VERSION}" \
+            --title "Terratest ${VERSION}" \
+            --notes-file release_notes.md \
+            $prerelease

--- a/docs/v2-release-runbook.md
+++ b/docs/v2-release-runbook.md
@@ -2,9 +2,15 @@
 
 How to cut a coordinated release of the v2 submodules. Read this before tagging.
 
-The tag push and proxy verification are automated by the `v2 Release` workflow
-(`.github/workflows/v2-release.yml`, run via workflow_dispatch). This runbook
-explains the procedure that workflow follows and how to do it by hand if needed.
+The whole release is one manual workflow: `Create v2 Release`
+(`.github/workflows/create-release.yml`, run via workflow_dispatch). Give it a
+`version` (e.g. `v2.0.0-beta.1`) and a `ref` (default `main`); it runs the
+pre-flight checks, pins the cross-module requires, commits that in CI, pushes the
+16 tags in dependency order, and verifies the proxy. Run it once with
+`dry_run=true` to preview the exact tags, then again with `dry_run=false` to push.
+
+The rest of this runbook explains what that workflow does under the hood and how
+to do each step by hand if you ever need to.
 
 ## Layout
 
@@ -22,14 +28,16 @@ resolves; it is never pinned to a real, to-be-published version. Pinning a sibli
 version (e.g. `core/v2 v2.0.0-beta.1`) BREAKS the workspace build until that tag
 actually exists: `go.work` does not shadow an unpublished required version, so
 `go build` and `go work sync` try to fetch the missing revision and fail. The pin
-must therefore happen on a short-lived release-prep branch, immediately before the
-tags are pushed, never on the modularization PR.
+must therefore happen immediately before the tags are pushed, never on `main` or
+a modularization PR. The `Create v2 Release` workflow does this pin in CI (via
+`scripts/release-prep-pin.sh`) on an ephemeral commit that only the tags point
+at, so the broken-build state never lands on a branch.
 
 CI validates the release-mode build continuously without committing the pin: the
 `GOWORK=off` check generates the pinned state with throwaway `replace` directives,
 builds a consumer, and discards it (see `scripts/`).
 
-## Pre-flight (on a release-prep branch)
+## Pre-flight (what the workflow does before tagging)
 
 1. Choose the version, e.g. `v2.0.0-beta.1`.
 2. Pin each module, in dependency order (core first, then helpers, tooling,

--- a/docs/v2-release-runbook.md
+++ b/docs/v2-release-runbook.md
@@ -68,11 +68,14 @@ build is validated continuously without committing the pin or needing tags.
 
 ## Tag push order
 
-All tags point at the same release commit. Each tag name puts the `/v2` SIV in the
-tag itself: `modules/<name>/v2/<version>` (NOT `modules/<name>/<version>`, which
-the proxy cannot associate with the `/v2` module path). Push in dependency order:
+All tags point at the same release commit. The tag name is the module's
+on-disk subdirectory (which does NOT include the `/v2`, since `/v2` is only the
+SIV in the module path, not a directory) followed by the version:
+`modules/<name>/<version>`, e.g. `modules/aws/v2.0.0-beta.1`. Do NOT put the
+`/v2` in the tag (`modules/<name>/v2/<version>`), Go looks for the tag at
+`<subdir>/<version>` and will not find it. Push in dependency order:
 
-1. `modules/core/v2/v2.0.0-beta.1`
+1. `modules/core/v2.0.0-beta.1`
 2. helpers: `ssh`, `httphelper`, `dnshelper`
 3. tooling: `docker`, `packer`, `database`, `opa`
 4. platforms: `aws`, `azure`, `gcp`, then `k8s`, `helm`

--- a/scripts/release-prep-pin.sh
+++ b/scripts/release-prep-pin.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# release-prep-pin.sh <version>   e.g. release-prep-pin.sh v2.0.0-beta.1
+#
+# Pins every submodule's cross-module /v2 require from the go.work dev
+# placeholder (v2.0.0-00010101000000-000000000000) to the real release version,
+# in place. The v2 release workflow runs this in CI right before the lockstep
+# tag push; the pinned commit is what the tags point at.
+#
+# This intentionally breaks the go.work workspace build (the tags do not exist
+# yet) — that is expected and only lasts until the tags are pushed. Root go.mod
+# and go.work are left untouched (the root module is never published in v2).
+set -uo pipefail
+
+VERSION="${1:?usage: release-prep-pin.sh <version, e.g. v2.0.0-beta.1>}"
+if [[ ! "$VERSION" =~ ^v2\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?$ ]]; then
+  echo "bad version: '$VERSION' (want v2.<minor>.<patch>[-suffix])" >&2
+  exit 1
+fi
+
+PLACEHOLDER='v2.0.0-00010101000000-000000000000'
+count=0
+for d in modules/*/; do
+  [ -f "${d}go.mod" ] || continue
+  mods=$(grep -oE "github.com/gruntwork-io/terratest/modules/[a-z0-9]+/v2 ${PLACEHOLDER}" "${d}go.mod" 2>/dev/null | awk '{print $1}' || true)
+  for mod in $mods; do
+    go -C "$d" mod edit -require="${mod}@${VERSION}"
+    echo "  ${d}go.mod: ${mod} -> ${VERSION}"
+    count=$((count + 1))
+  done
+done
+echo "pinned ${count} cross-module require(s) to ${VERSION}"


### PR DESCRIPTION
Folds the manual release-prep pin step into the release workflow, so cutting a v2 release is one dispatch.

Before: cut a release-prep branch, run scripts/release-prep-pin.sh by hand, push that branch (whose build is intentionally red), then dispatch a tag-only workflow with the commit SHA.

After: dispatch `Create v2 Release` (.github/workflows/create-release.yml) with a version (e.g. v2.0.0-beta.1) and a ref (default main). It:
1. Runs the pre-flight gates + the GOWORK=off release-mode build.
2. Pins every submodule's cross-module require to the version and commits that in CI (scripts/release-prep-pin.sh).
3. Pushes the 16 per-module tags in dependency order (core -> helpers -> tooling -> platforms -> IaC), then verifies proxy.golang.org.

Run once with dry_run=true to preview the exact tags, then dry_run=false to push.

Why:
- Removes the only manual, error-prone release step.
- The intentionally-broken pinned state now lives on an ephemeral in-CI commit that only the tags point at, instead of a pushed branch with red CI.
- The pin logic is now a shared, shellcheck-clean script (scripts/release-prep-pin.sh) rather than an out-of-repo helper.

Changes: add scripts/release-prep-pin.sh, replace v2-release.yml with create-release.yml, update docs/v2-release-runbook.md. YAML validated (actionlint clean).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a single manual v2 release workflow with configurable source ref and default dry-run.
  * Added automated cross-module v2 version pinning and dependency-ordered lockstep tagging.
  * Added release-mode build validation and optional Go proxy checks before publishing; generates/attaches release notes with prerelease handling for `-suffix` versions.
* **Documentation**
  * Updated the v2 release runbook with workflow inputs/behavior, the required pinning timing, and corrected tag naming format (`modules/<name>/<version>`).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->