### PR TITLE
chore: remove sunset Go Report Card badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Terratest
 
 [![Maintained by Gruntwork.io](https://img.shields.io/badge/maintained%20by-gruntwork.io-%235849a6.svg)](https://gruntwork.io/?ref=repo_terratest)
-[![Go Report Card](https://goreportcard.com/badge/github.com/gruntwork-io/terratest)](https://goreportcard.com/report/github.com/gruntwork-io/terratest)
 [![go.dev reference](https://img.shields.io/badge/go.dev-reference-007d9c?logo=go&logoColor=white&style=flat-square)](https://pkg.go.dev/mod/github.com/gruntwork-io/terratest?tab=overview)
 ![go.mod version](https://img.shields.io/github/go-mod/go-version/gruntwork-io/terratest)
 


### PR DESCRIPTION
Go Report Card has been sunset, so the README badge renders as `retired` and links to a shutdown notice.

There is no successor service. The `go.dev reference` badge already covers the same ground, so the line is just removed. This was the only reference to goreportcard.com in the repo.

Reported in #1875.

## Test plan

Docs only, no code change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the README header badges by replacing the Go Report Card badge with a “Maintained by Gruntwork.io” badge linking to the Gruntwork website.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->