### PR TITLE
feat(gcp): read a notification channel's settings back so a test can assert them

### DIFF
--- a/modules/gcp/monitoring.go
+++ b/modules/gcp/monitoring.go
@@ -1,0 +1,67 @@
+package gcp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/gruntwork-io/terratest/modules/core/v2/logger"
+	"github.com/gruntwork-io/terratest/modules/core/v2/testing"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/api/googleapi"
+	"google.golang.org/api/monitoring/v3"
+	"google.golang.org/api/option"
+)
+
+// GetNotificationChannelAttrs returns the settings Google Cloud holds for the given notification
+// channel, so a test can assert on what was actually created rather than only that it exists. The
+// id is the one Google assigns, which a caller reads from whatever created the channel.
+// This will fail the test if there is an error.
+// The ctx parameter supports cancellation and timeouts.
+func GetNotificationChannelAttrs(t testing.TestingT, ctx context.Context, projectID string, channelID string) *monitoring.NotificationChannel {
+	channel, err := GetNotificationChannelAttrsE(t, ctx, projectID, channelID)
+	require.NoError(t, err)
+
+	return channel
+}
+
+// GetNotificationChannelAttrsE returns the settings Google Cloud holds for the given notification
+// channel.
+// The ctx parameter supports cancellation and timeouts.
+func GetNotificationChannelAttrsE(t testing.TestingT, ctx context.Context, projectID string, channelID string) (*monitoring.NotificationChannel, error) {
+	logger.Default.Logf(t, "Getting settings for notification channel %s in project %s", channelID, projectID)
+
+	service, err := NewMonitoringServiceE(t, ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return GetNotificationChannelAttrsWithClient(ctx, service, projectID, channelID)
+}
+
+// GetNotificationChannelAttrsWithClient returns the settings Google Cloud holds for the given
+// notification channel using the supplied *monitoring.Service. Prefer this variant in unit tests
+// where the service is backed by an httptest fake server (see monitoring_test.go for the pattern).
+// The ctx parameter supports cancellation and timeouts.
+func GetNotificationChannelAttrsWithClient(ctx context.Context, service *monitoring.Service, projectID string, channelID string) (*monitoring.NotificationChannel, error) {
+	name := fmt.Sprintf("projects/%s/notificationChannels/%s", projectID, channelID)
+
+	channel, err := service.Projects.NotificationChannels.Get(name).Context(ctx).Do()
+	if err != nil {
+		var apiErr *googleapi.Error
+		if errors.As(err, &apiErr) && apiErr.Code == 404 {
+			return nil, fmt.Errorf("notification channel %s does not exist in project %s", channelID, projectID)
+		}
+
+		return nil, fmt.Errorf("failed to get settings for notification channel %s in project %s: %w", channelID, projectID, err)
+	}
+
+	return channel, nil
+}
+
+// NewMonitoringServiceE creates a Cloud Monitoring service authenticated the same way every other
+// client in this module is.
+// The ctx parameter supports cancellation and timeouts.
+func NewMonitoringServiceE(t testing.TestingT, ctx context.Context) (*monitoring.Service, error) {
+	return monitoring.NewService(ctx, append(withOptions(), option.WithScopes(monitoring.CloudPlatformScope))...)
+}

--- a/modules/gcp/monitoring_test.go
+++ b/modules/gcp/monitoring_test.go
@@ -1,0 +1,77 @@
+package gcp_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/gcp/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/api/monitoring/v3"
+	"google.golang.org/api/option"
+)
+
+// newFakeMonitoringService points a real *monitoring.Service at a local test server, so the Google
+// transport is exercised rather than a hand-written stand-in for a type we do not own.
+func newFakeMonitoringService(t *testing.T, handler http.Handler) *monitoring.Service {
+	t.Helper()
+
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	service, err := monitoring.NewService(context.Background(),
+		option.WithEndpoint(server.URL), option.WithoutAuthentication())
+	require.NoError(t, err)
+
+	return service
+}
+
+func TestGetNotificationChannelAttrsWithClient(t *testing.T) {
+	t.Parallel()
+
+	// The values are the ones the terraform-google-observability notification channel module sets,
+	// because the point of reading settings back is asserting a module configured the channel it
+	// was asked for.
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.True(t, strings.HasSuffix(r.URL.Path, "/notificationChannels/1234567890"))
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"name":"projects/gw-library-test-project/notificationChannels/1234567890",
+			"type":"email",
+			"displayName":"terratest channel",
+			"description":"created by terratest",
+			"labels":{"email_address":"terratest@example.com"},
+			"userLabels":{"purpose":"terratest"},
+			"enabled":false
+		}`))
+	})
+
+	channel, err := gcp.GetNotificationChannelAttrsWithClient(context.Background(), newFakeMonitoringService(t, handler), "gw-library-test-project", "1234567890")
+	require.NoError(t, err)
+
+	assert.Equal(t, "email", channel.Type)
+	assert.Equal(t, "terratest channel", channel.DisplayName)
+	assert.Equal(t, "created by terratest", channel.Description)
+	assert.Equal(t, "terratest@example.com", channel.Labels["email_address"])
+	assert.Equal(t, map[string]string{"purpose": "terratest"}, channel.UserLabels)
+	assert.False(t, channel.Enabled)
+}
+
+func TestGetNotificationChannelAttrsWithClientMissingChannel(t *testing.T) {
+	t.Parallel()
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+
+	// The error names the channel and the project as well as saying it is absent, so all three are
+	// asserted rather than only the phrase.
+	_, err := gcp.GetNotificationChannelAttrsWithClient(context.Background(), newFakeMonitoringService(t, handler), "gw-library-test-project", "gone")
+	require.ErrorContains(t, err, "does not exist")
+	require.ErrorContains(t, err, "gone")
+	require.ErrorContains(t, err, "gw-library-test-project")
+}


### PR DESCRIPTION
**TL;DR:** A test holding a notification channel id can now read that channel's type, display name, description, labels and enabled flag. The GCP module had nothing for Cloud Monitoring at all before this.

**Why:** the module covers compute, storage, Pub/Sub, Cloud Build, GCR and OS Login, and nothing else. A Terraform module that creates a notification channel has no way to prove it created the channel it was asked for, which is the same gap `GetStorageBucketAttrs` closed for buckets in #1890.

**What changed**

* **modules/gcp · monitoring.go**, new: `GetNotificationChannelAttrs`, `GetNotificationChannelAttrsE` and `GetNotificationChannelAttrsWithClient`, returning the channel as `*monitoring.NotificationChannel` so a caller asserts on the API's own fields. It takes the id Google assigns rather than a name the caller chose, because a notification channel has none. A missing channel returns an error naming the channel and the project, in the wording the other read functions here use. `NewMonitoringServiceE` builds the service through the same `withOptions` helper every other client uses.
* **modules/gcp · monitoring_test.go**, new: a configured channel and a missing one, both against a local test server the Google transport actually talks to, in the shape `storage_test.go` already uses.
* **No new dependency.** `google.golang.org/api` is already required for the compute client and the Cloud Monitoring service lives in the same module, so `go.mod` is unchanged.
* **Deliberately not handled:** alert policies, uptime checks, dashboards and services. Each is its own resource with its own read, and none is needed to prove a channel.

**Landing it**
* **Rollback:** revert is enough. One new file and one new test file; nothing existing changes.
* **Rule bent:** none.

**Validation**
* **Unit**: the whole `modules/gcp` package passes, including both new cases. They fail on `main`, where `monitoring.go` does not exist.
* **Not run**: anything against a real project. The consumer that does is [terraform-google-test-library](https://github.com/gruntwork-io-team/terraform-google-test-library), whose suite applies the notification channel module and reads it back through this function.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for retrieving Google Cloud Monitoring notification channel settings.
  * Added clear error reporting when a requested notification channel cannot be found.

* **Tests**
  * Added coverage for successful notification channel retrieval and missing-channel errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->