### PR TITLE
feat(gcp): read a log-based metric's settings back so a test can assert them

### DIFF
--- a/modules/gcp/logging.go
+++ b/modules/gcp/logging.go
@@ -1,0 +1,65 @@
+package gcp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/gruntwork-io/terratest/modules/core/v2/logger"
+	"github.com/gruntwork-io/terratest/modules/core/v2/testing"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/api/googleapi"
+	"google.golang.org/api/logging/v2"
+	"google.golang.org/api/option"
+)
+
+// GetLogMetricAttrs returns the settings Google Cloud holds for the given log-based metric, so a
+// test can assert on what was actually created rather than only that it exists.
+// This will fail the test if there is an error.
+// The ctx parameter supports cancellation and timeouts.
+func GetLogMetricAttrs(t testing.TestingT, ctx context.Context, projectID string, metricName string) *logging.LogMetric {
+	metric, err := GetLogMetricAttrsE(t, ctx, projectID, metricName)
+	require.NoError(t, err)
+
+	return metric
+}
+
+// GetLogMetricAttrsE returns the settings Google Cloud holds for the given log-based metric.
+// The ctx parameter supports cancellation and timeouts.
+func GetLogMetricAttrsE(t testing.TestingT, ctx context.Context, projectID string, metricName string) (*logging.LogMetric, error) {
+	logger.Default.Logf(t, "Getting settings for log-based metric %s in project %s", metricName, projectID)
+
+	service, err := NewLoggingServiceE(t, ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return GetLogMetricAttrsWithClient(ctx, service, projectID, metricName)
+}
+
+// GetLogMetricAttrsWithClient returns the settings Google Cloud holds for the given log-based
+// metric using the supplied *logging.Service. Prefer this variant in unit tests where the service
+// is backed by an httptest fake server (see logging_test.go for the pattern).
+// The ctx parameter supports cancellation and timeouts.
+func GetLogMetricAttrsWithClient(ctx context.Context, service *logging.Service, projectID string, metricName string) (*logging.LogMetric, error) {
+	name := fmt.Sprintf("projects/%s/metrics/%s", projectID, metricName)
+
+	metric, err := service.Projects.Metrics.Get(name).Context(ctx).Do()
+	if err != nil {
+		var apiErr *googleapi.Error
+		if errors.As(err, &apiErr) && apiErr.Code == 404 {
+			return nil, fmt.Errorf("log-based metric %s does not exist in project %s", metricName, projectID)
+		}
+
+		return nil, fmt.Errorf("failed to get settings for log-based metric %s in project %s: %w", metricName, projectID, err)
+	}
+
+	return metric, nil
+}
+
+// NewLoggingServiceE creates a Cloud Logging service authenticated the same way every other client
+// in this module is.
+// The ctx parameter supports cancellation and timeouts.
+func NewLoggingServiceE(t testing.TestingT, ctx context.Context) (*logging.Service, error) {
+	return logging.NewService(ctx, append(withOptions(), option.WithScopes(logging.CloudPlatformScope))...)
+}

--- a/modules/gcp/logging_test.go
+++ b/modules/gcp/logging_test.go
@@ -1,0 +1,71 @@
+package gcp_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/gcp/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/api/logging/v2"
+	"google.golang.org/api/option"
+)
+
+// newFakeLoggingService points a real *logging.Service at a local test server, so the Google
+// transport is exercised rather than a hand-written stand-in for a type we do not own.
+func newFakeLoggingService(t *testing.T, handler http.Handler) *logging.Service {
+	t.Helper()
+
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	service, err := logging.NewService(context.Background(),
+		option.WithEndpoint(server.URL), option.WithoutAuthentication())
+	require.NoError(t, err)
+
+	return service
+}
+
+func TestGetLogMetricAttrsWithClient(t *testing.T) {
+	t.Parallel()
+
+	// The values are the ones the terraform-google-observability metric module sets, because the
+	// point of reading settings back is asserting a module configured the metric it was asked for.
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.True(t, strings.HasSuffix(r.URL.Path, "/projects/gw-library-test-project/metrics/gw-library-test"))
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"name":"gw-library-test",
+			"description":"created by terratest",
+			"filter":"severity >= ERROR",
+			"disabled":true
+		}`))
+	})
+
+	metric, err := gcp.GetLogMetricAttrsWithClient(context.Background(), newFakeLoggingService(t, handler), "gw-library-test-project", "gw-library-test")
+	require.NoError(t, err)
+
+	assert.Equal(t, "gw-library-test", metric.Name)
+	assert.Equal(t, "created by terratest", metric.Description)
+	assert.Equal(t, "severity >= ERROR", metric.Filter)
+	assert.True(t, metric.Disabled)
+}
+
+func TestGetLogMetricAttrsWithClientMissingMetric(t *testing.T) {
+	t.Parallel()
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+
+	// The error names the metric and the project as well as saying it is absent, so all three are
+	// asserted rather than only the phrase.
+	_, err := gcp.GetLogMetricAttrsWithClient(context.Background(), newFakeLoggingService(t, handler), "gw-library-test-project", "gone")
+	require.ErrorContains(t, err, "does not exist")
+	require.ErrorContains(t, err, "gone")
+	require.ErrorContains(t, err, "gw-library-test-project")
+}


### PR DESCRIPTION
**TL;DR:** A test holding a log-based metric name can now read that metric's description, filter and disabled flag. The GCP module had nothing for Cloud Logging at all before this.

**Why:** the module covers compute, storage, Pub/Sub, Cloud Build, GCR and OS Login, and nothing else. A Terraform module that creates a log-based metric has no way to prove it created the metric it was asked for, which is the same gap `GetStorageBucketAttrs` closed for buckets in #1890.

**What changed**

* **modules/gcp · logging.go**, new: `GetLogMetricAttrs`, `GetLogMetricAttrsE` and `GetLogMetricAttrsWithClient`, returning the metric as `*logging.LogMetric` so a caller asserts on the API's own fields. A missing metric returns an error naming the metric and the project, in the wording the other read functions here use. `NewLoggingServiceE` builds the service through the same `withOptions` helper every other client uses.
* **modules/gcp · logging_test.go**, new: a configured metric and a missing one, both against a local test server the Google transport actually talks to, in the shape `storage_test.go` already uses.
* **No new dependency.** `google.golang.org/api` is already required for the compute client and the Cloud Logging service lives in the same module, so `go.mod` is unchanged.
* **Deliberately not handled:** sinks, exclusions, buckets and views. Each is its own resource with its own read, and none is needed to prove a metric.

**Landing it**
* **Rollback:** revert is enough. One new file and one new test file; nothing existing changes.
* **Rule bent:** none.

**Validation**
* **Unit**: the whole `modules/gcp` package passes, including both new cases. They fail on `main`, where `logging.go` does not exist.
* **Not run**: anything against a real project. The consumer that does is [terraform-google-test-library](https://github.com/gruntwork-io-team/terraform-google-test-library), whose suite applies the metric module and reads it back through this function.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for retrieving Google Cloud log-based metric settings, including metric name, description, filter, and status.
  * Added clear error reporting when a requested log-based metric does not exist.
  * Added a helper for creating authenticated Google Cloud Logging service connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->