### PR TITLE
feat(gcp): read a Secret Manager secret's settings back so a test can assert them

### DIFF
--- a/modules/gcp/secretmanager.go
+++ b/modules/gcp/secretmanager.go
@@ -1,0 +1,66 @@
+package gcp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/gruntwork-io/terratest/modules/core/v2/logger"
+	"github.com/gruntwork-io/terratest/modules/core/v2/testing"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/api/googleapi"
+	"google.golang.org/api/option"
+	"google.golang.org/api/secretmanager/v1"
+)
+
+// GetSecretAttrs returns the settings Google Cloud holds for the given Secret Manager secret, so a
+// test can assert on what was actually created rather than only that it exists. This reads the
+// secret's settings and never its value, which no test needs and which would land in a log.
+// This will fail the test if there is an error.
+// The ctx parameter supports cancellation and timeouts.
+func GetSecretAttrs(t testing.TestingT, ctx context.Context, projectID string, secretID string) *secretmanager.Secret {
+	secret, err := GetSecretAttrsE(t, ctx, projectID, secretID)
+	require.NoError(t, err)
+
+	return secret
+}
+
+// GetSecretAttrsE returns the settings Google Cloud holds for the given Secret Manager secret.
+// The ctx parameter supports cancellation and timeouts.
+func GetSecretAttrsE(t testing.TestingT, ctx context.Context, projectID string, secretID string) (*secretmanager.Secret, error) {
+	logger.Default.Logf(t, "Getting settings for secret %s in project %s", secretID, projectID)
+
+	service, err := NewSecretManagerServiceE(t, ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return GetSecretAttrsWithClient(ctx, service, projectID, secretID)
+}
+
+// GetSecretAttrsWithClient returns the settings Google Cloud holds for the given Secret Manager
+// secret using the supplied *secretmanager.Service. Prefer this variant in unit tests where the
+// service is backed by an httptest fake server (see secretmanager_test.go for the pattern).
+// The ctx parameter supports cancellation and timeouts.
+func GetSecretAttrsWithClient(ctx context.Context, service *secretmanager.Service, projectID string, secretID string) (*secretmanager.Secret, error) {
+	name := fmt.Sprintf("projects/%s/secrets/%s", projectID, secretID)
+
+	secret, err := service.Projects.Secrets.Get(name).Context(ctx).Do()
+	if err != nil {
+		var apiErr *googleapi.Error
+		if errors.As(err, &apiErr) && apiErr.Code == 404 {
+			return nil, fmt.Errorf("secret %s does not exist in project %s", secretID, projectID)
+		}
+
+		return nil, fmt.Errorf("failed to get settings for secret %s in project %s: %w", secretID, projectID, err)
+	}
+
+	return secret, nil
+}
+
+// NewSecretManagerServiceE creates a Secret Manager service authenticated the same way every other
+// client in this module is.
+// The ctx parameter supports cancellation and timeouts.
+func NewSecretManagerServiceE(t testing.TestingT, ctx context.Context) (*secretmanager.Service, error) {
+	return secretmanager.NewService(ctx, append(withOptions(), option.WithScopes(secretmanager.CloudPlatformScope))...)
+}

--- a/modules/gcp/secretmanager_test.go
+++ b/modules/gcp/secretmanager_test.go
@@ -1,0 +1,73 @@
+package gcp_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/gcp/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/api/option"
+	"google.golang.org/api/secretmanager/v1"
+)
+
+// newFakeSecretManagerService points a real *secretmanager.Service at a local test server, so the
+// Google transport is exercised rather than a hand-written stand-in for a type we do not own.
+func newFakeSecretManagerService(t *testing.T, handler http.Handler) *secretmanager.Service {
+	t.Helper()
+
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	service, err := secretmanager.NewService(context.Background(),
+		option.WithEndpoint(server.URL), option.WithoutAuthentication())
+	require.NoError(t, err)
+
+	return service
+}
+
+func TestGetSecretAttrsWithClient(t *testing.T) {
+	t.Parallel()
+
+	// The values are the ones the terraform-google-security secret module sets, because the point
+	// of reading settings back is asserting a module configured the secret it was asked for.
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.True(t, strings.HasSuffix(r.URL.Path, "/secrets/gw-library-test"))
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"name":"projects/gw-library-test-project/secrets/gw-library-test",
+			"replication":{"userManaged":{"replicas":[{"location":"us-central1"}]}},
+			"labels":{"purpose":"terratest"},
+			"annotations":{"owner":"terratest"},
+			"ttl":"3600s"
+		}`))
+	})
+
+	secret, err := gcp.GetSecretAttrsWithClient(context.Background(), newFakeSecretManagerService(t, handler), "gw-library-test-project", "gw-library-test")
+	require.NoError(t, err)
+
+	assert.Equal(t, "projects/gw-library-test-project/secrets/gw-library-test", secret.Name)
+	assert.Equal(t, map[string]string{"purpose": "terratest"}, secret.Labels)
+	assert.Equal(t, map[string]string{"owner": "terratest"}, secret.Annotations)
+	require.Len(t, secret.Replication.UserManaged.Replicas, 1)
+	assert.Equal(t, "us-central1", secret.Replication.UserManaged.Replicas[0].Location)
+}
+
+func TestGetSecretAttrsWithClientMissingSecret(t *testing.T) {
+	t.Parallel()
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+
+	// The error names the secret and the project as well as saying it is absent, so all three are
+	// asserted rather than only the phrase.
+	_, err := gcp.GetSecretAttrsWithClient(context.Background(), newFakeSecretManagerService(t, handler), "gw-library-test-project", "gone")
+	require.ErrorContains(t, err, "does not exist")
+	require.ErrorContains(t, err, "gone")
+	require.ErrorContains(t, err, "gw-library-test-project")
+}


### PR DESCRIPTION
**TL;DR:** A test holding a Secret Manager secret id can now read that secret's replication, labels, annotations and TTL. The GCP module had nothing for Secret Manager at all before this.

**Why:** the module covers compute, storage, Pub/Sub, BigQuery, Cloud Logging, Cloud Monitoring, IAM and Cloud DNS, and nothing for secrets. A Terraform module that creates a secret has no way to prove it created the secret it was asked for, which is the same gap `GetStorageBucketAttrs` closed for buckets in #1890.

**What changed**

* **modules/gcp · secretmanager.go**, new: `GetSecretAttrs`, `GetSecretAttrsE` and `GetSecretAttrsWithClient`, returning the secret as `*secretmanager.Secret` so a caller asserts on the API's own fields. A missing secret returns an error naming the secret and the project, in the wording the other read functions here use. `NewSecretManagerServiceE` builds the service through the same `withOptions` helper every other client uses.
* **It reads settings and never a value.** No test needs the secret material, and a helper that returned it would put it in a test log.
* **modules/gcp · secretmanager_test.go**, new: a configured secret and a missing one, both against a local test server the Google transport actually talks to, in the shape `storage_test.go` already uses.
* **No new dependency.** `google.golang.org/api` is already required for the compute client and the Secret Manager service lives in the same module, so `go.mod` is unchanged.
* **Deliberately not handled:** secret versions and IAM policies. Each is its own resource with its own read, and neither is needed to prove a secret.

**Landing it**
* **Rollback:** revert is enough. One new file and one new test file; nothing existing changes.
* **Rule bent:** none.

**Validation**
* **Unit**: the whole `modules/gcp` package passes, including both new cases. They fail on `main`, where `secretmanager.go` does not exist.
* **Not run**: anything against a real project. The consumer that does is [terraform-google-test-library](https://github.com/gruntwork-io-team/terraform-google-test-library), whose suite applies the secret module and reads it back through this function.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Google Cloud Secret Manager support for retrieving secret metadata, including labels, annotations, replication details, project identifiers, and secret names.
  - Added clear error reporting when requested secrets do not exist.
- **Tests**
  - Added coverage for successful metadata retrieval and missing-secret responses, including request validation and returned error details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->