### PR TITLE
feat(gcp): read a workflow's settings back so a test can assert them

### DIFF
--- a/modules/gcp/workflows.go
+++ b/modules/gcp/workflows.go
@@ -1,0 +1,66 @@
+package gcp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/gruntwork-io/terratest/modules/core/v2/logger"
+	"github.com/gruntwork-io/terratest/modules/core/v2/testing"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/api/googleapi"
+	"google.golang.org/api/option"
+	"google.golang.org/api/workflows/v1"
+)
+
+// GetWorkflowAttrs returns the settings Google Cloud holds for the given workflow, so a test can
+// assert on what was actually created rather than only that it exists. A workflow is regional, so
+// the region it was created in has to be given.
+// This will fail the test if there is an error.
+// The ctx parameter supports cancellation and timeouts.
+func GetWorkflowAttrs(t testing.TestingT, ctx context.Context, projectID string, region string, workflowName string) *workflows.Workflow {
+	workflow, err := GetWorkflowAttrsE(t, ctx, projectID, region, workflowName)
+	require.NoError(t, err)
+
+	return workflow
+}
+
+// GetWorkflowAttrsE returns the settings Google Cloud holds for the given workflow.
+// The ctx parameter supports cancellation and timeouts.
+func GetWorkflowAttrsE(t testing.TestingT, ctx context.Context, projectID string, region string, workflowName string) (*workflows.Workflow, error) {
+	logger.Default.Logf(t, "Getting settings for workflow %s in project %s", workflowName, projectID)
+
+	service, err := NewWorkflowsServiceE(t, ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return GetWorkflowAttrsWithClient(ctx, service, projectID, region, workflowName)
+}
+
+// GetWorkflowAttrsWithClient returns the settings Google Cloud holds for the given workflow using
+// the supplied *workflows.Service. Prefer this variant in unit tests where the service is backed by
+// an httptest fake server (see workflows_test.go for the pattern).
+// The ctx parameter supports cancellation and timeouts.
+func GetWorkflowAttrsWithClient(ctx context.Context, service *workflows.Service, projectID string, region string, workflowName string) (*workflows.Workflow, error) {
+	name := fmt.Sprintf("projects/%s/locations/%s/workflows/%s", projectID, region, workflowName)
+
+	workflow, err := service.Projects.Locations.Workflows.Get(name).Context(ctx).Do()
+	if err != nil {
+		var apiErr *googleapi.Error
+		if errors.As(err, &apiErr) && apiErr.Code == 404 {
+			return nil, fmt.Errorf("workflow %s does not exist in project %s", workflowName, projectID)
+		}
+
+		return nil, fmt.Errorf("failed to get settings for workflow %s in project %s: %w", workflowName, projectID, err)
+	}
+
+	return workflow, nil
+}
+
+// NewWorkflowsServiceE creates a Workflows service authenticated the same way every other client in
+// this module is.
+// The ctx parameter supports cancellation and timeouts.
+func NewWorkflowsServiceE(t testing.TestingT, ctx context.Context) (*workflows.Service, error) {
+	return workflows.NewService(ctx, append(withOptions(), option.WithScopes(workflows.CloudPlatformScope))...)
+}

--- a/modules/gcp/workflows_test.go
+++ b/modules/gcp/workflows_test.go
@@ -1,0 +1,73 @@
+package gcp_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/gcp/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/api/option"
+	"google.golang.org/api/workflows/v1"
+)
+
+// newFakeWorkflowsService points a real *workflows.Service at a local test server, so the Google
+// transport is exercised rather than a hand-written stand-in for a type we do not own.
+func newFakeWorkflowsService(t *testing.T, handler http.Handler) *workflows.Service {
+	t.Helper()
+
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	service, err := workflows.NewService(context.Background(),
+		option.WithEndpoint(server.URL), option.WithoutAuthentication())
+	require.NoError(t, err)
+
+	return service
+}
+
+func TestGetWorkflowAttrsWithClient(t *testing.T) {
+	t.Parallel()
+
+	// The values are the ones the terraform-google-serverless workflow module sets, because the
+	// point of reading settings back is asserting a module configured the workflow it was asked
+	// for.
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.True(t, strings.HasSuffix(r.URL.Path, "/locations/us-central1/workflows/gw-library-test"))
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"name":"projects/gw-library-test-project/locations/us-central1/workflows/gw-library-test",
+			"description":"created by terratest",
+			"state":"ACTIVE",
+			"callLogLevel":"LOG_ERRORS_ONLY",
+			"labels":{"purpose":"terratest"}
+		}`))
+	})
+
+	workflow, err := gcp.GetWorkflowAttrsWithClient(context.Background(), newFakeWorkflowsService(t, handler), "gw-library-test-project", "us-central1", "gw-library-test")
+	require.NoError(t, err)
+
+	assert.Equal(t, "created by terratest", workflow.Description)
+	assert.Equal(t, "ACTIVE", workflow.State)
+	assert.Equal(t, "LOG_ERRORS_ONLY", workflow.CallLogLevel)
+	assert.Equal(t, map[string]string{"purpose": "terratest"}, workflow.Labels)
+}
+
+func TestGetWorkflowAttrsWithClientMissingWorkflow(t *testing.T) {
+	t.Parallel()
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+
+	// The error names the workflow and the project as well as saying it is absent, so all three are
+	// asserted rather than only the phrase.
+	_, err := gcp.GetWorkflowAttrsWithClient(context.Background(), newFakeWorkflowsService(t, handler), "gw-library-test-project", "us-central1", "gone")
+	require.ErrorContains(t, err, "does not exist")
+	require.ErrorContains(t, err, "gone")
+	require.ErrorContains(t, err, "gw-library-test-project")
+}


### PR DESCRIPTION
**TL;DR:** A test holding a workflow name can now read that workflow's description, state, call log level and labels. The GCP module had nothing for Workflows at all before this.

**Why:** a Terraform module that creates a workflow has no way to prove it created the workflow it was asked for. It is the same gap `GetStorageBucketAttrs` closed for buckets in #1890.

**What changed**

* **modules/gcp · workflows.go**, new: `GetWorkflowAttrs`, `GetWorkflowAttrsE` and `GetWorkflowAttrsWithClient`, returning the workflow as `*workflows.Workflow` so a caller asserts on the API's own fields. It takes the region as well as the name, because a workflow is a regional resource. A missing workflow returns an error naming the workflow and the project, in the wording the other read functions here use. `NewWorkflowsServiceE` builds the service through the same `withOptions` helper every other client uses.
* **modules/gcp · workflows_test.go**, new: a configured workflow and a missing one, both against a local test server the Google transport actually talks to, in the shape `storage_test.go` already uses.
* **No new dependency.** `google.golang.org/api` is already required for the compute client and the Workflows service lives in the same module, so `go.mod` is unchanged.
* **Deliberately not handled:** executions. Running a workflow and reading its result is a different thing from proving one was created as asked, and it is its own change.

**Landing it**
* **Rollback:** revert is enough. One new file and one new test file; nothing existing changes.
* **Rule bent:** none.

**Validation**
* **Unit**: the whole `modules/gcp` package passes, including both new cases. They fail on `main`, where `workflows.go` does not exist.
* **Not run**: anything against a real project. The consumer that does is [terraform-google-test-library](https://github.com/gruntwork-io-team/terraform-google-test-library), whose suite applies the workflow module and reads it back through this function.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for retrieving Google Cloud Workflows and their configuration details.
  - Added clear error reporting when a requested workflow does not exist.
  - Added support for request cancellation and timeouts through context-aware operations.
  - Added authenticated Google Cloud service setup for accessing Workflows.

- **Tests**
  - Added coverage for successful workflow retrieval, response parsing, and missing-workflow errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->