### PR TITLE
feat(gcp): read an API key's settings back so a test can assert them

### DIFF
--- a/modules/gcp/apikeys.go
+++ b/modules/gcp/apikeys.go
@@ -1,0 +1,67 @@
+package gcp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/gruntwork-io/terratest/modules/core/v2/logger"
+	"github.com/gruntwork-io/terratest/modules/core/v2/testing"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/api/apikeys/v2"
+	"google.golang.org/api/googleapi"
+	"google.golang.org/api/option"
+)
+
+// GetAPIKeyAttrs returns the settings Google Cloud holds for the given API key, so a test can
+// assert on what was actually created rather than only that it exists. The id is the one Google
+// assigns, and this reads the key's settings and never its secret string, which no test needs and
+// which would land in a log.
+// This will fail the test if there is an error.
+// The ctx parameter supports cancellation and timeouts.
+func GetAPIKeyAttrs(t testing.TestingT, ctx context.Context, projectID string, keyID string) *apikeys.V2Key {
+	key, err := GetAPIKeyAttrsE(t, ctx, projectID, keyID)
+	require.NoError(t, err)
+
+	return key
+}
+
+// GetAPIKeyAttrsE returns the settings Google Cloud holds for the given API key.
+// The ctx parameter supports cancellation and timeouts.
+func GetAPIKeyAttrsE(t testing.TestingT, ctx context.Context, projectID string, keyID string) (*apikeys.V2Key, error) {
+	logger.Default.Logf(t, "Getting settings for API key %s in project %s", keyID, projectID)
+
+	service, err := NewAPIKeysServiceE(t, ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return GetAPIKeyAttrsWithClient(ctx, service, projectID, keyID)
+}
+
+// GetAPIKeyAttrsWithClient returns the settings Google Cloud holds for the given API key using the
+// supplied *apikeys.Service. Prefer this variant in unit tests where the service is backed by an
+// httptest fake server (see apikeys_test.go for the pattern).
+// The ctx parameter supports cancellation and timeouts.
+func GetAPIKeyAttrsWithClient(ctx context.Context, service *apikeys.Service, projectID string, keyID string) (*apikeys.V2Key, error) {
+	name := fmt.Sprintf("projects/%s/locations/global/keys/%s", projectID, keyID)
+
+	key, err := service.Projects.Locations.Keys.Get(name).Context(ctx).Do()
+	if err != nil {
+		var apiErr *googleapi.Error
+		if errors.As(err, &apiErr) && apiErr.Code == 404 {
+			return nil, fmt.Errorf("API key %s does not exist in project %s", keyID, projectID)
+		}
+
+		return nil, fmt.Errorf("failed to get settings for API key %s in project %s: %w", keyID, projectID, err)
+	}
+
+	return key, nil
+}
+
+// NewAPIKeysServiceE creates an API Keys service authenticated the same way every other client in
+// this module is.
+// The ctx parameter supports cancellation and timeouts.
+func NewAPIKeysServiceE(t testing.TestingT, ctx context.Context) (*apikeys.Service, error) {
+	return apikeys.NewService(ctx, append(withOptions(), option.WithScopes(apikeys.CloudPlatformScope))...)
+}

--- a/modules/gcp/apikeys_test.go
+++ b/modules/gcp/apikeys_test.go
@@ -1,0 +1,72 @@
+package gcp_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/gcp/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/api/apikeys/v2"
+	"google.golang.org/api/option"
+)
+
+// newFakeAPIKeysService points a real *apikeys.Service at a local test server, so the Google
+// transport is exercised rather than a hand-written stand-in for a type we do not own.
+func newFakeAPIKeysService(t *testing.T, handler http.Handler) *apikeys.Service {
+	t.Helper()
+
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	service, err := apikeys.NewService(context.Background(),
+		option.WithEndpoint(server.URL), option.WithoutAuthentication())
+	require.NoError(t, err)
+
+	return service
+}
+
+func TestGetAPIKeyAttrsWithClient(t *testing.T) {
+	t.Parallel()
+
+	// The values are the ones the terraform-google-api-management key module sets, because the
+	// point of reading settings back is asserting a module configured the key it was asked for.
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.True(t, strings.HasSuffix(r.URL.Path, "/locations/global/keys/gw-library-test"))
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"name":"projects/gw-library-test-project/locations/global/keys/gw-library-test",
+			"uid":"gw-library-test",
+			"displayName":"terratest key",
+			"restrictions":{"apiTargets":[{"service":"translate.googleapis.com"}]}
+		}`))
+	})
+
+	key, err := gcp.GetAPIKeyAttrsWithClient(context.Background(), newFakeAPIKeysService(t, handler), "gw-library-test-project", "gw-library-test")
+	require.NoError(t, err)
+
+	assert.Equal(t, "terratest key", key.DisplayName)
+	assert.Equal(t, "gw-library-test", key.Uid)
+	require.NotNil(t, key.Restrictions)
+	require.Len(t, key.Restrictions.ApiTargets, 1)
+	assert.Equal(t, "translate.googleapis.com", key.Restrictions.ApiTargets[0].Service)
+}
+
+func TestGetAPIKeyAttrsWithClientMissingKey(t *testing.T) {
+	t.Parallel()
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+
+	// The error names the key and the project as well as saying it is absent, so all three are
+	// asserted rather than only the phrase.
+	_, err := gcp.GetAPIKeyAttrsWithClient(context.Background(), newFakeAPIKeysService(t, handler), "gw-library-test-project", "gone")
+	require.ErrorContains(t, err, "does not exist")
+	require.ErrorContains(t, err, "gone")
+	require.ErrorContains(t, err, "gw-library-test-project")
+}


### PR DESCRIPTION
**TL;DR:** A test holding an API key id can now read that key's display name, uid and restrictions. The GCP module had nothing for API Keys at all before this.

**Why:** a Terraform module that creates an API key has no way to prove it created the key it was asked for, and a key whose API restrictions did not apply is exactly the case worth catching. It is the same gap `GetStorageBucketAttrs` closed for buckets in #1890.

**What changed**

* **modules/gcp · apikeys.go**, new: `GetAPIKeyAttrs`, `GetAPIKeyAttrsE` and `GetAPIKeyAttrsWithClient`, returning the key as `*apikeys.V2Key` so a caller asserts on the API's own fields. A missing key returns an error naming the key and the project, in the wording the other read functions here use. `NewAPIKeysServiceE` builds the service through the same `withOptions` helper every other client uses.
* **It reads settings and never the key string.** No test needs the secret, and a helper that returned it would put it in a test log.
* **modules/gcp · apikeys_test.go**, new: a configured key and a missing one, both against a local test server the Google transport actually talks to, in the shape `storage_test.go` already uses.
* **No new dependency.** `google.golang.org/api` is already required for the compute client and the API Keys service lives in the same module, so `go.mod` is unchanged.
* **Deliberately not handled:** key strings and the `lookupKey` call, neither of which a test needs.

**Landing it**
* **Rollback:** revert is enough. One new file and one new test file; nothing existing changes.
* **Rule bent:** none.

**Validation**
* **Unit**: the whole `modules/gcp` package passes, including both new cases. They fail on `main`, where `apikeys.go` does not exist.
* **Not run**: anything against a real project. The consumer that does is [terraform-google-test-library](https://github.com/gruntwork-io-team/terraform-google-test-library), whose suite applies the key module and reads it back through this function.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for retrieving Google Cloud API key settings, including display name, identifier, and API target restrictions.
  * Added clear error reporting when a requested API key does not exist.

* **Tests**
  * Added coverage for successful API key lookups and missing-key responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->