### PR TITLE
feat(gcp): read a Dialogflow CX agent's settings back so a test can assert them

### DIFF
--- a/modules/gcp/dialogflow.go
+++ b/modules/gcp/dialogflow.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"regexp"
 
 	"github.com/gruntwork-io/terratest/modules/core/v2/logger"
 	"github.com/gruntwork-io/terratest/modules/core/v2/testing"
@@ -59,11 +60,21 @@ func GetDialogflowAgentAttrsWithClient(ctx context.Context, service *dialogflow.
 	return agent, nil
 }
 
+// dialogflowLocationPattern is what a Google Cloud location identifier may contain. It is checked
+// before a location reaches an endpoint, because a value carrying a slash, a colon or an at sign
+// would build a URL pointing at a host of the caller's choosing rather than at Google.
+var dialogflowLocationPattern = regexp.MustCompile(`^[a-z0-9]+(-[a-z0-9]+)*$`)
+
 // NewDialogflowServiceE creates a Dialogflow service authenticated the same way every other client
 // in this module is. Dialogflow answers on a per-location host for every location but `global`, so
-// the location decides which endpoint the service talks to.
+// the location decides which endpoint the service talks to, and a location that is not a plain
+// identifier is refused.
 // The ctx parameter supports cancellation and timeouts.
 func NewDialogflowServiceE(t testing.TestingT, ctx context.Context, location string) (*dialogflow.Service, error) {
+	if !dialogflowLocationPattern.MatchString(location) {
+		return nil, fmt.Errorf("%q is not a valid location: a location may hold only lowercase letters, digits and hyphens", location)
+	}
+
 	opts := append(withOptions(), option.WithScopes(dialogflow.CloudPlatformScope))
 	if location != "global" {
 		opts = append(opts, option.WithEndpoint(fmt.Sprintf("https://%s-dialogflow.googleapis.com/", location)))

--- a/modules/gcp/dialogflow.go
+++ b/modules/gcp/dialogflow.go
@@ -1,0 +1,73 @@
+package gcp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/gruntwork-io/terratest/modules/core/v2/logger"
+	"github.com/gruntwork-io/terratest/modules/core/v2/testing"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/api/dialogflow/v3"
+	"google.golang.org/api/googleapi"
+	"google.golang.org/api/option"
+)
+
+// GetDialogflowAgentAttrs returns the settings Google Cloud holds for the given Dialogflow CX
+// agent, so a test can assert on what was actually created rather than only that it exists. An
+// agent lives in a location, which has to be given, and the id is the one Google assigns.
+// This will fail the test if there is an error.
+// The ctx parameter supports cancellation and timeouts.
+func GetDialogflowAgentAttrs(t testing.TestingT, ctx context.Context, projectID string, location string, agentID string) *dialogflow.GoogleCloudDialogflowCxV3Agent {
+	agent, err := GetDialogflowAgentAttrsE(t, ctx, projectID, location, agentID)
+	require.NoError(t, err)
+
+	return agent
+}
+
+// GetDialogflowAgentAttrsE returns the settings Google Cloud holds for the given Dialogflow CX
+// agent.
+// The ctx parameter supports cancellation and timeouts.
+func GetDialogflowAgentAttrsE(t testing.TestingT, ctx context.Context, projectID string, location string, agentID string) (*dialogflow.GoogleCloudDialogflowCxV3Agent, error) {
+	logger.Default.Logf(t, "Getting settings for Dialogflow agent %s in project %s", agentID, projectID)
+
+	service, err := NewDialogflowServiceE(t, ctx, location)
+	if err != nil {
+		return nil, err
+	}
+
+	return GetDialogflowAgentAttrsWithClient(ctx, service, projectID, location, agentID)
+}
+
+// GetDialogflowAgentAttrsWithClient returns the settings Google Cloud holds for the given
+// Dialogflow CX agent using the supplied *dialogflow.Service. Prefer this variant in unit tests
+// where the service is backed by an httptest fake server (see dialogflow_test.go for the pattern).
+// The ctx parameter supports cancellation and timeouts.
+func GetDialogflowAgentAttrsWithClient(ctx context.Context, service *dialogflow.Service, projectID string, location string, agentID string) (*dialogflow.GoogleCloudDialogflowCxV3Agent, error) {
+	name := fmt.Sprintf("projects/%s/locations/%s/agents/%s", projectID, location, agentID)
+
+	agent, err := service.Projects.Locations.Agents.Get(name).Context(ctx).Do()
+	if err != nil {
+		var apiErr *googleapi.Error
+		if errors.As(err, &apiErr) && apiErr.Code == 404 {
+			return nil, fmt.Errorf("Dialogflow agent %s does not exist in project %s", agentID, projectID)
+		}
+
+		return nil, fmt.Errorf("failed to get settings for Dialogflow agent %s in project %s: %w", agentID, projectID, err)
+	}
+
+	return agent, nil
+}
+
+// NewDialogflowServiceE creates a Dialogflow service authenticated the same way every other client
+// in this module is. Dialogflow answers on a per-location host for every location but `global`, so
+// the location decides which endpoint the service talks to.
+// The ctx parameter supports cancellation and timeouts.
+func NewDialogflowServiceE(t testing.TestingT, ctx context.Context, location string) (*dialogflow.Service, error) {
+	opts := append(withOptions(), option.WithScopes(dialogflow.CloudPlatformScope))
+	if location != "global" {
+		opts = append(opts, option.WithEndpoint(fmt.Sprintf("https://%s-dialogflow.googleapis.com/", location)))
+	}
+
+	return dialogflow.NewService(ctx, opts...)
+}

--- a/modules/gcp/dialogflow_test.go
+++ b/modules/gcp/dialogflow_test.go
@@ -72,3 +72,20 @@ func TestGetDialogflowAgentAttrsWithClientMissingAgent(t *testing.T) {
 	require.ErrorContains(t, err, "gone")
 	require.ErrorContains(t, err, "gw-library-test-project")
 }
+
+func TestNewDialogflowServiceERefusesABadLocation(t *testing.T) {
+	t.Parallel()
+
+	// Each of these would build a URL pointing somewhere other than Google, so the constructor has
+	// to refuse them before the endpoint is built.
+	for _, location := range []string{"us/../evil.com", "evil.com", "us:8080", "user@evil.com", "US", ""} {
+		_, err := gcp.NewDialogflowServiceE(t, context.Background(), location)
+		require.ErrorContains(t, err, "not a valid location", "location %q should be refused", location)
+	}
+
+	// A real one is accepted, and so is the global one that builds no endpoint.
+	for _, location := range []string{"us-central1", "global"} {
+		_, err := gcp.NewDialogflowServiceE(t, context.Background(), location)
+		require.NoError(t, err, "location %q should be accepted", location)
+	}
+}

--- a/modules/gcp/dialogflow_test.go
+++ b/modules/gcp/dialogflow_test.go
@@ -1,0 +1,74 @@
+package gcp_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/gcp/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/api/dialogflow/v3"
+	"google.golang.org/api/option"
+)
+
+// newFakeDialogflowService points a real *dialogflow.Service at a local test server, so the Google
+// transport is exercised rather than a hand-written stand-in for a type we do not own.
+func newFakeDialogflowService(t *testing.T, handler http.Handler) *dialogflow.Service {
+	t.Helper()
+
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	service, err := dialogflow.NewService(context.Background(),
+		option.WithEndpoint(server.URL), option.WithoutAuthentication())
+	require.NoError(t, err)
+
+	return service
+}
+
+func TestGetDialogflowAgentAttrsWithClient(t *testing.T) {
+	t.Parallel()
+
+	// The values are the ones the terraform-google-ml agent module sets, because the point of
+	// reading settings back is asserting a module configured the agent it was asked for.
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.True(t, strings.HasSuffix(r.URL.Path, "/locations/global/agents/abc123"))
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"name":"projects/gw-library-test-project/locations/global/agents/abc123",
+			"displayName":"terratest agent",
+			"description":"created by terratest",
+			"defaultLanguageCode":"en",
+			"timeZone":"America/New_York",
+			"enableSpellCorrection":true
+		}`))
+	})
+
+	agent, err := gcp.GetDialogflowAgentAttrsWithClient(context.Background(), newFakeDialogflowService(t, handler), "gw-library-test-project", "global", "abc123")
+	require.NoError(t, err)
+
+	assert.Equal(t, "terratest agent", agent.DisplayName)
+	assert.Equal(t, "created by terratest", agent.Description)
+	assert.Equal(t, "en", agent.DefaultLanguageCode)
+	assert.Equal(t, "America/New_York", agent.TimeZone)
+	assert.True(t, agent.EnableSpellCorrection)
+}
+
+func TestGetDialogflowAgentAttrsWithClientMissingAgent(t *testing.T) {
+	t.Parallel()
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+
+	// The error names the agent and the project as well as saying it is absent, so all three are
+	// asserted rather than only the phrase.
+	_, err := gcp.GetDialogflowAgentAttrsWithClient(context.Background(), newFakeDialogflowService(t, handler), "gw-library-test-project", "global", "gone")
+	require.ErrorContains(t, err, "does not exist")
+	require.ErrorContains(t, err, "gone")
+	require.ErrorContains(t, err, "gw-library-test-project")
+}


### PR DESCRIPTION
**TL;DR:** A test holding a Dialogflow CX agent id can now read that agent's display name, description, default language, time zone and spell-correction flag. The GCP module had nothing for Dialogflow at all before this.

**Why:** a Terraform module that creates an agent has no way to prove it created the agent it was asked for. It is the same gap `GetStorageBucketAttrs` closed for buckets in #1890.

**What changed**

* **modules/gcp · dialogflow.go**, new: `GetDialogflowAgentAttrs`, `GetDialogflowAgentAttrsE` and `GetDialogflowAgentAttrsWithClient`, returning the agent as `*dialogflow.GoogleCloudDialogflowCxV3Agent` so a caller asserts on the API's own fields. A missing agent returns an error naming the agent and the project, in the wording the other read functions here use.
* **`NewDialogflowServiceE` takes a location.** Dialogflow answers on a per-location host for every location but `global`, so the location decides the endpoint. A service built against the global host returns 404 for a regional agent that exists.
* **modules/gcp · dialogflow_test.go**, new: a configured agent and a missing one, both against a local test server the Google transport actually talks to, in the shape `storage_test.go` already uses.
* **No new dependency.** `google.golang.org/api` is already required for the compute client and the Dialogflow service lives in the same module, so `go.mod` is unchanged.
* **Deliberately not handled:** flows, intents, entity types and sessions. Each is its own resource with its own read, and none is needed to prove an agent.

**Landing it**
* **Rollback:** revert is enough. One new file and one new test file; nothing existing changes.
* **Rule bent:** none.

**Validation**
* **Unit**: the whole `modules/gcp` package passes, including both new cases. They fail on `main`, where `dialogflow.go` does not exist.
* **Not run**: anything against a real project. The consumer that does is [terraform-google-test-library](https://github.com/gruntwork-io-team/terraform-google-test-library), whose suite applies the agent module and reads it back through this function.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for retrieving Dialogflow CX agent settings from Google Cloud.
  * Supports agents in regional and global locations.
  * Provides clear errors when an agent cannot be found.
  * Validates location values to help prevent invalid service requests.

* **Tests**
  * Added coverage for successful agent retrieval, missing-agent errors, and valid or invalid location handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->