### PR TITLE
feat(gcp): read a service account's settings back so a test can assert them

### DIFF
--- a/modules/gcp/iam.go
+++ b/modules/gcp/iam.go
@@ -1,0 +1,66 @@
+package gcp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/gruntwork-io/terratest/modules/core/v2/logger"
+	"github.com/gruntwork-io/terratest/modules/core/v2/testing"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/api/googleapi"
+	"google.golang.org/api/iam/v1"
+	"google.golang.org/api/option"
+)
+
+// GetServiceAccountAttrs returns the settings Google Cloud holds for the given service account, so
+// a test can assert on what was actually created rather than only that it exists. The email is the
+// full one, `<account-id>@<project>.iam.gserviceaccount.com`.
+// This will fail the test if there is an error.
+// The ctx parameter supports cancellation and timeouts.
+func GetServiceAccountAttrs(t testing.TestingT, ctx context.Context, projectID string, email string) *iam.ServiceAccount {
+	account, err := GetServiceAccountAttrsE(t, ctx, projectID, email)
+	require.NoError(t, err)
+
+	return account
+}
+
+// GetServiceAccountAttrsE returns the settings Google Cloud holds for the given service account.
+// The ctx parameter supports cancellation and timeouts.
+func GetServiceAccountAttrsE(t testing.TestingT, ctx context.Context, projectID string, email string) (*iam.ServiceAccount, error) {
+	logger.Default.Logf(t, "Getting settings for service account %s in project %s", email, projectID)
+
+	service, err := NewIAMServiceE(t, ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return GetServiceAccountAttrsWithClient(ctx, service, projectID, email)
+}
+
+// GetServiceAccountAttrsWithClient returns the settings Google Cloud holds for the given service
+// account using the supplied *iam.Service. Prefer this variant in unit tests where the service is
+// backed by an httptest fake server (see iam_test.go for the pattern).
+// The ctx parameter supports cancellation and timeouts.
+func GetServiceAccountAttrsWithClient(ctx context.Context, service *iam.Service, projectID string, email string) (*iam.ServiceAccount, error) {
+	name := fmt.Sprintf("projects/%s/serviceAccounts/%s", projectID, email)
+
+	account, err := service.Projects.ServiceAccounts.Get(name).Context(ctx).Do()
+	if err != nil {
+		var apiErr *googleapi.Error
+		if errors.As(err, &apiErr) && apiErr.Code == 404 {
+			return nil, fmt.Errorf("service account %s does not exist in project %s", email, projectID)
+		}
+
+		return nil, fmt.Errorf("failed to get settings for service account %s in project %s: %w", email, projectID, err)
+	}
+
+	return account, nil
+}
+
+// NewIAMServiceE creates an IAM service authenticated the same way every other client in this
+// module is.
+// The ctx parameter supports cancellation and timeouts.
+func NewIAMServiceE(t testing.TestingT, ctx context.Context) (*iam.Service, error) {
+	return iam.NewService(ctx, append(withOptions(), option.WithScopes(iam.CloudPlatformScope))...)
+}

--- a/modules/gcp/iam_test.go
+++ b/modules/gcp/iam_test.go
@@ -1,0 +1,78 @@
+package gcp_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/gcp/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/api/iam/v1"
+	"google.golang.org/api/option"
+)
+
+// newFakeIAMService points a real *iam.Service at a local test server, so the Google transport is
+// exercised rather than a hand-written stand-in for a type we do not own.
+func newFakeIAMService(t *testing.T, handler http.Handler) *iam.Service {
+	t.Helper()
+
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	service, err := iam.NewService(context.Background(),
+		option.WithEndpoint(server.URL), option.WithoutAuthentication())
+	require.NoError(t, err)
+
+	return service
+}
+
+func TestGetServiceAccountAttrsWithClient(t *testing.T) {
+	t.Parallel()
+
+	// The values are the ones the terraform-google-management service account module sets, because
+	// the point of reading settings back is asserting a module configured the account it was asked
+	// for.
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.True(t, strings.HasSuffix(r.URL.Path, "/serviceAccounts/gw-library-test@gw-library-test-project.iam.gserviceaccount.com"))
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"name":"projects/gw-library-test-project/serviceAccounts/gw-library-test@gw-library-test-project.iam.gserviceaccount.com",
+			"projectId":"gw-library-test-project",
+			"uniqueId":"104000000000000000000",
+			"email":"gw-library-test@gw-library-test-project.iam.gserviceaccount.com",
+			"displayName":"terratest account",
+			"description":"created by terratest",
+			"disabled":true
+		}`))
+	})
+
+	account, err := gcp.GetServiceAccountAttrsWithClient(context.Background(), newFakeIAMService(t, handler),
+		"gw-library-test-project", "gw-library-test@gw-library-test-project.iam.gserviceaccount.com")
+	require.NoError(t, err)
+
+	assert.Equal(t, "gw-library-test@gw-library-test-project.iam.gserviceaccount.com", account.Email)
+	assert.Equal(t, "terratest account", account.DisplayName)
+	assert.Equal(t, "created by terratest", account.Description)
+	assert.Equal(t, "gw-library-test-project", account.ProjectId)
+	assert.True(t, account.Disabled)
+}
+
+func TestGetServiceAccountAttrsWithClientMissingAccount(t *testing.T) {
+	t.Parallel()
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+
+	// The error names the account and the project as well as saying it is absent, so all three are
+	// asserted rather than only the phrase.
+	_, err := gcp.GetServiceAccountAttrsWithClient(context.Background(), newFakeIAMService(t, handler),
+		"gw-library-test-project", "gone@gw-library-test-project.iam.gserviceaccount.com")
+	require.ErrorContains(t, err, "does not exist")
+	require.ErrorContains(t, err, "gone@")
+	require.ErrorContains(t, err, "gw-library-test-project")
+}


### PR DESCRIPTION
**TL;DR:** A test holding a service account email can now read that account's display name, description, project and disabled flag. The GCP module had nothing for IAM at all before this.

**Why:** the module covers compute, storage, Pub/Sub, Cloud Build, GCR and OS Login, and nothing else. A Terraform module that creates a service account has no way to prove it created the account it was asked for, which is the same gap `GetStorageBucketAttrs` closed for buckets in #1890.

**What changed**

* **modules/gcp · iam.go**, new: `GetServiceAccountAttrs`, `GetServiceAccountAttrsE` and `GetServiceAccountAttrsWithClient`, returning the account as `*iam.ServiceAccount` so a caller asserts on the API's own fields. It takes the full email, which is what the API's resource path needs. A missing account returns an error naming the account and the project, in the wording the other read functions here use. `NewIAMServiceE` builds the service through the same `withOptions` helper every other client uses.
* **modules/gcp · iam_test.go**, new: a configured account and a missing one, both against a local test server the Google transport actually talks to, in the shape `storage_test.go` already uses.
* **No new dependency.** `google.golang.org/api` is already required for the compute client and the IAM service lives in the same module, so `go.mod` is unchanged.
* **Deliberately not handled:** keys, IAM policies and workload identity pools. Each is its own resource with its own read, and none is needed to prove an account.

**Landing it**
* **Rollback:** revert is enough. One new file and one new test file; nothing existing changes.
* **Rule bent:** none.

**Validation**
* **Unit**: the whole `modules/gcp` package passes, including both new cases. They fail on `main`, where `iam.go` does not exist.
* **Not run**: anything against a real project. The consumer that does is [terraform-google-test-library](https://github.com/gruntwork-io-team/terraform-google-test-library), whose suite applies the service account module and reads it back through this function.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added helpers for retrieving Google Cloud service account details.
  - Added support for creating authenticated IAM service clients with context-based cancellation and timeouts.
  - Improved handling and messaging when a requested service account does not exist.

- **Tests**
  - Added coverage for successful service account retrieval and missing-account errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->