### PR TITLE
feat(gcp): read a Pub/Sub topic's settings back so a test can assert them (LIB-5570)

### DIFF
--- a/modules/gcp/pubsub.go
+++ b/modules/gcp/pubsub.go
@@ -2,6 +2,7 @@ package gcp
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"cloud.google.com/go/pubsub/v2"
@@ -54,6 +55,53 @@ func AssertTopicExistsWithClient(ctx context.Context, client *pubsub.Client, top
 	}
 
 	return nil
+}
+
+// GetTopicAttrs returns the settings Google Cloud holds for the given Pub/Sub topic, so a test can
+// assert on what was actually created rather than only that it exists.
+// This will fail the test if there is an error.
+// The ctx parameter supports cancellation and timeouts.
+func GetTopicAttrs(t testing.TestingT, ctx context.Context, projectID string, topicName string) *pubsubpb.Topic {
+	topic, err := GetTopicAttrsE(t, ctx, projectID, topicName)
+	require.NoError(t, err)
+
+	return topic
+}
+
+// GetTopicAttrsE returns the settings Google Cloud holds for the given Pub/Sub topic.
+// The ctx parameter supports cancellation and timeouts.
+func GetTopicAttrsE(t testing.TestingT, ctx context.Context, projectID string, topicName string) (topic *pubsubpb.Topic, err error) {
+	logger.Default.Logf(t, "Getting settings for Pub/Sub topic %s in project %s", topicName, projectID)
+
+	client, err := newPubSubClient(ctx, projectID)
+	if err != nil {
+		return nil, err
+	}
+
+	defer func() { err = errors.Join(err, client.Close()) }()
+
+	return GetTopicAttrsWithClient(ctx, client, topicName)
+}
+
+// GetTopicAttrsWithClient returns the settings Google Cloud holds for the given Pub/Sub topic
+// using the supplied *pubsub.Client. Prefer this variant in unit tests where the client is backed
+// by a pstest in-memory fake server (see pubsub_test.go for the pattern).
+// The ctx parameter supports cancellation and timeouts.
+func GetTopicAttrsWithClient(ctx context.Context, client *pubsub.Client, topicName string) (*pubsubpb.Topic, error) {
+	projectID := client.Project()
+
+	topic, err := client.TopicAdminClient.GetTopic(ctx, &pubsubpb.GetTopicRequest{
+		Topic: topicResource(projectID, topicName),
+	})
+	if err != nil {
+		if status.Code(err) == codes.NotFound {
+			return nil, fmt.Errorf("Pub/Sub topic %s does not exist in project %s", topicName, projectID)
+		}
+
+		return nil, fmt.Errorf("failed to get settings for Pub/Sub topic %s in project %s: %w", topicName, projectID, err)
+	}
+
+	return topic, nil
 }
 
 // AssertSubscriptionExistsContext checks if the given Pub/Sub subscription exists and fails the test if it does not.

--- a/modules/gcp/pubsub_test.go
+++ b/modules/gcp/pubsub_test.go
@@ -3,14 +3,18 @@ package gcp_test
 import (
 	"context"
 	"testing"
+	"time"
 
 	"cloud.google.com/go/pubsub/v2"
+	"cloud.google.com/go/pubsub/v2/apiv1/pubsubpb"
 	"cloud.google.com/go/pubsub/v2/pstest"
 	"github.com/gruntwork-io/terratest/modules/gcp/v2"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/api/option"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/protobuf/types/known/durationpb"
 )
 
 // newFakePubSubClient wires a *pubsub.Client to the pstest in-memory fake Pub/Sub server —
@@ -52,6 +56,40 @@ func TestPubSubTopicLifecycleWithClient(t *testing.T) {
 	// Re-creating the same topic name within the same run is an error on pstest (matches prod).
 	require.NoError(t, gcp.CreateTopicWithClient(ctx, client, "dup"))
 	require.ErrorContains(t, gcp.CreateTopicWithClient(ctx, client, "dup"), "failed to create")
+}
+
+func TestGetTopicAttrsWithClient(t *testing.T) {
+	t.Parallel()
+
+	client := newFakePubSubClient(t)
+	ctx := context.Background()
+
+	// The error names the topic and the project as well as saying it is absent, so all three
+	// are asserted rather than only the phrase.
+	_, err := gcp.GetTopicAttrsWithClient(ctx, client, "missing")
+	require.ErrorContains(t, err, "does not exist")
+	require.ErrorContains(t, err, "missing")
+	require.ErrorContains(t, err, "test-project")
+
+	// The values are the ones the terraform-google-messaging topic module sets, because the point
+	// of reading settings back is asserting a module configured the topic it was asked for.
+	_, err = client.TopicAdminClient.CreateTopic(ctx, &pubsubpb.Topic{
+		Name:                     "projects/test-project/topics/configured",
+		Labels:                   map[string]string{"purpose": "terratest"},
+		MessageRetentionDuration: durationpb.New(600 * time.Second),
+		MessageStoragePolicy: &pubsubpb.MessageStoragePolicy{
+			AllowedPersistenceRegions: []string{"us-central1"},
+		},
+	})
+	require.NoError(t, err)
+
+	topic, err := gcp.GetTopicAttrsWithClient(ctx, client, "configured")
+	require.NoError(t, err)
+
+	assert.Equal(t, "projects/test-project/topics/configured", topic.GetName())
+	assert.Equal(t, map[string]string{"purpose": "terratest"}, topic.GetLabels())
+	assert.Equal(t, 600*time.Second, topic.GetMessageRetentionDuration().AsDuration())
+	assert.Equal(t, []string{"us-central1"}, topic.GetMessageStoragePolicy().GetAllowedPersistenceRegions())
 }
 
 func TestPubSubSubscriptionLifecycleWithClient(t *testing.T) {

--- a/modules/gcp/storage.go
+++ b/modules/gcp/storage.go
@@ -295,21 +295,21 @@ func AssertStorageBucketExistsWithClient(ctx context.Context, client *storage.Cl
 	return nil
 }
 
-// GetStorageBucketAttrsContext returns the settings Google Cloud holds for the given bucket, so a
+// GetStorageBucketAttrs returns the settings Google Cloud holds for the given bucket, so a
 // test can assert on what was actually created rather than only that it exists.
 // This will fail the test if there is an error.
 // The ctx parameter supports cancellation and timeouts.
-func GetStorageBucketAttrsContext(t testing.TestingT, ctx context.Context, name string) *storage.BucketAttrs {
-	attrs, err := GetStorageBucketAttrsContextE(t, ctx, name)
+func GetStorageBucketAttrs(t testing.TestingT, ctx context.Context, name string) *storage.BucketAttrs {
+	attrs, err := GetStorageBucketAttrsE(t, ctx, name)
 	require.NoError(t, err)
 
 	return attrs
 }
 
-// GetStorageBucketAttrsContextE returns the settings Google Cloud holds for the given bucket, or an
+// GetStorageBucketAttrsE returns the settings Google Cloud holds for the given bucket, or an
 // error if they cannot be read.
 // The ctx parameter supports cancellation and timeouts.
-func GetStorageBucketAttrsContextE(t testing.TestingT, ctx context.Context, name string) (*storage.BucketAttrs, error) {
+func GetStorageBucketAttrsE(t testing.TestingT, ctx context.Context, name string) (attrs *storage.BucketAttrs, err error) {
 	logger.Default.Logf(t, "Reading attributes of bucket %s", name)
 
 	client, err := newStorageClient(ctx)
@@ -317,7 +317,7 @@ func GetStorageBucketAttrsContextE(t testing.TestingT, ctx context.Context, name
 		return nil, err
 	}
 
-	defer func() { _ = client.Close() }()
+	defer func() { err = errors.Join(err, client.Close()) }()
 
 	return GetStorageBucketAttrsWithClient(ctx, client, name)
 }


### PR DESCRIPTION
**TL;DR:** A test holding a Pub/Sub topic name can now read that topic's labels, message retention and storage policy, instead of only asking whether the topic exists.

Closes [LIB-5570](https://linear.app/gruntwork/issue/LIB-5570), part of [LIB-5569](https://linear.app/gruntwork/issue/LIB-5569).

**Why:** the GCP module is write-only about topic settings, so a test can watch a Terraform module set the wrong message retention and still pass. This is the same gap `GetStorageBucketAttrs` closed for buckets in #1890.

**What changed**

* **modules/gcp · pubsub.go**: `GetTopicAttrs`, `GetTopicAttrsE` and `GetTopicAttrsWithClient`, returning the topic as `*pubsubpb.Topic` so a caller asserts on the API's own fields and a field the API adds later needs no change here. It goes through the same `TopicAdminClient` the existence check uses, and the error variant uses a named return so the deferred `Close` is joined onto the error rather than dropped.
* **modules/gcp · pubsub_test.go**: a case against the pstest in-memory fake, creating a topic with the labels, retention and storage policy a real module sets and reading all three back. The missing-topic case asserts the topic name and the project as well as the phrase, so an error that dropped either would fail.
* **modules/gcp · storage.go**: `GetStorageBucketAttrsContext` and its `E` variant lose the `Context` suffix and gain the same joined `Close`. That suffix is for backwards compatibility with v1 names, and both are new in v2 with no v1 name to preserve. Neither is in a release, so nothing outside this repository can be holding the old name.
* **Deliberately not handled:** subscriptions and schemas, where the same read gap exists and each is its own change. Also the twelve other places in `modules/gcp` that discard a `Close` error: those are pre-existing rather than new, so sweeping them belongs in its own change.

**Landing it**
* **Rollback:** revert is enough. Nothing existing changes behaviour; this only adds functions.
* **Rule bent:** none.

**Validation**
* **Unit**: the whole `modules/gcp` package passes, including the new case. It fails on the base branch, where `GetTopicAttrsWithClient` does not exist.
* **Rename**: no reference to `GetStorageBucketAttrsContext` is left anywhere in the repository, and the only caller outside it is [terraform-google-test-library](https://github.com/gruntwork-io-team/terraform-google-test-library), which pins terratest by commit and so keeps building until that pin moves.
* **Not run**: anything against a real project. The consumer that does is [terraform-google-test-library](https://github.com/gruntwork-io-team/terraform-google-test-library), whose suite applies the topic module and reads it back through this function.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for retrieving Google Cloud Pub/Sub topic settings and attributes.
  - Topic details include labels, message-retention duration, and allowed persistence regions.
  - Added clear error reporting when topics are unavailable or retrieval fails, including the affected topic and project.

- **Changes**
  - Simplified the naming of Google Cloud Storage bucket attribute retrieval helpers.

- **Tests**
  - Added coverage for successful topic retrieval and validation of topic attributes and missing-topic errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->