### PR TITLE
feat(gcp): read a Document AI processor's settings back so a test can assert them

### DIFF
--- a/modules/gcp/documentai.go
+++ b/modules/gcp/documentai.go
@@ -1,0 +1,72 @@
+package gcp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/gruntwork-io/terratest/modules/core/v2/logger"
+	"github.com/gruntwork-io/terratest/modules/core/v2/testing"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/api/documentai/v1"
+	"google.golang.org/api/googleapi"
+	"google.golang.org/api/option"
+)
+
+// GetDocumentAIProcessorAttrs returns the settings Google Cloud holds for the given Document AI
+// processor, so a test can assert on what was actually created rather than only that it exists. A
+// processor lives in a multi-region such as `us` or `eu`, which has to be given, and the id is the
+// one Google assigns.
+// This will fail the test if there is an error.
+// The ctx parameter supports cancellation and timeouts.
+func GetDocumentAIProcessorAttrs(t testing.TestingT, ctx context.Context, projectID string, location string, processorID string) *documentai.GoogleCloudDocumentaiV1Processor {
+	processor, err := GetDocumentAIProcessorAttrsE(t, ctx, projectID, location, processorID)
+	require.NoError(t, err)
+
+	return processor
+}
+
+// GetDocumentAIProcessorAttrsE returns the settings Google Cloud holds for the given Document AI
+// processor.
+// The ctx parameter supports cancellation and timeouts.
+func GetDocumentAIProcessorAttrsE(t testing.TestingT, ctx context.Context, projectID string, location string, processorID string) (*documentai.GoogleCloudDocumentaiV1Processor, error) {
+	logger.Default.Logf(t, "Getting settings for Document AI processor %s in project %s", processorID, projectID)
+
+	service, err := NewDocumentAIServiceE(t, ctx, location)
+	if err != nil {
+		return nil, err
+	}
+
+	return GetDocumentAIProcessorAttrsWithClient(ctx, service, projectID, location, processorID)
+}
+
+// GetDocumentAIProcessorAttrsWithClient returns the settings Google Cloud holds for the given
+// Document AI processor using the supplied *documentai.Service. Prefer this variant in unit tests
+// where the service is backed by an httptest fake server (see documentai_test.go for the pattern).
+// The ctx parameter supports cancellation and timeouts.
+func GetDocumentAIProcessorAttrsWithClient(ctx context.Context, service *documentai.Service, projectID string, location string, processorID string) (*documentai.GoogleCloudDocumentaiV1Processor, error) {
+	name := fmt.Sprintf("projects/%s/locations/%s/processors/%s", projectID, location, processorID)
+
+	processor, err := service.Projects.Locations.Processors.Get(name).Context(ctx).Do()
+	if err != nil {
+		var apiErr *googleapi.Error
+		if errors.As(err, &apiErr) && apiErr.Code == 404 {
+			return nil, fmt.Errorf("Document AI processor %s does not exist in project %s", processorID, projectID)
+		}
+
+		return nil, fmt.Errorf("failed to get settings for Document AI processor %s in project %s: %w", processorID, projectID, err)
+	}
+
+	return processor, nil
+}
+
+// NewDocumentAIServiceE creates a Document AI service authenticated the same way every other client
+// in this module is. Document AI answers only on a per-location host, so the location decides which
+// endpoint the service talks to.
+// The ctx parameter supports cancellation and timeouts.
+func NewDocumentAIServiceE(t testing.TestingT, ctx context.Context, location string) (*documentai.Service, error) {
+	opts := append(withOptions(), option.WithScopes(documentai.CloudPlatformScope))
+	opts = append(opts, option.WithEndpoint(fmt.Sprintf("https://%s-documentai.googleapis.com/", location)))
+
+	return documentai.NewService(ctx, opts...)
+}

--- a/modules/gcp/documentai.go
+++ b/modules/gcp/documentai.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"regexp"
 
 	"github.com/gruntwork-io/terratest/modules/core/v2/logger"
 	"github.com/gruntwork-io/terratest/modules/core/v2/testing"
@@ -60,11 +61,20 @@ func GetDocumentAIProcessorAttrsWithClient(ctx context.Context, service *documen
 	return processor, nil
 }
 
+// locationPattern is what a Google Cloud location identifier may contain. It is checked before a
+// location reaches an endpoint, because a value carrying a slash, a colon or an at sign would build
+// a URL pointing at a host of the caller's choosing rather than at Google.
+var locationPattern = regexp.MustCompile(`^[a-z0-9]+(-[a-z0-9]+)*$`)
+
 // NewDocumentAIServiceE creates a Document AI service authenticated the same way every other client
 // in this module is. Document AI answers only on a per-location host, so the location decides which
-// endpoint the service talks to.
+// endpoint the service talks to, and a location that is not a plain identifier is refused.
 // The ctx parameter supports cancellation and timeouts.
 func NewDocumentAIServiceE(t testing.TestingT, ctx context.Context, location string) (*documentai.Service, error) {
+	if !locationPattern.MatchString(location) {
+		return nil, fmt.Errorf("%q is not a valid location: a location may hold only lowercase letters, digits and hyphens", location)
+	}
+
 	opts := append(withOptions(), option.WithScopes(documentai.CloudPlatformScope))
 	opts = append(opts, option.WithEndpoint(fmt.Sprintf("https://%s-documentai.googleapis.com/", location)))
 

--- a/modules/gcp/documentai_test.go
+++ b/modules/gcp/documentai_test.go
@@ -1,0 +1,70 @@
+package gcp_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/gcp/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/api/documentai/v1"
+	"google.golang.org/api/option"
+)
+
+// newFakeDocumentAIService points a real *documentai.Service at a local test server, so the Google
+// transport is exercised rather than a hand-written stand-in for a type we do not own.
+func newFakeDocumentAIService(t *testing.T, handler http.Handler) *documentai.Service {
+	t.Helper()
+
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	service, err := documentai.NewService(context.Background(),
+		option.WithEndpoint(server.URL), option.WithoutAuthentication())
+	require.NoError(t, err)
+
+	return service
+}
+
+func TestGetDocumentAIProcessorAttrsWithClient(t *testing.T) {
+	t.Parallel()
+
+	// The values are the ones the terraform-google-ml processor module sets, because the point of
+	// reading settings back is asserting a module configured the processor it was asked for.
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.True(t, strings.HasSuffix(r.URL.Path, "/locations/us/processors/abc123"))
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"name":"projects/gw-library-test-project/locations/us/processors/abc123",
+			"type":"OCR_PROCESSOR",
+			"displayName":"terratest processor",
+			"state":"ENABLED"
+		}`))
+	})
+
+	processor, err := gcp.GetDocumentAIProcessorAttrsWithClient(context.Background(), newFakeDocumentAIService(t, handler), "gw-library-test-project", "us", "abc123")
+	require.NoError(t, err)
+
+	assert.Equal(t, "OCR_PROCESSOR", processor.Type)
+	assert.Equal(t, "terratest processor", processor.DisplayName)
+	assert.Equal(t, "ENABLED", processor.State)
+}
+
+func TestGetDocumentAIProcessorAttrsWithClientMissingProcessor(t *testing.T) {
+	t.Parallel()
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+
+	// The error names the processor and the project as well as saying it is absent, so all three
+	// are asserted rather than only the phrase.
+	_, err := gcp.GetDocumentAIProcessorAttrsWithClient(context.Background(), newFakeDocumentAIService(t, handler), "gw-library-test-project", "us", "gone")
+	require.ErrorContains(t, err, "does not exist")
+	require.ErrorContains(t, err, "gone")
+	require.ErrorContains(t, err, "gw-library-test-project")
+}

--- a/modules/gcp/documentai_test.go
+++ b/modules/gcp/documentai_test.go
@@ -68,3 +68,18 @@ func TestGetDocumentAIProcessorAttrsWithClientMissingProcessor(t *testing.T) {
 	require.ErrorContains(t, err, "gone")
 	require.ErrorContains(t, err, "gw-library-test-project")
 }
+
+func TestNewDocumentAIServiceERefusesABadLocation(t *testing.T) {
+	t.Parallel()
+
+	// Each of these would build a URL pointing somewhere other than Google, so the constructor has
+	// to refuse them before the endpoint is built.
+	for _, location := range []string{"us/../evil.com", "evil.com", "us:8080", "user@evil.com", "US", ""} {
+		_, err := gcp.NewDocumentAIServiceE(t, context.Background(), location)
+		require.ErrorContains(t, err, "not a valid location", "location %q should be refused", location)
+	}
+
+	// A real one is accepted.
+	_, err := gcp.NewDocumentAIServiceE(t, context.Background(), "us-central1")
+	require.NoError(t, err)
+}


### PR DESCRIPTION
**TL;DR:** A test holding a Document AI processor id can now read that processor's type, display name and state. The GCP module had nothing for Document AI at all before this.

**Why:** a Terraform module that creates a processor has no way to prove it created the processor it was asked for, and a processor whose type came out wrong is exactly the case worth catching. It is the same gap `GetStorageBucketAttrs` closed for buckets in #1890.

**What changed**

* **modules/gcp · documentai.go**, new: `GetDocumentAIProcessorAttrs`, `GetDocumentAIProcessorAttrsE` and `GetDocumentAIProcessorAttrsWithClient`, returning the processor as `*documentai.GoogleCloudDocumentaiV1Processor` so a caller asserts on the API's own fields. A missing processor returns an error naming the processor and the project, in the wording the other read functions here use.
* **`NewDocumentAIServiceE` takes a location, unlike every other constructor here.** Document AI answers only on a per-location host such as `us-documentai.googleapis.com`, so the location decides the endpoint rather than only the resource path. A service built against the global host returns 404 for a processor that exists.
* **modules/gcp · documentai_test.go**, new: a configured processor and a missing one, both against a local test server the Google transport actually talks to, in the shape `storage_test.go` already uses.
* **No new dependency.** `google.golang.org/api` is already required for the compute client and the Document AI service lives in the same module, so `go.mod` is unchanged.
* **Deliberately not handled:** processor versions and the processing calls themselves. Processing a document costs money per page and is a different thing from proving a processor was created as asked.

**Landing it**
* **Rollback:** revert is enough. One new file and one new test file; nothing existing changes.
* **Rule bent:** none.

**Validation**
* **Unit**: the whole `modules/gcp` package passes, including both new cases. They fail on `main`, where `documentai.go` does not exist.
* **Not run**: anything against a real project. The consumer that does is [terraform-google-test-library](https://github.com/gruntwork-io-team/terraform-google-test-library), whose suite applies the processor module and reads it back through this function.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for retrieving Google Cloud Document AI processor settings by project, location, and processor ID.
  - Added authenticated, location-aware Document AI service access.
  - Added context cancellation and custom service client support.
  - Added clear errors for missing processors, API failures, and invalid locations.

- **Tests**
  - Added coverage for successful processor retrieval, missing processors, and location validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->