### PR TITLE
feat(gcp): read a delivery pipeline's settings back so a test can assert them

### DIFF
--- a/modules/gcp/clouddeploy.go
+++ b/modules/gcp/clouddeploy.go
@@ -1,0 +1,68 @@
+package gcp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/gruntwork-io/terratest/modules/core/v2/logger"
+	"github.com/gruntwork-io/terratest/modules/core/v2/testing"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/api/clouddeploy/v1"
+	"google.golang.org/api/googleapi"
+	"google.golang.org/api/option"
+)
+
+// GetDeliveryPipelineAttrs returns the settings Google Cloud holds for the given Cloud Deploy
+// delivery pipeline, so a test can assert on what was actually created rather than only that it
+// exists. A pipeline is regional, so the location it was created in has to be given.
+// This will fail the test if there is an error.
+// The ctx parameter supports cancellation and timeouts.
+func GetDeliveryPipelineAttrs(t testing.TestingT, ctx context.Context, projectID string, location string, pipelineName string) *clouddeploy.DeliveryPipeline {
+	pipeline, err := GetDeliveryPipelineAttrsE(t, ctx, projectID, location, pipelineName)
+	require.NoError(t, err)
+
+	return pipeline
+}
+
+// GetDeliveryPipelineAttrsE returns the settings Google Cloud holds for the given Cloud Deploy
+// delivery pipeline.
+// The ctx parameter supports cancellation and timeouts.
+func GetDeliveryPipelineAttrsE(t testing.TestingT, ctx context.Context, projectID string, location string, pipelineName string) (*clouddeploy.DeliveryPipeline, error) {
+	logger.Default.Logf(t, "Getting settings for delivery pipeline %s in project %s", pipelineName, projectID)
+
+	service, err := NewCloudDeployServiceE(t, ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return GetDeliveryPipelineAttrsWithClient(ctx, service, projectID, location, pipelineName)
+}
+
+// GetDeliveryPipelineAttrsWithClient returns the settings Google Cloud holds for the given Cloud
+// Deploy delivery pipeline using the supplied *clouddeploy.Service. Prefer this variant in unit
+// tests where the service is backed by an httptest fake server (see clouddeploy_test.go for the
+// pattern).
+// The ctx parameter supports cancellation and timeouts.
+func GetDeliveryPipelineAttrsWithClient(ctx context.Context, service *clouddeploy.Service, projectID string, location string, pipelineName string) (*clouddeploy.DeliveryPipeline, error) {
+	name := fmt.Sprintf("projects/%s/locations/%s/deliveryPipelines/%s", projectID, location, pipelineName)
+
+	pipeline, err := service.Projects.Locations.DeliveryPipelines.Get(name).Context(ctx).Do()
+	if err != nil {
+		var apiErr *googleapi.Error
+		if errors.As(err, &apiErr) && apiErr.Code == 404 {
+			return nil, fmt.Errorf("delivery pipeline %s does not exist in project %s", pipelineName, projectID)
+		}
+
+		return nil, fmt.Errorf("failed to get settings for delivery pipeline %s in project %s: %w", pipelineName, projectID, err)
+	}
+
+	return pipeline, nil
+}
+
+// NewCloudDeployServiceE creates a Cloud Deploy service authenticated the same way every other
+// client in this module is.
+// The ctx parameter supports cancellation and timeouts.
+func NewCloudDeployServiceE(t testing.TestingT, ctx context.Context) (*clouddeploy.Service, error) {
+	return clouddeploy.NewService(ctx, append(withOptions(), option.WithScopes(clouddeploy.CloudPlatformScope))...)
+}

--- a/modules/gcp/clouddeploy_test.go
+++ b/modules/gcp/clouddeploy_test.go
@@ -1,0 +1,72 @@
+package gcp_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/gcp/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/api/clouddeploy/v1"
+	"google.golang.org/api/option"
+)
+
+// newFakeCloudDeployService points a real *clouddeploy.Service at a local test server, so the
+// Google transport is exercised rather than a hand-written stand-in for a type we do not own.
+func newFakeCloudDeployService(t *testing.T, handler http.Handler) *clouddeploy.Service {
+	t.Helper()
+
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	service, err := clouddeploy.NewService(context.Background(),
+		option.WithEndpoint(server.URL), option.WithoutAuthentication())
+	require.NoError(t, err)
+
+	return service
+}
+
+func TestGetDeliveryPipelineAttrsWithClient(t *testing.T) {
+	t.Parallel()
+
+	// The values are the ones the terraform-google-devtools pipeline module sets, because the point
+	// of reading settings back is asserting a module configured the pipeline it was asked for.
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.True(t, strings.HasSuffix(r.URL.Path, "/locations/us-central1/deliveryPipelines/gw-library-test"))
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"name":"projects/gw-library-test-project/locations/us-central1/deliveryPipelines/gw-library-test",
+			"description":"created by terratest",
+			"labels":{"purpose":"terratest"},
+			"annotations":{"owner":"terratest"},
+			"suspended":true
+		}`))
+	})
+
+	pipeline, err := gcp.GetDeliveryPipelineAttrsWithClient(context.Background(), newFakeCloudDeployService(t, handler), "gw-library-test-project", "us-central1", "gw-library-test")
+	require.NoError(t, err)
+
+	assert.Equal(t, "created by terratest", pipeline.Description)
+	assert.Equal(t, map[string]string{"purpose": "terratest"}, pipeline.Labels)
+	assert.Equal(t, map[string]string{"owner": "terratest"}, pipeline.Annotations)
+	assert.True(t, pipeline.Suspended)
+}
+
+func TestGetDeliveryPipelineAttrsWithClientMissingPipeline(t *testing.T) {
+	t.Parallel()
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+
+	// The error names the pipeline and the project as well as saying it is absent, so all three are
+	// asserted rather than only the phrase.
+	_, err := gcp.GetDeliveryPipelineAttrsWithClient(context.Background(), newFakeCloudDeployService(t, handler), "gw-library-test-project", "us-central1", "gone")
+	require.ErrorContains(t, err, "does not exist")
+	require.ErrorContains(t, err, "gone")
+	require.ErrorContains(t, err, "gw-library-test-project")
+}


### PR DESCRIPTION
**TL;DR:** A test holding a Cloud Deploy delivery pipeline name can now read that pipeline's description, labels, annotations and suspended flag. The GCP module had nothing for Cloud Deploy at all before this.

**Why:** a Terraform module that creates a delivery pipeline has no way to prove it created the pipeline it was asked for. It is the same gap `GetStorageBucketAttrs` closed for buckets in #1890.

**What changed**

* **modules/gcp · clouddeploy.go**, new: `GetDeliveryPipelineAttrs`, `GetDeliveryPipelineAttrsE` and `GetDeliveryPipelineAttrsWithClient`, returning the pipeline as `*clouddeploy.DeliveryPipeline` so a caller asserts on the API's own fields. It takes the location as well as the name, because a pipeline is a regional resource. A missing pipeline returns an error naming the pipeline and the project, in the wording the other read functions here use. `NewCloudDeployServiceE` builds the service through the same `withOptions` helper every other client uses.
* **modules/gcp · clouddeploy_test.go**, new: a configured pipeline and a missing one, both against a local test server the Google transport actually talks to, in the shape `storage_test.go` already uses.
* **No new dependency.** `google.golang.org/api` is already required for the compute client and the Cloud Deploy service lives in the same module, so `go.mod` is unchanged.
* **Deliberately not handled:** targets, releases, rollouts and automations. Each is its own resource with its own read, and none is needed to prove a pipeline.

**Landing it**
* **Rollback:** revert is enough. One new file and one new test file; nothing existing changes.
* **Rule bent:** none.

**Validation**
* **Unit**: the whole `modules/gcp` package passes, including both new cases. They fail on `main`, where `clouddeploy.go` does not exist.
* **Not run**: anything against a real project. The consumer that does is [terraform-google-test-library](https://github.com/gruntwork-io-team/terraform-google-test-library), whose suite applies the pipeline module and reads it back through this function.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for retrieving Google Cloud Deploy delivery pipeline settings.
  - Pipeline details now include descriptions, labels, annotations, and suspension status.
  - Clear errors are reported when a requested pipeline does not exist or cannot be retrieved.

- **Tests**
  - Added coverage for successful pipeline retrieval and missing-pipeline error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->