### PR TITLE
feat(gcp): read a BigQuery dataset's settings back so a test can assert them

### DIFF
--- a/modules/gcp/bigquery.go
+++ b/modules/gcp/bigquery.go
@@ -1,0 +1,63 @@
+package gcp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/gruntwork-io/terratest/modules/core/v2/logger"
+	"github.com/gruntwork-io/terratest/modules/core/v2/testing"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/api/bigquery/v2"
+	"google.golang.org/api/googleapi"
+	"google.golang.org/api/option"
+)
+
+// GetBigQueryDatasetAttrs returns the settings Google Cloud holds for the given BigQuery dataset,
+// so a test can assert on what was actually created rather than only that it exists.
+// This will fail the test if there is an error.
+// The ctx parameter supports cancellation and timeouts.
+func GetBigQueryDatasetAttrs(t testing.TestingT, ctx context.Context, projectID string, datasetID string) *bigquery.Dataset {
+	dataset, err := GetBigQueryDatasetAttrsE(t, ctx, projectID, datasetID)
+	require.NoError(t, err)
+
+	return dataset
+}
+
+// GetBigQueryDatasetAttrsE returns the settings Google Cloud holds for the given BigQuery dataset.
+// The ctx parameter supports cancellation and timeouts.
+func GetBigQueryDatasetAttrsE(t testing.TestingT, ctx context.Context, projectID string, datasetID string) (*bigquery.Dataset, error) {
+	logger.Default.Logf(t, "Getting settings for BigQuery dataset %s in project %s", datasetID, projectID)
+
+	service, err := NewBigQueryServiceE(t, ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return GetBigQueryDatasetAttrsWithClient(ctx, service, projectID, datasetID)
+}
+
+// GetBigQueryDatasetAttrsWithClient returns the settings Google Cloud holds for the given BigQuery
+// dataset using the supplied *bigquery.Service. Prefer this variant in unit tests where the service
+// is backed by an httptest fake server (see bigquery_test.go for the pattern).
+// The ctx parameter supports cancellation and timeouts.
+func GetBigQueryDatasetAttrsWithClient(ctx context.Context, service *bigquery.Service, projectID string, datasetID string) (*bigquery.Dataset, error) {
+	dataset, err := service.Datasets.Get(projectID, datasetID).Context(ctx).Do()
+	if err != nil {
+		var apiErr *googleapi.Error
+		if errors.As(err, &apiErr) && apiErr.Code == 404 {
+			return nil, fmt.Errorf("BigQuery dataset %s does not exist in project %s", datasetID, projectID)
+		}
+
+		return nil, fmt.Errorf("failed to get settings for BigQuery dataset %s in project %s: %w", datasetID, projectID, err)
+	}
+
+	return dataset, nil
+}
+
+// NewBigQueryServiceE creates a BigQuery service authenticated the same way every other client in
+// this module is.
+// The ctx parameter supports cancellation and timeouts.
+func NewBigQueryServiceE(t testing.TestingT, ctx context.Context) (*bigquery.Service, error) {
+	return bigquery.NewService(ctx, append(withOptions(), option.WithScopes(bigquery.CloudPlatformScope))...)
+}

--- a/modules/gcp/bigquery_test.go
+++ b/modules/gcp/bigquery_test.go
@@ -1,0 +1,77 @@
+package gcp_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/gcp/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/api/bigquery/v2"
+	"google.golang.org/api/option"
+)
+
+// newFakeBigQueryService points a real *bigquery.Service at a local test server, so the Google
+// transport is exercised rather than a hand-written stand-in for a type we do not own.
+func newFakeBigQueryService(t *testing.T, handler http.Handler) *bigquery.Service {
+	t.Helper()
+
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	service, err := bigquery.NewService(context.Background(),
+		option.WithEndpoint(server.URL), option.WithoutAuthentication())
+	require.NoError(t, err)
+
+	return service
+}
+
+func TestGetBigQueryDatasetAttrsWithClient(t *testing.T) {
+	t.Parallel()
+
+	// The values are the ones the terraform-google-data-analytics dataset module sets, because the
+	// point of reading settings back is asserting a module configured the dataset it was asked for.
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.True(t, strings.HasSuffix(r.URL.Path, "/datasets/gw_library_test"))
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"kind":"bigquery#dataset",
+			"id":"gw-library-test-project:gw_library_test",
+			"datasetReference":{"datasetId":"gw_library_test","projectId":"gw-library-test-project"},
+			"friendlyName":"terratest dataset",
+			"description":"created by terratest",
+			"location":"US",
+			"defaultTableExpirationMs":"7200000",
+			"labels":{"purpose":"terratest"}
+		}`))
+	})
+
+	dataset, err := gcp.GetBigQueryDatasetAttrsWithClient(context.Background(), newFakeBigQueryService(t, handler), "gw-library-test-project", "gw_library_test")
+	require.NoError(t, err)
+
+	assert.Equal(t, "gw_library_test", dataset.DatasetReference.DatasetId)
+	assert.Equal(t, "terratest dataset", dataset.FriendlyName)
+	assert.Equal(t, "created by terratest", dataset.Description)
+	assert.Equal(t, "US", dataset.Location)
+	assert.Equal(t, int64(7200000), dataset.DefaultTableExpirationMs)
+	assert.Equal(t, map[string]string{"purpose": "terratest"}, dataset.Labels)
+}
+
+func TestGetBigQueryDatasetAttrsWithClientMissingDataset(t *testing.T) {
+	t.Parallel()
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+
+	// The error names the dataset and the project as well as saying it is absent, so all three are
+	// asserted rather than only the phrase.
+	_, err := gcp.GetBigQueryDatasetAttrsWithClient(context.Background(), newFakeBigQueryService(t, handler), "gw-library-test-project", "gone")
+	require.ErrorContains(t, err, "does not exist")
+	require.ErrorContains(t, err, "gone")
+	require.ErrorContains(t, err, "gw-library-test-project")
+}


### PR DESCRIPTION
**TL;DR:** A test holding a BigQuery dataset id can now read that dataset's friendly name, description, location, default table expiration and labels. The GCP module had nothing for BigQuery at all before this.

**Why:** the module covers compute, storage, Pub/Sub, Cloud Build, GCR and OS Login, and nothing else. A Terraform module that creates a dataset has no way to prove it created the dataset it was asked for, which is the same gap `GetStorageBucketAttrs` closed for buckets in #1890.

**What changed**

* **modules/gcp · bigquery.go**, new: `GetBigQueryDatasetAttrs`, `GetBigQueryDatasetAttrsE` and `GetBigQueryDatasetAttrsWithClient`, returning the dataset as `*bigquery.Dataset` so a caller asserts on the API's own fields. A missing dataset returns an error naming the dataset and the project, in the wording the other read functions here use. `NewBigQueryServiceE` builds the service through the same `withOptions` helper every other client uses.
* **modules/gcp · bigquery_test.go**, new: a configured dataset and a missing one, both against a local test server the Google transport actually talks to, in the shape `storage_test.go` already uses.
* **No new dependency.** `google.golang.org/api` is already required for the compute client and the BigQuery service lives in the same module, so `go.mod` is unchanged.
* **Deliberately not handled:** tables, jobs and reservations. Each is its own resource with its own read, and none is needed to prove a dataset.

**Landing it**
* **Rollback:** revert is enough. One new file and one new test file; nothing existing changes.
* **Rule bent:** none.

**Validation**
* **Unit**: the whole `modules/gcp` package passes, including both new cases. They fail on `main`, where `bigquery.go` does not exist.
* **Not run**: anything against a real project. The consumer that does is [terraform-google-test-library](https://github.com/gruntwork-io-team/terraform-google-test-library), whose suite applies the dataset module and reads it back through this function.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for retrieving Google BigQuery dataset settings.
  * Added clear handling for missing datasets and other retrieval errors.
  * Added support for creating BigQuery services with standard cloud configuration.

* **Tests**
  * Added coverage for successful dataset retrieval.
  * Added coverage for missing datasets, including validation of project and dataset identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->