### PR TITLE
feat(gcp): read a workload identity pool's settings back so a test can assert them

### DIFF
--- a/modules/gcp/iam.go
+++ b/modules/gcp/iam.go
@@ -58,6 +58,52 @@ func GetServiceAccountAttrsWithClient(ctx context.Context, service *iam.Service,
 	return account, nil
 }
 
+// GetWorkloadIdentityPoolAttrs returns the settings Google Cloud holds for the given workload
+// identity pool, so a test can assert on what was actually created rather than only that it exists.
+// The pool lives in a location, which is `global` for every pool the console creates.
+// This will fail the test if there is an error.
+// The ctx parameter supports cancellation and timeouts.
+func GetWorkloadIdentityPoolAttrs(t testing.TestingT, ctx context.Context, projectID string, location string, poolID string) *iam.WorkloadIdentityPool {
+	pool, err := GetWorkloadIdentityPoolAttrsE(t, ctx, projectID, location, poolID)
+	require.NoError(t, err)
+
+	return pool
+}
+
+// GetWorkloadIdentityPoolAttrsE returns the settings Google Cloud holds for the given workload
+// identity pool.
+// The ctx parameter supports cancellation and timeouts.
+func GetWorkloadIdentityPoolAttrsE(t testing.TestingT, ctx context.Context, projectID string, location string, poolID string) (*iam.WorkloadIdentityPool, error) {
+	logger.Default.Logf(t, "Getting settings for workload identity pool %s in project %s", poolID, projectID)
+
+	service, err := NewIAMServiceE(t, ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return GetWorkloadIdentityPoolAttrsWithClient(ctx, service, projectID, location, poolID)
+}
+
+// GetWorkloadIdentityPoolAttrsWithClient returns the settings Google Cloud holds for the given
+// workload identity pool using the supplied *iam.Service. Prefer this variant in unit tests where
+// the service is backed by an httptest fake server (see iam_test.go for the pattern).
+// The ctx parameter supports cancellation and timeouts.
+func GetWorkloadIdentityPoolAttrsWithClient(ctx context.Context, service *iam.Service, projectID string, location string, poolID string) (*iam.WorkloadIdentityPool, error) {
+	name := fmt.Sprintf("projects/%s/locations/%s/workloadIdentityPools/%s", projectID, location, poolID)
+
+	pool, err := service.Projects.Locations.WorkloadIdentityPools.Get(name).Context(ctx).Do()
+	if err != nil {
+		var apiErr *googleapi.Error
+		if errors.As(err, &apiErr) && apiErr.Code == 404 {
+			return nil, fmt.Errorf("workload identity pool %s does not exist in project %s", poolID, projectID)
+		}
+
+		return nil, fmt.Errorf("failed to get settings for workload identity pool %s in project %s: %w", poolID, projectID, err)
+	}
+
+	return pool, nil
+}
+
 // NewIAMServiceE creates an IAM service authenticated the same way every other client in this
 // module is.
 // The ctx parameter supports cancellation and timeouts.

--- a/modules/gcp/iam_test.go
+++ b/modules/gcp/iam_test.go
@@ -61,6 +61,52 @@ func TestGetServiceAccountAttrsWithClient(t *testing.T) {
 	assert.True(t, account.Disabled)
 }
 
+func TestGetWorkloadIdentityPoolAttrsWithClient(t *testing.T) {
+	t.Parallel()
+
+	// The values are the ones the terraform-google-identity pool module sets, because the point of
+	// reading settings back is asserting a module configured the pool it was asked for.
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.True(t, strings.HasSuffix(r.URL.Path, "/locations/global/workloadIdentityPools/gw-library-test"))
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"name":"projects/gw-library-test-project/locations/global/workloadIdentityPools/gw-library-test",
+			"displayName":"terratest pool",
+			"description":"created by terratest",
+			"state":"ACTIVE",
+			"disabled":true,
+			"mode":"FEDERATION_ONLY"
+		}`))
+	})
+
+	pool, err := gcp.GetWorkloadIdentityPoolAttrsWithClient(context.Background(), newFakeIAMService(t, handler),
+		"gw-library-test-project", "global", "gw-library-test")
+	require.NoError(t, err)
+
+	assert.Equal(t, "terratest pool", pool.DisplayName)
+	assert.Equal(t, "created by terratest", pool.Description)
+	assert.Equal(t, "ACTIVE", pool.State)
+	assert.Equal(t, "FEDERATION_ONLY", pool.Mode)
+	assert.True(t, pool.Disabled)
+}
+
+func TestGetWorkloadIdentityPoolAttrsWithClientMissingPool(t *testing.T) {
+	t.Parallel()
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+
+	// The error names the pool and the project as well as saying it is absent, so all three are
+	// asserted rather than only the phrase.
+	_, err := gcp.GetWorkloadIdentityPoolAttrsWithClient(context.Background(), newFakeIAMService(t, handler),
+		"gw-library-test-project", "global", "gone")
+	require.ErrorContains(t, err, "does not exist")
+	require.ErrorContains(t, err, "gone")
+	require.ErrorContains(t, err, "gw-library-test-project")
+}
+
 func TestGetServiceAccountAttrsWithClientMissingAccount(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
**TL;DR:** A test holding a workload identity pool id can now read that pool's display name, description, state, mode and disabled flag. The IAM helpers could read a service account and nothing else.

**Why:** a Terraform module that creates a workload identity pool has no way to prove it created the pool it was asked for. It is the same gap `GetServiceAccountAttrs` closed for accounts in #1903, one resource along.

**What changed**

* **modules/gcp · iam.go**: `GetWorkloadIdentityPoolAttrs`, `GetWorkloadIdentityPoolAttrsE` and `GetWorkloadIdentityPoolAttrsWithClient`, returning the pool as `*iam.WorkloadIdentityPool`. It follows `GetServiceAccountAttrs` exactly, and takes the location as well as the id because a pool is a regional resource, even though every pool the console creates is global.
* **modules/gcp · iam_test.go**: a configured pool and a missing one, against the same local test server the service account cases already use.
* **No new dependency.** This is the IAM service the file already talks to.
* **Deliberately not handled:** pool providers and managed identities, each of which is its own resource with its own read.

**Landing it**
* **Rollback:** revert is enough. This only adds functions.
* **Rule bent:** none.

**Validation**
* **Unit**: the whole `modules/gcp` package passes, including both new cases. They fail on `main`, where `GetWorkloadIdentityPoolAttrsWithClient` does not exist.
* **Not run**: anything against a real project. The consumer that does is [terraform-google-test-library](https://github.com/gruntwork-io-team/terraform-google-test-library), whose suite applies the pool module and reads it back through this function.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for retrieving Google Cloud Workload Identity Pool settings.
  * Added variants for standard use, error handling, and custom IAM clients.
  * Missing pools now return clear not-found errors identifying the requested resource.

* **Tests**
  * Added coverage for successful retrieval and missing-pool error responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->