### PR TITLE
feat(gcp): read a bucket's settings back so a test can assert them

### DIFF
--- a/modules/gcp/storage.go
+++ b/modules/gcp/storage.go
@@ -295,6 +295,41 @@ func AssertStorageBucketExistsWithClient(ctx context.Context, client *storage.Cl
 	return nil
 }
 
+// GetStorageBucketAttrsContext returns the settings Google Cloud holds for the given bucket, so a
+// test can assert on what was actually created rather than only that it exists.
+// This will fail the test if there is an error.
+// The ctx parameter supports cancellation and timeouts.
+func GetStorageBucketAttrsContext(t testing.TestingT, ctx context.Context, name string) *storage.BucketAttrs {
+	attrs, err := GetStorageBucketAttrsContextE(t, ctx, name)
+	require.NoError(t, err)
+
+	return attrs
+}
+
+// GetStorageBucketAttrsContextE returns the settings Google Cloud holds for the given bucket, or an
+// error if they cannot be read.
+// The ctx parameter supports cancellation and timeouts.
+func GetStorageBucketAttrsContextE(t testing.TestingT, ctx context.Context, name string) (*storage.BucketAttrs, error) {
+	logger.Default.Logf(t, "Reading attributes of bucket %s", name)
+
+	client, err := newStorageClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	defer func() { _ = client.Close() }()
+
+	return GetStorageBucketAttrsWithClient(ctx, client, name)
+}
+
+// GetStorageBucketAttrsWithClient returns the settings Google Cloud holds for the given bucket using
+// the supplied *storage.Client. Prefer this variant in unit tests where the client is backed by an
+// httptest fake server (see storage_test.go for the pattern).
+// The ctx parameter supports cancellation and timeouts.
+func GetStorageBucketAttrsWithClient(ctx context.Context, client *storage.Client, name string) (*storage.BucketAttrs, error) {
+	return client.Bucket(name).Attrs(ctx)
+}
+
 func newStorageClient(ctx context.Context) (*storage.Client, error) {
 	client, err := storage.NewClient(ctx, withOptions()...)
 	if err != nil {

--- a/modules/gcp/storage_test.go
+++ b/modules/gcp/storage_test.go
@@ -138,3 +138,50 @@ func TestEmptyStorageBucketWithClient(t *testing.T) {
 	require.NoError(t, gcp.EmptyStorageBucketWithClient(context.Background(), client, "b"))
 	assert.ElementsMatch(t, []string{"a", "b"}, deleted)
 }
+
+func TestGetStorageBucketAttrsWithClient(t *testing.T) {
+	t.Parallel()
+
+	// The values are the ones the terraform-google-data-storage bucket module sets, because the
+	// point of reading attributes back is asserting a module configured the bucket it was asked for.
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.True(t, strings.HasSuffix(r.URL.Path, "/b/gw-library-test"))
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"kind":"storage#bucket",
+			"id":"gw-library-test",
+			"name":"gw-library-test",
+			"location":"US",
+			"storageClass":"NEARLINE",
+			"iamConfiguration":{
+				"uniformBucketLevelAccess":{"enabled":true},
+				"publicAccessPrevention":"enforced"
+			},
+			"versioning":{"enabled":true},
+			"labels":{"purpose":"terratest"}
+		}`))
+	})
+
+	attrs, err := gcp.GetStorageBucketAttrsWithClient(context.Background(), newFakeStorageClient(t, handler), "gw-library-test")
+	require.NoError(t, err)
+
+	assert.Equal(t, "gw-library-test", attrs.Name)
+	assert.Equal(t, "US", attrs.Location)
+	assert.Equal(t, "NEARLINE", attrs.StorageClass)
+	assert.True(t, attrs.UniformBucketLevelAccess.Enabled)
+	assert.Equal(t, "enforced", attrs.PublicAccessPrevention.String())
+	assert.True(t, attrs.VersioningEnabled)
+	assert.Equal(t, map[string]string{"purpose": "terratest"}, attrs.Labels)
+}
+
+func TestGetStorageBucketAttrsWithClientMissingBucket(t *testing.T) {
+	t.Parallel()
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+
+	_, err := gcp.GetStorageBucketAttrsWithClient(context.Background(), newFakeStorageClient(t, handler), "gw-library-missing")
+	require.ErrorIs(t, err, storage.ErrBucketNotExist)
+}


### PR DESCRIPTION
## Description

**TL;DR:** A test can now ask Google what a bucket's settings actually are, instead of only whether the bucket exists.

Linear: [LIB-5549](https://linear.app/gruntwork/issue/LIB-5549) · part of [LIB-5548](https://linear.app/gruntwork/issue/LIB-5548)

**Why:** every function in `storage.go` that touched `BucketAttrs` was write-only. A test could watch a module set the wrong storage class and still pass, which makes the module tests worth writing impossible to write.

**What changed**

* **modules/gcp · storage.go**: `GetStorageBucketAttrs` returns the settings Google holds for a bucket, in the `Context` / `ContextE` / `WithClient` triple the rest of the file uses.
* **modules/gcp · storage_test.go**: two cases on the `httptest` fake already in the file, asserting the fields the `terraform-google-data-storage` bucket module sets, and `ErrBucketNotExist` for a missing bucket.
* **Left for later:** nothing. This closes the ticket.
* **Deliberately not handled:** no wrapper type over `*storage.BucketAttrs`. Callers assert on the SDK's own struct, so a field the SDK adds needs no change here.

**Landing it**
* **Rollback:** revert is enough. Nothing calls it inside this repository yet.
* **Rule bent:** none.
* **Seen in production by:** not applicable, this is test-only tooling.

**Validation**
* **Unit**: 2 pass, 0 fail. Both fail on `origin/main`, where the function does not exist.
* **Local stack, end to end**: driven from a terratest suite in `terraform-google-test-library`, which applied the storage bucket module to a real GCP project, read seven settings back through this function, and destroyed the bucket. Mutating one expected value failed exactly that subtest with the live API's value.
* **Not run**: nothing in this repository's CI exercises it against real GCP; the live coverage sits in the library repo's suite.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs. Godoc on all three functions; no prose docs cover this package's function list.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our license policy. No new dependencies.
- [x] Include release notes. Below. Backward compatible: this only adds functions.
- [ ] Make a plan for release of the functionality in this PR. `terraform-google-test-library` pins this by local replace until it is released, so it needs a maintainer to cut one.

## Release Notes (draft)

Added `gcp.GetStorageBucketAttrs`, which returns the settings Google holds for a storage bucket so a test can assert on them.

### Migration Guide

Not applicable. Nothing existing changes behaviour.