### PR TITLE
feat(gcp): read a healthcare dataset's settings back so a test can assert them

### DIFF
--- a/modules/gcp/healthcare.go
+++ b/modules/gcp/healthcare.go
@@ -1,0 +1,67 @@
+package gcp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/gruntwork-io/terratest/modules/core/v2/logger"
+	"github.com/gruntwork-io/terratest/modules/core/v2/testing"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/api/googleapi"
+	"google.golang.org/api/healthcare/v1"
+	"google.golang.org/api/option"
+)
+
+// GetHealthcareDatasetAttrs returns the settings Google Cloud holds for the given Cloud Healthcare
+// dataset, so a test can assert on what was actually created rather than only that it exists. A
+// dataset is regional, so the location it was created in has to be given.
+// This will fail the test if there is an error.
+// The ctx parameter supports cancellation and timeouts.
+func GetHealthcareDatasetAttrs(t testing.TestingT, ctx context.Context, projectID string, location string, datasetID string) *healthcare.Dataset {
+	dataset, err := GetHealthcareDatasetAttrsE(t, ctx, projectID, location, datasetID)
+	require.NoError(t, err)
+
+	return dataset
+}
+
+// GetHealthcareDatasetAttrsE returns the settings Google Cloud holds for the given Cloud Healthcare
+// dataset.
+// The ctx parameter supports cancellation and timeouts.
+func GetHealthcareDatasetAttrsE(t testing.TestingT, ctx context.Context, projectID string, location string, datasetID string) (*healthcare.Dataset, error) {
+	logger.Default.Logf(t, "Getting settings for healthcare dataset %s in project %s", datasetID, projectID)
+
+	service, err := NewHealthcareServiceE(t, ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return GetHealthcareDatasetAttrsWithClient(ctx, service, projectID, location, datasetID)
+}
+
+// GetHealthcareDatasetAttrsWithClient returns the settings Google Cloud holds for the given Cloud
+// Healthcare dataset using the supplied *healthcare.Service. Prefer this variant in unit tests
+// where the service is backed by an httptest fake server (see healthcare_test.go for the pattern).
+// The ctx parameter supports cancellation and timeouts.
+func GetHealthcareDatasetAttrsWithClient(ctx context.Context, service *healthcare.Service, projectID string, location string, datasetID string) (*healthcare.Dataset, error) {
+	name := fmt.Sprintf("projects/%s/locations/%s/datasets/%s", projectID, location, datasetID)
+
+	dataset, err := service.Projects.Locations.Datasets.Get(name).Context(ctx).Do()
+	if err != nil {
+		var apiErr *googleapi.Error
+		if errors.As(err, &apiErr) && apiErr.Code == 404 {
+			return nil, fmt.Errorf("healthcare dataset %s does not exist in project %s", datasetID, projectID)
+		}
+
+		return nil, fmt.Errorf("failed to get settings for healthcare dataset %s in project %s: %w", datasetID, projectID, err)
+	}
+
+	return dataset, nil
+}
+
+// NewHealthcareServiceE creates a Cloud Healthcare service authenticated the same way every other
+// client in this module is.
+// The ctx parameter supports cancellation and timeouts.
+func NewHealthcareServiceE(t testing.TestingT, ctx context.Context) (*healthcare.Service, error) {
+	return healthcare.NewService(ctx, append(withOptions(), option.WithScopes(healthcare.CloudPlatformScope))...)
+}

--- a/modules/gcp/healthcare_test.go
+++ b/modules/gcp/healthcare_test.go
@@ -1,0 +1,67 @@
+package gcp_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/gcp/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/api/healthcare/v1"
+	"google.golang.org/api/option"
+)
+
+// newFakeHealthcareService points a real *healthcare.Service at a local test server, so the Google
+// transport is exercised rather than a hand-written stand-in for a type we do not own.
+func newFakeHealthcareService(t *testing.T, handler http.Handler) *healthcare.Service {
+	t.Helper()
+
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	service, err := healthcare.NewService(context.Background(),
+		option.WithEndpoint(server.URL), option.WithoutAuthentication())
+	require.NoError(t, err)
+
+	return service
+}
+
+func TestGetHealthcareDatasetAttrsWithClient(t *testing.T) {
+	t.Parallel()
+
+	// The values are the ones the terraform-google-healthcare dataset module sets, because the point
+	// of reading settings back is asserting a module configured the dataset it was asked for.
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.True(t, strings.HasSuffix(r.URL.Path, "/locations/us-central1/datasets/gw-library-test"))
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"name":"projects/gw-library-test-project/locations/us-central1/datasets/gw-library-test",
+			"timeZone":"America/New_York"
+		}`))
+	})
+
+	dataset, err := gcp.GetHealthcareDatasetAttrsWithClient(context.Background(), newFakeHealthcareService(t, handler), "gw-library-test-project", "us-central1", "gw-library-test")
+	require.NoError(t, err)
+
+	assert.Equal(t, "projects/gw-library-test-project/locations/us-central1/datasets/gw-library-test", dataset.Name)
+	assert.Equal(t, "America/New_York", dataset.TimeZone)
+}
+
+func TestGetHealthcareDatasetAttrsWithClientMissingDataset(t *testing.T) {
+	t.Parallel()
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+
+	// The error names the dataset and the project as well as saying it is absent, so all three are
+	// asserted rather than only the phrase.
+	_, err := gcp.GetHealthcareDatasetAttrsWithClient(context.Background(), newFakeHealthcareService(t, handler), "gw-library-test-project", "us-central1", "gone")
+	require.ErrorContains(t, err, "does not exist")
+	require.ErrorContains(t, err, "gone")
+	require.ErrorContains(t, err, "gw-library-test-project")
+}


### PR DESCRIPTION
**TL;DR:** A test holding a Cloud Healthcare dataset id can now read that dataset's name and time zone. The GCP module had nothing for Cloud Healthcare at all before this.

**Why:** a Terraform module that creates a healthcare dataset has no way to prove it created the dataset it was asked for. It is the same gap `GetStorageBucketAttrs` closed for buckets in #1890.

**What changed**

* **modules/gcp · healthcare.go**, new: `GetHealthcareDatasetAttrs`, `GetHealthcareDatasetAttrsE` and `GetHealthcareDatasetAttrsWithClient`, returning the dataset as `*healthcare.Dataset` so a caller asserts on the API's own fields. It takes the location as well as the id, because a dataset is a regional resource. A missing dataset returns an error naming the dataset and the project, in the wording the other read functions here use. `NewHealthcareServiceE` builds the service through the same `withOptions` helper every other client uses.
* **The dataset is the only thing read, and it holds no patient data.** A dataset is the container; the FHIR, DICOM and HL7v2 stores inside it are separate resources, and none of them is read here.
* **modules/gcp · healthcare_test.go**, new: a configured dataset and a missing one, both against a local test server the Google transport actually talks to, in the shape `storage_test.go` already uses.
* **No new dependency.** `google.golang.org/api` is already required for the compute client and the Cloud Healthcare service lives in the same module, so `go.mod` is unchanged.
* **Deliberately not handled:** FHIR, DICOM, HL7v2 and consent stores. Each is its own resource with its own read, and none is needed to prove a dataset.

**Landing it**
* **Rollback:** revert is enough. One new file and one new test file; nothing existing changes.
* **Rule bent:** none.

**Validation**
* **Unit**: the whole `modules/gcp` package passes, including both new cases. They fail on `main`, where `healthcare.go` does not exist.
* **Not run**: anything against a real project. The consumer that does is [terraform-google-test-library](https://github.com/gruntwork-io-team/terraform-google-test-library), whose suite applies the dataset module and reads it back through this function.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for retrieving Google Cloud Healthcare dataset details.
  * Added clear error reporting when a requested dataset does not exist.

* **Tests**
  * Added coverage for successful dataset retrieval and verification of returned details.
  * Added coverage for missing datasets and validation of descriptive error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->